### PR TITLE
feat(seo,a11y): PR-E — finish — a11y to 100, sitemap hreflang complete, Identify followups

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ sync_primary_id_trigger (Postgres)
 activity_events row (visible in /profile/ feed)
 ```
 
-### 2. Photo identification — two cascade modes
+### 2. Photo identification — two cascade modes {#identifier-cascade}
 
 The identification pipeline runs differently depending on where it's triggered. See [`docs/specs/modules/21-identify.md`](specs/modules/21-identify.md) for the full contract.
 
@@ -155,6 +155,15 @@ identification row written by client + sync trigger
 The model is shipped from R2 rather than bundled (~50 MB) so the static
 PWA stays small. The Cornell Lab license is non-commercial; the v2.0
 B2G dashboard would require a separate commercial license.
+
+#### In-browser AI {#in-browser-ai}
+
+EfficientNet-Lite0 ONNX and Phi-3.5-vision are the on-device fallbacks at the
+bottom of both cascade modes. EfficientNet is always available (preloaded ONNX
+via `onnxruntime-web`). Phi-3.5-vision requires a first-run download
+(~2.7 GB cached via the Cache API) and is gated by `localStorage.rastrum.localAiOptIn`.
+Both run entirely in the browser — no server round-trip, no key needed.
+See `src/lib/local-ai.ts` and `src/lib/identifiers/phi-vision.ts`.
 
 ### 4. Sync after offline
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "npm run build:og && astro build",
+    "build": "npm run build:og && astro build && node scripts/sitemap-hreflang.js",
     "build:og": "npx --yes tsx scripts/generate-og.ts",
     "preview": "astro preview",
     "astro": "astro",

--- a/scripts/sitemap-hreflang.js
+++ b/scripts/sitemap-hreflang.js
@@ -1,0 +1,102 @@
+/**
+ * Post-build: inject missing hreflang alternates into sitemap-0.xml.
+ *
+ * @astrojs/sitemap's i18n resolver only pairs URLs whose path structure
+ * is identical in both locales (e.g. /en/chat/ ↔ /es/chat/).  App pages
+ * with slug-aliased routes (/en/observe/ ↔ /es/observar/) are left
+ * unpaired.  This script reads the same routes map used at build time,
+ * finds every unpaired <url> that has a known EN↔ES counterpart, and
+ * rewrites the XML to inject the correct <xhtml:link> alternates.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const SITEMAP = resolve(ROOT, 'dist/sitemap-0.xml');
+const SITE = 'https://rastrum.org';
+
+// ---------------------------------------------------------------------------
+// Route pairs: EN slug → ES slug (path only, no locale prefix, no trailing /)
+// Mirrors src/i18n/utils.ts `routes` map.
+// ---------------------------------------------------------------------------
+const ROUTES = {
+  '':                        '',         // home
+  '/identify':               '/identificar',
+  '/explore':                '/explorar',
+  '/explore/map':            '/explorar/mapa',
+  '/explore/recent':         '/explorar/recientes',
+  '/explore/watchlist':      '/explorar/seguimiento',
+  '/explore/species':        '/explorar/especies',
+  '/explore/validate':       '/explorar/validar',
+  '/observe':                '/observar',
+  '/about':                  '/acerca',
+  '/docs':                   '/docs',
+  '/sign-in':                '/ingresar',
+  '/profile':                '/perfil',
+  '/profile/edit':           '/perfil/editar',
+  '/profile/export':         '/perfil/exportar',
+  '/profile/observations':   '/perfil/observaciones',
+  '/profile/observations/local': '/perfil/observaciones/local',
+  '/profile/expert-apply':   '/perfil/aplicar-experto',
+  '/profile/validate':       '/perfil/validar',
+  '/profile/admin/experts':  '/perfil/admin/expertos',
+  '/profile/u':              '/perfil/u',
+  '/profile/import':         '/perfil/importar',
+  '/profile/import/camera-trap': '/perfil/importar/camara-trampa',
+  '/profile/tokens':         '/perfil/tokens',
+  '/chat':                   '/chat',
+  '/privacy':                '/privacidad',
+  '/terms':                  '/terminos',
+  '/faq':                    '/preguntas-frecuentes',
+};
+
+/** Build lookup: canonical URL → { en, es } absolute URLs */
+function buildPairMap() {
+  const map = new Map();
+  for (const [enSlug, esSlug] of Object.entries(ROUTES)) {
+    const enUrl = `${SITE}/en${enSlug}/`;
+    const esUrl = `${SITE}/es${esSlug}/`;
+    map.set(enUrl, { en: enUrl, es: esUrl });
+    map.set(esUrl, { en: enUrl, es: esUrl });
+  }
+  // Root (locale-neutral) already handled by @astrojs/sitemap
+  return map;
+}
+
+function hreflangBlock(enUrl, esUrl) {
+  return (
+    `<xhtml:link rel="alternate" hreflang="en-US" href="${enUrl}"/>` +
+    `<xhtml:link rel="alternate" hreflang="es-MX" href="${esUrl}"/>` +
+    `<xhtml:link rel="alternate" hreflang="x-default" href="${enUrl}"/>`
+  );
+}
+
+function run() {
+  const xml = readFileSync(SITEMAP, 'utf-8');
+  const pairMap = buildPairMap();
+
+  let injected = 0;
+  const result = xml.replace(/<url><loc>(https:\/\/rastrum\.org\/[^<]+)<\/loc><\/url>/g, (match, url) => {
+    // Already has hreflang (shouldn't match — but be defensive)
+    if (match.includes('xhtml:link')) return match;
+
+    const pair = pairMap.get(url);
+    if (!pair) return match; // no known pair (e.g. /share/obs/)
+
+    injected++;
+    return `<url><loc>${url}</loc>${hreflangBlock(pair.en, pair.es)}</url>`;
+  });
+
+  if (injected === 0) {
+    console.log('[sitemap-hreflang] No unpaired URLs found — sitemap already complete.');
+    return;
+  }
+
+  writeFileSync(SITEMAP, result, 'utf-8');
+  console.log(`[sitemap-hreflang] Injected hreflang into ${injected} previously-unpaired URLs.`);
+}
+
+run();

--- a/src/components/ArchitectureView.astro
+++ b/src/components/ArchitectureView.astro
@@ -201,6 +201,7 @@ const intro = isEs
   <!-- ========================================================== -->
   <section>
     <h2 id="cascade" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-2 flex items-center gap-2">
+      <span id="identifier-cascade" class="sr-only"></span>
       <span class="text-zinc-400 dark:text-zinc-600 font-mono">02</span>
       <a href="#cascade" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Cascada de identificación' : 'Identification cascade'}</a>
     </h2>
@@ -562,6 +563,7 @@ const intro = isEs
   <!-- Stack table -->
   <section>
     <h2 id="stack" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-3 flex items-center gap-2">
+      <span id="in-browser-ai" class="sr-only"></span>
       <span class="text-zinc-400 dark:text-zinc-600 font-mono">05</span>
       <a href="#stack" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Decisiones de stack' : 'Stack decisions'}</a>
     </h2>

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -111,7 +111,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
         <button id="webllm-ok" class="rounded bg-amber-700 px-3 py-1.5 text-xs text-white hover:bg-amber-800">
           {isEs ? 'Entendido, continuar' : 'Got it, continue'}
         </button>
-        <button id="webllm-skip" class="rounded border px-3 py-1.5 text-xs text-amber-700 border-amber-300 hover:bg-amber-100">
+        <button id="webllm-skip" class="rounded border px-3 py-1.5 text-xs text-amber-800 border-amber-400 hover:bg-amber-100">
           {isEs ? 'Solo usar PlantNet' : 'Use PlantNet only'}
         </button>
       </div>
@@ -202,7 +202,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
         <p class="text-sm text-zinc-700 dark:text-zinc-300">{idStrings.phi_offer_body}</p>
         <div class="flex flex-wrap gap-2">
           <button id="phi-download-btn" type="button" class="min-h-11 inline-flex items-center gap-2 rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-2 text-sm font-semibold text-white">{idStrings.phi_download}</button>
-          <button id="phi-skip-btn" type="button" class="min-h-11 inline-flex items-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40">{idStrings.phi_skip}</button>
+          <button id="phi-skip-btn" type="button" data-phi-skip-hint={idStrings.phi_skip_hint} class="min-h-11 inline-flex items-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40">{idStrings.phi_skip}</button>
         </div>
       </div>
 
@@ -652,6 +652,9 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
   const isEs            = document.documentElement.lang === 'es';
 
   // Source registry — display name, license, doc-spec link, short description.
+  const docLang = document.documentElement.lang === 'es' ? 'es' : 'en';
+  const archCascadeUrl = `/${docLang}/docs/architecture/#identifier-cascade`;
+  const archInBrowserUrl = `/${docLang}/docs/architecture/#in-browser-ai`;
   const SOURCE_META: Record<string, { name: string; meta: string; desc: string; spec: string; isInterpreter?: boolean }> = {
     plantnet: {
       name: 'PlantNet',
@@ -661,7 +664,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       desc: isEs
         ? 'Modelo especializado en plantas. Alta precisión para flora.'
         : 'Specialized plant model. High accuracy for flora.',
-      spec: '/en/docs/architecture/#identifier-cascade',
+      spec: archCascadeUrl,
     },
     claude_haiku: {
       name: 'Claude Haiku 4.5',
@@ -671,7 +674,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       desc: isEs
         ? 'Modelo de lenguaje. Útil cuando los modelos especializados no están seguros.'
         : 'Language model. Useful when specialized models aren\'t confident.',
-      spec: '/en/docs/architecture/#identifier-cascade',
+      spec: archCascadeUrl,
       isInterpreter: true,
     },
     webllm_phi35_vision: {
@@ -682,7 +685,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       desc: isEs
         ? 'IA en tu dispositivo. Funciona sin internet.'
         : 'On-device AI. Works without internet.',
-      spec: '/en/docs/architecture/#in-browser-ai',
+      spec: archInBrowserUrl,
       isInterpreter: true,
     },
     birdnet: {
@@ -693,7 +696,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       desc: isEs
         ? 'Modelo especializado en aves por sonido. Cornell Lab.'
         : 'Specialized bird model by sound. Cornell Lab.',
-      spec: '/en/docs/architecture/#identifier-cascade',
+      spec: archCascadeUrl,
     },
     onnx_base: {
       name: 'EfficientNet-Lite0',
@@ -703,7 +706,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       desc: isEs
         ? 'Clasificador offline de respaldo. Baja precisión, siempre disponible.'
         : 'Offline fallback classifier. Low accuracy, always available.',
-      spec: '/en/docs/architecture/#in-browser-ai',
+      spec: archInBrowserUrl,
     },
   };
 
@@ -810,7 +813,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     all_failed:      isEs ? 'Todos los identificadores fallaron. Revisa tu conexión y prueba con una foto más clara.' : 'All identifiers failed. Check your connection and try a clearer photo.',
     result_unknown:  isEs ? 'No se pudo identificar esta foto con confianza.' : 'Could not identify this photo confidently.',
     phi_running:     isEs ? 'Identificando con IA en el dispositivo…' : 'Identifying with on-device AI…',
-    phi_skip_hint:   isEs ? 'Agrega una clave Claude en Perfil → Editar para identificación instantánea.' : 'Add a Claude key in Profile → Edit for instant ID.',
+    phi_skip_hint:   phiSkipBtn?.dataset.phiSkipHint ?? (isEs ? 'Puedes descargar el modelo más tarde desde Perfil → Editar → Configuración de IA, o escribe el nombre de la especie manualmente.' : 'You can download the model later from Profile → Edit → AI settings, or just type the species name manually.'),
   };
 
   let currentAlternates: Array<{ scientific_name: string; common_name: string | null; score: number }> = [];
@@ -1127,6 +1130,9 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
 
   function offerPhiVision() {
     if (!phiOffer) return;
+    try {
+      if (localStorage.getItem(LOCAL_AI_OPTIN) === 'false') return;
+    } catch { /* ignore */ }
     phiOffer.classList.remove('hidden');
   }
 

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -111,7 +111,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
         <button id="webllm-ok" class="rounded bg-amber-700 px-3 py-1.5 text-xs text-white hover:bg-amber-800">
           {isEs ? 'Entendido, continuar' : 'Got it, continue'}
         </button>
-        <button id="webllm-skip" class="rounded border px-3 py-1.5 text-xs text-amber-800 border-amber-400 hover:bg-amber-100">
+        <button id="webllm-skip" class="rounded border px-3 py-1.5 text-xs font-semibold text-amber-900 border-amber-500 bg-amber-50 hover:bg-amber-100">
           {isEs ? 'Solo usar PlantNet' : 'Use PlantNet only'}
         </button>
       </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -133,7 +133,7 @@ const explorePath = getLocalizedPath(lang, routes.explore[lang as 'en' | 'es'] +
     <div class="flex flex-col sm:flex-row gap-3">
       <a
         href={homePath}
-        class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-lg transition-colors"
+        class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
           <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -174,7 +174,7 @@ const tr = t(lang);
         href="https://github.com/ArtemIO/rastrum"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-medium transition-colors"
+        class="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-emerald-700 hover:bg-emerald-800 text-white font-medium transition-colors"
       >
         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" class="shrink-0">
           <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 17.07 3.633 16.7 3.633 16.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.694.825.576C20.565 21.795 24 17.295 24 12 24 5.37 18.63 0 12 0z"/>

--- a/src/pages/en/docs/vision.astro
+++ b/src/pages/en/docs/vision.astro
@@ -10,13 +10,13 @@ const tr = t(lang);
   <article class="space-y-8">
     <div>
       <h1 class="text-3xl font-bold tracking-tight mb-4">{tr.docs.sections.vision}</h1>
-      <p class="text-lg text-zinc-600 dark:text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.vision}</p>
+      <p class="text-lg text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.vision}</p>
     </div>
 
     <!-- Mission Statement -->
     <section>
       <h2 id="mission" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
-        <a href="#mission" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Mission Statement
+        <a href="#mission" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors underline decoration-zinc-300 dark:decoration-zinc-600">#</a> Mission Statement
       </h2>
       <blockquote class="border-l-4 border-emerald-500 pl-4 py-2 text-zinc-700 dark:text-zinc-300 italic text-lg">
         "Rastrum exists to make every living thing identifiable by anyone, anywhere — even without cell signal, even without formal training, even in the languages that field guides forgot."
@@ -29,7 +29,7 @@ const tr = t(lang);
     <!-- The Problem -->
     <section>
       <h2 id="problem" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
-        <a href="#problem" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> The Problem
+        <a href="#problem" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors underline decoration-zinc-300 dark:decoration-zinc-600">#</a> The Problem
       </h2>
       <div class="space-y-4 text-zinc-700 dark:text-zinc-300">
         <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-200 dark:border-zinc-800">
@@ -58,7 +58,7 @@ const tr = t(lang);
     <!-- Our Approach -->
     <section>
       <h2 id="approach" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
-        <a href="#approach" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Our Approach
+        <a href="#approach" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors underline decoration-zinc-300 dark:decoration-zinc-600">#</a> Our Approach
       </h2>
       <div class="space-y-3 text-zinc-700 dark:text-zinc-300">
         <div class="flex items-start gap-3">
@@ -91,7 +91,7 @@ const tr = t(lang);
     <!-- Why Oaxaca First -->
     <section>
       <h2 id="oaxaca" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
-        <a href="#oaxaca" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Why Oaxaca First
+        <a href="#oaxaca" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors underline decoration-zinc-300 dark:decoration-zinc-600">#</a> Why Oaxaca First
       </h2>
       <p class="text-zinc-700 dark:text-zinc-300 mb-4">
         Oaxaca is the ideal proving ground — a megadiverse state where every challenge Rastrum solves is concentrated in one place.

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -18,7 +18,7 @@ const tr = t(lang);
     <div class="flex flex-wrap justify-center gap-3">
       <a
         href={getLocalizedPath(lang, routes.identify[lang] + '/')}
-        class="inline-block px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-lg transition-colors"
+        class="inline-block px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
       >
         {tr.home.cta}
       </a>

--- a/src/pages/es/acerca.astro
+++ b/src/pages/es/acerca.astro
@@ -174,7 +174,7 @@ const tr = t(lang);
         href="https://github.com/ArtemIO/rastrum"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-medium transition-colors"
+        class="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-emerald-700 hover:bg-emerald-800 text-white font-medium transition-colors"
       >
         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" class="shrink-0">
           <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 17.07 3.633 16.7 3.633 16.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.694.825.576C20.565 21.795 24 17.295 24 12 24 5.37 18.63 0 12 0z"/>

--- a/src/pages/es/docs/vision.astro
+++ b/src/pages/es/docs/vision.astro
@@ -16,7 +16,7 @@ const tr = t(lang);
     <!-- Misión -->
     <section>
       <h2 id="mision" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
-        <a href="#mision" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Misión
+        <a href="#mision" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors underline decoration-zinc-300 dark:decoration-zinc-600">#</a> Misión
       </h2>
       <blockquote class="border-l-4 border-emerald-500 pl-4 py-2 text-zinc-700 dark:text-zinc-300 italic text-lg">
         "Rastrum existe para hacer que cada ser vivo sea identificable por cualquier persona, en cualquier lugar — incluso sin señal celular, sin formación académica, incluso en los idiomas que las guías de campo olvidaron."
@@ -29,7 +29,7 @@ const tr = t(lang);
     <!-- El Problema -->
     <section>
       <h2 id="problema" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
-        <a href="#problema" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> El Problema
+        <a href="#problema" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors underline decoration-zinc-300 dark:decoration-zinc-600">#</a> El Problema
       </h2>
       <div class="space-y-4 text-zinc-700 dark:text-zinc-300">
         <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
@@ -58,7 +58,7 @@ const tr = t(lang);
     <!-- Nuestro Enfoque -->
     <section>
       <h2 id="enfoque" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
-        <a href="#enfoque" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Nuestro Enfoque
+        <a href="#enfoque" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors underline decoration-zinc-300 dark:decoration-zinc-600">#</a> Nuestro Enfoque
       </h2>
       <div class="space-y-3 text-zinc-700 dark:text-zinc-300">
         <div class="flex items-start gap-3">
@@ -91,7 +91,7 @@ const tr = t(lang);
     <!-- ¿Por Qué Oaxaca Primero? -->
     <section>
       <h2 id="oaxaca" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
-        <a href="#oaxaca" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> ¿Por qué Oaxaca primero?
+        <a href="#oaxaca" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors underline decoration-zinc-300 dark:decoration-zinc-600">#</a> ¿Por qué Oaxaca primero?
       </h2>
       <p class="text-zinc-700 dark:text-zinc-300 mb-4">
         Oaxaca es el campo de pruebas ideal — un estado megadiverso donde cada problema que Rastrum resuelve está concentrado en un solo lugar.

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -18,7 +18,7 @@ const tr = t(lang);
     <div class="flex flex-wrap justify-center gap-3">
       <a
         href={getLocalizedPath(lang, routes.identify[lang] + '/')}
-        class="inline-block px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-lg transition-colors"
+        class="inline-block px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
       >
         {tr.home.cta}
       </a>


### PR DESCRIPTION
## Summary

Final pass closing every executable item in the SEO/UX backlog. Five commits cover three workstreams.

### A11y final push — Lighthouse a11y → 100 on all 5 audited URLs

| URL | Before | After |
|---|---:|---:|
| /en/ | 95 | **100** |
| /es/ | 95 | **100** |
| /en/docs/vision/ | 90 | **100** |
| /en/identify/ | 95 | **100** |
| /en/observe/ | 95 | **100** |

Specific fixes:
- Emerald CTA buttons: `bg-emerald-600 text-white` → `bg-emerald-700` (passes WCAG AA 4.5:1)
- Phi-skip button: `text-amber-700/border-amber-300` → `text-amber-900 bg-amber-50 border-amber-500 font-semibold` (~9.1:1)
- `/en/docs/vision/` had a `dark:text-zinc-600 dark:text-zinc-400` duplicate class collision; removed the lower-contrast one
- 4 inline TOC anchors in `/en/docs/vision/` and `/es/docs/vision/`: added `underline decoration-zinc-300 dark:decoration-zinc-600` so they don't rely on color alone

### Sitemap hreflang completion — 31 → 81 paired URLs (215 hreflang annotations)

`@astrojs/sitemap`'s i18n resolver only matched the homepages and docs paths; ~47 app pages had no hreflang despite being locale-paired.

Solution: post-build script `scripts/sitemap-hreflang.js` that reads each URL, finds the locale twin via the `routes` map, and rewrites the sitemap XML with proper `<xhtml:link rel="alternate">` annotations. Wired into `npm run build`.

Result: **81 of 82 URLs** now carry hreflang pairs (only `/share/obs/` remains unpaired by design — locale-neutral route).

### Identify-overhaul follow-ups (Opus review C1, I1, I2)

- **C1**: `idStringsRT.phi_skip_hint` runtime now reads from `data-phi-skip-hint` on the button (set at build time from i18n) instead of the hardcoded literal that contradicted commit `3d80a58`'s intentional reframe
- **I1**: `offerPhiVision()` gains a `localStorage[LOCAL_AI_OPTIN] === 'false'` guard. Clicking "Use PlantNet only" now actually suppresses the offer card on subsequent uploads.
- **I2**: Source tooltip anchor links use `document.documentElement.lang` for the locale prefix (was hardcoded `/en/`); `ArchitectureView.astro` gains `<span id="identifier-cascade">` and `<span id="in-browser-ai">` so the anchor IDs the tooltips reference actually exist; `docs/architecture.md` gets matching MDX heading IDs.

### Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 372 passed across 28 files
- [x] `npm run build` — 80 pages, 0 errors
- [x] `npm run test:e2e` — 81/81 passed, 10 intentionally skipped
- [x] `npm run test:lhci` — a11y=100 on all 5 URLs
- [x] EN/ES parity — 933/933 keys
- [x] Sitemap hreflang count — 81/82 paired URLs

### Coordination

Touches `ObservationForm.astro` for C1+I1+I2 — minimal surface (data attribute, localStorage guard, runtime lang derivation), should rebase cleanly against the parallel-cascade work. Does NOT touch `IdentifyView.astro`, `lib/identifiers/*`, or `lib/identify-runners.ts`.

### What this closes

Every executable item from the audit + Opus review backlog. The remaining items (Phase 3 bundle slim, the 4 deferred UX revamp sub-PRs — Account hub / Footer / Settings / Command palette / Onboarding tour) are days-each design+implementation projects, not session-scope quick wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)