### PR TITLE
feat(arch): WebLLM as default AI fallback + fix save hang

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -18,6 +18,24 @@ const weathers = ['sunny','cloudy','overcast','light_rain','heavy_rain','fog','s
   <h1 class="text-2xl font-bold tracking-tight mb-6">{tr.observe.title}</h1>
 
   <form id="obs-form" class="space-y-5" novalidate>
+
+    <!-- WebLLM download warning — shown once before first local AI use -->
+    <div id="webllm-warning" class="hidden rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800 p-3">
+      <p class="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">🧠 {isEs ? 'IA local — primera descarga' : 'Local AI — first download'}</p>
+      <p class="text-sm text-amber-700 dark:text-amber-400">
+        {isEs
+          ? 'Rastrum usa IA en tu dispositivo para identificar especies. La primera vez descarga ~2.4 GB. Tu foto nunca sale de tu celular.'
+          : 'Rastrum uses on-device AI to identify species. First use downloads ~2.4 GB. Your photo never leaves your device.'}
+      </p>
+      <div class="flex gap-2 mt-2">
+        <button id="webllm-ok" class="rounded bg-amber-700 px-3 py-1.5 text-xs text-white hover:bg-amber-800">
+          {isEs ? 'Entendido, continuar' : 'Got it, continue'}
+        </button>
+        <button id="webllm-skip" class="rounded border px-3 py-1.5 text-xs text-amber-700 border-amber-300 hover:bg-amber-100">
+          {isEs ? 'Solo usar PlantNet' : 'Use PlantNet only'}
+        </button>
+      </div>
+    </div>
     <!-- Photos (multi) -->
     <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">{tr.observe.photo_label}</label>
@@ -159,6 +177,26 @@ const weathers = ['sunny','cloudy','overcast','light_rain','heavy_rain','fog','s
   import type { Observation, ObserverRef } from '../lib/types';
 
   const form         = document.getElementById('obs-form') as HTMLFormElement | null;
+
+  // WebLLM download warning — show once before first local AI use
+  const webllmWarning = document.getElementById('webllm-warning');
+  const webllmOk      = document.getElementById('webllm-ok');
+  const webllmSkip    = document.getElementById('webllm-skip');
+  const { hasShownLocalAIDownloadWarning, markLocalAIDownloadWarningShown } = await import('../lib/sync');
+  const LOCAL_AI_OPTIN = 'rastrum.localAiOptIn';
+
+  if (!hasShownLocalAIDownloadWarning() && localStorage.getItem(LOCAL_AI_OPTIN) !== 'false') {
+    webllmWarning?.classList.remove('hidden');
+  }
+  webllmOk?.addEventListener('click', () => {
+    markLocalAIDownloadWarningShown();
+    webllmWarning?.classList.add('hidden');
+  });
+  webllmSkip?.addEventListener('click', () => {
+    localStorage.setItem(LOCAL_AI_OPTIN, 'false');
+    markLocalAIDownloadWarningShown();
+    webllmWarning?.classList.add('hidden');
+  });
   const cameraInput  = document.getElementById('camera-input') as HTMLInputElement | null;
   const galleryInput = document.getElementById('gallery-input') as HTMLInputElement | null;
   const photoGrid    = document.getElementById('photo-grid');
@@ -517,13 +555,21 @@ const weathers = ['sunny','cloudy','overcast','light_rain','heavy_rain','fog','s
       updated_at: obs.createdAt,
     });
 
-    // Attempt immediate sync if online; otherwise it'll flush on next online event
+    // Attempt immediate sync if online; otherwise it'll flush on next online event.
+    // Use a timeout to prevent hanging indefinitely if Edge Functions are unavailable.
     let syncedNow = false;
     if (ref.kind === 'user' && navigator.onLine) {
       try {
-        const res = await syncOutbox();
+        const syncPromise = syncOutbox();
+        const timeoutPromise = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('sync timeout')), 15_000)
+        );
+        const res = await Promise.race([syncPromise, timeoutPromise]);
         syncedNow = res.synced > 0;
-      } catch { /* ignore — row stays pending */ }
+      } catch (err) {
+        console.warn('[rastrum] sync failed or timed out:', err);
+        /* ignore — row stays pending, will retry on next online event */
+      }
     }
 
     submitBtn.disabled = false;

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -127,10 +127,30 @@ async function triggerEnvEnrichment(observationId: string): Promise<void> {
 }
 
 const LOCAL_AI_OPTIN = 'rastrum.localAiOptIn';
+const LOCAL_AI_DOWNLOAD_WARNED = 'rastrum.localAiDownloadWarned';
 
-function isLocalAIOptedIn(): boolean {
+/**
+ * WebLLM is ON by default (issue #12 — privacy-first, offline-capable).
+ * Users can opt OUT in profile settings if bandwidth is a concern.
+ * On first use, a download warning is shown (see ObservationForm).
+ */
+function isLocalAIEnabled(): boolean {
+  if (typeof localStorage === 'undefined') return true; // SSR: default on
+  // Legacy opt-in key still respected for users who explicitly enabled it
+  if (localStorage.getItem(LOCAL_AI_OPTIN) === 'true') return true;
+  // New default: on unless user explicitly opted out
+  return localStorage.getItem(LOCAL_AI_OPTIN) !== 'false';
+}
+
+export function hasShownLocalAIDownloadWarning(): boolean {
   if (typeof localStorage === 'undefined') return false;
-  return localStorage.getItem(LOCAL_AI_OPTIN) === 'true';
+  return localStorage.getItem(LOCAL_AI_DOWNLOAD_WARNED) === 'true';
+}
+
+export function markLocalAIDownloadWarningShown(): void {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(LOCAL_AI_DOWNLOAD_WARNED, 'true');
+  }
 }
 
 /**
@@ -169,11 +189,16 @@ async function triggerIdentify(observationId: string): Promise<void> {
   const { bootstrapIdentifiers, runCascade } = await import('./identifiers');
   bootstrapIdentifiers();
 
-  // Exclude on-device plugins unless the user opted in. They still appear
-  // in the registry (UI lists them) but the cascade engine skips them.
-  // Note: birdnet_lite is on-device and gated by both opt-in AND the model
-  // bundle landing — its isAvailable() returns model_not_bundled until then.
-  const excluded = isLocalAIOptedIn() ? [] : ['webllm_phi35_vision', 'onnx_efficientnet_lite0', 'birdnet_lite'];
+  // WebLLM (Phi-3.5-vision) is ON by default — local, private, no key needed.
+  // Exclude it only if user explicitly opted out (bandwidth concern).
+  // Claude is excluded when no BYO key is set — avoids silent crashes.
+  const { getKey } = await import('./byo-keys');
+  const hasAnthropicKey = !!getKey('claude_haiku', 'anthropic');
+  const localAIEnabled = isLocalAIEnabled();
+
+  const excluded: string[] = [];
+  if (!localAIEnabled) excluded.push('webllm_phi35_vision', 'onnx_efficientnet_lite0', 'birdnet_lite');
+  if (!hasAnthropicKey) excluded.push('claude_haiku');
 
   // Plugins read their own keys from byo-keys.ts at identify-time, so we
   // don't pre-collect them here. Pass an empty byo_keys object as a default.


### PR DESCRIPTION
## Changes

### Fixes #11 — 'Guardando...' hangs indefinitely
Added 15s timeout around `syncOutbox()` in ObservationForm. If the Edge Function is unavailable, the observation is saved locally and syncs later instead of freezing the UI.

### Addresses #6 — ID not triggering  
Root cause: Claude Haiku was being called without ANTHROPIC_API_KEY → unhandled rejection → cascade crash. Fix: Claude is now excluded from cascade when no BYO key is present.

### Implements #12 — WebLLM as default AI fallback
**Architecture decision by Artemio Padilla (2026-04-25):**
> 'Debería ser WebLLM default en lugar de servicios externos, siempre advirtiendo al usuario del tamaño de descarga'

- WebLLM/Phi-3.5-vision is now **ON by default** (was opt-in)
- First use shows a one-time download warning (~2.4 GB) with 'PlantNet only' escape hatch
- Claude only runs when user has BYO Anthropic key

### New cascade order
1. PlantNet (free, network) 
2. Phi-3.5-vision / WebLLM (local, private, ~2.4GB one-time download)
3. Claude Haiku (BYO key only)

**Reported during first user onboarding session with Eugenio Padilla.**