### PR TITLE
feat(chrome): UX revamp PR 1 — IA + chrome rebuild

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 > Briefing for AI coding agents (Claude Code, Copilot, Cursor, Codex, …)
 > working in this repo. Read this before making changes.
 >
-> **Last full doc sync:** 2026-04-26 (v1.0 shipped).
+> **Last full doc sync:** 2026-04-26 (v1.0 + chrome revamp).
 
 ---
 
@@ -69,11 +69,17 @@ src/
 ├── components/             Astro components — both pages + shared widgets
 │   ├── *View.astro         Shared per-feature views (RoadmapView, TasksView,
 │   │                       ProfileView, ExploreMap, ExportView, …)
-│   └── *Form.astro         Forms (ObservationForm, ProfileEditForm, SignInForm)
+│   ├── *Form.astro         Forms (ObservationForm, ProfileEditForm, SignInForm)
+│   ├── Header.astro        Verb-first chrome (Observe/Explore ▾/Chat | About/Docs ▾)
+│   ├── MegaMenu.astro      3-col dropdown shell, used by Docs ▾
+│   ├── MobileBottomBar.astro 5-slot bottom bar with center camera FAB (signed-in)
+│   └── MobileDrawer.astro  Right-side hamburger overlay (mobile only)
 ├── i18n/{en,es}.json       Translations. ANY new UI string lives here.
-├── i18n/utils.ts           t(lang) helper, route map, docPages list.
+├── i18n/utils.ts           t(lang) helper, routes + routeTree, docPages list.
 ├── layouts/                BaseLayout (PWA, theme, SW reg) + DocLayout (sidebar)
 ├── lib/
+│   ├── chrome-mode.ts      resolveChromeMode(path) → 'app' | 'read'
+│   ├── chrome-helpers.ts   getFabTarget, isActiveSection
 │   ├── supabase.ts         Singleton supabase-js client
 │   ├── auth.ts             Magic link, OAuth, OTP, passkey, signOut
 │   ├── byo-keys.ts         Per-plugin user-supplied API keys (localStorage)
@@ -89,7 +95,8 @@ src/
 │   │   ├── index.ts        bootstrapIdentifiers() registers built-ins
 │   │   └── *.ts            One file per plugin
 │   └── types.ts            ObserverRef, Observation, MediaFile, …
-├── pages/{en,es}/          Locale-paired routes. /en/observe ↔ /es/observar
+├── pages/{en,es}/          Locale-paired routes. /en/observe ↔ /es/observar;
+│                           explore subroutes: /explore/{recent,watchlist,species}
 ├── pages/auth/callback.astro  Language-neutral OAuth/PKCE landing page
 ├── pages/share/obs/        Public OG-card observation viewer
 └── env.d.ts                Typed import.meta.env
@@ -191,6 +198,27 @@ Adding a new model/service for species ID is a 3-step recipe:
 3. (Server-side only) extend the Edge Function's `force_provider` switch.
 The registry has runtime collision detection on `id`. See
 `docs/specs/modules/13-identifier-registry.md` for the full contract.
+
+### Chrome / IA conventions
+
+The app chrome is verb-first. Three action items on the left of the header
+— **Observe**, **Explore ▾** (dropdown), **Chat** — and a reference cluster
+on the right — **About**, **Docs ▾**. Identify is hub-spoke off the home
+hero and is intentionally absent from persistent nav.
+
+Mobile uses a bottom bar (`MobileBottomBar.astro`) with a center camera FAB;
+when the user is on `/observe`, the FAB shifts to `/identify` with a
+"⚡ Quick ID" badge. A right-side drawer (`MobileDrawer.astro`) handles
+reference links, account, and preferences.
+
+Per-section accent rail: Observe = emerald (brand), Explore = teal, Chat =
+sky, About/Docs = stone. The dynamic `railClass()` helper in `Header.astro`
+builds these class names at runtime, so they must be **SAFELISTED** in
+`tailwind.config.mjs`. Adding a new top-level section with its own accent
+colour requires extending that safelist or the classes will be purged in
+production builds.
+
+Full design rationale: `docs/superpowers/specs/2026-04-26-ux-revamp-design.md`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 > Briefing for AI coding agents (Claude Code, Copilot, Cursor, Codex, …)
 > working in this repo. Read this before making changes.
 >
-> **Last full doc sync:** 2026-04-26 (v1.0 shipped).
+> **Last full doc sync:** 2026-04-26 (v1.0 + chrome revamp).
 
 ---
 
@@ -69,11 +69,17 @@ src/
 ├── components/             Astro components — both pages + shared widgets
 │   ├── *View.astro         Shared per-feature views (RoadmapView, TasksView,
 │   │                       ProfileView, ExploreMap, ExportView, …)
-│   └── *Form.astro         Forms (ObservationForm, ProfileEditForm, SignInForm)
+│   ├── *Form.astro         Forms (ObservationForm, ProfileEditForm, SignInForm)
+│   ├── Header.astro        Verb-first chrome (Observe/Explore ▾/Chat | About/Docs ▾)
+│   ├── MegaMenu.astro      3-col dropdown shell, used by Docs ▾
+│   ├── MobileBottomBar.astro 5-slot bottom bar with center camera FAB (signed-in)
+│   └── MobileDrawer.astro  Right-side hamburger overlay (mobile only)
 ├── i18n/{en,es}.json       Translations. ANY new UI string lives here.
-├── i18n/utils.ts           t(lang) helper, route map, docPages list.
+├── i18n/utils.ts           t(lang) helper, routes + routeTree, docPages list.
 ├── layouts/                BaseLayout (PWA, theme, SW reg) + DocLayout (sidebar)
 ├── lib/
+│   ├── chrome-mode.ts      resolveChromeMode(path) → 'app' | 'read'
+│   ├── chrome-helpers.ts   getFabTarget, isActiveSection
 │   ├── supabase.ts         Singleton supabase-js client
 │   ├── auth.ts             Magic link, OAuth, OTP, passkey, signOut
 │   ├── byo-keys.ts         Per-plugin user-supplied API keys (localStorage)
@@ -89,7 +95,8 @@ src/
 │   │   ├── index.ts        bootstrapIdentifiers() registers built-ins
 │   │   └── *.ts            One file per plugin
 │   └── types.ts            ObserverRef, Observation, MediaFile, …
-├── pages/{en,es}/          Locale-paired routes. /en/observe ↔ /es/observar
+├── pages/{en,es}/          Locale-paired routes. /en/observe ↔ /es/observar;
+│                           explore subroutes: /explore/{recent,watchlist,species}
 ├── pages/auth/callback.astro  Language-neutral OAuth/PKCE landing page
 ├── pages/share/obs/        Public OG-card observation viewer
 └── env.d.ts                Typed import.meta.env
@@ -191,6 +198,27 @@ Adding a new model/service for species ID is a 3-step recipe:
 3. (Server-side only) extend the Edge Function's `force_provider` switch.
 The registry has runtime collision detection on `id`. See
 `docs/specs/modules/13-identifier-registry.md` for the full contract.
+
+### Chrome / IA conventions
+
+The app chrome is verb-first. Three action items on the left of the header
+— **Observe**, **Explore ▾** (dropdown), **Chat** — and a reference cluster
+on the right — **About**, **Docs ▾**. Identify is hub-spoke off the home
+hero and is intentionally absent from persistent nav.
+
+Mobile uses a bottom bar (`MobileBottomBar.astro`) with a center camera FAB;
+when the user is on `/observe`, the FAB shifts to `/identify` with a
+"⚡ Quick ID" badge. A right-side drawer (`MobileDrawer.astro`) handles
+reference links, account, and preferences.
+
+Per-section accent rail: Observe = emerald (brand), Explore = teal, Chat =
+sky, About/Docs = stone. The dynamic `railClass()` helper in `Header.astro`
+builds these class names at runtime, so they must be **SAFELISTED** in
+`tailwind.config.mjs`. Adding a new top-level section with its own accent
+colour requires extending that safelist or the classes will be purged in
+production builds.
+
+Full design rationale: `docs/superpowers/specs/2026-04-26-ux-revamp-design.md`.
 
 ---
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,9 +20,7 @@ export default defineConfig({
   // not personal admin, so it lives under /explore now. Old URL keeps
   // working via 301 so existing bookmarks survive.
   redirects: {
-    '/en/profile/watchlist':    { status: 301, destination: '/en/explore/watchlist/' },
-    '/en/profile/watchlist/':   { status: 301, destination: '/en/explore/watchlist/' },
-    '/es/perfil/seguimiento':   { status: 301, destination: '/es/explorar/seguimiento/' },
-    '/es/perfil/seguimiento/':  { status: 301, destination: '/es/explorar/seguimiento/' },
+    '/en/profile/watchlist':  { status: 301, destination: '/en/explore/watchlist/' },
+    '/es/perfil/seguimiento': { status: 301, destination: '/es/explorar/seguimiento/' },
   },
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,4 +16,13 @@ export default defineConfig({
       prefixDefaultLocale: true,
     },
   },
+  // PR-1 (UX revamp) IA reshuffle: watchlist is public-data exploration,
+  // not personal admin, so it lives under /explore now. Old URL keeps
+  // working via 301 so existing bookmarks survive.
+  redirects: {
+    '/en/profile/watchlist':    { status: 301, destination: '/en/explore/watchlist/' },
+    '/en/profile/watchlist/':   { status: 301, destination: '/en/explore/watchlist/' },
+    '/es/perfil/seguimiento':   { status: 301, destination: '/es/explorar/seguimiento/' },
+    '/es/perfil/seguimiento/':  { status: 301, destination: '/es/explorar/seguimiento/' },
+  },
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 > file is for "how do the pieces fit together" — block diagram + the
 > four critical-path flows + decision rationale.
 >
-> Last sync: 2026-04-26 (v1.0 shipped).
+> Last sync: 2026-04-26 (v1.0 + chrome revamp).
 
 ---
 
@@ -62,6 +62,22 @@ The MCP server (`/functions/v1/mcp`) sits inline with the REST API
 (`/functions/v1/api/*`) — same `rst_*` token, same scope strings, same
 RLS gates. AI agents (Claude Desktop, Cursor, Copilot Coding Agent)
 call the MCP surface; shell scripts call the REST surface.
+
+---
+
+## Frontend chrome
+
+The app shell uses a verb-first IA introduced in the UX-revamp PR 1
+(2026-04-26). Three action items sit on the left of the header — **Observe**,
+**Explore ▾**, **Chat** — and a reference cluster (**About**, **Docs ▾**) on
+the right. On mobile, a bottom bar with a center camera FAB replaces the
+header actions; a right-side drawer handles reference links and account
+settings. Each top-level section has a named accent colour (Observe = emerald,
+Explore = teal, Chat = sky, About/Docs = stone) rendered via a dynamic
+`railClass()` in `Header.astro` — those classes are safelisted in
+`tailwind.config.mjs`. New explore subroutes `/explore/{recent,watchlist,species}`
+are placeholder pages as of this sync; `/profile/watchlist` issues a 301 to
+`/explore/watchlist`.
 
 ---
 
@@ -164,7 +180,7 @@ the Edge Function rather than at the client to keep the outbox simple.
 | Shared per-feature views | `src/components/*View.astro` |
 | Forms | `src/components/*Form.astro` |
 | i18n strings | `src/i18n/{en,es}.json` |
-| i18n helpers | `src/i18n/utils.ts` (`t()`, `routes`, `docPages`) |
+| i18n helpers | `src/i18n/utils.ts` (`t()`, `routes`, `routeTree`, `docPages`) |
 | Auth (magic link, OAuth, OTP, passkey) | `src/lib/auth.ts` |
 | BYO key store | `src/lib/byo-keys.ts` |
 | Identifier plugin platform | `src/lib/identifiers/` |
@@ -173,6 +189,8 @@ the Edge Function rather than at the client to keep the outbox simple.
 | Upload (R2 + Supabase Storage) | `src/lib/upload.ts` |
 | Darwin Core mapping | `src/lib/darwin-core.ts` + `src/lib/dwca.ts` |
 | In-browser AI bootstrap | `src/lib/local-ai.ts` |
+| Chrome mode helper | `src/lib/chrome-mode.ts` (`resolveChromeMode`) |
+| Chrome accent / FAB helpers | `src/lib/chrome-helpers.ts` (`getFabTarget`, `isActiveSection`) |
 | Edge Functions | `supabase/functions/<name>/index.ts` |
 | Schema (idempotent SQL) | `docs/specs/infra/supabase-schema.sql` |
 | Module specs | `docs/specs/modules/NN-*.md` |

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -392,6 +392,12 @@
           "label": "Migrate canonical domain to rastrum.org (was rastrum.artemiop.com)",
           "label_es": "Migrar dominio canónico a rastrum.org (antes rastrum.artemiop.com)",
           "done": true
+        },
+        {
+          "id": "ux-revamp-pr1-ia-chrome",
+          "label": "UX revamp PR 1: IA + chrome rebuild",
+          "label_es": "Renovación UX PR 1: arquitectura + chrome",
+          "done": true
         }
       ]
     },

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -956,6 +956,22 @@
         { "label_en": "Old domain (rastrum.artemiop.com) 301-redirects",       "label_es": "Dominio antiguo redirige 301",                         "status": "done" },
         { "label_en": "Documentation updated to reference rastrum.org",         "label_es": "Documentación actualizada a rastrum.org",              "status": "done" }
       ]
+    },
+    "ux-revamp-pr1-ia-chrome": {
+      "phase": "v1.0",
+      "title_en": "UX revamp PR 1: IA + chrome rebuild",
+      "title_es": "Renovación UX PR 1: arquitectura + chrome",
+      "modules": ["00-index.md"],
+      "subtasks": [
+        { "label_en": "chrome-mode helper + chrome-helpers module + routeTree (TDD)", "label_es": "Helper chrome-mode + módulo chrome-helpers + routeTree (TDD)", "status": "done" },
+        { "label_en": "i18n strings for tagline, explore dropdown, docs groups, drawer, bottom bar", "label_es": "Strings i18n para tagline, dropdown explorar, grupos docs, drawer, barra inferior", "status": "done" },
+        { "label_en": "Explore subroute placeholder pages (/explore/recent, /explore/watchlist, /explore/species)", "label_es": "Páginas placeholder de subrutas (/explorar/recientes, /explorar/seguimiento, /explorar/especies)", "status": "done" },
+        { "label_en": "301 redirect for /profile/watchlist to /explore/watchlist", "label_es": "Redirección 301 de /perfil/seguimiento a /explorar/seguimiento", "status": "done" },
+        { "label_en": "MegaMenu, MobileBottomBar, MobileDrawer components", "label_es": "Componentes MegaMenu, MobileBottomBar, MobileDrawer", "status": "done" },
+        { "label_en": "Header.astro rewrite with verb-first copy, mobile-friendly layout, accent-color classnames", "label_es": "Reescritura de Header.astro con copy por verbo, layout mobile-friendly, classnames accent-color", "status": "done" },
+        { "label_en": "BaseLayout pb-20 sm:pb-0 for mobile bottom-bar clearance", "label_es": "BaseLayout pb-20 sm:pb-0 para separación de barra inferior móvil", "status": "done" },
+        { "label_en": "e2e coverage: active rail highlight, mega-menu renders, FAB targets /observe, drawer toggle, watchlist 301", "label_es": "Cobertura e2e: highlight de rail activo, mega-menu renderiza, FAB apunta a /observar, toggle drawer, 301 watchlist", "status": "done" }
+      ]
     }
   }
 }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,9 +1,13 @@
 # Rastrum Tasks — Phase Summary
 
 > **Skim-friendly view of [`docs/tasks.json`](tasks.json).** The JSON is
-> the source of truth and renders the live page at [/docs/tasks/](https://rastrum.org/en/docs/tasks/).
-> 
-> **Updated:** 2026-04-27 (post-launch cleanup).
+> the source of truth for the per-phase progress bars rendered at
+> [`/{lang}/docs/tasks/`](https://rastrum.org/en/docs/tasks/). This
+> markdown is regenerated when JSON drifts and is intentionally short —
+> open the JSON for full subtask detail.
+>
+> Last sync: 2026-04-27 (post-launch cleanup + chrome revamp). Roadmap source:
+> [`docs/progress.json`](progress.json).
 
 ---
 
@@ -48,6 +52,63 @@ Remaining:
 
 Remaining:
 
-- `bioblitz-events-ui` — Bioblitz events — UI (event detail page, live aggregates, participation badges)  _(! blocked: Build when first community organizer requests one — speculative without a pilot event)_
-- `capacitor-ios` — Capacitor iOS App Store wrapper (v1.2)  _(! blocked: Apple Developer Program ($99/yr) + Capacitor build pipeline)_
-- `oauth-custom-domain` — Custom auth domain on Supabase OAuth (auth.rastrum.org instead of raw Supabase URL)  _(! blocked: Supabase Pro plan ($25/mo) — deferred for zero-cost target)_
+| Item | Status | Note |
+|---|---|---|
+| `bioblitz-events-ui` | blocked | Build when first community organizer requests one — speculative without a pilot event |
+| `camera-trap-ingest` | partial | UI shipped at `/profile/import/camera-trap`; `camera_trap_megadetector` plugin stub registered; weights operator-hosted (env: `PUBLIC_MEGADETECTOR_ENDPOINT`) |
+| `capacitor-ios` | blocked | Apple Developer Program ($99/yr) |
+| `oauth-custom-domain` | deferred | Supabase Pro plan ($25/mo) — out of scope for zero-cost target |
+
+Newly closed in this phase:
+
+- **UX revamp PR 1 — IA + chrome rebuild** (2026-04-26): verb-first header, mobile bottom-bar with camera FAB, /explore/{recent,watchlist,species} placeholders, watchlist 301.
+- Schema, RLS, Edge Functions: `streaks`, `shareable-cards`,
+  `social-features`, `expert-system`, `bioblitz-events`,
+  `institutional-export`, `credentialed-access`, `env-enrichment`,
+  `video-support`.
+- New v1.0 modules: `mcp-server` (module 15), `map-location-picker`
+  (module 15 — duplicate prefix), `my-observations` (module 16),
+  `camera-getUserMedia` (module 17), `batch-exif-importer` (module 19),
+  `follows-comments-ui`.
+- Domain migration: `rastrum-org-domain` —
+  `rastrum.artemiop.com` → `rastrum.org`.
+
+## v1.5 — Territory Layer — planned
+
+Roadmap: 0 / 5. All five items live as named subtasks in `tasks.json`
+but no module spec exists yet. Items: `biodiversity-trails`, `pits-qr`,
+`spatial-analysis`, `diversity-indices`, `trail-pdf-export`.
+
+## v2.0 — Institutional — planned
+
+Roadmap: 0 / 5. Items: `camera-trap-advanced`, `gbif-publisher`,
+`regional-ml`, `b2g-dashboard`, `inat-bridge`. The `b2g-dashboard` work
+requires the Cornell BirdNET commercial license (governance track).
+
+## v2.5 — AI + AR — planned
+
+Roadmap: 0 / 4. Items: `scout-full`, `ar-overlay`, `voice-indigenous`,
+`conabio-api`.
+
+---
+
+## Governance track (parallel to all phases)
+
+Tracked in `progress.json` under `governance_track`. Status:
+
+- `license-framework` — done (CC BY / BY-NC / CC0 propagated through DwC export).
+- `zapoteco-fpic` — community-led, no shipping date.
+- `local-contexts` — community-consent gated.
+- `data-sovereignty` — policy draft pending CARI advisory input.
+- `birdnet-cornell` — only required for v2.0 commercial use.
+
+---
+
+## Where to look
+
+- **Live progress UI:** [/en/docs/tasks/](https://rastrum.org/en/docs/tasks/)
+  · [/es/docs/tareas/](https://rastrum.org/es/docs/tareas/)
+- **Roadmap:** [/en/docs/roadmap/](https://rastrum.org/en/docs/roadmap/)
+- **Per-item subtasks:** [`docs/tasks.json`](tasks.json) (edit there;
+  the page rerenders automatically).
+- **Module specs:** [`docs/specs/modules/`](specs/modules/00-index.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1022,9 +1022,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1040,9 +1037,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1060,9 +1054,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1078,9 +1069,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1098,9 +1086,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1116,9 +1101,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1136,9 +1118,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1155,9 +1134,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1173,9 +1149,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1199,9 +1172,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1223,9 +1193,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1249,9 +1216,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1273,9 +1237,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1299,9 +1260,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1324,9 +1282,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1348,9 +1303,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2068,9 +2020,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2083,9 +2032,6 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2100,9 +2046,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2115,9 +2058,6 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2132,9 +2072,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,9 +2084,6 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2164,9 +2098,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2179,9 +2110,6 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2196,9 +2124,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2211,9 +2136,6 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2228,9 +2150,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2244,9 +2163,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2259,9 +2175,6 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1022,6 +1022,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1037,6 +1040,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1054,6 +1060,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1069,6 +1078,9 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1086,6 +1098,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1101,6 +1116,9 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1118,6 +1136,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1134,6 +1155,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1149,6 +1173,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1172,6 +1199,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1193,6 +1223,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1216,6 +1249,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1237,6 +1273,9 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1260,6 +1299,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1282,6 +1324,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1303,6 +1348,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2020,6 +2068,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2032,6 +2083,9 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2046,6 +2100,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2058,6 +2115,9 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2072,6 +2132,9 @@
       "cpu": [
         "loong64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2084,6 +2147,9 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2098,6 +2164,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2110,6 +2179,9 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2124,6 +2196,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2136,6 +2211,9 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2150,6 +2228,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2163,6 +2244,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2175,6 +2259,9 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,3 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M17 8C8 10 5.9 16.17 3.82 21.34l1.89.66.95-2.3c.48.17.98.3 1.34.3C19 20 22 3 22 3c-1 2-8 2.25-13 3.25S2 11.5 2 13.5s1.75 3.75 1.75 3.75"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="#10b981">
+  <path d="M 50 54 C 60 54 66 61 64 73 C 62 82 56 80 50 76 C 44 80 38 82 36 73 C 34 61 40 54 50 54 Z" />
+  <ellipse cx="28" cy="46" rx="6" ry="12" transform="rotate(-25 28 46)" />
+  <ellipse cx="41" cy="30" rx="6" ry="13" transform="rotate(-8 41 30)" />
+  <ellipse cx="59" cy="30" rx="6" ry="13" transform="rotate(8 59 30)" />
+  <ellipse cx="72" cy="46" rx="6" ry="12" transform="rotate(25 72 46)" />
 </svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -10,6 +10,9 @@
   "orientation": "portrait-primary",
   "icons": [
     { "src": "/rastrum-logo.svg", "type": "image/svg+xml", "sizes": "any", "purpose": "any" },
+    { "src": "/rastrum-logo-512.png", "type": "image/png", "sizes": "512x512", "purpose": "any" },
+    { "src": "/rastrum-logo-240.png", "type": "image/png", "sizes": "240x240", "purpose": "any" },
+    { "src": "/rastrum-logo-120.png", "type": "image/png", "sizes": "120x120", "purpose": "any" },
     { "src": "/favicon.svg",      "type": "image/svg+xml", "sizes": "any", "purpose": "maskable" }
   ],
   "categories": ["education", "science", "nature"],

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -147,7 +147,7 @@ const docColumns = [
          ]}>
         {tr.nav.about}
       </a>
-      <MegaMenu lang={locale} trigger={tr.nav.docs} columns={docColumns} align="right" />
+      <MegaMenu lang={locale} trigger={tr.nav.docs} columns={docColumns} align="right" active={docsActive} />
     </nav>
 
     <!-- Auth + utilities -->

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -87,7 +87,7 @@ const docColumns = [
     <!-- Lockup -->
     <a href={getLocalizedPath(lang, '/')} class="flex flex-col leading-tight">
       <span class="flex items-center gap-2 text-lg font-bold text-emerald-600 dark:text-emerald-400">
-        <img src="/rastrum-logo.svg" alt="Rastrum" class="w-7 h-7" />
+        <img src="/rastrum-logo.svg" alt="" class="w-7 h-7" />
         Rastrum
       </span>
       <span class="hidden md:block text-[11px] text-zinc-500 dark:text-zinc-500 -mt-0.5 ml-9">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,10 @@
 ---
-import { t, getLocalizedPath, getDocPath, routes, getAlternateLocale, docPages, type Locale } from '../i18n/utils';
+import { t, getLocalizedPath, getAlternateLocale, routes, type Locale } from '../i18n/utils';
+import { isActiveSection } from '../lib/chrome-helpers';
 import BellIcon from './BellIcon.astro';
+import MegaMenu from './MegaMenu.astro';
+import MobileBottomBar from './MobileBottomBar.astro';
+import MobileDrawer from './MobileDrawer.astro';
 
 interface Props {
   lang: string;
@@ -10,196 +14,247 @@ interface Props {
 const { lang, currentPath = '/' } = Astro.props;
 const tr = t(lang);
 const alt = getAlternateLocale(lang);
+const locale = (lang === 'es' ? 'es' : 'en') as Locale;
 
+// alt-language href (preserves the existing route-key swap behavior)
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const pathWithoutBase = currentPath.replace(base, '') || '/';
 const segments = pathWithoutBase.split('/').filter(Boolean);
 const currentLang = segments[0] || lang;
 const currentSlug = '/' + (segments.slice(1).join('/') || '');
-
 const matchedKey = Object.keys(routes).find(key => {
-  const routeSlug = routes[key][currentLang as Locale] || '';
-  return routeSlug === currentSlug || (currentSlug === '/' && routeSlug === '');
+  const slug = routes[key][currentLang as Locale] || '';
+  return slug === currentSlug || (currentSlug === '/' && slug === '');
 });
-
 const altSlug = matchedKey ? (routes[matchedKey][alt] || '') : currentSlug;
-const altHref = base + '/' + alt + altSlug + '/';
+const altHref = `${base}/${alt}${altSlug}/`;
 
-const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>)[key] || key;
+// Active-state precomputes for the verbs
+const obsActive  = isActiveSection(currentPath, 'observe',  lang);
+const expActive  = isActiveSection(currentPath, 'explore',  lang);
+const chatActive = isActiveSection(currentPath, 'chat',     lang);
+const docsActive = isActiveSection(currentPath, 'docs',     lang);
+const aboutActive = isActiveSection(currentPath, 'about',   lang);
 
-const isDocsPage = currentPath.includes('/docs');
+// Section accent — emerald is the default (the brand). Per spec §7,
+// Explore = teal-500, Chat = sky-500, Docs/About = stone-500. The active
+// rail picks the right token. PR 1 wires the rail; refinement is in PR 5.
+const railClass = (active: boolean, accent: 'emerald' | 'teal' | 'sky' | 'stone') => active
+  ? `text-${accent}-600 dark:text-${accent}-400 after:bg-${accent}-500 after:scale-x-100`
+  : 'text-zinc-700 dark:text-zinc-300 hover:text-emerald-600 dark:hover:text-emerald-400 after:scale-x-0';
+
+// Safelist note: the dynamic section-accent class strings (`text-teal-600`,
+// `after:bg-sky-500`, etc.) must be kept reachable for Tailwind. The
+// safelist is wired in `tailwind.config.mjs`; if a build emits unstyled
+// rails, check that file.
+
+const explorePath = getLocalizedPath(lang, routes.explore[locale] + '/');
+const exploreMapPath = getLocalizedPath(lang, routes.exploreMap[locale] + '/');
+const exploreRecentPath = getLocalizedPath(lang, routes.exploreRecent[locale] + '/');
+const exploreWatchlistPath = getLocalizedPath(lang, routes.exploreWatchlist[locale] + '/');
+const exploreSpeciesPath = getLocalizedPath(lang, routes.exploreSpecies[locale] + '/');
+
+const docColumns = [
+  {
+    heading: tr.nav.docs_groups.product,
+    items: [
+      { key: 'vision',       label: tr.nav.docs_groups.product_items.vision },
+      { key: 'features',     label: tr.nav.docs_groups.product_items.features },
+      { key: 'architecture', label: tr.nav.docs_groups.product_items.architecture },
+    ],
+  },
+  {
+    heading: tr.nav.docs_groups.progress,
+    items: [
+      { key: 'roadmap', label: tr.nav.docs_groups.progress_items.roadmap },
+      { key: 'tasks',   label: tr.nav.docs_groups.progress_items.tasks },
+      { key: 'market',  label: tr.nav.docs_groups.progress_items.market },
+    ],
+  },
+  {
+    heading: tr.nav.docs_groups.community,
+    items: [
+      { key: 'indigenous', label: tr.nav.docs_groups.community_items.indigenous },
+      { key: 'funding',    label: tr.nav.docs_groups.community_items.funding },
+      { key: 'contribute', label: tr.nav.docs_groups.community_items.contribute },
+    ],
+  },
+];
 ---
 
 <header class="border-b border-zinc-200 dark:border-zinc-800">
-  <div class="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
-    <a href={getLocalizedPath(lang, '/')} class="flex items-center gap-2 text-xl font-bold tracking-tight text-emerald-600 dark:text-emerald-400">
-      <img src="/rastrum-logo.svg" alt="Rastrum" class="w-8 h-8" />
-      Rastrum
+  <div class="max-w-5xl mx-auto px-4 py-3 flex items-center gap-4">
+    <!-- Lockup -->
+    <a href={getLocalizedPath(lang, '/')} class="flex flex-col leading-tight">
+      <span class="flex items-center gap-2 text-lg font-bold text-emerald-600 dark:text-emerald-400">
+        <img src="/rastrum-logo.svg" alt="Rastrum" class="w-7 h-7" />
+        Rastrum
+      </span>
+      <span class="hidden md:block text-[11px] text-zinc-500 dark:text-zinc-500 -mt-0.5 ml-9">
+        {tr.nav.tagline}
+      </span>
     </a>
-    <nav class="hidden sm:flex items-center gap-6 text-sm">
-      <a href={getLocalizedPath(lang, routes.home[lang as 'en'|'es'] + '/')} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{tr.nav.home}</a>
-      <a href={getLocalizedPath(lang, routes.observe[lang as 'en'|'es'] + '/')} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{tr.nav.observe}</a>
-      <a href={getLocalizedPath(lang, (lang === 'es' ? '/explorar/mapa' : '/explore/map') + '/')} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{tr.nav.map}</a>
-      <a href={getLocalizedPath(lang, routes.chat[lang as 'en'|'es'] + '/')} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{tr.nav.chat}</a>
-      <a href={getLocalizedPath(lang, routes.about[lang as 'en'|'es'] + '/')} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{tr.nav.about}</a>
 
-      <!-- Docs dropdown -->
-      <div class="relative" id="docs-dropdown">
+    <span class="hidden sm:block w-px h-6 bg-zinc-200 dark:bg-zinc-800"></span>
+
+    <!-- Verbs (left) -->
+    <nav class="hidden sm:flex items-center gap-5 text-sm">
+      <a href={getLocalizedPath(lang, routes.observe[locale] + '/')}
+         class:list={[
+           'relative pb-1 transition-colors after:content-[""] after:absolute after:left-0 after:right-0 after:-bottom-3 after:h-[2px] after:rounded after:transition-transform after:origin-left',
+           railClass(obsActive, 'emerald'),
+         ]}>
+        {tr.nav.observe}
+      </a>
+
+      <!-- Explore dropdown (small list, not mega) -->
+      <div class="relative" id="hdr-explore">
         <button
+          id="hdr-explore-btn"
+          type="button"
           class:list={[
-            "flex items-center gap-1 transition-colors",
-            isDocsPage
-              ? "text-emerald-600 dark:text-emerald-400"
-              : "hover:text-emerald-600 dark:hover:text-emerald-400"
+            'flex items-center gap-1 pb-1 transition-colors after:content-[""] after:absolute after:left-0 after:right-0 after:-bottom-3 after:h-[2px] after:rounded after:transition-transform after:origin-left',
+            railClass(expActive, 'teal'),
           ]}
-          id="docs-dropdown-btn"
+          aria-haspopup="true" aria-expanded="false" aria-controls="hdr-explore-menu"
         >
-          {tr.nav.docs}
-          <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-          </svg>
+          {tr.nav.explore}
+          <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
         </button>
-        <div id="docs-dropdown-menu" class="hidden absolute right-0 top-full mt-2 w-56 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-lg py-1 z-50">
-          <a href={getDocPath(lang)} class="block px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 font-medium">
-            {tr.docs.back_to_docs}
-          </a>
-          <div class="border-t border-zinc-200 dark:border-zinc-800 my-1"></div>
-          {docPages.map(page => (
-            <a
-              href={getDocPath(lang, page)}
-              class="block px-4 py-1.5 text-sm text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-zinc-100"
-            >
-              {getDocLabel(page)}
-            </a>
-          ))}
+        <div id="hdr-explore-menu" class="hidden absolute left-0 top-full mt-2 w-56 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-lg py-1 z-50">
+          <a href={exploreMapPath}        class="block px-4 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.nav.explore_dropdown.map}</a>
+          <a href={exploreRecentPath}     class="block px-4 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.nav.explore_dropdown.recent}</a>
+          <a href={exploreWatchlistPath}  class="block px-4 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.nav.explore_dropdown.watchlist}</a>
+          <a href={exploreSpeciesPath}    class="block px-4 py-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.nav.explore_dropdown.species}</a>
         </div>
       </div>
+
+      <a href={getLocalizedPath(lang, routes.chat[locale] + '/')}
+         class:list={[
+           'relative pb-1 transition-colors after:content-[""] after:absolute after:left-0 after:right-0 after:-bottom-3 after:h-[2px] after:rounded after:transition-transform after:origin-left',
+           railClass(chatActive, 'sky'),
+         ]}>
+        {tr.nav.chat}
+      </a>
     </nav>
-    <div class="flex items-center gap-3">
+
+    <!-- Reference (right of verbs, before auth) -->
+    <nav class="hidden sm:flex items-center gap-5 text-sm ml-auto">
+      <a href={getLocalizedPath(lang, routes.about[locale] + '/')}
+         class:list={[
+           'relative pb-1 transition-colors after:content-[""] after:absolute after:left-0 after:right-0 after:-bottom-3 after:h-[2px] after:rounded after:transition-transform after:origin-left',
+           railClass(aboutActive, 'stone'),
+         ]}>
+        {tr.nav.about}
+      </a>
+      <MegaMenu lang={locale} trigger={tr.nav.docs} columns={docColumns} align="right" />
+    </nav>
+
+    <!-- Auth + utilities -->
+    <div class="flex items-center gap-2 sm:ml-2">
       <a
-        href={getLocalizedPath(lang, routes.signIn[lang as 'en'|'es'] + '/')}
+        href={getLocalizedPath(lang, routes.signIn[locale] + '/')}
         id="sign-in-link"
         class="hidden text-xs font-medium px-2.5 py-1 rounded border border-emerald-600/60 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors"
       >
         {tr.auth.sign_in}
       </a>
-      <BellIcon lang={lang as 'en' | 'es'} />
-      <!-- Avatar dropdown (hidden until authenticated) -->
+      <BellIcon lang={locale} />
       <div id="avatar-wrap" class="hidden relative">
-        <button id="avatar-btn" aria-label="Account menu" class="block rounded-full relative focus:outline-none focus:ring-2 focus:ring-emerald-500">
+        <button id="avatar-btn" aria-label="Account menu" class="block rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-500">
           <img id="header-avatar" src="" alt="" class="w-8 h-8 rounded-full bg-emerald-600 object-cover" />
         </button>
         <div id="avatar-menu" class="hidden absolute right-0 top-full mt-2 w-48 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-lg py-1 z-50">
-          <a id="menu-profile" href={getLocalizedPath(lang, routes.profile[lang as 'en'|'es'] + '/')} class="block px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.profile.view_profile}</a>
-          <a id="menu-edit" href={getLocalizedPath(lang, routes.profileEdit[lang as 'en'|'es'] + '/')} class="block px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.profile.edit}</a>
+          <a id="menu-profile" href={getLocalizedPath(lang, routes.profile[locale] + '/')} class="block px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.profile.view_profile}</a>
+          <a id="menu-edit"    href={getLocalizedPath(lang, routes.profileEdit[locale] + '/')} class="block px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.profile.edit}</a>
           <div class="border-t border-zinc-200 dark:border-zinc-800 my-1"></div>
           <button id="sign-out-btn" class="block w-full text-left px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.auth.sign_out}</button>
         </div>
       </div>
+
       <a
         href={altHref}
         id="lang-toggle"
         data-target-lang={alt}
-        class="text-xs font-medium px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+        class="hidden md:block text-xs font-medium px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
       >
         {alt.toUpperCase()}
       </a>
       <button
         id="theme-toggle"
         aria-label="Toggle dark mode"
-        class="p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+        class="hidden md:block p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
       >
-        <svg class="w-5 h-5 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-        </svg>
-        <svg class="w-5 h-5 block dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-        </svg>
+        <svg aria-hidden="true" class="w-5 h-5 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+        <svg aria-hidden="true" class="w-5 h-5 block dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
       </button>
-      <button id="mobile-menu-toggle" class="sm:hidden p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors" aria-label="Toggle menu">
-        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
+
+      <!-- Hamburger (mobile only) — opens MobileDrawer via window hook -->
+      <button
+        id="mobile-menu-toggle"
+        type="button"
+        class="sm:hidden p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+        aria-label={tr.nav.drawer.open_menu}
+      >
+        <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>
       </button>
     </div>
   </div>
-  <nav id="mobile-menu" class="sm:hidden hidden border-t border-zinc-200 dark:border-zinc-800 px-4 py-3 space-y-2 text-sm">
-    <a href={getLocalizedPath(lang, routes.home[lang as 'en'|'es'] + '/')} class="block hover:text-emerald-600 dark:hover:text-emerald-400">{tr.nav.home}</a>
-    <a href={getLocalizedPath(lang, routes.observe[lang as 'en'|'es'] + '/')} class="block hover:text-emerald-600 dark:hover:text-emerald-400">{tr.nav.observe}</a>
-    <a href={getLocalizedPath(lang, (lang === 'es' ? '/explorar/mapa' : '/explore/map') + '/')} class="block hover:text-emerald-600 dark:hover:text-emerald-400">{tr.nav.map}</a>
-    <a href={getLocalizedPath(lang, routes.chat[lang as 'en'|'es'] + '/')} class="block hover:text-emerald-600 dark:hover:text-emerald-400">{tr.nav.chat}</a>
-    <a href={getLocalizedPath(lang, routes.about[lang as 'en'|'es'] + '/')} class="block hover:text-emerald-600 dark:hover:text-emerald-400">{tr.nav.about}</a>
-    <div class="border-t border-zinc-200 dark:border-zinc-800 pt-2 mt-2">
-      <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-2">{tr.nav.docs}</p>
-      <a href={getDocPath(lang)} class="block py-1 hover:text-emerald-600 dark:hover:text-emerald-400">{tr.docs.back_to_docs}</a>
-      {docPages.map(page => (
-        <a href={getDocPath(lang, page)} class="block py-1 text-zinc-600 dark:text-zinc-400 hover:text-emerald-600 dark:hover:text-emerald-400">
-          {getDocLabel(page)}
-        </a>
-      ))}
-    </div>
-    <div id="mobile-auth-links" class="hidden border-t border-zinc-200 dark:border-zinc-800 pt-2 mt-2 space-y-1">
-      <a id="mobile-menu-profile" href={getLocalizedPath(lang, routes.profile[lang as 'en'|'es'] + '/')} class="block py-1 hover:text-emerald-600 dark:hover:text-emerald-400">{tr.profile.view_profile}</a>
-      <a id="mobile-menu-edit" href={getLocalizedPath(lang, routes.profileEdit[lang as 'en'|'es'] + '/')} class="block py-1 hover:text-emerald-600 dark:hover:text-emerald-400">{tr.profile.edit}</a>
-      <button id="mobile-sign-out-btn" class="block w-full text-left py-1 text-red-600 dark:text-red-400 hover:text-red-700">{tr.auth.sign_out}</button>
-    </div>
-  </nav>
 </header>
 
+<MobileDrawer lang={locale} currentPath={currentPath} />
+<MobileBottomBar lang={locale} currentPath={currentPath} />
+
 <script is:inline>
+  // Theme + lang toggles (desktop chrome — kept until PR 3 moves them into the footer/Preferences)
   document.getElementById('theme-toggle')?.addEventListener('click', () => {
-    const isDark = document.documentElement.classList.toggle('dark');
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    const dark = document.documentElement.classList.toggle('dark');
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
   });
-  document.getElementById('mobile-menu-toggle')?.addEventListener('click', () => {
-    document.getElementById('mobile-menu')?.classList.toggle('hidden');
-  });
-  // Docs dropdown
-  const ddBtn = document.getElementById('docs-dropdown-btn');
-  const ddMenu = document.getElementById('docs-dropdown-menu');
-  if (ddBtn && ddMenu) {
-    ddBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      ddMenu.classList.toggle('hidden');
-    });
-    document.addEventListener('click', () => {
-      ddMenu.classList.add('hidden');
-    });
-  }
-  // Save language preference when toggling
   document.getElementById('lang-toggle')?.addEventListener('click', function() {
-    const targetLang = this.dataset.targetLang;
-    if (targetLang) localStorage.setItem('rastrum.lang', targetLang);
+    const target = this.dataset.targetLang;
+    if (target) localStorage.setItem('rastrum.lang', target);
   });
+
+  // Hamburger → drawer (handler exposed by MobileDrawer)
+  document.getElementById('mobile-menu-toggle')?.addEventListener('click', () => {
+    if (typeof window.__rastrumOpenDrawer === 'function') window.__rastrumOpenDrawer();
+  });
+
+  // Explore dropdown
+  (function() {
+    const btn  = document.getElementById('hdr-explore-btn');
+    const menu = document.getElementById('hdr-explore-menu');
+    if (!btn || !menu) return;
+    btn.addEventListener('click', (e) => { e.stopPropagation(); menu.classList.toggle('hidden'); btn.setAttribute('aria-expanded', menu.classList.contains('hidden') ? 'false' : 'true'); });
+    document.addEventListener('click', (e) => {
+      if (!menu.classList.contains('hidden') && !menu.contains(e.target) && e.target !== btn) {
+        menu.classList.add('hidden'); btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { menu.classList.add('hidden'); btn.setAttribute('aria-expanded', 'false'); } });
+  })();
 </script>
 
-<!-- Auth status: swaps sign-in link for avatar dropdown when authenticated. -->
+<!-- Auth status: keeps the existing avatar-swap behavior -->
 <script>
   import { getSupabase } from '../lib/supabase';
   import { signOut } from '../lib/auth';
   import type { UserProfile } from '../lib/types';
 
-  const signInLink       = document.getElementById('sign-in-link');
-  const avatarWrap       = document.getElementById('avatar-wrap');
-  const avatarBtn        = document.getElementById('avatar-btn');
-  const avatarMenu       = document.getElementById('avatar-menu');
-  const avatarImg        = document.getElementById('header-avatar') as HTMLImageElement | null;
-  const signOutBtn       = document.getElementById('sign-out-btn');
-  const mobileAuthLinks  = document.getElementById('mobile-auth-links');
-  const mobileSignOutBtn = document.getElementById('mobile-sign-out-btn');
+  const signInLink = document.getElementById('sign-in-link');
+  const avatarWrap = document.getElementById('avatar-wrap');
+  const avatarBtn  = document.getElementById('avatar-btn');
+  const avatarMenu = document.getElementById('avatar-menu');
+  const avatarImg  = document.getElementById('header-avatar') as HTMLImageElement | null;
+  const signOutBtn = document.getElementById('sign-out-btn');
 
   function initialsAvatar(name: string): string {
     const clean = (name || '?').trim().slice(0, 2).toUpperCase();
-    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'>
-      <rect width='32' height='32' fill='#10b981'/>
-      <text x='50%' y='58%' text-anchor='middle' fill='white' font-family='system-ui,sans-serif' font-size='14' font-weight='700'>${clean}</text>
-    </svg>`;
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><rect width='32' height='32' fill='#10b981'/><text x='50%' y='58%' text-anchor='middle' fill='white' font-family='system-ui,sans-serif' font-size='14' font-weight='700'>${clean}</text></svg>`;
     return 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
   }
 
-  // Cached avatar src so reloads don't flash the placeholder while we
-  // wait for getSession() + the public.users round-trip. Updated below
-  // every time paint() resolves a fresh URL.
   const AVATAR_CACHE_KEY = 'rastrum.headerAvatar';
   const AVATAR_NAME_KEY  = 'rastrum.headerName';
   function paintCachedAvatar() {
@@ -212,27 +267,19 @@ const isDocsPage = currentPath.includes('/docs');
         if (cachedAlt) avatarImg.alt = cachedAlt;
         avatarWrap?.classList.remove('hidden');
         signInLink?.classList.add('hidden');
-        mobileAuthLinks?.classList.remove('hidden');
       }
     } catch { /* localStorage unavailable */ }
   }
   paintCachedAvatar();
 
-  // Unread badge handled by <BellIcon> — see BellIcon.astro.
   async function paint(hasSession: boolean, sessionUser?: { id: string; email?: string; user_metadata?: Record<string, unknown> }) {
     if (signInLink) signInLink.classList.toggle('hidden', hasSession);
     if (avatarWrap) avatarWrap.classList.toggle('hidden', !hasSession);
-    if (mobileAuthLinks) mobileAuthLinks.classList.toggle('hidden', !hasSession);
-
     if (!hasSession) {
-      // Signed out — clear the cache so the next render starts clean.
       try { localStorage.removeItem(AVATAR_CACHE_KEY); localStorage.removeItem(AVATAR_NAME_KEY); } catch { /* ignore */ }
       return;
     }
     if (!avatarImg) return;
-
-    // Fast path: read avatar straight from the session's user_metadata
-    // (already in localStorage from Supabase auth — no DB round-trip).
     if (sessionUser) {
       const meta = (sessionUser.user_metadata ?? {}) as Record<string, string | undefined>;
       const fastSrc = meta.picture || meta.avatar_url;
@@ -245,9 +292,6 @@ const isDocsPage = currentPath.includes('/docs');
         avatarImg.alt = fastName;
       }
     }
-
-    // Slow path: refine from public.users (in case the operator-controlled
-    // record has a different avatar — e.g. user uploaded a custom one).
     try {
       const supabase = getSupabase();
       const userId = sessionUser?.id;
@@ -261,10 +305,7 @@ const isDocsPage = currentPath.includes('/docs');
       const finalSrc = profile?.avatar_url || avatarImg.src || initialsAvatar(name);
       avatarImg.src = finalSrc;
       avatarImg.alt = name;
-      try {
-        localStorage.setItem(AVATAR_CACHE_KEY, finalSrc);
-        localStorage.setItem(AVATAR_NAME_KEY, name);
-      } catch { /* ignore */ }
+      try { localStorage.setItem(AVATAR_CACHE_KEY, finalSrc); localStorage.setItem(AVATAR_NAME_KEY, name); } catch { /* ignore */ }
     } catch { /* env not set */ }
   }
 
@@ -276,18 +317,7 @@ const isDocsPage = currentPath.includes('/docs');
     } catch { /* env not set */ }
   })();
 
-  avatarBtn?.addEventListener('click', (e) => {
-    e.stopPropagation();
-    avatarMenu?.classList.toggle('hidden');
-  });
+  avatarBtn?.addEventListener('click', (e) => { e.stopPropagation(); avatarMenu?.classList.toggle('hidden'); });
   document.addEventListener('click', () => avatarMenu?.classList.add('hidden'));
-
-  signOutBtn?.addEventListener('click', async () => {
-    await signOut();
-    window.location.reload();
-  });
-  mobileSignOutBtn?.addEventListener('click', async () => {
-    await signOut();
-    window.location.reload();
-  });
+  signOutBtn?.addEventListener('click', async () => { await signOut(); window.location.reload(); });
 </script>

--- a/src/components/MegaMenu.astro
+++ b/src/components/MegaMenu.astro
@@ -8,16 +8,26 @@ interface Props {
   trigger: string;          // visible button label, e.g. "Docs"
   columns: Column[];        // 3 columns by convention
   align?: 'left' | 'right'; // dropdown anchor; defaults to right
+  active?: boolean;
 }
-const { lang, trigger, columns, align = 'right' } = Astro.props;
-const id = `megamenu-${trigger.toLowerCase()}`;
+const { lang, trigger, columns, align = 'right', active = false } = Astro.props;
+const safeTriggerId = trigger
+  .normalize('NFKD')
+  .replace(/[̀-ͯ]/g, '')
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-+|-+$/g, '');
+const id = `megamenu-${safeTriggerId || 'menu'}`;
 ---
 
 <div class="relative" data-megamenu-root>
   <button
     id={`${id}-btn`}
     type="button"
-    class="flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+    class:list={[
+      'flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors',
+      active && 'text-stone-600 dark:text-stone-400 font-semibold',
+    ]}
     aria-haspopup="true"
     aria-expanded="false"
     aria-controls={`${id}-menu`}

--- a/src/components/MegaMenu.astro
+++ b/src/components/MegaMenu.astro
@@ -1,0 +1,84 @@
+---
+import { getDocPath } from '../i18n/utils';
+
+interface Item { key: string; label: string; desc?: string; }
+interface Column { heading: string; items: Item[]; }
+interface Props {
+  lang: 'en' | 'es';
+  trigger: string;          // visible button label, e.g. "Docs"
+  columns: Column[];        // 3 columns by convention
+  align?: 'left' | 'right'; // dropdown anchor; defaults to right
+}
+const { lang, trigger, columns, align = 'right' } = Astro.props;
+const id = `megamenu-${trigger.toLowerCase()}`;
+---
+
+<div class="relative" data-megamenu-root>
+  <button
+    id={`${id}-btn`}
+    type="button"
+    class="flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+    aria-haspopup="true"
+    aria-expanded="false"
+    aria-controls={`${id}-menu`}
+  >
+    {trigger}
+    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  </button>
+
+  <div
+    id={`${id}-menu`}
+    class:list={[
+      'hidden absolute top-full mt-2 z-50',
+      align === 'right' ? 'right-0' : 'left-0',
+      'min-w-[640px] grid grid-cols-3 gap-6',
+      'rounded-lg border border-zinc-200 dark:border-zinc-800',
+      'bg-white dark:bg-zinc-900 shadow-lg p-4',
+    ]}
+    role="menu"
+  >
+    {columns.map(col => (
+      <div>
+        <p class="text-xs font-semibold text-emerald-600 dark:text-emerald-400 uppercase tracking-wider mb-2">
+          {col.heading}
+        </p>
+        <ul class="space-y-1">
+          {col.items.map(item => (
+            <li>
+              <a
+                href={getDocPath(lang, item.key)}
+                class="block px-2 py-1.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 text-sm text-zinc-700 dark:text-zinc-300"
+                role="menuitem"
+              >
+                <span class="block font-medium">{item.label}</span>
+                {item.desc && (
+                  <span class="block text-xs text-zinc-500 dark:text-zinc-500">{item.desc}</span>
+                )}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    ))}
+  </div>
+</div>
+
+<script is:inline define:vars={{ id }}>
+  (function() {
+    const btn  = document.getElementById(id + '-btn');
+    const menu = document.getElementById(id + '-menu');
+    if (!btn || !menu) return;
+
+    function open()  { menu.classList.remove('hidden'); btn.setAttribute('aria-expanded', 'true');  }
+    function close() { menu.classList.add('hidden');    btn.setAttribute('aria-expanded', 'false'); }
+    function toggle() { menu.classList.contains('hidden') ? open() : close(); }
+
+    btn.addEventListener('click', (e) => { e.stopPropagation(); toggle(); });
+    document.addEventListener('click', (e) => {
+      if (!menu.classList.contains('hidden') && !menu.contains(e.target) && e.target !== btn) close();
+    });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+  })();
+</script>

--- a/src/components/MegaMenu.astro
+++ b/src/components/MegaMenu.astro
@@ -25,8 +25,11 @@ const id = `megamenu-${safeTriggerId || 'menu'}`;
     id={`${id}-btn`}
     type="button"
     class:list={[
-      'flex items-center gap-1 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors',
-      active && 'text-stone-600 dark:text-stone-400 font-semibold',
+      'relative flex items-center gap-1 pb-1 transition-colors',
+      'after:content-[""] after:absolute after:left-0 after:right-0 after:-bottom-3 after:h-[2px] after:rounded after:transition-transform after:origin-left',
+      active
+        ? 'text-stone-600 dark:text-stone-400 font-semibold after:bg-stone-500 after:scale-x-100'
+        : 'text-zinc-700 dark:text-zinc-300 hover:text-emerald-600 dark:hover:text-emerald-400 after:scale-x-0',
     ]}
     aria-haspopup="true"
     aria-expanded="false"

--- a/src/components/MobileBottomBar.astro
+++ b/src/components/MobileBottomBar.astro
@@ -1,0 +1,154 @@
+---
+import { t, getLocalizedPath, routes, type Locale } from '../i18n/utils';
+import { getFabTarget, isActiveSection } from '../lib/chrome-helpers';
+
+interface Props {
+  lang: 'en' | 'es';
+  currentPath: string;
+}
+const { lang, currentPath } = Astro.props;
+const tr = t(lang);
+const locale = lang as Locale;
+
+const fab = getFabTarget(currentPath, lang);
+
+// Build href helpers — these read from `routes` so they stay symmetric across locales.
+const explorePath = getLocalizedPath(lang, routes.explore[locale] + '/');
+const exploreRecentPath = getLocalizedPath(lang, routes.exploreRecent[locale] + '/');
+const chatPath    = getLocalizedPath(lang, routes.chat[locale] + '/');
+const profilePath = getLocalizedPath(lang, routes.profile[locale] + '/');
+const homePath    = getLocalizedPath(lang, '/');
+const identifyPath = getLocalizedPath(lang, routes.identify[locale] + '/');
+const exploreMapPath = getLocalizedPath(lang, routes.exploreMap[locale] + '/');
+const signInPath  = getLocalizedPath(lang, routes.signIn[locale] + '/');
+
+// Active-state precomputes (so the markup stays tidy)
+const obsActive  = isActiveSection(currentPath, 'observe',  lang);
+const expActive  = isActiveSection(currentPath, 'explore',  lang);
+const chatActive = isActiveSection(currentPath, 'chat',     lang);
+const profActive = isActiveSection(currentPath, 'profile',  lang);
+const homeActive = isActiveSection(currentPath, 'home',     lang);
+const idActive   = isActiveSection(currentPath, 'identify', lang);
+---
+
+<!--
+  Mobile bottom bar. Two layouts driven by auth state, swapped by the
+  inline script below: the signed-in 5-slot version (Explore · Chat ·
+  [FAB] · Recent · Profile) and the signed-out 4-slot version (Home ·
+  Identify · Map · Sign in) — sacred geometry: the FAB only appears
+  when it means "observe."
+-->
+<nav
+  id="mobile-bottom-bar"
+  class="sm:hidden fixed inset-x-0 bottom-0 z-40 border-t border-zinc-200 dark:border-zinc-800 bg-white/90 dark:bg-zinc-950/90 backdrop-blur"
+  style="padding-bottom: max(env(safe-area-inset-bottom), 0px);"
+  aria-label={tr.nav.bottom.observe}
+>
+  <!-- Signed-in: 5 slots, center FAB -->
+  <div id="mbb-authed" class="hidden grid grid-cols-5 items-end h-16 relative">
+    <a href={explorePath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      expActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]} data-tour="explore-tab">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-1.447-.894L15 9m0 8V9"/></svg>
+      <span>{tr.nav.bottom.explore}</span>
+    </a>
+    <a href={chatPath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      chatActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]}>
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.83L3 20l1.41-3.18A8 8 0 0121 12z"/></svg>
+      <span>{tr.nav.bottom.chat}</span>
+    </a>
+
+    <!-- FAB slot -->
+    <div class="relative">
+      <a
+        href={fab.href}
+        data-tour="fab"
+        aria-label={fab.mode === 'quick-id' ? tr.nav.bottom.fab_quick_id_label : tr.nav.bottom.fab_observe_label}
+        class="absolute left-1/2 -translate-x-1/2 -top-7 w-14 h-14 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white flex items-center justify-center shadow-lg ring-4 ring-white dark:ring-zinc-950 motion-reduce:transition-none transition-transform active:scale-95"
+      >
+        <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+        {fab.mode === 'quick-id' && (
+          <span aria-hidden="true" class="absolute -top-1 -right-1 w-5 h-5 bg-yellow-400 text-zinc-900 rounded-full flex items-center justify-center text-[10px] font-bold border-2 border-white dark:border-zinc-950">⚡</span>
+        )}
+      </a>
+      <span class="absolute left-1/2 -translate-x-1/2 top-9 text-[9px] text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+        {fab.mode === 'quick-id' ? tr.nav.bottom.quick_id : tr.nav.bottom.observe}
+      </span>
+    </div>
+
+    <a href={exploreRecentPath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      currentPath.includes('/explore/recent') || currentPath.includes('/explorar/recientes')
+        ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]}>
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      <span>{tr.nav.bottom.recent}</span>
+    </a>
+    <a href={profilePath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      profActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]}>
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      <span>{tr.nav.bottom.profile}</span>
+    </a>
+  </div>
+
+  <!-- Signed-out: 4-tab no-FAB layout -->
+  <div id="mbb-anon" class="grid grid-cols-4 items-end h-16">
+    <a href={homePath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      homeActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]}>
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 12l9-9 9 9M5 10v10a1 1 0 001 1h3v-7h6v7h3a1 1 0 001-1V10"/></svg>
+      <span>{tr.nav.bottom.home}</span>
+    </a>
+    <a href={identifyPath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      idActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]}>
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+      <span>{tr.nav.bottom.identify}</span>
+    </a>
+    <a href={exploreMapPath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      expActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]}>
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-1.447-.894L15 9m0 8V9"/></svg>
+      <span>{tr.nav.bottom.explore}</span>
+    </a>
+    <a href={signInPath} class="flex flex-col items-center justify-center gap-0.5 py-1 text-[10px] text-emerald-600 dark:text-emerald-400">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H9m-4 8H4a1 1 0 01-1-1V5a1 1 0 011-1h1"/></svg>
+      <span>{tr.nav.bottom.sign_in}</span>
+    </a>
+  </div>
+</nav>
+
+<!--
+  Auth-state swap. Mirrors the existing pattern in Header.astro: read the
+  Supabase session, toggle visibility for the signed-in vs signed-out
+  layout. The `mbb-anon` block is shown by default so the layout never
+  flashes empty.
+-->
+<script>
+  import { getSupabase } from '../lib/supabase';
+
+  const authed = document.getElementById('mbb-authed');
+  const anon   = document.getElementById('mbb-anon');
+
+  function paint(hasSession: boolean) {
+    if (!authed || !anon) return;
+    authed.classList.toggle('hidden', !hasSession);
+    anon.classList.toggle('hidden',   hasSession);
+  }
+
+  (async () => {
+    try {
+      const { data: { session } } = await getSupabase().auth.getSession();
+      paint(!!session);
+      getSupabase().auth.onAuthStateChange((_e, s) => paint(!!s));
+    } catch { /* env not set; leave anon visible */ }
+  })();
+</script>

--- a/src/components/MobileBottomBar.astro
+++ b/src/components/MobileBottomBar.astro
@@ -23,12 +23,13 @@ const exploreMapPath = getLocalizedPath(lang, routes.exploreMap[locale] + '/');
 const signInPath  = getLocalizedPath(lang, routes.signIn[locale] + '/');
 
 // Active-state precomputes (so the markup stays tidy)
-const obsActive  = isActiveSection(currentPath, 'observe',  lang);
-const expActive  = isActiveSection(currentPath, 'explore',  lang);
-const chatActive = isActiveSection(currentPath, 'chat',     lang);
-const profActive = isActiveSection(currentPath, 'profile',  lang);
-const homeActive = isActiveSection(currentPath, 'home',     lang);
-const idActive   = isActiveSection(currentPath, 'identify', lang);
+const obsActive    = isActiveSection(currentPath, 'observe',       lang);
+const expActive    = isActiveSection(currentPath, 'explore',       lang);
+const chatActive   = isActiveSection(currentPath, 'chat',          lang);
+const profActive   = isActiveSection(currentPath, 'profile',       lang);
+const homeActive   = isActiveSection(currentPath, 'home',          lang);
+const idActive     = isActiveSection(currentPath, 'identify',      lang);
+const recentActive = isActiveSection(currentPath, 'exploreRecent', lang);
 ---
 
 <!--
@@ -81,8 +82,7 @@ const idActive   = isActiveSection(currentPath, 'identify', lang);
 
     <a href={exploreRecentPath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
-      currentPath.includes('/explore/recent') || currentPath.includes('/explorar/recientes')
-        ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+      recentActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]}>
       <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
       <span>{tr.nav.bottom.recent}</span>

--- a/src/components/MobileBottomBar.astro
+++ b/src/components/MobileBottomBar.astro
@@ -50,14 +50,14 @@ const idActive   = isActiveSection(currentPath, 'identify', lang);
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
       expActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]} data-tour="explore-tab">
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-1.447-.894L15 9m0 8V9"/></svg>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-1.447-.894L15 9m0 8V9"/></svg>
       <span>{tr.nav.bottom.explore}</span>
     </a>
     <a href={chatPath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
       chatActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]}>
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.83L3 20l1.41-3.18A8 8 0 0121 12z"/></svg>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.83L3 20l1.41-3.18A8 8 0 0121 12z"/></svg>
       <span>{tr.nav.bottom.chat}</span>
     </a>
 
@@ -69,7 +69,7 @@ const idActive   = isActiveSection(currentPath, 'identify', lang);
         aria-label={fab.mode === 'quick-id' ? tr.nav.bottom.fab_quick_id_label : tr.nav.bottom.fab_observe_label}
         class="absolute left-1/2 -translate-x-1/2 -top-7 w-14 h-14 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white flex items-center justify-center shadow-lg ring-4 ring-white dark:ring-zinc-950 motion-reduce:transition-none transition-transform active:scale-95"
       >
-        <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+        <svg aria-hidden="true" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
         {fab.mode === 'quick-id' && (
           <span aria-hidden="true" class="absolute -top-1 -right-1 w-5 h-5 bg-yellow-400 text-zinc-900 rounded-full flex items-center justify-center text-[10px] font-bold border-2 border-white dark:border-zinc-950">⚡</span>
         )}
@@ -84,14 +84,14 @@ const idActive   = isActiveSection(currentPath, 'identify', lang);
       currentPath.includes('/explore/recent') || currentPath.includes('/explorar/recientes')
         ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]}>
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
       <span>{tr.nav.bottom.recent}</span>
     </a>
     <a href={profilePath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
       profActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]}>
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
       <span>{tr.nav.bottom.profile}</span>
     </a>
   </div>
@@ -102,25 +102,25 @@ const idActive   = isActiveSection(currentPath, 'identify', lang);
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
       homeActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]}>
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 12l9-9 9 9M5 10v10a1 1 0 001 1h3v-7h6v7h3a1 1 0 001-1V10"/></svg>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 12l9-9 9 9M5 10v10a1 1 0 001 1h3v-7h6v7h3a1 1 0 001-1V10"/></svg>
       <span>{tr.nav.bottom.home}</span>
     </a>
     <a href={identifyPath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
       idActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]}>
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
       <span>{tr.nav.bottom.identify}</span>
     </a>
     <a href={exploreMapPath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
       expActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]}>
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-1.447-.894L15 9m0 8V9"/></svg>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-1.447-.894L15 9m0 8V9"/></svg>
       <span>{tr.nav.bottom.explore}</span>
     </a>
     <a href={signInPath} class="flex flex-col items-center justify-center gap-0.5 py-1 text-[10px] text-emerald-600 dark:text-emerald-400">
-      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H9m-4 8H4a1 1 0 01-1-1V5a1 1 0 011-1h1"/></svg>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H9m-4 8H4a1 1 0 01-1-1V5a1 1 0 011-1h1"/></svg>
       <span>{tr.nav.bottom.sign_in}</span>
     </a>
   </div>

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -112,7 +112,7 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
       </div>
       <div class="flex items-center justify-between py-1.5">
         <span>{tr.nav.drawer.theme}</span>
-        <button id="drawer-theme-toggle" class="p-1.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Toggle theme">
+        <button id="drawer-theme-toggle" class="p-1.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label={tr.nav.drawer.toggle_theme}>
           <svg aria-hidden="true" class="w-5 h-5 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
           <svg aria-hidden="true" class="w-5 h-5 block dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
         </button>

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -1,0 +1,179 @@
+---
+import { t, getLocalizedPath, getDocPath, getAlternateLocale, routes, docPages, type Locale } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+  currentPath: string;
+}
+const { lang, currentPath } = Astro.props;
+const tr = t(lang);
+const alt = getAlternateLocale(lang);
+const locale = lang as Locale;
+
+// alt-language href for the segmented switch
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const pathWithoutBase = currentPath.replace(base, '') || '/';
+const segments = pathWithoutBase.split('/').filter(Boolean);
+const currentLang = segments[0] || lang;
+const currentSlug = '/' + (segments.slice(1).join('/') || '');
+const matchedKey = Object.keys(routes).find(key => {
+  const slug = routes[key][currentLang as Locale] || '';
+  return slug === currentSlug || (currentSlug === '/' && slug === '');
+});
+const altSlug = matchedKey ? (routes[matchedKey][alt] || '') : currentSlug;
+const altHref = `${base}/${alt}${altSlug}/`;
+
+const aboutPath = getLocalizedPath(lang, routes.about[locale] + '/');
+const signInPath = getLocalizedPath(lang, routes.signIn[locale] + '/');
+const profilePath = getLocalizedPath(lang, routes.profile[locale] + '/');
+
+const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>)[key] || key;
+---
+
+<!-- Off-canvas drawer for mobile (<sm). Hidden until ≡ in the header is tapped. -->
+<div
+  id="mobile-drawer-backdrop"
+  class="hidden fixed inset-0 z-50 sm:hidden bg-black/60"
+  aria-hidden="true"
+></div>
+<aside
+  id="mobile-drawer"
+  class="hidden fixed top-0 right-0 bottom-0 z-50 sm:hidden w-[260px] bg-white dark:bg-zinc-950 border-l border-zinc-200 dark:border-zinc-800 overflow-y-auto"
+  role="dialog"
+  aria-modal="true"
+  aria-label={tr.nav.drawer.open_menu}
+>
+  <div class="flex items-center justify-between p-3 border-b border-zinc-200 dark:border-zinc-800">
+    <span class="text-emerald-600 dark:text-emerald-400 font-bold flex items-center gap-2">
+      <img src="/rastrum-logo.svg" alt="" class="w-6 h-6" />
+      Rastrum
+    </span>
+    <button
+      id="mobile-drawer-close"
+      class="p-2 -mr-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800"
+      aria-label={tr.nav.drawer.close_menu}
+    >
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+    </button>
+  </div>
+
+  <div class="p-4 space-y-5 text-sm">
+    <!-- Reference -->
+    <section>
+      <p class="text-xs font-semibold text-emerald-600 dark:text-emerald-400 uppercase tracking-wider mb-2">{tr.nav.drawer.reference}</p>
+      <a href={aboutPath} class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{tr.nav.about}</a>
+      <details class="group">
+        <summary class="flex items-center justify-between py-1.5 cursor-pointer list-none">
+          <span>{tr.nav.docs}</span>
+          <svg aria-hidden="true" class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+        </summary>
+        <div class="mt-1 ml-2 space-y-1 border-l border-zinc-200 dark:border-zinc-800 pl-3">
+          <a href={getDocPath(lang)} class="block py-1 text-zinc-700 dark:text-zinc-300 hover:text-emerald-600 dark:hover:text-emerald-400">
+            {tr.docs.back_to_docs}
+          </a>
+          {docPages.map(page => (
+            <a
+              href={getDocPath(lang, page)}
+              class="block py-1 text-zinc-600 dark:text-zinc-400 hover:text-emerald-600 dark:hover:text-emerald-400"
+            >
+              {getDocLabel(page)}
+            </a>
+          ))}
+        </div>
+      </details>
+    </section>
+
+    <!-- Account: signed-in branch -->
+    <section id="drawer-authed" class="hidden">
+      <p class="text-xs font-semibold text-emerald-600 dark:text-emerald-400 uppercase tracking-wider mb-2">{tr.nav.drawer.account}</p>
+      <a href={profilePath} class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{tr.profile.view_profile}</a>
+      <button id="drawer-sign-out" class="block w-full text-left py-1.5 text-red-600 dark:text-red-400 hover:text-red-700">{tr.auth.sign_out}</button>
+    </section>
+
+    <!-- Account: signed-out branch -->
+    <section id="drawer-anon">
+      <p class="text-xs font-semibold text-emerald-600 dark:text-emerald-400 uppercase tracking-wider mb-2">{tr.nav.drawer.account}</p>
+      <a href={signInPath} class="block py-1.5 text-emerald-700 dark:text-emerald-400">{tr.auth.sign_in}</a>
+    </section>
+
+    <!-- Preferences (lang + theme shortcuts) -->
+    <section>
+      <p class="text-xs font-semibold text-emerald-600 dark:text-emerald-400 uppercase tracking-wider mb-2">{tr.nav.drawer.preferences}</p>
+      <div class="flex items-center justify-between py-1.5">
+        <span>{tr.nav.drawer.language}</span>
+        <a
+          href={altHref}
+          data-target-lang={alt}
+          id="drawer-lang-toggle"
+          class="text-xs px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700"
+        >
+          {alt.toUpperCase()}
+        </a>
+      </div>
+      <div class="flex items-center justify-between py-1.5">
+        <span>{tr.nav.drawer.theme}</span>
+        <button id="drawer-theme-toggle" class="p-1.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Toggle theme">
+          <svg aria-hidden="true" class="w-5 h-5 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+          <svg aria-hidden="true" class="w-5 h-5 block dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+        </button>
+      </div>
+    </section>
+  </div>
+</aside>
+
+<script>
+  import { getSupabase } from '../lib/supabase';
+  import { signOut } from '../lib/auth';
+
+  const drawer   = document.getElementById('mobile-drawer');
+  const backdrop = document.getElementById('mobile-drawer-backdrop');
+  const closeBtn = document.getElementById('mobile-drawer-close');
+  const authed   = document.getElementById('drawer-authed');
+  const anon     = document.getElementById('drawer-anon');
+  const signOutBtn = document.getElementById('drawer-sign-out');
+  const themeBtn = document.getElementById('drawer-theme-toggle');
+  const langTog  = document.getElementById('drawer-lang-toggle') as HTMLAnchorElement | null;
+
+  function open() {
+    drawer?.classList.remove('hidden');
+    backdrop?.classList.remove('hidden');
+    document.documentElement.style.overflow = 'hidden';
+  }
+  function close() {
+    drawer?.classList.add('hidden');
+    backdrop?.classList.add('hidden');
+    document.documentElement.style.overflow = '';
+  }
+
+  // Public hook for Header.astro's hamburger button.
+  (window as Window & { __rastrumOpenDrawer?: () => void }).__rastrumOpenDrawer = open;
+
+  closeBtn?.addEventListener('click', close);
+  backdrop?.addEventListener('click', close);
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+
+  // Auth-state swap, same shape as MobileBottomBar
+  function paintAuth(has: boolean) {
+    authed?.classList.toggle('hidden', !has);
+    anon?.classList.toggle('hidden',  has);
+  }
+  (async () => {
+    try {
+      const { data: { session } } = await getSupabase().auth.getSession();
+      paintAuth(!!session);
+      getSupabase().auth.onAuthStateChange((_e, s) => paintAuth(!!s));
+    } catch { /* env not set */ }
+  })();
+
+  signOutBtn?.addEventListener('click', async () => { await signOut(); window.location.reload(); });
+
+  themeBtn?.addEventListener('click', () => {
+    const dark = document.documentElement.classList.toggle('dark');
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  });
+
+  langTog?.addEventListener('click', () => {
+    const target = langTog.dataset.targetLang;
+    if (target) localStorage.setItem('rastrum.lang', target);
+  });
+</script>

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -33,6 +33,9 @@ const cameraStarting    = observeStrings.camera_starting     ?? (isEs ? 'Inician
 const videoRecord       = observeStrings.video_record        ?? (isEs ? 'Grabar video' : 'Record video');
 const videoLabel        = observeStrings.video_label         ?? 'Video';
 const videoMaxDuration  = observeStrings.video_max_duration  ?? (isEs ? 'Máximo 30 segundos' : 'Maximum 30 seconds');
+const gpsErrPermission  = observeStrings.gps_error_permission_denied ?? (isEs ? 'Permiso de ubicación denegado. Actívalo en ajustes.' : 'Location permission denied. Enable it in settings.');
+const gpsErrUnavailable = observeStrings.gps_error_unavailable       ?? (isEs ? 'Ubicación no disponible.' : 'Location unavailable.');
+const gpsErrTimeout     = observeStrings.gps_error_timeout           ?? (isEs ? 'Tiempo de espera agotado.' : 'Location timed out.');
 ---
 
 <div class="max-w-xl mx-auto">
@@ -164,7 +167,11 @@ const videoMaxDuration  = observeStrings.video_max_duration  ?? (isEs ? 'Máximo
     <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">{tr.observe.gps_label}</label>
       <div id="gps-display" class="rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 px-3 py-2 text-sm">
-        <span id="gps-status" class="text-zinc-500">{tr.observe.gps_getting}</span>
+        <span id="gps-status" class="text-zinc-500"
+          data-err-permission={gpsErrPermission}
+          data-err-unavailable={gpsErrUnavailable}
+          data-err-timeout={gpsErrTimeout}
+        >{tr.observe.gps_getting}</span>
       </div>
       <div id="gps-manual-wrap" class="hidden mt-2 grid grid-cols-2 gap-2">
         <input id="manual-lat" name="lat" type="number" step="any" placeholder="Lat" class="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-base" />
@@ -1094,11 +1101,11 @@ const videoMaxDuration  = observeStrings.video_max_duration  ?? (isEs ? 'Máximo
 
   function showGpsError(code: number) {
     if (!gpsStatus) return;
-    const obs = tr.observe as Record<string, string>;
+    const d = (gpsStatus as HTMLElement).dataset;
     let msg: string;
-    if (code === 1)      msg = obs.gps_error_permission_denied;
-    else if (code === 2) msg = obs.gps_error_unavailable;
-    else                 msg = obs.gps_error_timeout;
+    if (code === 1)      msg = d.errPermission ?? '';
+    else if (code === 2) msg = d.errUnavailable ?? '';
+    else                 msg = d.errTimeout ?? '';
     gpsStatus.textContent = msg;
     gpsStatus.className = 'text-amber-700 dark:text-amber-400 text-xs';
     // Auto-reveal manual entry — that's the recovery path the message

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -71,12 +71,12 @@ const videoMaxDuration  = observeStrings.video_max_duration  ?? (isEs ? 'Máximo
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
           {tr.observe.use_camera}
         </button>
-        <input id="camera-input" type="file" accept="image/*" capture="environment" class="sr-only" />
+        <input id="camera-input" type="file" accept="image/*" capture="environment" class="sr-only" aria-label={isEs ? 'Tomar foto' : 'Take photo'} />
         <button id="gallery-btn" type="button" class="flex-1 cursor-pointer min-h-11 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 text-center hover:bg-zinc-50 dark:hover:bg-zinc-800/40 flex items-center justify-center gap-2">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 5h16v14H4z"/><path stroke-linecap="round" stroke-linejoin="round" d="m4 16 4-4 4 4 3-3 5 5"/><circle cx="9" cy="9" r="1.5" fill="currentColor"/></svg>
           {tr.observe.choose_file}
         </button>
-        <input id="gallery-input" type="file" accept="image/*" multiple class="sr-only" />
+        <input id="gallery-input" type="file" accept="image/*" multiple class="sr-only" aria-label={isEs ? 'Subir de galería' : 'Upload from gallery'} />
       </div>
       <p class="mt-1 text-xs text-zinc-500">{tr.observe.photo_hint}</p>
       <p id="photo-hint-android" class="hidden mt-1 text-xs text-amber-700 dark:text-amber-400">{observeStrings.photo_hint_android}</p>

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -74,12 +74,12 @@ const gpsErrTimeout     = observeStrings.gps_error_timeout           ?? (isEs ? 
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
           {tr.observe.use_camera}
         </button>
-        <input id="camera-input" type="file" accept="image/*" capture="environment" class="sr-only" aria-label={isEs ? 'Tomar foto' : 'Take photo'} />
+        <input id="camera-input" type="file" accept="image/*" capture="environment" class="sr-only" aria-label={tr.observe.use_camera} />
         <button id="gallery-btn" type="button" class="flex-1 cursor-pointer min-h-11 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 text-center hover:bg-zinc-50 dark:hover:bg-zinc-800/40 flex items-center justify-center gap-2">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 5h16v14H4z"/><path stroke-linecap="round" stroke-linejoin="round" d="m4 16 4-4 4 4 3-3 5 5"/><circle cx="9" cy="9" r="1.5" fill="currentColor"/></svg>
           {tr.observe.choose_file}
         </button>
-        <input id="gallery-input" type="file" accept="image/*" multiple class="sr-only" aria-label={isEs ? 'Subir de galería' : 'Upload from gallery'} />
+        <input id="gallery-input" type="file" accept="image/*" multiple class="sr-only" aria-label={tr.observe.choose_file} />
       </div>
       <p class="mt-1 text-xs text-zinc-500">{tr.observe.photo_hint}</p>
       <p id="photo-hint-android" class="hidden mt-1 text-xs text-amber-700 dark:text-amber-400">{observeStrings.photo_hint_android}</p>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -46,7 +46,8 @@
       "language":     "Language",
       "theme":        "Theme",
       "open_menu":    "Open menu",
-      "close_menu":   "Close menu"
+      "close_menu":   "Close menu",
+      "toggle_theme": "Toggle theme"
     },
     "bottom": {
       "explore":  "Explore",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -11,7 +11,56 @@
     "map": "Map",
     "about": "About",
     "docs": "Docs",
-    "chat": "Chat"
+    "chat": "Chat",
+    "tagline": "Biodiversity, observed in your language.",
+    "explore_dropdown": {
+      "map": "Map",
+      "recent": "Recent",
+      "watchlist": "Watchlist",
+      "species": "Species"
+    },
+    "docs_groups": {
+      "product": "Product",
+      "progress": "Progress",
+      "community": "Community",
+      "product_items": {
+        "vision":       "Vision",
+        "features":     "Features",
+        "architecture": "Architecture"
+      },
+      "progress_items": {
+        "roadmap": "Roadmap",
+        "tasks":   "Tasks",
+        "market":  "Market"
+      },
+      "community_items": {
+        "indigenous": "Indigenous",
+        "funding":    "Funding",
+        "contribute": "Contribute"
+      }
+    },
+    "drawer": {
+      "reference":    "Reference",
+      "account":      "Account",
+      "preferences":  "Preferences",
+      "language":     "Language",
+      "theme":        "Theme",
+      "open_menu":    "Open menu",
+      "close_menu":   "Close menu"
+    },
+    "bottom": {
+      "explore":  "Explore",
+      "chat":     "Chat",
+      "observe":  "Observe",
+      "quick_id": "Quick ID",
+      "recent":   "Recent",
+      "profile":  "Profile",
+      "home":     "Home",
+      "identify": "Identify",
+      "sign_in":  "Sign in",
+      "fab_observe_label":  "Start observation",
+      "fab_quick_id_label": "Quick identify"
+    }
   },
   "home": {
     "hero_title": "Identify any living thing — anywhere",
@@ -733,5 +782,23 @@
     "days": "days",
     "year": "year",
     "create": "Create token"
+  },
+  "explore_pages": {
+    "recent": {
+      "title":       "Recent observations",
+      "subtitle":    "What's been spotted around you, lately.",
+      "empty":       "No recent public observations yet — be the first."
+    },
+    "watchlist": {
+      "title":       "Watchlist",
+      "subtitle":    "Species and places you're following.",
+      "empty":       "Add a species or place to follow it here.",
+      "moved_note":  "Watchlist moved here from your profile — same data, public-facing home."
+    },
+    "species": {
+      "title":       "Species",
+      "subtitle":    "Per-species pages are on the way.",
+      "coming_soon": "Coming in a future release. In the meantime, browse the map or your watchlist."
+    }
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -46,7 +46,8 @@
       "language":    "Idioma",
       "theme":       "Tema",
       "open_menu":   "Abrir menú",
-      "close_menu":  "Cerrar menú"
+      "close_menu":  "Cerrar menú",
+      "toggle_theme": "Cambiar tema"
     },
     "bottom": {
       "explore":  "Explorar",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -9,9 +9,58 @@
     "observe": "Observar",
     "explore": "Explorar",
     "map": "Mapa",
-    "about": "Acerca de",
+    "about": "Acerca",
     "docs": "Docs",
-    "chat": "Chat"
+    "chat": "Chat",
+    "tagline": "Biodiversidad, observada en tu idioma.",
+    "explore_dropdown": {
+      "map":       "Mapa",
+      "recent":    "Recientes",
+      "watchlist": "Seguimiento",
+      "species":   "Especies"
+    },
+    "docs_groups": {
+      "product":   "Producto",
+      "progress":  "Progreso",
+      "community": "Comunidad",
+      "product_items": {
+        "vision":       "Visión",
+        "features":     "Funcionalidades",
+        "architecture": "Arquitectura"
+      },
+      "progress_items": {
+        "roadmap": "Hoja de ruta",
+        "tasks":   "Tareas",
+        "market":  "Mercado"
+      },
+      "community_items": {
+        "indigenous": "Lenguas indígenas",
+        "funding":    "Financiamiento",
+        "contribute": "Contribuir"
+      }
+    },
+    "drawer": {
+      "reference":   "Referencia",
+      "account":     "Cuenta",
+      "preferences": "Preferencias",
+      "language":    "Idioma",
+      "theme":       "Tema",
+      "open_menu":   "Abrir menú",
+      "close_menu":  "Cerrar menú"
+    },
+    "bottom": {
+      "explore":  "Explorar",
+      "chat":     "Chat",
+      "observe":  "Observar",
+      "quick_id": "ID rápida",
+      "recent":   "Recientes",
+      "profile":  "Perfil",
+      "home":     "Inicio",
+      "identify": "Identificar",
+      "sign_in":  "Ingresar",
+      "fab_observe_label":  "Iniciar observación",
+      "fab_quick_id_label": "Identificación rápida"
+    }
   },
   "home": {
     "hero_title": "Identifica cualquier ser vivo — donde sea",
@@ -733,5 +782,23 @@
     "days": "días",
     "year": "año",
     "create": "Crear token"
+  },
+  "explore_pages": {
+    "recent": {
+      "title":       "Observaciones recientes",
+      "subtitle":    "Lo que se ha visto cerca de ti, recientemente.",
+      "empty":       "Aún no hay observaciones públicas recientes — sé el primero."
+    },
+    "watchlist": {
+      "title":       "Seguimiento",
+      "subtitle":    "Especies y lugares que estás siguiendo.",
+      "empty":       "Agrega una especie o lugar para seguirlo aquí.",
+      "moved_note":  "El seguimiento se movió aquí desde tu perfil — mismos datos, ahora público."
+    },
+    "species": {
+      "title":       "Especies",
+      "subtitle":    "Las páginas por especie están en camino.",
+      "coming_soon": "Llegará en una versión futura. Mientras tanto, explora el mapa o tu lista de seguimiento."
+    }
   }
 }

--- a/src/i18n/route-tree.test.ts
+++ b/src/i18n/route-tree.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { routeTree, getRouteLabel, getRouteParent } from './utils';
+
+describe('routeTree', () => {
+  it('contains every route key in `routes`', async () => {
+    const { routes } = await import('./utils');
+    for (const key of Object.keys(routes)) {
+      expect(routeTree[key], `missing routeTree entry for ${key}`).toBeDefined();
+    }
+  });
+
+  it('maps explore subroutes to the explore parent', () => {
+    expect(getRouteParent('exploreMap')).toBe('explore');
+    expect(getRouteParent('exploreRecent')).toBe('explore');
+    expect(getRouteParent('exploreWatchlist')).toBe('explore');
+    expect(getRouteParent('exploreSpecies')).toBe('explore');
+  });
+
+  it('returns localized labels for known routes', () => {
+    expect(getRouteLabel('observe', 'en')).toBe('Observe');
+    expect(getRouteLabel('observe', 'es')).toBe('Observar');
+    expect(getRouteLabel('exploreMap', 'en')).toBe('Map');
+    expect(getRouteLabel('exploreMap', 'es')).toBe('Mapa');
+  });
+
+  it('falls back to the route key when no label is registered', () => {
+    expect(getRouteLabel('definitely-not-a-route', 'en')).toBe('definitely-not-a-route');
+  });
+
+  it('top-level routes have no parent', () => {
+    expect(getRouteParent('observe')).toBeUndefined();
+    expect(getRouteParent('chat')).toBeUndefined();
+  });
+});

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -26,6 +26,10 @@ export const routes: Record<string, Record<Locale, string>> = {
   home: { en: '', es: '' },
   identify: { en: '/identify', es: '/identificar' },
   explore: { en: '/explore', es: '/explorar' },
+  exploreMap: { en: '/explore/map', es: '/explorar/mapa' },
+  exploreRecent: { en: '/explore/recent', es: '/explorar/recientes' },
+  exploreWatchlist: { en: '/explore/watchlist', es: '/explorar/seguimiento' },
+  exploreSpecies: { en: '/explore/species', es: '/explorar/especies' },
   observe: { en: '/observe', es: '/observar' },
   about: { en: '/about', es: '/acerca' },
   docs: { en: '/docs', es: '/docs' },
@@ -62,4 +66,54 @@ export function getDocPath(lang: string, page?: string) {
 
 export function getAlternateLocale(lang: string): Locale {
   return lang === 'es' ? 'en' : 'es';
+}
+
+// ---------------------------------------------------------------------------
+// Route tree — single source for nav labels + parent relationships.
+// Consumed by the chrome (mega-menu, mobile drawer), and from PR 3 onward by
+// breadcrumbs and (PR 4) the search index.
+// ---------------------------------------------------------------------------
+
+export interface RouteNode {
+  /** Human-readable labels per locale. Falls back to the route key. */
+  labels: Record<Locale, string>;
+  /** Optional parent route key — used by breadcrumbs (PR 3) and IA grouping. */
+  parent?: string;
+}
+
+export const routeTree: Record<string, RouteNode> = {
+  home:        { labels: { en: 'Home',         es: 'Inicio' } },
+  identify:    { labels: { en: 'Identify',     es: 'Identificar' } },
+  observe:     { labels: { en: 'Observe',      es: 'Observar' } },
+  explore:     { labels: { en: 'Explore',      es: 'Explorar' } },
+  exploreMap:        { labels: { en: 'Map',       es: 'Mapa' },         parent: 'explore' },
+  exploreRecent:     { labels: { en: 'Recent',    es: 'Recientes' },    parent: 'explore' },
+  exploreWatchlist:  { labels: { en: 'Watchlist', es: 'Seguimiento' },  parent: 'explore' },
+  exploreSpecies:    { labels: { en: 'Species',   es: 'Especies' },     parent: 'explore' },
+  chat:        { labels: { en: 'Chat',          es: 'Chat' } },
+  about:       { labels: { en: 'About',         es: 'Acerca' } },
+  docs:        { labels: { en: 'Docs',          es: 'Docs' } },
+  signIn:      { labels: { en: 'Sign in',       es: 'Ingresar' } },
+  profile:     { labels: { en: 'Profile',       es: 'Perfil' } },
+  profileEdit:               { labels: { en: 'Edit profile',     es: 'Editar perfil' },     parent: 'profile' },
+  profileExport:             { labels: { en: 'Export',           es: 'Exportar' },          parent: 'profile' },
+  profileObservations:       { labels: { en: 'My observations',  es: 'Mis observaciones' }, parent: 'profile' },
+  profileExpertApply:        { labels: { en: 'Apply expert',     es: 'Aplicar experto' },   parent: 'profile' },
+  profileUser:               { labels: { en: 'Public profile',   es: 'Perfil público' },    parent: 'profile' },
+  profileImport:             { labels: { en: 'Import',           es: 'Importar' },          parent: 'profile' },
+  profileImportCameraTrap:   { labels: { en: 'Camera trap',      es: 'Cámara trampa' },     parent: 'profileImport' },
+  privacy:     { labels: { en: 'Privacy',       es: 'Privacidad' } },
+  terms:       { labels: { en: 'Terms',         es: 'Términos' } },
+  faq:         { labels: { en: 'FAQ',           es: 'Preguntas frecuentes' } },
+};
+
+export function getRouteLabel(key: string, lang: string): string {
+  const node = routeTree[key];
+  if (!node) return key;
+  const locale: Locale = lang === 'es' ? 'es' : 'en';
+  return node.labels[locale];
+}
+
+export function getRouteParent(key: string): string | undefined {
+  return routeTree[key]?.parent;
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -47,7 +47,7 @@ const installLang: 'en' | 'es' = lang === 'es' ? 'es' : 'en';
       }
     </script>
   </head>
-  <body class="min-h-screen bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100 transition-colors">
+  <body class="min-h-screen bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100 transition-colors pb-20 sm:pb-0">
     <Header lang={lang} currentPath={currentPath} />
     <main class="max-w-5xl mx-auto px-4 py-8">
       <slot />

--- a/src/lib/chrome-helpers.test.ts
+++ b/src/lib/chrome-helpers.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { getFabTarget, isActiveSection } from './chrome-helpers';
+
+describe('getFabTarget', () => {
+  it('default: any non-observe page → /observe (auth-respecting)', () => {
+    expect(getFabTarget('/en/explore/map/', 'en')).toEqual({
+      href: '/en/observe/', mode: 'observe',
+    });
+    expect(getFabTarget('/en/profile/', 'en')).toEqual({
+      href: '/en/observe/', mode: 'observe',
+    });
+    expect(getFabTarget('/es/explorar/', 'es')).toEqual({
+      href: '/es/observar/', mode: 'observe',
+    });
+  });
+
+  it('on /observe (en) → /identify in quick mode', () => {
+    expect(getFabTarget('/en/observe/', 'en')).toEqual({
+      href: '/en/identify/', mode: 'quick-id',
+    });
+  });
+
+  it('on /observar (es) → /identificar in quick mode', () => {
+    expect(getFabTarget('/es/observar/', 'es')).toEqual({
+      href: '/es/identificar/', mode: 'quick-id',
+    });
+  });
+
+  it('handles missing trailing slash on observe', () => {
+    expect(getFabTarget('/en/observe', 'en').mode).toBe('quick-id');
+  });
+});
+
+describe('isActiveSection', () => {
+  it('observe matches /observe and /observar', () => {
+    expect(isActiveSection('/en/observe/', 'observe', 'en')).toBe(true);
+    expect(isActiveSection('/es/observar/', 'observe', 'es')).toBe(true);
+    expect(isActiveSection('/en/observe', 'observe', 'en')).toBe(true);
+  });
+
+  it('explore is active on any /explore subroute', () => {
+    expect(isActiveSection('/en/explore/', 'explore', 'en')).toBe(true);
+    expect(isActiveSection('/en/explore/map/', 'explore', 'en')).toBe(true);
+    expect(isActiveSection('/es/explorar/seguimiento/', 'explore', 'es')).toBe(true);
+  });
+
+  it('docs is active on any /docs subroute (both locales share /docs)', () => {
+    expect(isActiveSection('/en/docs/', 'docs', 'en')).toBe(true);
+    expect(isActiveSection('/en/docs/architecture/', 'docs', 'en')).toBe(true);
+    expect(isActiveSection('/es/docs/vision/', 'docs', 'es')).toBe(true);
+  });
+
+  it('does not cross-contaminate sections', () => {
+    expect(isActiveSection('/en/observe/', 'explore', 'en')).toBe(false);
+    expect(isActiveSection('/en/about/', 'docs', 'en')).toBe(false);
+  });
+
+  it('home only matches the bare locale path', () => {
+    expect(isActiveSection('/en/', 'home', 'en')).toBe(true);
+    expect(isActiveSection('/es/', 'home', 'es')).toBe(true);
+    expect(isActiveSection('/en/about/', 'home', 'en')).toBe(false);
+  });
+});

--- a/src/lib/chrome-helpers.ts
+++ b/src/lib/chrome-helpers.ts
@@ -1,0 +1,50 @@
+import { routes, type Locale } from '../i18n/utils';
+
+export interface FabTarget {
+  href: string;
+  /** 'observe' = full save flow; 'quick-id' = lightweight photo lookup. */
+  mode: 'observe' | 'quick-id';
+}
+
+/**
+ * Default = /observe. On /observe itself the FAB shifts to /identify (quick
+ * lookup, no save) so the camera button is never a no-op while still
+ * meaning "photo → identification."
+ */
+export function getFabTarget(pathname: string, lang: string): FabTarget {
+  const locale: Locale = lang === 'es' ? 'es' : 'en';
+  const base = import.meta.env?.BASE_URL?.replace(/\/$/, '') ?? '';
+  const observeSlug = routes.observe[locale];
+  const identifySlug = routes.identify[locale];
+
+  // Match /en/observe, /en/observe/, /es/observar, /es/observar/
+  const onObserve = pathname.replace(/\/$/, '') === `${base}/${locale}${observeSlug}`;
+
+  if (onObserve) {
+    return { href: `${base}/${locale}${identifySlug}/`, mode: 'quick-id' };
+  }
+  return { href: `${base}/${locale}${observeSlug}/`, mode: 'observe' };
+}
+
+/**
+ * Returns true when `currentPath` is inside the section identified by
+ * `sectionKey`. Used by Header.astro / MobileBottomBar.astro to render the
+ * active rail / active tab.
+ *
+ * Section keys mirror the top-level entries in `routes`/`routeTree`:
+ *   'home', 'observe', 'explore', 'chat', 'about', 'docs', 'profile'
+ */
+export function isActiveSection(currentPath: string, sectionKey: string, lang: string): boolean {
+  const locale: Locale = lang === 'es' ? 'es' : 'en';
+  const base = import.meta.env?.BASE_URL?.replace(/\/$/, '') ?? '';
+  const norm = currentPath.replace(/\/$/, '');
+  const localeRoot = `${base}/${locale}`;
+
+  if (sectionKey === 'home') {
+    return norm === localeRoot || norm === '';
+  }
+  const slug = routes[sectionKey]?.[locale];
+  if (slug === undefined) return false;
+  const sectionRoot = `${localeRoot}${slug}`;
+  return norm === sectionRoot || norm.startsWith(sectionRoot + '/');
+}

--- a/src/lib/chrome-mode.test.ts
+++ b/src/lib/chrome-mode.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { resolveChromeMode } from './chrome-mode';
 
 describe('resolveChromeMode', () => {
@@ -55,5 +55,31 @@ describe('resolveChromeMode', () => {
   it('handles missing trailing slash', () => {
     expect(resolveChromeMode('/en/observe')).toBe('app');
     expect(resolveChromeMode('/en/about')).toBe('read');
+  });
+});
+
+describe('resolveChromeMode with BASE_URL=/rastrum/', () => {
+  afterEach(() => {
+    // nothing to tear down — baseUrl is passed explicitly
+  });
+
+  it('observe under base is app-mode', () => {
+    expect(resolveChromeMode('/rastrum/en/observe/', '/rastrum/')).toBe('app');
+  });
+
+  it('observe (es) under base is app-mode', () => {
+    expect(resolveChromeMode('/rastrum/es/observar/', '/rastrum/')).toBe('app');
+  });
+
+  it('docs under base is read-mode', () => {
+    expect(resolveChromeMode('/rastrum/en/docs/', '/rastrum/')).toBe('read');
+  });
+
+  it('auth callback under base is app-mode', () => {
+    expect(resolveChromeMode('/rastrum/auth/callback/', '/rastrum/')).toBe('app');
+  });
+
+  it('home under base is read-mode', () => {
+    expect(resolveChromeMode('/rastrum/en/', '/rastrum/')).toBe('read');
   });
 });

--- a/src/lib/chrome-mode.test.ts
+++ b/src/lib/chrome-mode.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { resolveChromeMode } from './chrome-mode';
+
+describe('resolveChromeMode', () => {
+  it('home is read-mode', () => {
+    expect(resolveChromeMode('/en/')).toBe('read');
+    expect(resolveChromeMode('/es/')).toBe('read');
+  });
+
+  it('observe is app-mode (en + es)', () => {
+    expect(resolveChromeMode('/en/observe/')).toBe('app');
+    expect(resolveChromeMode('/es/observar/')).toBe('app');
+  });
+
+  it('explore and its subroutes are app-mode', () => {
+    expect(resolveChromeMode('/en/explore/')).toBe('app');
+    expect(resolveChromeMode('/en/explore/map/')).toBe('app');
+    expect(resolveChromeMode('/en/explore/recent/')).toBe('app');
+    expect(resolveChromeMode('/es/explorar/')).toBe('app');
+    expect(resolveChromeMode('/es/explorar/seguimiento/')).toBe('app');
+  });
+
+  it('chat is app-mode', () => {
+    expect(resolveChromeMode('/en/chat/')).toBe('app');
+    expect(resolveChromeMode('/es/chat/')).toBe('app');
+  });
+
+  it('profile and its subroutes are app-mode', () => {
+    expect(resolveChromeMode('/en/profile/')).toBe('app');
+    expect(resolveChromeMode('/en/profile/observations/')).toBe('app');
+    expect(resolveChromeMode('/en/profile/settings/profile/')).toBe('app');
+    expect(resolveChromeMode('/es/perfil/')).toBe('app');
+    expect(resolveChromeMode('/es/perfil/exportar/')).toBe('app');
+  });
+
+  it('auth callback is app-mode (no chrome distractions)', () => {
+    expect(resolveChromeMode('/auth/callback/')).toBe('app');
+  });
+
+  it('identify, about, docs, share are read-mode', () => {
+    expect(resolveChromeMode('/en/identify/')).toBe('read');
+    expect(resolveChromeMode('/es/identificar/')).toBe('read');
+    expect(resolveChromeMode('/en/about/')).toBe('read');
+    expect(resolveChromeMode('/es/acerca/')).toBe('read');
+    expect(resolveChromeMode('/en/docs/')).toBe('read');
+    expect(resolveChromeMode('/en/docs/architecture/')).toBe('read');
+    expect(resolveChromeMode('/share/obs/abc123/')).toBe('read');
+  });
+
+  it('unknown paths default to read', () => {
+    expect(resolveChromeMode('/something/totally/new/')).toBe('read');
+    expect(resolveChromeMode('')).toBe('read');
+  });
+
+  it('handles missing trailing slash', () => {
+    expect(resolveChromeMode('/en/observe')).toBe('app');
+    expect(resolveChromeMode('/en/about')).toBe('read');
+  });
+});

--- a/src/lib/chrome-mode.ts
+++ b/src/lib/chrome-mode.ts
@@ -17,15 +17,23 @@ const APP_PREFIXES = [
 
 const AUTH_PREFIXES = ['/auth/'] as const;
 
-export function resolveChromeMode(pathname: string): ChromeMode {
+function normalizeBase(baseUrl: string | undefined): string {
+  if (!baseUrl || baseUrl === '/') return '';
+  const withSlash = baseUrl.startsWith('/') ? baseUrl : `/${baseUrl}`;
+  return withSlash.replace(/\/$/, '');
+}
+
+export function resolveChromeMode(pathname: string, baseUrl?: string): ChromeMode {
   if (!pathname) return 'read';
+  const base = normalizeBase(baseUrl ?? import.meta.env?.BASE_URL);
+  const noBase = base && pathname.startsWith(base) ? pathname.slice(base.length) : pathname;
   // Locale-neutral check for /auth/* first
   for (const p of AUTH_PREFIXES) {
-    if (pathname.startsWith(p)) return 'app';
+    if (noBase.startsWith(p)) return 'app';
   }
   // Strip the leading locale (e.g. "/en", "/es"); handle missing trailing slash.
   // Pathnames look like "/en/observe/" or "/es/perfil/exportar/" or "/en".
-  const stripped = pathname.replace(/^\/(en|es)(?=\/|$)/, '') || '/';
+  const stripped = noBase.replace(/^\/(en|es)(?=\/|$)/, '') || '/';
   for (const p of APP_PREFIXES) {
     if (stripped === p || stripped.startsWith(p + '/') || stripped.startsWith(p + '?')) {
       return 'app';

--- a/src/lib/chrome-mode.ts
+++ b/src/lib/chrome-mode.ts
@@ -1,0 +1,35 @@
+export type ChromeMode = 'app' | 'read';
+
+// Path prefixes that should render the app-mode chrome (no footer, bottom
+// bar dominant on mobile). Order doesn't matter; matched by `startsWith`
+// after the locale prefix is stripped, plus the auth callback path.
+//
+// Read PR 3 to see how the footer reads from this; PR 4 for search.
+const APP_PREFIXES = [
+  '/observe',
+  '/observar',
+  '/explore',
+  '/explorar',
+  '/chat',
+  '/profile',
+  '/perfil',
+] as const;
+
+const AUTH_PREFIXES = ['/auth/'] as const;
+
+export function resolveChromeMode(pathname: string): ChromeMode {
+  if (!pathname) return 'read';
+  // Locale-neutral check for /auth/* first
+  for (const p of AUTH_PREFIXES) {
+    if (pathname.startsWith(p)) return 'app';
+  }
+  // Strip the leading locale (e.g. "/en", "/es"); handle missing trailing slash.
+  // Pathnames look like "/en/observe/" or "/es/perfil/exportar/" or "/en".
+  const stripped = pathname.replace(/^\/(en|es)(?=\/|$)/, '') || '/';
+  for (const p of APP_PREFIXES) {
+    if (stripped === p || stripped.startsWith(p + '/') || stripped.startsWith(p + '?')) {
+      return 'app';
+    }
+  }
+  return 'read';
+}

--- a/src/pages/en/explore/recent.astro
+++ b/src/pages/en/explore/recent.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+const page = tr.explore_pages.recent;
+---
+
+<BaseLayout title={`${page.title} — Rastrum`} description={page.subtitle} lang={lang}>
+  <section class="space-y-3 py-6">
+    <h1 class="text-3xl font-bold tracking-tight">{page.title}</h1>
+    <p class="text-zinc-600 dark:text-zinc-400">{page.subtitle}</p>
+  </section>
+
+  <section class="rounded-xl border border-zinc-200 dark:border-zinc-800 p-8 text-center text-zinc-500 dark:text-zinc-400">
+    {page.empty}
+  </section>
+</BaseLayout>

--- a/src/pages/en/explore/species.astro
+++ b/src/pages/en/explore/species.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+const page = tr.explore_pages.species;
+---
+
+<BaseLayout title={`${page.title} — Rastrum`} description={page.subtitle} lang={lang}>
+  <section class="space-y-3 py-6">
+    <h1 class="text-3xl font-bold tracking-tight">{page.title}</h1>
+    <p class="text-zinc-600 dark:text-zinc-400">{page.subtitle}</p>
+  </section>
+
+  <section class="rounded-xl border border-zinc-200 dark:border-zinc-800 p-8 text-center text-zinc-500 dark:text-zinc-400">
+    {page.coming_soon}
+  </section>
+</BaseLayout>

--- a/src/pages/en/explore/watchlist.astro
+++ b/src/pages/en/explore/watchlist.astro
@@ -1,0 +1,20 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+const page = tr.explore_pages.watchlist;
+---
+
+<BaseLayout title={`${page.title} — Rastrum`} description={page.subtitle} lang={lang}>
+  <section class="space-y-3 py-6">
+    <h1 class="text-3xl font-bold tracking-tight">{page.title}</h1>
+    <p class="text-zinc-600 dark:text-zinc-400">{page.subtitle}</p>
+    <p class="text-xs text-zinc-500 dark:text-zinc-500">{page.moved_note}</p>
+  </section>
+
+  <section class="rounded-xl border border-zinc-200 dark:border-zinc-800 p-8 text-center text-zinc-500 dark:text-zinc-400">
+    {page.empty}
+  </section>
+</BaseLayout>

--- a/src/pages/es/explorar/especies.astro
+++ b/src/pages/es/explorar/especies.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+const page = tr.explore_pages.species;
+---
+
+<BaseLayout title={`${page.title} — Rastrum`} description={page.subtitle} lang={lang}>
+  <section class="space-y-3 py-6">
+    <h1 class="text-3xl font-bold tracking-tight">{page.title}</h1>
+    <p class="text-zinc-600 dark:text-zinc-400">{page.subtitle}</p>
+  </section>
+
+  <section class="rounded-xl border border-zinc-200 dark:border-zinc-800 p-8 text-center text-zinc-500 dark:text-zinc-400">
+    {page.coming_soon}
+  </section>
+</BaseLayout>

--- a/src/pages/es/explorar/recientes.astro
+++ b/src/pages/es/explorar/recientes.astro
@@ -1,0 +1,19 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+const page = tr.explore_pages.recent;
+---
+
+<BaseLayout title={`${page.title} — Rastrum`} description={page.subtitle} lang={lang}>
+  <section class="space-y-3 py-6">
+    <h1 class="text-3xl font-bold tracking-tight">{page.title}</h1>
+    <p class="text-zinc-600 dark:text-zinc-400">{page.subtitle}</p>
+  </section>
+
+  <section class="rounded-xl border border-zinc-200 dark:border-zinc-800 p-8 text-center text-zinc-500 dark:text-zinc-400">
+    {page.empty}
+  </section>
+</BaseLayout>

--- a/src/pages/es/explorar/seguimiento.astro
+++ b/src/pages/es/explorar/seguimiento.astro
@@ -1,0 +1,20 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+const page = tr.explore_pages.watchlist;
+---
+
+<BaseLayout title={`${page.title} — Rastrum`} description={page.subtitle} lang={lang}>
+  <section class="space-y-3 py-6">
+    <h1 class="text-3xl font-bold tracking-tight">{page.title}</h1>
+    <p class="text-zinc-600 dark:text-zinc-400">{page.subtitle}</p>
+    <p class="text-xs text-zinc-500 dark:text-zinc-500">{page.moved_note}</p>
+  </section>
+
+  <section class="rounded-xl border border-zinc-200 dark:border-zinc-800 p-8 text-center text-zinc-500 dark:text-zinc-400">
+    {page.empty}
+  </section>
+</BaseLayout>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -2,6 +2,13 @@
 export default {
   darkMode: 'class',
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  safelist: [
+    'text-emerald-600', 'dark:text-emerald-400', 'after:bg-emerald-500',
+    'text-teal-600',    'dark:text-teal-400',    'after:bg-teal-500',
+    'text-sky-600',     'dark:text-sky-400',     'after:bg-sky-500',
+    'text-stone-600',   'dark:text-stone-400',   'after:bg-stone-500',
+    'after:scale-x-0', 'after:scale-x-100',
+  ],
   theme: {
     extend: {},
   },

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -40,12 +40,27 @@ test('mobile menu toggle is reachable', async ({ page }) => {
   expect(Math.min(box!.width, box!.height)).toBeGreaterThanOrEqual(32);
 });
 
-test('opening mobile menu shows nav items', async ({ page }) => {
+test('hamburger opens the mobile drawer', async ({ page }) => {
   await page.goto('/en/');
   await page.locator('#mobile-menu-toggle').click();
-  const menu = page.locator('#mobile-menu');
-  // Note: the menu retains the `sm:hidden` utility class even when open
-  // (it should hide on >=sm). We assert visibility instead of class state.
-  await expect(menu).toBeVisible();
-  await expect(menu.getByRole('link', { name: /Observe/i }).first()).toBeVisible();
+  await expect(page.locator('#mobile-drawer')).toBeVisible();
+  await page.locator('#mobile-drawer-close').click();
+  await expect(page.locator('#mobile-drawer')).toBeHidden();
+});
+
+test('mobile bottom bar — FAB target defaults to /observe', async ({ page }) => {
+  await page.goto('/en/explore/map/');
+  // FAB is rendered server-side inside #mbb-authed (which starts hidden until
+  // auth resolves). The anchor still exists in the DOM and its href is the
+  // computed observe path; that's the target we care about for this test.
+  const fab = page.locator('#mobile-bottom-bar a[data-tour="fab"]');
+  await expect(fab).toHaveAttribute('href', '/en/observe/');
+});
+
+test('FAB on /observe targets /identify (quick id) with ⚡ badge', async ({ page }) => {
+  await page.goto('/en/observe/');
+  const fab = page.locator('#mobile-bottom-bar a[data-tour="fab"]');
+  await expect(fab).toHaveAttribute('href', '/en/identify/');
+  // The ⚡ badge is inside the FAB; assert it's present in the markup.
+  await expect(fab.locator('span:has-text("⚡")')).toHaveCount(1);
 });

--- a/tests/e2e/nav.spec.ts
+++ b/tests/e2e/nav.spec.ts
@@ -1,5 +1,41 @@
 import { test, expect } from '@playwright/test';
 
+const ROUTES: Record<'en' | 'es', string[]> = {
+  en: [
+    '/en/',
+    '/en/identify/',
+    '/en/observe/',
+    '/en/explore/',
+    '/en/explore/map/',
+    '/en/explore/recent/',
+    '/en/explore/watchlist/',
+    '/en/explore/species/',
+    '/en/about/',
+    '/en/docs/',
+    '/en/sign-in/',
+    '/en/profile/',
+  ],
+  es: [
+    '/es/',
+    '/es/identificar/',
+    '/es/observar/',
+    '/es/explorar/',
+    '/es/explorar/mapa/',
+    '/es/explorar/recientes/',
+    '/es/explorar/seguimiento/',
+    '/es/explorar/especies/',
+    '/es/acerca/',
+    '/es/docs/',
+    '/es/ingresar/',
+    '/es/perfil/',
+  ],
+};
+
+// Suppress the unused-variable lint warning — ROUTES is exported for reference
+// by other tooling (e.g. smoke.spec.ts mirrors it). The constant documents the
+// canonical IA and is intentionally kept here even if tests don't iterate it.
+void ROUTES;
+
 test.describe('navigation', () => {
   test('header nav links resolve (en)', async ({ page }) => {
     await page.goto('/en/');
@@ -28,11 +64,34 @@ test.describe('navigation', () => {
     await expect(page).toHaveURL(/\/es\/docs\/vision\/?$/);
   });
 
-  test('docs dropdown reveals doc pages', async ({ page }) => {
+  test('docs mega-menu mounts on click', async ({ page }) => {
     await page.goto('/en/');
-    await page.getByRole('button', { name: /^Docs/i }).click();
-    // The dropdown menu links to /en/docs/. Just assert the menu opens.
-    const menuLink = page.locator('#docs-dropdown-menu a[href="/en/docs/"]');
-    await expect(menuLink).toBeVisible();
+    const docsBtn = page.locator('#megamenu-docs-btn');
+    await docsBtn.click();
+    // The mega-menu uses 3 columns; just assert one known item is visible.
+    await expect(page.locator('#megamenu-docs-menu a[href="/en/docs/architecture/"]')).toBeVisible();
+  });
+
+  test('active section rail highlights Observe on /observe', async ({ page }) => {
+    await page.goto('/en/observe/');
+    // The link gets the emerald color class when active.
+    const link = page.locator('header nav a[href="/en/observe/"]').first();
+    await expect(link).toHaveClass(/text-emerald-600/);
+  });
+
+  test('explore dropdown reveals 4 sub-items', async ({ page }) => {
+    await page.goto('/en/');
+    const expBtn = page.locator('#hdr-explore-btn');
+    await expBtn.click();
+    await expect(page.locator('#hdr-explore-menu a[href="/en/explore/recent/"]')).toBeVisible();
+    await expect(page.locator('#hdr-explore-menu a[href="/en/explore/watchlist/"]')).toBeVisible();
+    await expect(page.locator('#hdr-explore-menu a[href="/en/explore/species/"]')).toBeVisible();
+  });
+
+  test('legacy /profile/watchlist redirects to /explore/watchlist', async ({ page }) => {
+    // Astro emits a meta-refresh redirect for static-build redirects; following
+    // it should land us on the new path.
+    await page.goto('/en/profile/watchlist');
+    await page.waitForURL(/\/en\/explore\/watchlist\/?$/, { timeout: 5000 });
   });
 });

--- a/tests/e2e/nav.spec.ts
+++ b/tests/e2e/nav.spec.ts
@@ -31,9 +31,9 @@ const ROUTES: Record<'en' | 'es', string[]> = {
   ],
 };
 
-// Suppress the unused-variable lint warning — ROUTES is exported for reference
-// by other tooling (e.g. smoke.spec.ts mirrors it). The constant documents the
-// canonical IA and is intentionally kept here even if tests don't iterate it.
+// ROUTES is the canonical IA reference for this spec — not exported, but kept
+// so the list of expected paths is visible alongside the navigation tests. If
+// routes change, sync this list AND the smoke spec's equivalent.
 void ROUTES;
 
 test.describe('navigation', () => {

--- a/tests/e2e/nav.spec.ts
+++ b/tests/e2e/nav.spec.ts
@@ -79,6 +79,13 @@ test.describe('navigation', () => {
     await expect(link).toHaveClass(/text-emerald-600/);
   });
 
+  test('active section rail highlights Docs on /docs/*', async ({ page }) => {
+    await page.goto('/en/docs/architecture/');
+    // The MegaMenu trigger button gets the stone accent classes when active.
+    const docsBtn = page.locator('#megamenu-docs-btn');
+    await expect(docsBtn).toHaveClass(/text-stone-600/);
+  });
+
   test('explore dropdown reveals 4 sub-items', async ({ page }) => {
     await page.goto('/en/');
     const expBtn = page.locator('#hdr-explore-btn');


### PR DESCRIPTION
## Summary
- Verb-first desktop header (Observe / Explore ▾ / Chat | About / Docs ▾) with active-section rail in per-section accent colors (Observe emerald, Explore teal, Chat sky, About/Docs stone) and a tagline lockup on md+
- Mobile chrome: 5-slot bottom bar with center camera FAB; FAB shifts to ⚡ Quick ID on /observe; right-side hamburger drawer for reference / account / preferences
- New `/explore/{recent,watchlist,species}` placeholder pages (EN + ES); watchlist relocates here from /profile (with 301 redirect)
- Mega-menu Docs dropdown grouping the 9 doc pages into Product / Progress / Community columns
- New helpers: `chrome-mode.ts` (app/read mode), `chrome-helpers.ts` (getFabTarget + isActiveSection), `routeTree` in i18n/utils.ts (label + parent map for breadcrumbs and search in later PRs)
- Tailwind safelist for dynamic accent classes
- Pre-existing a11y fixes bundled in: aria-label on sr-only file inputs in ObservationForm; aria-hidden on decorative SVGs across new chrome

Spec: `docs/superpowers/specs/2026-04-26-ux-revamp-design.md` (PR 1 of 5).
Plan: `docs/superpowers/plans/2026-04-26-ux-revamp-pr1-ia-chrome.md`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 265/265 (28 new unit tests for the helpers)
- [x] `npm run build` — 75 pages, EN/ES paired
- [x] `npm run test:e2e` — 72/72 (chromium + mobile-chrome) including 7 new tests
- [ ] Manual smoke on real mobile: bottom bar visible, FAB tappable, hamburger opens drawer, ⚡ badge appears on /observe
- [ ] Manual smoke on desktop: active-section rail color matches verb, Docs ▾ mega-menu hovers cleanly, lang/theme toggles still work on ≥md

🤖 Generated with [Claude Code](https://claude.com/claude-code)