### PR TITLE
fix(onboarding): batch fixes — username error, mobile header, GPS two-pass

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -136,6 +136,11 @@ const isDocsPage = currentPath.includes('/docs');
         </a>
       ))}
     </div>
+    <div id="mobile-auth-links" class="hidden border-t border-zinc-200 dark:border-zinc-800 pt-2 mt-2 space-y-1">
+      <a id="mobile-menu-profile" href={getLocalizedPath(lang, routes.profile[lang as 'en'|'es'] + '/')} class="block py-1 hover:text-emerald-600 dark:hover:text-emerald-400">{tr.profile.view_profile}</a>
+      <a id="mobile-menu-edit" href={getLocalizedPath(lang, routes.profileEdit[lang as 'en'|'es'] + '/')} class="block py-1 hover:text-emerald-600 dark:hover:text-emerald-400">{tr.profile.edit}</a>
+      <button id="mobile-sign-out-btn" class="block w-full text-left py-1 text-red-600 dark:text-red-400 hover:text-red-700">{tr.auth.sign_out}</button>
+    </div>
   </nav>
 </header>
 
@@ -167,12 +172,14 @@ const isDocsPage = currentPath.includes('/docs');
   import { signOut } from '../lib/auth';
   import type { UserProfile } from '../lib/types';
 
-  const signInLink  = document.getElementById('sign-in-link');
-  const avatarWrap  = document.getElementById('avatar-wrap');
-  const avatarBtn   = document.getElementById('avatar-btn');
-  const avatarMenu  = document.getElementById('avatar-menu');
-  const avatarImg   = document.getElementById('header-avatar') as HTMLImageElement | null;
-  const signOutBtn  = document.getElementById('sign-out-btn');
+  const signInLink       = document.getElementById('sign-in-link');
+  const avatarWrap       = document.getElementById('avatar-wrap');
+  const avatarBtn        = document.getElementById('avatar-btn');
+  const avatarMenu       = document.getElementById('avatar-menu');
+  const avatarImg        = document.getElementById('header-avatar') as HTMLImageElement | null;
+  const signOutBtn       = document.getElementById('sign-out-btn');
+  const mobileAuthLinks  = document.getElementById('mobile-auth-links');
+  const mobileSignOutBtn = document.getElementById('mobile-sign-out-btn');
 
   function initialsAvatar(name: string): string {
     const clean = (name || '?').trim().slice(0, 2).toUpperCase();
@@ -187,6 +194,7 @@ const isDocsPage = currentPath.includes('/docs');
   async function paint(hasSession: boolean) {
     if (signInLink) signInLink.classList.toggle('hidden', hasSession);
     if (avatarWrap) avatarWrap.classList.toggle('hidden', !hasSession);
+    if (mobileAuthLinks) mobileAuthLinks.classList.toggle('hidden', !hasSession);
     if (hasSession && avatarImg) {
       try {
         const supabase = getSupabase();
@@ -219,6 +227,10 @@ const isDocsPage = currentPath.includes('/docs');
   document.addEventListener('click', () => avatarMenu?.classList.add('hidden'));
 
   signOutBtn?.addEventListener('click', async () => {
+    await signOut();
+    window.location.reload();
+  });
+  mobileSignOutBtn?.addEventListener('click', async () => {
     await signOut();
     window.location.reload();
   });

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -517,6 +517,7 @@ const weatherLabels = (tr.observe as any).weather_options as Record<string,strin
   async function getLiveGPS(): Promise<void> {
     if (!navigator.geolocation) return;
     return new Promise<void>((resolve) => {
+      // First pass: quick low-accuracy fix (coarse network location)
       navigator.geolocation.getCurrentPosition(
         (pos) => {
           location = {
@@ -527,10 +528,27 @@ const weatherLabels = (tr.observe as any).weather_options as Record<string,strin
             capturedFrom: 'gps',
           };
           paintLocation();
-          resolve();
+          // Second pass: refine with high-accuracy GPS (up to 30s)
+          navigator.geolocation.getCurrentPosition(
+            (pos2) => {
+              if (pos2.coords.accuracy < (location?.accuracyM ?? 9999)) {
+                location = {
+                  lat: pos2.coords.latitude,
+                  lng: pos2.coords.longitude,
+                  accuracyM: pos2.coords.accuracy,
+                  altitudeM: pos2.coords.altitude,
+                  capturedFrom: 'gps',
+                };
+                paintLocation();
+              }
+              resolve();
+            },
+            () => resolve(),
+            { enableHighAccuracy: true, timeout: 30_000, maximumAge: 0 }
+          );
         },
         () => resolve(),
-        { enableHighAccuracy: true, timeout: 10_000, maximumAge: 20_000 }
+        { enableHighAccuracy: false, timeout: 8_000, maximumAge: 60_000 }
       );
     });
   }

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -336,7 +336,17 @@ const tr = t(lang);
 
     if (error) {
       if (err) {
-        err.textContent = error.message;
+        // Translate constraint violation to friendly message
+        const isEs = document.documentElement.lang === 'es';
+        if (error.message.includes('username_check') || error.message.includes('users_username_check')) {
+          err.textContent = isEs
+            ? 'El nombre de usuario solo puede tener letras, números y guion bajo (_), entre 3 y 30 caracteres. Ej: eugenio_bio'
+            : 'Username can only contain letters, numbers, and underscores (_), 3–30 characters. E.g. eugenio_bio';
+        } else if (error.message.includes('username') && error.message.includes('unique')) {
+          err.textContent = isEs ? 'Ese nombre de usuario ya está en uso.' : 'That username is already taken.';
+        } else {
+          err.textContent = error.message;
+        }
         err.classList.remove('hidden');
       }
       return;


### PR DESCRIPTION
Batch of fixes from Eugenio Padilla's first user onboarding session (2026-04-25).

## Fixes #14 — Raw DB error on profile save
ProfileEditForm now translates constraint violations to friendly Spanish/English messages instead of showing raw Postgres error text.

## Fixes #2 — Header duplicated on mobile  
Added auth section to mobile menu (Ver perfil / Editar perfil / Cerrar sesión) so logged-in users have proper navigation on mobile. Previously avatar dropdown was desktop-only.

## Improves #5 — GPS slow on Android
Two-pass GPS strategy:
1. Fast coarse fix (network, 8s timeout) → shows location immediately
2. Refine with high-accuracy GPS (30s timeout) → updates if more accurate

User sees coordinates fast, then they improve automatically as GPS locks.