### PR TITLE
feat(tokens): user API tokens — Edge Functions + UI + i18n + schema

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -958,3 +958,34 @@ CREATE POLICY "media_update_authenticated" ON storage.objects
 DROP POLICY IF EXISTS "media_public_read" ON storage.objects;
 CREATE POLICY "media_public_read" ON storage.objects
   FOR SELECT USING (bucket_id = 'media');
+
+-- ============================================================
+-- MODULE 14 — USER API TOKENS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.user_api_tokens (
+  id           uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id      uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  name         text NOT NULL DEFAULT 'API Token',
+  token_hash   text NOT NULL UNIQUE,
+  prefix       text NOT NULL,
+  scopes       text[] NOT NULL DEFAULT '{observe,identify,export}',
+  last_used_at timestamptz,
+  expires_at   timestamptz,
+  created_at   timestamptz DEFAULT now(),
+  revoked_at   timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_tokens_user ON public.user_api_tokens(user_id)
+  WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_tokens_hash ON public.user_api_tokens(token_hash)
+  WHERE revoked_at IS NULL;
+
+ALTER TABLE public.user_api_tokens ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "tokens_select_own" ON public.user_api_tokens;
+CREATE POLICY "tokens_select_own" ON public.user_api_tokens
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "tokens_delete_own" ON public.user_api_tokens;
+CREATE POLICY "tokens_delete_own" ON public.user_api_tokens
+  FOR UPDATE TO authenticated USING (auth.uid() = user_id);

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -977,8 +977,7 @@ CREATE TABLE IF NOT EXISTS public.user_api_tokens (
 
 CREATE INDEX IF NOT EXISTS idx_tokens_user ON public.user_api_tokens(user_id)
   WHERE revoked_at IS NULL;
-CREATE INDEX IF NOT EXISTS idx_tokens_hash ON public.user_api_tokens(token_hash)
-  WHERE revoked_at IS NULL;
+-- Note: idx_tokens_hash not needed — token_hash UNIQUE constraint creates its own index.
 
 ALTER TABLE public.user_api_tokens ENABLE ROW LEVEL SECURITY;
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -485,5 +485,21 @@
     "view_github": "GitHub",
     "view_roadmap": "Roadmap",
     "view_spec": "Full Spec"
+  },
+  "tokens": {
+    "title": "API Tokens",
+    "desc": "Personal tokens to use Rastrum from AI agents, scripts, or external tools.",
+    "copy_now": "Save this token now — you won't be able to see it again.",
+    "copy": "Copy",
+    "loading": "Loading tokens…",
+    "new": "New token",
+    "name_label": "Name",
+    "name_placeholder": "e.g. My AI agent, Field laptop",
+    "scopes_label": "Permissions",
+    "expires_label": "Expiration",
+    "no_expiry": "Never expires",
+    "days": "days",
+    "year": "year",
+    "create": "Create token"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -485,5 +485,21 @@
     "view_github": "GitHub",
     "view_roadmap": "Hoja de Ruta",
     "view_spec": "Spec Completo"
+  },
+  "tokens": {
+    "title": "Tokens de API",
+    "desc": "Tokens personales para usar Rastrum desde agentes de IA, scripts o herramientas externas.",
+    "copy_now": "Guarda este token ahora — no podrás verlo de nuevo.",
+    "copy": "Copiar",
+    "loading": "Cargando tokens…",
+    "new": "Nuevo token",
+    "name_label": "Nombre",
+    "name_placeholder": "Ej. Mi agente IA, Laptop de campo",
+    "scopes_label": "Permisos",
+    "expires_label": "Expiración",
+    "no_expiry": "Sin expiración",
+    "days": "días",
+    "year": "año",
+    "create": "Crear token"
   }
 }

--- a/src/pages/en/profile/tokens.astro
+++ b/src/pages/en/profile/tokens.astro
@@ -74,39 +74,59 @@ const t = getT(lang);
     return `Bearer ${data.session?.access_token ?? ''}`;
   }
 
+  function buildTokenRow(t: Record<string, any>): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'flex items-center justify-between rounded-lg border px-4 py-3 gap-4';
+    const content = document.createElement('div');
+    content.className = 'min-w-0';
+    const name = document.createElement('p');
+    name.className = 'font-medium text-sm truncate';
+    name.textContent = t.name ?? '';
+    const prefix = document.createElement('p');
+    prefix.className = 'text-xs text-gray-400 font-mono';
+    prefix.textContent = `${t.prefix ?? ''}…`;
+    const meta = document.createElement('p');
+    meta.className = 'text-xs text-gray-400 mt-0.5';
+    const scopes = Array.isArray(t.scopes) ? t.scopes.join(', ') : '';
+    const lastUsed = t.last_used_at
+      ? `Last used: ${new Date(t.last_used_at).toLocaleDateString()}`
+      : 'Never used';
+    const expires = t.expires_at ? ` · Expires: ${new Date(t.expires_at).toLocaleDateString()}` : '';
+    meta.textContent = `${scopes} · ${lastUsed}${expires}`;
+    content.append(name, prefix, meta);
+    const btn = document.createElement('button');
+    btn.dataset.id = t.id ?? '';
+    btn.className = 'revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50';
+    btn.textContent = 'Revoke';
+    btn.addEventListener('click', async () => {
+      if (!confirm('Revoke this token? This cannot be undone.')) return;
+      const r = await fetch(`${TOKENS_URL}/${t.id}`, { method: 'DELETE', headers: { Authorization: await getAuthHeader() } });
+      if (!r.ok) { alert('Failed to revoke token.'); return; }
+      loadTokens();
+    });
+    row.append(content, btn);
+    return row;
+  }
+
   async function loadTokens() {
-    const res = await fetch(TOKENS_URL, { headers: { Authorization: await getAuthHeader() } });
-    const tokens = await res.json();
     const list = document.getElementById('token-list')!;
-    if (!Array.isArray(tokens) || tokens.length === 0) {
-      list.innerHTML = `<p class="text-sm text-gray-400">No tokens yet.</p>`;
+    const res = await fetch(TOKENS_URL, { headers: { Authorization: await getAuthHeader() } });
+    if (!res.ok) {
+      const p = document.createElement('p');
+      p.className = 'text-sm text-red-500';
+      p.textContent = `Error loading tokens (${res.status}). Make sure you are signed in.`;
+      list.replaceChildren(p);
       return;
     }
-    list.innerHTML = tokens.map((t: Record<string, string>) => `
-      <div class="flex items-center justify-between rounded-lg border px-4 py-3 gap-4">
-        <div class="min-w-0">
-          <p class="font-medium text-sm truncate">${t.name}</p>
-          <p class="text-xs text-gray-400 font-mono">${t.prefix}…</p>
-          <p class="text-xs text-gray-400 mt-0.5">
-            ${t.scopes?.join(', ')} ·
-            ${t.last_used_at ? `Last used: ${new Date(t.last_used_at).toLocaleDateString()}` : 'Never used'}
-            ${t.expires_at ? ` · Expires: ${new Date(t.expires_at).toLocaleDateString()}` : ''}
-          </p>
-        </div>
-        <button data-id="${t.id}"
-          class="revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50">
-          Revoke
-        </button>
-      </div>
-    `).join('');
-    document.querySelectorAll('.revoke-btn').forEach(btn => {
-      btn.addEventListener('click', async (e) => {
-        const id = (e.currentTarget as HTMLElement).dataset.id!;
-        if (!confirm('Revoke this token? This cannot be undone.')) return;
-        await fetch(`${TOKENS_URL}/${id}`, { method: 'DELETE', headers: { Authorization: await getAuthHeader() } });
-        loadTokens();
-      });
-    });
+    const tokens = await res.json();
+    if (!Array.isArray(tokens) || tokens.length === 0) {
+      const p = document.createElement('p');
+      p.className = 'text-sm text-gray-400';
+      p.textContent = 'No tokens yet.';
+      list.replaceChildren(p);
+      return;
+    }
+    list.replaceChildren(...tokens.map(buildTokenRow));
   }
 
   document.getElementById('create-form')!.addEventListener('submit', async (e) => {

--- a/src/pages/en/profile/tokens.astro
+++ b/src/pages/en/profile/tokens.astro
@@ -1,0 +1,139 @@
+---
+/**
+ * Token management UI (English) — mirrors es/perfil/tokens.astro
+ * See docs/specs/modules/14-user-api-tokens.md
+ */
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { t as getT } from '../../../i18n/utils';
+
+const lang = 'en';
+const t = getT(lang);
+---
+
+<BaseLayout title={t('tokens.title')} description={t('tokens.desc')}>
+  <main class="mx-auto max-w-2xl px-4 py-10">
+    <h1 class="text-2xl font-bold mb-1">{t('tokens.title')}</h1>
+    <p class="text-sm text-gray-500 mb-8">{t('tokens.desc')}</p>
+
+    <div id="new-token-banner" class="hidden mb-6 rounded-lg border border-green-300 bg-green-50 p-4">
+      <p class="text-sm font-semibold text-green-800 mb-2">{t('tokens.copy_now')}</p>
+      <div class="flex items-center gap-2">
+        <code id="new-token-value" class="flex-1 rounded bg-white border px-3 py-2 text-sm font-mono break-all"></code>
+        <button id="copy-btn" class="shrink-0 rounded bg-green-600 px-3 py-2 text-sm text-white hover:bg-green-700">
+          {t('tokens.copy')}
+        </button>
+      </div>
+    </div>
+
+    <section id="token-list" class="mb-8 space-y-3">
+      <div class="animate-pulse text-sm text-gray-400">{t('tokens.loading')}</div>
+    </section>
+
+    <form id="create-form" class="rounded-xl border p-5 space-y-4">
+      <h2 class="font-semibold">{t('tokens.new')}</h2>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="token-name">{t('tokens.name_label')}</label>
+        <input id="token-name" type="text" placeholder={t('tokens.name_placeholder')}
+          class="w-full rounded border px-3 py-2 text-sm" maxlength="64" required />
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1">{t('tokens.scopes_label')}</label>
+        <div class="flex flex-wrap gap-3">
+          {['observe', 'identify', 'export', 'read_all'].map(scope => (
+            <label class="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" name="scope" value={scope}
+                checked={['observe', 'identify', 'export'].includes(scope)} />
+              <code class="text-xs bg-gray-100 px-1 rounded">{scope}</code>
+            </label>
+          ))}
+        </div>
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="token-expires">{t('tokens.expires_label')}</label>
+        <select id="token-expires" class="rounded border px-3 py-2 text-sm">
+          <option value="">{t('tokens.no_expiry')}</option>
+          <option value="30">30 {t('tokens.days')}</option>
+          <option value="90">90 {t('tokens.days')}</option>
+          <option value="365">1 {t('tokens.year')}</option>
+        </select>
+      </div>
+      <button type="submit"
+        class="rounded-lg bg-green-700 px-5 py-2 text-sm font-semibold text-white hover:bg-green-800">
+        {t('tokens.create')}
+      </button>
+    </form>
+  </main>
+</BaseLayout>
+
+<script>
+  import { supabase } from '../../../lib/supabase';
+  const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
+
+  async function getAuthHeader() {
+    const { data } = await supabase.auth.getSession();
+    return `Bearer ${data.session?.access_token ?? ''}`;
+  }
+
+  async function loadTokens() {
+    const res = await fetch(TOKENS_URL, { headers: { Authorization: await getAuthHeader() } });
+    const tokens = await res.json();
+    const list = document.getElementById('token-list')!;
+    if (!Array.isArray(tokens) || tokens.length === 0) {
+      list.innerHTML = `<p class="text-sm text-gray-400">No tokens yet.</p>`;
+      return;
+    }
+    list.innerHTML = tokens.map((t: Record<string, string>) => `
+      <div class="flex items-center justify-between rounded-lg border px-4 py-3 gap-4">
+        <div class="min-w-0">
+          <p class="font-medium text-sm truncate">${t.name}</p>
+          <p class="text-xs text-gray-400 font-mono">${t.prefix}…</p>
+          <p class="text-xs text-gray-400 mt-0.5">
+            ${t.scopes?.join(', ')} ·
+            ${t.last_used_at ? `Last used: ${new Date(t.last_used_at).toLocaleDateString()}` : 'Never used'}
+            ${t.expires_at ? ` · Expires: ${new Date(t.expires_at).toLocaleDateString()}` : ''}
+          </p>
+        </div>
+        <button data-id="${t.id}"
+          class="revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50">
+          Revoke
+        </button>
+      </div>
+    `).join('');
+    document.querySelectorAll('.revoke-btn').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        const id = (e.currentTarget as HTMLElement).dataset.id!;
+        if (!confirm('Revoke this token? This cannot be undone.')) return;
+        await fetch(`${TOKENS_URL}/${id}`, { method: 'DELETE', headers: { Authorization: await getAuthHeader() } });
+        loadTokens();
+      });
+    });
+  }
+
+  document.getElementById('create-form')!.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const name = (document.getElementById('token-name') as HTMLInputElement).value.trim();
+    const scopes = Array.from(document.querySelectorAll<HTMLInputElement>('input[name="scope"]:checked')).map(el => el.value);
+    const expiresEl = document.getElementById('token-expires') as HTMLSelectElement;
+    const expires_in_days = expiresEl.value ? parseInt(expiresEl.value) : undefined;
+    const res = await fetch(TOKENS_URL, {
+      method: 'POST',
+      headers: { Authorization: await getAuthHeader(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, scopes, expires_in_days }),
+    });
+    const data = await res.json();
+    if (data.token) {
+      const banner = document.getElementById('new-token-banner')!;
+      document.getElementById('new-token-value')!.textContent = data.token;
+      banner.classList.remove('hidden');
+      banner.scrollIntoView({ behavior: 'smooth' });
+      document.getElementById('copy-btn')!.onclick = () => {
+        navigator.clipboard.writeText(data.token);
+        (document.getElementById('copy-btn') as HTMLButtonElement).textContent = '✓';
+      };
+      (document.getElementById('token-name') as HTMLInputElement).value = '';
+      loadTokens();
+    }
+  });
+
+  loadTokens();
+</script>

--- a/src/pages/es/perfil/tokens.astro
+++ b/src/pages/es/perfil/tokens.astro
@@ -1,0 +1,184 @@
+---
+/**
+ * Token management UI — list, create and revoke personal API tokens.
+ * See docs/specs/modules/14-user-api-tokens.md
+ */
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { t as getT } from '../../../i18n/utils';
+
+const lang = 'es';
+const t = getT(lang);
+---
+
+<BaseLayout title={t('tokens.title')} description={t('tokens.desc')}>
+  <main class="mx-auto max-w-2xl px-4 py-10">
+    <h1 class="text-2xl font-bold mb-1">{t('tokens.title')}</h1>
+    <p class="text-sm text-gray-500 mb-8">{t('tokens.desc')}</p>
+
+    <!-- New token banner (shown after creation) -->
+    <div id="new-token-banner" class="hidden mb-6 rounded-lg border border-green-300 bg-green-50 p-4">
+      <p class="text-sm font-semibold text-green-800 mb-2">
+        {t('tokens.copy_now')}
+      </p>
+      <div class="flex items-center gap-2">
+        <code id="new-token-value" class="flex-1 rounded bg-white border px-3 py-2 text-sm font-mono break-all"></code>
+        <button id="copy-btn" class="shrink-0 rounded bg-green-600 px-3 py-2 text-sm text-white hover:bg-green-700">
+          {t('tokens.copy')}
+        </button>
+      </div>
+    </div>
+
+    <!-- Token list -->
+    <section id="token-list" class="mb-8 space-y-3">
+      <div class="animate-pulse text-sm text-gray-400">{t('tokens.loading')}</div>
+    </section>
+
+    <!-- Create form -->
+    <form id="create-form" class="rounded-xl border p-5 space-y-4">
+      <h2 class="font-semibold">{t('tokens.new')}</h2>
+
+      <div>
+        <label class="block text-sm font-medium mb-1" for="token-name">
+          {t('tokens.name_label')}
+        </label>
+        <input
+          id="token-name"
+          type="text"
+          placeholder={t('tokens.name_placeholder')}
+          class="w-full rounded border px-3 py-2 text-sm"
+          maxlength="64"
+          required
+        />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-1">{t('tokens.scopes_label')}</label>
+        <div class="flex flex-wrap gap-3">
+          {['observe', 'identify', 'export', 'read_all'].map(scope => (
+            <label class="flex items-center gap-2 text-sm cursor-pointer">
+              <input
+                type="checkbox"
+                name="scope"
+                value={scope}
+                checked={['observe', 'identify', 'export'].includes(scope)}
+              />
+              <code class="text-xs bg-gray-100 px-1 rounded">{scope}</code>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-1" for="token-expires">
+          {t('tokens.expires_label')}
+        </label>
+        <select id="token-expires" class="rounded border px-3 py-2 text-sm">
+          <option value="">{t('tokens.no_expiry')}</option>
+          <option value="30">30 {t('tokens.days')}</option>
+          <option value="90">90 {t('tokens.days')}</option>
+          <option value="365">1 {t('tokens.year')}</option>
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        class="rounded-lg bg-green-700 px-5 py-2 text-sm font-semibold text-white hover:bg-green-800"
+      >
+        {t('tokens.create')}
+      </button>
+    </form>
+  </main>
+</BaseLayout>
+
+<script>
+  import { supabase } from '../../../lib/supabase';
+
+  const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
+
+  async function getAuthHeader() {
+    const { data } = await supabase.auth.getSession();
+    return `Bearer ${data.session?.access_token ?? ''}`;
+  }
+
+  async function loadTokens() {
+    const res = await fetch(TOKENS_URL, {
+      headers: { Authorization: await getAuthHeader() },
+    });
+    const tokens = await res.json();
+    const list = document.getElementById('token-list')!;
+
+    if (!Array.isArray(tokens) || tokens.length === 0) {
+      list.innerHTML = `<p class="text-sm text-gray-400">No hay tokens todavía.</p>`;
+      return;
+    }
+
+    list.innerHTML = tokens.map((t: Record<string, string>) => `
+      <div class="flex items-center justify-between rounded-lg border px-4 py-3 gap-4">
+        <div class="min-w-0">
+          <p class="font-medium text-sm truncate">${t.name}</p>
+          <p class="text-xs text-gray-400 font-mono">${t.prefix}…</p>
+          <p class="text-xs text-gray-400 mt-0.5">
+            ${t.scopes?.join(', ')} ·
+            ${t.last_used_at ? `Último uso: ${new Date(t.last_used_at).toLocaleDateString()}` : 'Sin usar'}
+            ${t.expires_at ? ` · Expira: ${new Date(t.expires_at).toLocaleDateString()}` : ''}
+          </p>
+        </div>
+        <button
+          data-id="${t.id}"
+          class="revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50"
+        >
+          Revocar
+        </button>
+      </div>
+    `).join('');
+
+    document.querySelectorAll('.revoke-btn').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        const id = (e.currentTarget as HTMLElement).dataset.id!;
+        if (!confirm('¿Revocar este token? Esta acción no se puede deshacer.')) return;
+        await fetch(`${TOKENS_URL}/${id}`, {
+          method: 'DELETE',
+          headers: { Authorization: await getAuthHeader() },
+        });
+        loadTokens();
+      });
+    });
+  }
+
+  document.getElementById('create-form')!.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const name = (document.getElementById('token-name') as HTMLInputElement).value.trim();
+    const scopes = Array.from(document.querySelectorAll<HTMLInputElement>('input[name="scope"]:checked'))
+      .map(el => el.value);
+    const expiresEl = document.getElementById('token-expires') as HTMLSelectElement;
+    const expires_in_days = expiresEl.value ? parseInt(expiresEl.value) : undefined;
+
+    const res = await fetch(TOKENS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: await getAuthHeader(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name, scopes, expires_in_days }),
+    });
+
+    const data = await res.json();
+    if (data.token) {
+      const banner = document.getElementById('new-token-banner')!;
+      const val = document.getElementById('new-token-value')!;
+      val.textContent = data.token;
+      banner.classList.remove('hidden');
+      banner.scrollIntoView({ behavior: 'smooth' });
+
+      document.getElementById('copy-btn')!.onclick = () => {
+        navigator.clipboard.writeText(data.token);
+        (document.getElementById('copy-btn') as HTMLButtonElement).textContent = '✓';
+      };
+
+      (document.getElementById('token-name') as HTMLInputElement).value = '';
+      loadTokens();
+    }
+  });
+
+  loadTokens();
+</script>

--- a/src/pages/es/perfil/tokens.astro
+++ b/src/pages/es/perfil/tokens.astro
@@ -100,49 +100,74 @@ const t = getT(lang);
     return `Bearer ${data.session?.access_token ?? ''}`;
   }
 
-  async function loadTokens() {
-    const res = await fetch(TOKENS_URL, {
-      headers: { Authorization: await getAuthHeader() },
-    });
-    const tokens = await res.json();
-    const list = document.getElementById('token-list')!;
+  function buildTokenRow(t: Record<string, any>): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'flex items-center justify-between rounded-lg border px-4 py-3 gap-4';
 
-    if (!Array.isArray(tokens) || tokens.length === 0) {
-      list.innerHTML = `<p class="text-sm text-gray-400">No hay tokens todavía.</p>`;
+    const content = document.createElement('div');
+    content.className = 'min-w-0';
+
+    const name = document.createElement('p');
+    name.className = 'font-medium text-sm truncate';
+    name.textContent = t.name ?? '';
+
+    const prefix = document.createElement('p');
+    prefix.className = 'text-xs text-gray-400 font-mono';
+    prefix.textContent = `${t.prefix ?? ''}…`;
+
+    const meta = document.createElement('p');
+    meta.className = 'text-xs text-gray-400 mt-0.5';
+    const scopes = Array.isArray(t.scopes) ? t.scopes.join(', ') : '';
+    const lastUsed = t.last_used_at
+      ? `Último uso: ${new Date(t.last_used_at).toLocaleDateString()}`
+      : 'Sin usar';
+    const expires = t.expires_at
+      ? ` · Expira: ${new Date(t.expires_at).toLocaleDateString()}`
+      : '';
+    meta.textContent = `${scopes} · ${lastUsed}${expires}`;
+
+    content.append(name, prefix, meta);
+
+    const btn = document.createElement('button');
+    btn.dataset.id = t.id ?? '';
+    btn.className = 'revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50';
+    btn.textContent = 'Revocar';
+    btn.addEventListener('click', async () => {
+      if (!confirm('¿Revocar este token? Esta acción no se puede deshacer.')) return;
+      const r = await fetch(`${TOKENS_URL}/${t.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: await getAuthHeader() },
+      });
+      if (!r.ok) { alert('Error al revocar el token.'); return; }
+      loadTokens();
+    });
+
+    row.append(content, btn);
+    return row;
+  }
+
+  async function loadTokens() {
+    const list = document.getElementById('token-list')!;
+    const res = await fetch(TOKENS_URL, { headers: { Authorization: await getAuthHeader() } });
+
+    if (!res.ok) {
+      const empty = document.createElement('p');
+      empty.className = 'text-sm text-red-500';
+      empty.textContent = `Error al cargar tokens (${res.status}). Verifica que hayas iniciado sesión.`;
+      list.replaceChildren(empty);
       return;
     }
 
-    list.innerHTML = tokens.map((t: Record<string, string>) => `
-      <div class="flex items-center justify-between rounded-lg border px-4 py-3 gap-4">
-        <div class="min-w-0">
-          <p class="font-medium text-sm truncate">${t.name}</p>
-          <p class="text-xs text-gray-400 font-mono">${t.prefix}…</p>
-          <p class="text-xs text-gray-400 mt-0.5">
-            ${t.scopes?.join(', ')} ·
-            ${t.last_used_at ? `Último uso: ${new Date(t.last_used_at).toLocaleDateString()}` : 'Sin usar'}
-            ${t.expires_at ? ` · Expira: ${new Date(t.expires_at).toLocaleDateString()}` : ''}
-          </p>
-        </div>
-        <button
-          data-id="${t.id}"
-          class="revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50"
-        >
-          Revocar
-        </button>
-      </div>
-    `).join('');
+    const tokens = await res.json();
+    if (!Array.isArray(tokens) || tokens.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'text-sm text-gray-400';
+      empty.textContent = 'No hay tokens todavía.';
+      list.replaceChildren(empty);
+      return;
+    }
 
-    document.querySelectorAll('.revoke-btn').forEach(btn => {
-      btn.addEventListener('click', async (e) => {
-        const id = (e.currentTarget as HTMLElement).dataset.id!;
-        if (!confirm('¿Revocar este token? Esta acción no se puede deshacer.')) return;
-        await fetch(`${TOKENS_URL}/${id}`, {
-          method: 'DELETE',
-          headers: { Authorization: await getAuthHeader() },
-        });
-        loadTokens();
-      });
-    });
+    list.replaceChildren(...tokens.map(buildTokenRow));
   }
 
   document.getElementById('create-form')!.addEventListener('submit', async (e) => {

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -1,10 +1,10 @@
 /**
- * /functions/v1/api/observe — Submit observation via personal API token.
- * /functions/v1/api/identify — Identify species via personal API token.
- * /functions/v1/api/observations — List own observations.
- * /functions/v1/api/export — Export Darwin Core CSV.
+ * /functions/v1/api/* — REST API authenticated via personal API tokens (rst_xxxx).
  *
- * Auth: Authorization: Bearer rst_xxxx  (personal API token)
+ * POST /api/observe       → submit observation (scope: observe)
+ * POST /api/identify      → photo ID cascade (scope: identify)
+ * GET  /api/observations  → list own observations (scope: observe)
+ * GET  /api/export        → export Darwin Core CSV (scope: export)
  *
  * See docs/specs/modules/14-user-api-tokens.md
  */
@@ -17,16 +17,10 @@ const corsHeaders = {
 };
 
 async function sha256(text: string): Promise<string> {
-  const buf = await crypto.subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(text)
-  );
-  return Array.from(new Uint8Array(buf))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('');
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
-/** Verify a personal API token. Returns { user_id, scopes } or null. */
 async function verifyToken(
   token: string,
   requiredScope: string,
@@ -39,15 +33,14 @@ async function verifyToken(
     .select('id, user_id, scopes, expires_at')
     .eq('token_hash', hash)
     .is('revoked_at', null)
-    .single();
+    .maybeSingle();
 
   if (error || !data) return null;
   if (data.expires_at && new Date(data.expires_at) < new Date()) return null;
-  if (!data.scopes.includes(requiredScope)) return null;
+  if (!Array.isArray(data.scopes) || !data.scopes.includes(requiredScope)) return null;
 
-  // Update last_used_at (fire and forget — don't await)
-  supabase
-    .from('user_api_tokens')
+  // Update last_used_at — fire and forget
+  supabase.from('user_api_tokens')
     .update({ last_used_at: new Date().toISOString() })
     .eq('id', data.id);
 
@@ -55,9 +48,7 @@ async function verifyToken(
 }
 
 Deno.serve(async (req: Request) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
-  }
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
 
   const supabase = createClient(
     Deno.env.get('SUPABASE_URL')!,
@@ -66,13 +57,13 @@ Deno.serve(async (req: Request) => {
 
   const token = req.headers.get('Authorization')?.replace('Bearer ', '');
   if (!token?.startsWith('rst_')) {
-    return json({ error: 'Missing or invalid API token. Use Authorization: Bearer rst_...' }, 401);
+    return json({ error: 'Missing or invalid API token. Use: Authorization: Bearer rst_...' }, 401);
   }
 
   const url = new URL(req.url);
-  const path = url.pathname.split('/api/')[1] ?? ''; // 'observe' | 'identify' | 'observations' | 'export'
+  const path = url.pathname.split('/api/')[1] ?? '';
 
-  // ── POST /api/observe ──────────────────────────────────────────────────────
+  // ── POST /api/observe ────────────────────────────────────────────────────
   if (req.method === 'POST' && path === 'observe') {
     const auth = await verifyToken(token, 'observe', supabase);
     if (!auth) return json({ error: 'Unauthorized or insufficient scope' }, 401);
@@ -80,27 +71,17 @@ Deno.serve(async (req: Request) => {
     const body = await req.json().catch(() => null);
     if (!body) return json({ error: 'Invalid JSON body' }, 400);
 
-    const {
-      scientific_name,
-      lat,
-      lng,
-      observed_at,
-      notes,
-      photo_url,
-      habitat,
-      evidence_type = 'direct_sighting',
-    } = body;
+    const { lat, lng, observed_at, notes, photo_url, habitat, evidence_type = 'direct_sighting' } = body;
+    if (lat == null || lng == null) return json({ error: 'lat and lng are required' }, 400);
 
-    if (!scientific_name || lat == null || lng == null) {
-      return json({ error: 'scientific_name, lat, and lng are required' }, 400);
-    }
-
-    const { data, error } = await supabase
+    // observations table has no scientific_name — insert bare observation,
+    // then create an identification row if a name was supplied.
+    const { data: obs, error: obsErr } = await supabase
       .from('observations')
       .insert({
         observer_id: auth.user_id,
-        scientific_name,
-        location: `POINT(${lng} ${lat})`,
+        // PostGIS geography: SRID=4326;POINT(lng lat)
+        location: `SRID=4326;POINT(${lng} ${lat})`,
         observed_at: observed_at ?? new Date().toISOString(),
         notes,
         habitat,
@@ -108,25 +89,36 @@ Deno.serve(async (req: Request) => {
         app_version: 'api/v1',
         sync_status: 'synced',
       })
-      .select('id, scientific_name, observed_at, created_at')
+      .select('id, observed_at, created_at')
       .single();
 
-    if (error) return json({ error: error.message }, 500);
+    if (obsErr) return json({ error: obsErr.message }, 500);
+
+    // Attach identification if scientific_name provided
+    if (body.scientific_name && obs?.id) {
+      await supabase.from('identifications').insert({
+        observation_id: obs.id,
+        identifier_id: auth.user_id,
+        scientific_name: body.scientific_name,
+        id_source: 'human',
+        confidence: 1.0,
+      });
+    }
 
     // Attach photo if provided
-    if (photo_url && data?.id) {
+    if (photo_url && obs?.id) {
       await supabase.from('media_files').insert({
-        observation_id: data.id,
+        observation_id: obs.id,
         url: photo_url,
         media_type: 'photo',
         is_primary: true,
       });
     }
 
-    return json(data, 201);
+    return json(obs, 201);
   }
 
-  // ── POST /api/identify ─────────────────────────────────────────────────────
+  // ── POST /api/identify ───────────────────────────────────────────────────
   if (req.method === 'POST' && path === 'identify') {
     const auth = await verifyToken(token, 'identify', supabase);
     if (!auth) return json({ error: 'Unauthorized or insufficient scope' }, 401);
@@ -134,7 +126,6 @@ Deno.serve(async (req: Request) => {
     const body = await req.json().catch(() => null);
     if (!body?.image_url) return json({ error: 'image_url is required' }, 400);
 
-    // Delegate to existing identify Edge Function
     const identifyRes = await fetch(
       `${Deno.env.get('SUPABASE_URL')}/functions/v1/identify`,
       {
@@ -145,9 +136,7 @@ Deno.serve(async (req: Request) => {
         },
         body: JSON.stringify({
           image_url: body.image_url,
-          location: body.lat != null
-            ? { lat: body.lat, lng: body.lng }
-            : undefined,
+          location: body.lat != null ? { lat: body.lat, lng: body.lng } : undefined,
           user_hint: body.user_hint,
         }),
       }
@@ -157,7 +146,7 @@ Deno.serve(async (req: Request) => {
     return json(result, identifyRes.status);
   }
 
-  // ── GET /api/observations ──────────────────────────────────────────────────
+  // ── GET /api/observations ────────────────────────────────────────────────
   if (req.method === 'GET' && path === 'observations') {
     const auth = await verifyToken(token, 'observe', supabase);
     if (!auth) return json({ error: 'Unauthorized or insufficient scope' }, 401);
@@ -169,9 +158,9 @@ Deno.serve(async (req: Request) => {
     let q = supabase
       .from('observations')
       .select(`
-        id, scientific_name, observed_at, notes, habitat, evidence_type,
-        location, created_at,
-        media_files(url, is_primary)
+        id, observed_at, notes, habitat, evidence_type, created_at,
+        media_files(url, is_primary),
+        identifications(scientific_name, confidence, id_source)
       `)
       .eq('observer_id', auth.user_id)
       .order('observed_at', { ascending: false })
@@ -181,10 +170,10 @@ Deno.serve(async (req: Request) => {
 
     const { data, error } = await q;
     if (error) return json({ error: error.message }, 500);
-    return json(data);
+    return json(data ?? []);
   }
 
-  // ── GET /api/export ────────────────────────────────────────────────────────
+  // ── GET /api/export ──────────────────────────────────────────────────────
   if (req.method === 'GET' && path === 'export') {
     const auth = await verifyToken(token, 'export', supabase);
     if (!auth) return json({ error: 'Unauthorized or insufficient scope' }, 401);
@@ -194,8 +183,8 @@ Deno.serve(async (req: Request) => {
     const { data, error } = await supabase
       .from('observations')
       .select(`
-        id, scientific_name, observed_at, notes, habitat,
-        location, created_at, app_version
+        id, observed_at, notes, habitat, location,
+        identifications(scientific_name, confidence, id_source)
       `)
       .eq('observer_id', auth.user_id)
       .order('observed_at', { ascending: false });
@@ -206,23 +195,29 @@ Deno.serve(async (req: Request) => {
       const header = [
         'occurrenceID', 'scientificName', 'eventDate',
         'decimalLatitude', 'decimalLongitude',
-        'habitat', 'occurrenceRemarks', 'basisOfRecord',
+        'habitat', 'occurrenceRemarks', 'basisOfRecord', 'identificationSource',
       ].join(',');
 
       const rows = (data ?? []).map(row => {
-        // PostGIS point → lat/lng
-        const match = (row.location as string)?.match(/POINT\(([^ ]+) ([^)]+)\)/);
+        // PostGIS geography → lat/lng
+        const match = (row.location as string)
+          ?.match(/POINT\(([^ ]+)\s+([^)]+)\)/);
         const lng = match ? match[1] : '';
         const lat = match ? match[2] : '';
+        // Primary identification (highest confidence)
+        const ids = Array.isArray(row.identifications) ? row.identifications : [];
+        const primary = ids.sort((a: {confidence: number}, b: {confidence: number}) =>
+          (b.confidence ?? 0) - (a.confidence ?? 0))[0];
         return [
           row.id,
-          `"${row.scientific_name}"`,
+          `"${(primary?.scientific_name ?? '').replace(/"/g, '""')}"`,
           row.observed_at,
           lat,
           lng,
           row.habitat ?? '',
           `"${(row.notes ?? '').replace(/"/g, '""')}"`,
           'HumanObservation',
+          primary?.id_source ?? '',
         ].join(',');
       });
 

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -1,0 +1,250 @@
+/**
+ * /functions/v1/api/observe — Submit observation via personal API token.
+ * /functions/v1/api/identify — Identify species via personal API token.
+ * /functions/v1/api/observations — List own observations.
+ * /functions/v1/api/export — Export Darwin Core CSV.
+ *
+ * Auth: Authorization: Bearer rst_xxxx  (personal API token)
+ *
+ * See docs/specs/modules/14-user-api-tokens.md
+ */
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+};
+
+async function sha256(text: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(text)
+  );
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Verify a personal API token. Returns { user_id, scopes } or null. */
+async function verifyToken(
+  token: string,
+  requiredScope: string,
+  supabase: ReturnType<typeof createClient>
+): Promise<{ user_id: string; scopes: string[] } | null> {
+  const hash = await sha256(token);
+
+  const { data, error } = await supabase
+    .from('user_api_tokens')
+    .select('id, user_id, scopes, expires_at')
+    .eq('token_hash', hash)
+    .is('revoked_at', null)
+    .single();
+
+  if (error || !data) return null;
+  if (data.expires_at && new Date(data.expires_at) < new Date()) return null;
+  if (!data.scopes.includes(requiredScope)) return null;
+
+  // Update last_used_at (fire and forget — don't await)
+  supabase
+    .from('user_api_tokens')
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('id', data.id);
+
+  return { user_id: data.user_id, scopes: data.scopes };
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  );
+
+  const token = req.headers.get('Authorization')?.replace('Bearer ', '');
+  if (!token?.startsWith('rst_')) {
+    return json({ error: 'Missing or invalid API token. Use Authorization: Bearer rst_...' }, 401);
+  }
+
+  const url = new URL(req.url);
+  const path = url.pathname.split('/api/')[1] ?? ''; // 'observe' | 'identify' | 'observations' | 'export'
+
+  // ── POST /api/observe ──────────────────────────────────────────────────────
+  if (req.method === 'POST' && path === 'observe') {
+    const auth = await verifyToken(token, 'observe', supabase);
+    if (!auth) return json({ error: 'Unauthorized or insufficient scope' }, 401);
+
+    const body = await req.json().catch(() => null);
+    if (!body) return json({ error: 'Invalid JSON body' }, 400);
+
+    const {
+      scientific_name,
+      lat,
+      lng,
+      observed_at,
+      notes,
+      photo_url,
+      habitat,
+      evidence_type = 'direct_sighting',
+    } = body;
+
+    if (!scientific_name || lat == null || lng == null) {
+      return json({ error: 'scientific_name, lat, and lng are required' }, 400);
+    }
+
+    const { data, error } = await supabase
+      .from('observations')
+      .insert({
+        observer_id: auth.user_id,
+        scientific_name,
+        location: `POINT(${lng} ${lat})`,
+        observed_at: observed_at ?? new Date().toISOString(),
+        notes,
+        habitat,
+        evidence_type,
+        app_version: 'api/v1',
+        sync_status: 'synced',
+      })
+      .select('id, scientific_name, observed_at, created_at')
+      .single();
+
+    if (error) return json({ error: error.message }, 500);
+
+    // Attach photo if provided
+    if (photo_url && data?.id) {
+      await supabase.from('media_files').insert({
+        observation_id: data.id,
+        url: photo_url,
+        media_type: 'photo',
+        is_primary: true,
+      });
+    }
+
+    return json(data, 201);
+  }
+
+  // ── POST /api/identify ─────────────────────────────────────────────────────
+  if (req.method === 'POST' && path === 'identify') {
+    const auth = await verifyToken(token, 'identify', supabase);
+    if (!auth) return json({ error: 'Unauthorized or insufficient scope' }, 401);
+
+    const body = await req.json().catch(() => null);
+    if (!body?.image_url) return json({ error: 'image_url is required' }, 400);
+
+    // Delegate to existing identify Edge Function
+    const identifyRes = await fetch(
+      `${Deno.env.get('SUPABASE_URL')}/functions/v1/identify`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          image_url: body.image_url,
+          location: body.lat != null
+            ? { lat: body.lat, lng: body.lng }
+            : undefined,
+          user_hint: body.user_hint,
+        }),
+      }
+    );
+
+    const result = await identifyRes.json();
+    return json(result, identifyRes.status);
+  }
+
+  // ── GET /api/observations ──────────────────────────────────────────────────
+  if (req.method === 'GET' && path === 'observations') {
+    const auth = await verifyToken(token, 'observe', supabase);
+    if (!auth) return json({ error: 'Unauthorized or insufficient scope' }, 401);
+
+    const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '20'), 100);
+    const offset = parseInt(url.searchParams.get('offset') ?? '0');
+    const from = url.searchParams.get('from');
+
+    let q = supabase
+      .from('observations')
+      .select(`
+        id, scientific_name, observed_at, notes, habitat, evidence_type,
+        location, created_at,
+        media_files(url, is_primary)
+      `)
+      .eq('observer_id', auth.user_id)
+      .order('observed_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (from) q = q.gte('observed_at', from);
+
+    const { data, error } = await q;
+    if (error) return json({ error: error.message }, 500);
+    return json(data);
+  }
+
+  // ── GET /api/export ────────────────────────────────────────────────────────
+  if (req.method === 'GET' && path === 'export') {
+    const auth = await verifyToken(token, 'export', supabase);
+    if (!auth) return json({ error: 'Unauthorized or insufficient scope' }, 401);
+
+    const format = url.searchParams.get('format') ?? 'darwin_core';
+
+    const { data, error } = await supabase
+      .from('observations')
+      .select(`
+        id, scientific_name, observed_at, notes, habitat,
+        location, created_at, app_version
+      `)
+      .eq('observer_id', auth.user_id)
+      .order('observed_at', { ascending: false });
+
+    if (error) return json({ error: error.message }, 500);
+
+    if (format === 'darwin_core') {
+      const header = [
+        'occurrenceID', 'scientificName', 'eventDate',
+        'decimalLatitude', 'decimalLongitude',
+        'habitat', 'occurrenceRemarks', 'basisOfRecord',
+      ].join(',');
+
+      const rows = (data ?? []).map(row => {
+        // PostGIS point → lat/lng
+        const match = (row.location as string)?.match(/POINT\(([^ ]+) ([^)]+)\)/);
+        const lng = match ? match[1] : '';
+        const lat = match ? match[2] : '';
+        return [
+          row.id,
+          `"${row.scientific_name}"`,
+          row.observed_at,
+          lat,
+          lng,
+          row.habitat ?? '',
+          `"${(row.notes ?? '').replace(/"/g, '""')}"`,
+          'HumanObservation',
+        ].join(',');
+      });
+
+      const csv = [header, ...rows].join('\n');
+      return new Response(csv, {
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="rastrum-observations-dwc.csv"',
+        },
+      });
+    }
+
+    return json({ error: `Unsupported format: ${format}` }, 400);
+  }
+
+  return json({ error: 'Not found' }, 404);
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}

--- a/supabase/functions/tokens/index.ts
+++ b/supabase/functions/tokens/index.ts
@@ -41,17 +41,15 @@ Deno.serve(async (req: Request) => {
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
   );
 
-  // Authenticate caller via session JWT
   const jwt = req.headers.get('Authorization')?.replace('Bearer ', '');
   if (!jwt) return json({ error: 'Missing Authorization header' }, 401);
 
-  const { data: { user }, error: authErr } =
-    await supabase.auth.getUser(jwt);
+  const { data: { user }, error: authErr } = await supabase.auth.getUser(jwt);
   if (authErr || !user) return json({ error: 'Unauthorized' }, 401);
 
   const url = new URL(req.url);
-  const segments = url.pathname.split('/').filter(Boolean); // ['tokens', ':id']
-  const tokenId = segments[1]; // optional
+  const segments = url.pathname.split('/').filter(Boolean);
+  const tokenId = segments[segments.length - 1] !== 'tokens' ? segments[segments.length - 1] : undefined;
 
   // ── GET /tokens ── list own tokens
   if (req.method === 'GET') {
@@ -63,7 +61,7 @@ Deno.serve(async (req: Request) => {
       .order('created_at', { ascending: false });
 
     if (error) return json({ error: error.message }, 500);
-    return json(data);
+    return json(data ?? []);
   }
 
   // ── POST /tokens ── create new token
@@ -75,7 +73,10 @@ Deno.serve(async (req: Request) => {
       expires_in_days,
     } = body;
 
-    // Validate scopes
+    // Validate scopes — must be array of strings
+    if (!Array.isArray(scopes) || !scopes.every((s): s is string => typeof s === 'string')) {
+      return json({ error: 'scopes must be an array of strings' }, 400);
+    }
     const ALLOWED_SCOPES = ['observe', 'identify', 'export', 'read_all'];
     const invalidScopes = scopes.filter((s: string) => !ALLOWED_SCOPES.includes(s));
     if (invalidScopes.length > 0) {
@@ -84,7 +85,7 @@ Deno.serve(async (req: Request) => {
 
     const raw = generateToken();
     const token_hash = await sha256(raw);
-    const prefix = raw.slice(0, 12); // "rst_a1b2c3d4"
+    const prefix = raw.slice(0, 12);
 
     const expires_at = expires_in_days
       ? new Date(Date.now() + expires_in_days * 86_400_000).toISOString()
@@ -92,32 +93,28 @@ Deno.serve(async (req: Request) => {
 
     const { data, error } = await supabase
       .from('user_api_tokens')
-      .insert({
-        user_id: user.id,
-        name,
-        token_hash,
-        prefix,
-        scopes,
-        expires_at,
-      })
+      .insert({ user_id: user.id, name, token_hash, prefix, scopes, expires_at })
       .select('id, name, prefix, scopes, expires_at, created_at')
       .single();
 
     if (error) return json({ error: error.message }, 500);
-
     // Return raw token ONCE — never stored, never logged
     return json({ ...data, token: raw }, 201);
   }
 
   // ── DELETE /tokens/:id ── revoke
   if (req.method === 'DELETE' && tokenId) {
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from('user_api_tokens')
       .update({ revoked_at: new Date().toISOString() })
       .eq('id', tokenId)
-      .eq('user_id', user.id); // ensure ownership
+      .eq('user_id', user.id)   // ownership check
+      .is('revoked_at', null)   // already-revoked guard
+      .select('id')
+      .maybeSingle();
 
     if (error) return json({ error: error.message }, 500);
+    if (!data) return json({ error: 'Token not found or already revoked' }, 404);
     return json({ revoked: true });
   }
 

--- a/supabase/functions/tokens/index.ts
+++ b/supabase/functions/tokens/index.ts
@@ -1,0 +1,132 @@
+/**
+ * /functions/v1/tokens — Create and revoke personal API tokens.
+ *
+ * POST /tokens          → create new token (returns raw token once)
+ * DELETE /tokens/:id    → revoke token
+ * GET /tokens           → list own tokens (prefix + metadata, no raw token)
+ *
+ * See docs/specs/modules/14-user-api-tokens.md
+ */
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+};
+
+async function sha256(text: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(text)
+  );
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function generateToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+  return `rst_${hex}`;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  );
+
+  // Authenticate caller via session JWT
+  const jwt = req.headers.get('Authorization')?.replace('Bearer ', '');
+  if (!jwt) return json({ error: 'Missing Authorization header' }, 401);
+
+  const { data: { user }, error: authErr } =
+    await supabase.auth.getUser(jwt);
+  if (authErr || !user) return json({ error: 'Unauthorized' }, 401);
+
+  const url = new URL(req.url);
+  const segments = url.pathname.split('/').filter(Boolean); // ['tokens', ':id']
+  const tokenId = segments[1]; // optional
+
+  // ── GET /tokens ── list own tokens
+  if (req.method === 'GET') {
+    const { data, error } = await supabase
+      .from('user_api_tokens')
+      .select('id, name, prefix, scopes, last_used_at, expires_at, created_at')
+      .eq('user_id', user.id)
+      .is('revoked_at', null)
+      .order('created_at', { ascending: false });
+
+    if (error) return json({ error: error.message }, 500);
+    return json(data);
+  }
+
+  // ── POST /tokens ── create new token
+  if (req.method === 'POST') {
+    const body = await req.json().catch(() => ({}));
+    const {
+      name = 'API Token',
+      scopes = ['observe', 'identify', 'export'],
+      expires_in_days,
+    } = body;
+
+    // Validate scopes
+    const ALLOWED_SCOPES = ['observe', 'identify', 'export', 'read_all'];
+    const invalidScopes = scopes.filter((s: string) => !ALLOWED_SCOPES.includes(s));
+    if (invalidScopes.length > 0) {
+      return json({ error: `Invalid scopes: ${invalidScopes.join(', ')}` }, 400);
+    }
+
+    const raw = generateToken();
+    const token_hash = await sha256(raw);
+    const prefix = raw.slice(0, 12); // "rst_a1b2c3d4"
+
+    const expires_at = expires_in_days
+      ? new Date(Date.now() + expires_in_days * 86_400_000).toISOString()
+      : null;
+
+    const { data, error } = await supabase
+      .from('user_api_tokens')
+      .insert({
+        user_id: user.id,
+        name,
+        token_hash,
+        prefix,
+        scopes,
+        expires_at,
+      })
+      .select('id, name, prefix, scopes, expires_at, created_at')
+      .single();
+
+    if (error) return json({ error: error.message }, 500);
+
+    // Return raw token ONCE — never stored, never logged
+    return json({ ...data, token: raw }, 201);
+  }
+
+  // ── DELETE /tokens/:id ── revoke
+  if (req.method === 'DELETE' && tokenId) {
+    const { error } = await supabase
+      .from('user_api_tokens')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', tokenId)
+      .eq('user_id', user.id); // ensure ownership
+
+    if (error) return json({ error: error.message }, 500);
+    return json({ revoked: true });
+  }
+
+  return json({ error: 'Not found' }, 404);
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
## What

Implements Module 14 — User API Tokens end-to-end.

## Changes

### Backend
- **`supabase/functions/tokens/index.ts`** — create / list / revoke tokens
  - `POST /tokens` → creates token, returns raw `rst_xxxx` **once** (never stored)
  - `GET /tokens` → list own tokens (prefix + metadata, no raw token)
  - `DELETE /tokens/:id` → revoke
- **`supabase/functions/api/index.ts`** — REST API authenticated via `Bearer rst_xxxx`
  - `POST /api/observe` — submit observation (scope: `observe`)
  - `POST /api/identify` — photo ID cascade (scope: `identify`)
  - `GET /api/observations` — list own observations
  - `GET /api/export?format=darwin_core` — export Darwin Core CSV
- **Schema** — `user_api_tokens` table with RLS, indexes, SHA-256 hash storage

### Frontend
- **`src/pages/es/perfil/tokens.astro`** — token management page (ES)
- **`src/pages/en/profile/tokens.astro`** — token management page (EN)
- i18n strings added to `es.json` + `en.json`

### Skills
- **`skills/rastrum-user/SKILL.md`** — public skill for users / AI agents

## Security
- Raw token shown **once** at creation, never stored
- SHA-256 hash stored in DB
- Scopes: `observe` / `identify` / `export` / `read_all`
- RLS: users can only see/revoke their own tokens

## How to test
1. Run schema migration
2. `supabase functions serve tokens`
3. Create token via UI at `/es/perfil/tokens`
4. `curl -H 'Authorization: Bearer rst_xxx' .../functions/v1/api/observations`

Spec: `docs/specs/modules/14-user-api-tokens.md`