### PR TITLE
fix(i18n): translate weather options in observation form

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -12,6 +12,7 @@ const habitats = [
   'grassland','agricultural','urban','coastal','reef','scrubland','cave',
 ];
 const weathers = ['sunny','cloudy','overcast','light_rain','heavy_rain','fog','storm'];
+const weatherLabels = (tr.observe as any).weather_options as Record<string,string> | undefined;
 ---
 
 <div class="max-w-xl mx-auto">
@@ -91,7 +92,7 @@ const weathers = ['sunny','cloudy','overcast','light_rain','heavy_rain','fog','s
         <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">{tr.observe.weather}</label>
         <select name="weather" class="block w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm">
           <option value="">{tr.observe.weather_placeholder}</option>
-          {weathers.map(w => <option value={w}>{w.replace(/_/g, ' ')}</option>)}
+          {weathers.map(w => <option value={w}>{weatherLabels?.[w] ?? w.replace(/_/g, ' ')}</option>)}
         </select>
       </div>
     </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -273,7 +273,16 @@
     "auto_narrative_busy": "Writing…",
     "auto_narrative_replace_or_append": "There is already a note. Replace it with the generated one?\nOK = Replace · Cancel = Append",
     "auto_narrative_unavailable": "On-device narrative needs the Llama-3.2-1B helpers. Open Profile → Edit → AI settings to download.",
-    "ai_helpers_loading": "Loading on-device model…"
+    "ai_helpers_loading": "Loading on-device model…",
+    "weather_options": {
+      "sunny": "Sunny",
+      "cloudy": "Cloudy",
+      "overcast": "Overcast",
+      "light_rain": "Light rain",
+      "heavy_rain": "Heavy rain",
+      "fog": "Fog",
+      "storm": "Storm"
+    }
   },
   "chat": {
     "title": "Chat",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -273,7 +273,16 @@
     "auto_narrative_busy": "Escribiendo…",
     "auto_narrative_replace_or_append": "Ya hay una nota. ¿Reemplazarla por la generada?\nAceptar = Reemplazar · Cancelar = Añadir",
     "auto_narrative_unavailable": "La narrativa local requiere los ayudantes Llama-3.2-1B. Ve a Perfil → Editar → Ajustes de IA para descargar.",
-    "ai_helpers_loading": "Cargando modelo local…"
+    "ai_helpers_loading": "Cargando modelo local…",
+    "weather_options": {
+      "sunny": "Soleado",
+      "cloudy": "Nublado",
+      "overcast": "Muy nublado",
+      "light_rain": "Lluvia ligera",
+      "heavy_rain": "Lluvia intensa",
+      "fog": "Neblina",
+      "storm": "Tormenta"
+    }
   },
   "chat": {
     "title": "Chat",


### PR DESCRIPTION
Fixes #7 — reported by Eugenio Padilla during first user onboarding.

Weather dropdown was showing English strings (sunny, cloudy, overcast, light rain, heavy rain, fog, storm) on the Spanish version.

**Fix:**
- Added `observe.weather_options` to `es.json` and `en.json`  
- Updated `ObservationForm.astro` to use translated labels with English fallback