### PR TITLE
fix(build): use getSupabase() in tokens pages — fixes CI deploy failure

### DIFF
--- a/src/pages/en/profile/tokens.astro
+++ b/src/pages/en/profile/tokens.astro
@@ -66,7 +66,8 @@ const t = getT(lang);
 </BaseLayout>
 
 <script>
-  import { supabase } from '../../../lib/supabase';
+  import { getSupabase } from '../../../lib/supabase';
+  const supabase = getSupabase();
   const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
 
   async function getAuthHeader() {

--- a/src/pages/es/perfil/tokens.astro
+++ b/src/pages/es/perfil/tokens.astro
@@ -91,7 +91,8 @@ const t = getT(lang);
 </BaseLayout>
 
 <script>
-  import { supabase } from '../../../lib/supabase';
+  import { getSupabase } from '../../../lib/supabase';
+  const supabase = getSupabase();
 
   const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
 


### PR DESCRIPTION
Fixes GitHub Pages deploy failure introduced in PR #1.

`src/lib/supabase.ts` exports `getSupabase()` (singleton factory), not a `supabase` named export. Both token pages were importing `{ supabase }` which doesn't exist → build error in CI.

**Fix:** Replace `import { supabase }` with `import { getSupabase }; const supabase = getSupabase()` in both EN and ES tokens pages.