### PR TITLE
feat(chrome): UX revamp PR-3 — real 5-col footer + breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,0 +1,100 @@
+---
+import { routes, routeTree, getRouteLabel, getRouteParent, getLocalizedPath, t, type Locale } from '../i18n/utils';
+import { resolveChromeMode } from '../lib/chrome-mode';
+
+interface Props {
+  lang: 'en' | 'es';
+  currentPath: string;
+}
+
+const { lang, currentPath } = Astro.props;
+
+// Skip breadcrumbs on app-mode pages (they have their own header treatment)
+const chromeMode = resolveChromeMode(currentPath, import.meta.env.BASE_URL);
+if (chromeMode === 'app') return;
+
+const locale: Locale = lang === 'es' ? 'es' : 'en';
+const tr = t(lang);
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const localePrefix = `${base}/${lang}`;
+
+// Strip base + locale to get the path slug like '/docs/architecture' or '/profile/observations'
+const pathPart = currentPath.startsWith(localePrefix)
+  ? currentPath.slice(localePrefix.length).replace(/\/$/, '')
+  : currentPath.replace(/\/$/, '');
+
+// Determine depth: number of non-empty segments in pathPart
+const segments = pathPart.split('/').filter(Boolean);
+if (segments.length < 2) return; // single-segment paths (e.g. /observe, /profile) — no crumbs
+
+type Crumb = { label: string; href?: string };
+const trail: Crumb[] = [];
+
+const isDocsPage = segments[0] === 'docs' && segments.length >= 2;
+const docSlug = isDocsPage ? segments[1] : null;
+
+if (isDocsPage && docSlug) {
+  // Docs › <Section>
+  const docsHref = `${base}/${lang}/docs/`;
+  trail.push({ label: tr.nav.docs, href: docsHref });
+  const sections = tr.docs.sections as Record<string, string>;
+  const sectionLabel = sections[docSlug] ?? docSlug;
+  trail.push({ label: sectionLabel });
+} else {
+  // Find which route key the current pathPart matches
+  let matchedKey: string | undefined;
+  for (const [key, slugMap] of Object.entries(routes)) {
+    const slug = slugMap[locale] ?? '';
+    if (slug === pathPart || (pathPart === '' && slug === '')) {
+      matchedKey = key;
+      break;
+    }
+  }
+
+  if (!matchedKey) return; // no matching route — skip breadcrumbs
+
+  // Walk up via getRouteParent to build ancestor chain
+  const chain: string[] = [];
+  let key: string | undefined = matchedKey;
+  while (key) {
+    chain.unshift(key);
+    key = getRouteParent(key);
+  }
+
+  // Prepend home if the chain doesn't start from home
+  if (chain[0] !== 'home') {
+    chain.unshift('home');
+  }
+
+  // Build crumbs from chain
+  for (let i = 0; i < chain.length; i++) {
+    const k = chain[i];
+    const isLast = i === chain.length - 1;
+    const routeSlug = routes[k]?.[locale];
+    let href: string | undefined;
+    if (!isLast && routeSlug !== undefined) {
+      href = getLocalizedPath(lang, routeSlug ? routeSlug + '/' : '/');
+    }
+    trail.push({ label: getRouteLabel(k, lang), href });
+  }
+
+  // Need at least 2 crumbs (home + page) to be useful; but only show if chain length >= 2 past home
+  // i.e. we actually have a parent node beyond home itself
+  if (chain.length < 3) return;
+}
+---
+
+{trail.length >= 2 && (
+  <nav aria-label="Breadcrumb" class="text-xs text-zinc-500 dark:text-zinc-400 mb-4 flex items-center gap-1.5 overflow-x-auto whitespace-nowrap">
+    {trail.map((crumb, i) => (
+      <>
+        {i > 0 && <span class="text-zinc-400 dark:text-zinc-600 select-none" aria-hidden="true">›</span>}
+        {crumb.href ? (
+          <a href={crumb.href} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors shrink-0">{crumb.label}</a>
+        ) : (
+          <span class="text-zinc-700 dark:text-zinc-300 font-medium shrink-0" aria-current="page">{crumb.label}</span>
+        )}
+      </>
+    ))}
+  </nav>
+)}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,35 +1,245 @@
 ---
-import { t, getLocalizedPath, routes } from '../i18n/utils';
+import { t, getLocalizedPath, getDocPath, getAlternateUrl, routes, type Locale } from '../i18n/utils';
+import { resolveChromeMode } from '../lib/chrome-mode';
 
 interface Props {
   lang: string;
+  currentPath?: string;
 }
 
-const { lang } = Astro.props;
+const { lang, currentPath = '' } = Astro.props;
+const chromeMode = resolveChromeMode(currentPath, import.meta.env.BASE_URL);
+if (chromeMode === 'app') return;
+
 const tr = t(lang);
-const isEs = lang === 'es';
-const locale = (lang === 'es' ? 'es' : 'en') as 'en' | 'es';
-const privacyHref = getLocalizedPath(locale, routes.privacy[locale] + '/');
-const termsHref = getLocalizedPath(locale, routes.terms[locale] + '/');
-const faqHref = getLocalizedPath(locale, routes.faq[locale] + '/');
+const locale = (lang === 'es' ? 'es' : 'en') as Locale;
+const alt: Locale = locale === 'es' ? 'en' : 'es';
+const altHref = currentPath ? getAlternateUrl(currentPath, alt) : getLocalizedPath(alt, '/');
+const enHref  = currentPath ? getAlternateUrl(currentPath, 'en') : getLocalizedPath('en', '/');
+
+const year = new Date().getFullYear();
+
+const observeHref      = getLocalizedPath(lang, routes.observe[locale] + '/');
+const identifyHref     = getLocalizedPath(lang, routes.identify[locale] + '/');
+const exploreHref      = getLocalizedPath(lang, routes.exploreMap[locale] + '/');
+const chatHref         = getLocalizedPath(lang, routes.chat[locale] + '/');
+
+const aboutHref        = getLocalizedPath(lang, routes.about[locale] + '/');
+const visionHref       = getDocPath(lang, 'vision');
+const roadmapHref      = getDocPath(lang, 'roadmap');
+const architectureHref = getDocPath(lang, 'architecture');
+const indigenousHref   = getDocPath(lang, 'indigenous');
+
+const contributeHref    = getDocPath(lang, 'contribute');
+const fundingHref       = getDocPath(lang, 'funding');
+const githubIssuesHref  = 'https://github.com/ArtemioPadilla/rastrum/issues';
+const githubDiscussHref = 'https://github.com/ArtemioPadilla/rastrum/discussions';
+
+const licenseHref = 'https://github.com/ArtemioPadilla/rastrum/blob/main/LICENSE';
+const privacyHref = getLocalizedPath(lang, routes.privacy[locale] + '/');
+const termsHref   = getLocalizedPath(lang, routes.terms[locale] + '/');
+const faqHref     = getLocalizedPath(lang, routes.faq[locale] + '/');
+
+const ftLinks = tr.footer.links as Record<string, string>;
+const ftCols  = tr.footer.columns as Record<string, string>;
+
+const linkClass = 'text-zinc-500 dark:text-zinc-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors';
+const mLinkClass = 'text-zinc-500 dark:text-zinc-400';
 ---
 
-<footer class="border-t border-zinc-200 dark:border-zinc-800 mt-16">
-  <div class="max-w-5xl mx-auto px-4 py-6 flex flex-col sm:flex-row items-center justify-between gap-3 text-sm text-zinc-500 dark:text-zinc-400">
-    <p>&copy; {new Date().getFullYear()} Rastrum &middot; {tr.footer.license}</p>
-    <nav class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
-      <a href={faqHref} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
-        {isEs ? 'Preguntas frecuentes' : 'FAQ'}
-      </a>
-      <a href={privacyHref} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
-        {isEs ? 'Privacidad' : 'Privacy'}
-      </a>
-      <a href={termsHref} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
-        {isEs ? 'Términos' : 'Terms'}
-      </a>
-      <a href="https://github.com/ArtemIOPadilla/rastrum" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors" target="_blank" rel="noopener">
-        {tr.footer.source}
-      </a>
-    </nav>
+<footer class="border-t border-zinc-200 dark:border-zinc-800 mt-16 bg-white dark:bg-zinc-950">
+  <div class="max-w-6xl mx-auto px-4 pt-10 pb-6">
+
+    <!-- ── Desktop grid (sm+): brand spans 2 of 5 cols on lg; 2-col on md/sm ── -->
+    <div class="hidden sm:grid sm:grid-cols-2 lg:grid-cols-5 gap-8">
+
+      <!-- Brand: spans 2 cols on lg -->
+      <div class="sm:col-span-2 lg:col-span-2 space-y-3">
+        <a href={getLocalizedPath(lang, '/')}
+           class="inline-flex items-center gap-2 text-emerald-600 dark:text-emerald-400 font-bold text-lg">
+          <img src="/rastrum-logo.svg" alt="" class="w-6 h-6" width="24" height="24" loading="lazy" />
+          Rastrum
+        </a>
+        <p class="text-sm text-zinc-500 dark:text-zinc-400">{tr.footer.tagline}</p>
+        <p class="text-xs text-zinc-400 dark:text-zinc-500 max-w-xs">{tr.footer.description_short}</p>
+        <div class="flex items-center gap-4 pt-1 text-xs">
+          <a href="https://github.com/ArtemioPadilla/rastrum" target="_blank" rel="noopener"
+             class={linkClass} aria-label="GitHub">
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
+            </svg>
+          </a>
+          <a href="#" class={linkClass}>{ftLinks.mastodon}</a>
+          <a href="#" class={linkClass}>{ftLinks.rss}</a>
+        </div>
+      </div>
+
+      <!-- Product -->
+      <div class="space-y-3">
+        <h3 class="text-xs font-semibold text-zinc-900 dark:text-zinc-100 uppercase tracking-wider">{ftCols.product}</h3>
+        <ul class="space-y-2 text-sm">
+          <li><a href={observeHref}  class={linkClass}>{tr.nav.observe}</a></li>
+          <li><a href={identifyHref} class={linkClass}>{tr.nav.identify}</a></li>
+          <li><a href={exploreHref}  class={linkClass}>{tr.nav.map}</a></li>
+          <li><a href={chatHref}     class={linkClass}>{tr.nav.chat}</a></li>
+          <li><span class={linkClass + ' cursor-default'} id="footer-install-pwa-trigger">{ftLinks.install_pwa}</span></li>
+        </ul>
+      </div>
+
+      <!-- Learn -->
+      <div class="space-y-3">
+        <h3 class="text-xs font-semibold text-zinc-900 dark:text-zinc-100 uppercase tracking-wider">{ftCols.learn}</h3>
+        <ul class="space-y-2 text-sm">
+          <li><a href={aboutHref}        class={linkClass}>{tr.nav.about}</a></li>
+          <li><a href={visionHref}       class={linkClass}>{tr.docs.sections.vision}</a></li>
+          <li><a href={roadmapHref}      class={linkClass}>{tr.docs.sections.roadmap}</a></li>
+          <li><a href={architectureHref} class={linkClass}>{tr.docs.sections.architecture}</a></li>
+          <li><a href={indigenousHref}   class={linkClass}>{tr.docs.sections.indigenous}</a></li>
+        </ul>
+      </div>
+
+      <!-- Community (sm: shown as 3rd col in 2-col; lg: 4th col) -->
+      <div class="space-y-3">
+        <h3 class="text-xs font-semibold text-zinc-900 dark:text-zinc-100 uppercase tracking-wider">{ftCols.community}</h3>
+        <ul class="space-y-2 text-sm">
+          <li><a href={contributeHref}    class={linkClass}>{ftLinks.contribute}</a></li>
+          <li><a href={fundingHref}       class={linkClass}>{ftLinks.funding}</a></li>
+          <li><a href={githubIssuesHref}  target="_blank" rel="noopener" class={linkClass}>{ftLinks.github_issues}</a></li>
+          <li><a href={githubDiscussHref} target="_blank" rel="noopener" class={linkClass}>{ftLinks.github_discussions}</a></li>
+        </ul>
+      </div>
+
+      <!-- Legal (lg: 5th col; hidden on sm/md, shown inline in bottom strip) -->
+      <div class="hidden lg:block space-y-3">
+        <h3 class="text-xs font-semibold text-zinc-900 dark:text-zinc-100 uppercase tracking-wider">{ftCols.legal}</h3>
+        <ul class="space-y-2 text-sm">
+          <li><a href={licenseHref} target="_blank" rel="noopener" class={linkClass}>{tr.footer.license}</a></li>
+          <li><a href={privacyHref} class={linkClass}>{ftLinks.privacy}</a></li>
+          <li><a href={termsHref}   class={linkClass}>{ftLinks.terms}</a></li>
+          <li><a href={faqHref}     class={linkClass}>{ftLinks.faq}</a></li>
+        </ul>
+      </div>
+
+    </div>
+
+    <!-- Legal row: sm/md only (between grid and bottom strip) -->
+    <div class="hidden sm:flex lg:hidden items-center gap-x-4 gap-y-2 flex-wrap mt-6 text-sm">
+      <a href={licenseHref} target="_blank" rel="noopener" class={linkClass}>{tr.footer.license}</a>
+      <a href={privacyHref} class={linkClass}>{ftLinks.privacy}</a>
+      <a href={termsHref}   class={linkClass}>{ftLinks.terms}</a>
+      <a href={faqHref}     class={linkClass}>{ftLinks.faq}</a>
+    </div>
+
+    <!-- ── Mobile: brand + 4 <details> accordions ── -->
+    <div class="sm:hidden space-y-4">
+      <div class="space-y-2">
+        <a href={getLocalizedPath(lang, '/')}
+           class="inline-flex items-center gap-2 text-emerald-600 dark:text-emerald-400 font-bold">
+          <img src="/rastrum-logo.svg" alt="" class="w-5 h-5" width="20" height="20" loading="lazy" />
+          Rastrum
+        </a>
+        <p class="text-xs text-zinc-400 dark:text-zinc-500">{tr.footer.tagline}</p>
+        <div class="flex items-center gap-3 text-xs">
+          <a href="https://github.com/ArtemioPadilla/rastrum" target="_blank" rel="noopener"
+             class={mLinkClass} aria-label="GitHub">GitHub</a>
+          <a href="#" class={mLinkClass}>{ftLinks.mastodon}</a>
+          <a href="#" class={mLinkClass}>{ftLinks.rss}</a>
+        </div>
+      </div>
+
+      {[
+        { label: ftCols.product, items: [
+          { href: observeHref,  label: tr.nav.observe },
+          { href: identifyHref, label: tr.nav.identify },
+          { href: exploreHref,  label: tr.nav.map },
+          { href: chatHref,     label: tr.nav.chat },
+        ]},
+        { label: ftCols.learn, items: [
+          { href: aboutHref,        label: tr.nav.about },
+          { href: visionHref,       label: tr.docs.sections.vision },
+          { href: roadmapHref,      label: tr.docs.sections.roadmap },
+          { href: architectureHref, label: tr.docs.sections.architecture },
+          { href: indigenousHref,   label: tr.docs.sections.indigenous },
+        ]},
+        { label: ftCols.community, items: [
+          { href: contributeHref,    label: ftLinks.contribute },
+          { href: fundingHref,       label: ftLinks.funding },
+          { href: githubIssuesHref,  label: ftLinks.github_issues },
+          { href: githubDiscussHref, label: ftLinks.github_discussions },
+        ]},
+        { label: ftCols.legal, items: [
+          { href: licenseHref, label: tr.footer.license },
+          { href: privacyHref, label: ftLinks.privacy },
+          { href: termsHref,   label: ftLinks.terms },
+          { href: faqHref,     label: ftLinks.faq },
+        ]},
+      ].map(col => (
+        <details class="group border-t border-zinc-100 dark:border-zinc-800 pt-3">
+          <summary class="flex items-center justify-between cursor-pointer list-none text-xs font-semibold text-zinc-900 dark:text-zinc-100 uppercase tracking-wider">
+            {col.label}
+            <svg aria-hidden="true" class="w-3 h-3 transition-transform group-open:rotate-90 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+          </summary>
+          <ul class="mt-2 space-y-2 text-sm pb-1">
+            {col.items.map(item => (
+              <li><a href={item.href} class={mLinkClass}>{item.label}</a></li>
+            ))}
+          </ul>
+        </details>
+      ))}
+    </div>
+
+    <!-- ── Bottom strip ── -->
+    <div class="mt-8 pt-5 border-t border-zinc-100 dark:border-zinc-800 flex flex-col sm:flex-row items-center justify-between gap-3 pb-[env(safe-area-inset-bottom,0px)]">
+      <p class="text-xs text-zinc-400 dark:text-zinc-500 text-center sm:text-left">
+        &copy; {year} Rastrum &middot; {ftLinks.license_summary}
+      </p>
+      <div class="flex items-center gap-2">
+        <!-- EN/ES segmented switch -->
+        <div class="flex items-center rounded border border-zinc-300 dark:border-zinc-700 text-xs overflow-hidden" role="group" aria-label="Language">
+          <a
+            href={enHref}
+            data-lang-switch="en"
+            class={`px-2 py-1 transition-colors ${locale === 'en' ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 font-medium' : 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300'}`}
+          >EN</a>
+          <span class="border-l border-zinc-300 dark:border-zinc-700 self-stretch" aria-hidden="true"></span>
+          <a
+            href={altHref}
+            data-lang-switch="es"
+            class={`px-2 py-1 transition-colors ${locale === 'es' ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 font-medium' : 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300'}`}
+          >ES</a>
+        </div>
+        <!-- Theme switch -->
+        <button
+          id="footer-theme-toggle"
+          class="p-1.5 rounded border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+          aria-label={tr.nav.drawer.toggle_theme}
+        >
+          <svg aria-hidden="true" class="w-3.5 h-3.5 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+          <svg aria-hidden="true" class="w-3.5 h-3.5 block dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+        </button>
+        <!-- Version stamp -->
+        <a
+          href="https://github.com/ArtemioPadilla/rastrum/releases"
+          target="_blank"
+          rel="noopener"
+          class="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-400 transition-colors font-mono"
+        >v1.0</a>
+      </div>
+    </div>
   </div>
 </footer>
+
+<script>
+  const themeBtn = document.getElementById('footer-theme-toggle');
+  themeBtn?.addEventListener('click', () => {
+    const dark = document.documentElement.classList.toggle('dark');
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  });
+
+  document.querySelectorAll('[data-lang-switch]').forEach(el => {
+    el.addEventListener('click', () => {
+      const target = (el as HTMLElement).dataset.langSwitch;
+      if (target) localStorage.setItem('rastrum.lang', target);
+    });
+  });
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -185,7 +185,29 @@
   },
   "footer": {
     "license": "AGPL-3.0 License",
-    "source": "Source on GitHub"
+    "source": "Source on GitHub",
+    "tagline": "Biodiversity, observed in your language.",
+    "description_short": "Open-source biodiversity observation for Latin America.",
+    "columns": {
+      "product": "Product",
+      "learn": "Learn",
+      "community": "Community",
+      "legal": "Legal"
+    },
+    "links": {
+      "github_issues": "Issues ↗",
+      "github_discussions": "Discussions ↗",
+      "license_summary": "MIT (code) · AGPL-3.0 (server) · CC observations",
+      "privacy": "Privacy",
+      "terms": "Terms",
+      "faq": "FAQ",
+      "install_pwa": "Install PWA",
+      "mastodon": "Mastodon ↗",
+      "rss": "RSS",
+      "contribute": "Contribute",
+      "funding": "Funding",
+      "changelog": "Changelog"
+    }
   },
   "report": {
     "button_label": "Report an issue",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -185,7 +185,29 @@
   },
   "footer": {
     "license": "Licencia AGPL-3.0",
-    "source": "Código en GitHub"
+    "source": "Código en GitHub",
+    "tagline": "Biodiversidad, observada en tu idioma.",
+    "description_short": "Observación de biodiversidad open-source para América Latina.",
+    "columns": {
+      "product": "Producto",
+      "learn": "Aprender",
+      "community": "Comunidad",
+      "legal": "Legal"
+    },
+    "links": {
+      "github_issues": "Issues ↗",
+      "github_discussions": "Discusiones ↗",
+      "license_summary": "MIT (código) · AGPL-3.0 (servidor) · CC observaciones",
+      "privacy": "Privacidad",
+      "terms": "Términos",
+      "faq": "FAQ",
+      "install_pwa": "Instalar PWA",
+      "mastodon": "Mastodon ↗",
+      "rss": "RSS",
+      "contribute": "Contribuir",
+      "funding": "Financiamiento",
+      "changelog": "Cambios"
+    }
   },
   "report": {
     "button_label": "Reportar un problema",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -131,7 +131,7 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogSlugForPath(currentPath)}
     <main class="max-w-5xl mx-auto px-4 py-8">
       <slot />
     </main>
-    <Footer lang={lang} />
+    <Footer lang={lang} currentPath={currentPath} />
     <InstallPwaButton lang={installLang} />
     <ReportIssueButton lang={lang} />
     <OnboardingTour lang={installLang} />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,6 +9,7 @@ import SwUpdateToast from '../components/SwUpdateToast.astro';
 import OfflineBanner from '../components/OfflineBanner.astro';
 import { getAlternateUrl } from '../i18n/utils';
 import StructuredData from '../components/StructuredData.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
 
 interface Props {
   title: string;
@@ -129,6 +130,7 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogSlugForPath(currentPath)}
     <Header lang={lang} currentPath={currentPath} />
     <InstallDiscoveryHint lang={installLang} />
     <main class="max-w-5xl mx-auto px-4 py-8">
+      <Breadcrumbs lang={installLang} currentPath={currentPath} />
       <slot />
     </main>
     <Footer lang={lang} currentPath={currentPath} />

--- a/tests/e2e/nav.spec.ts
+++ b/tests/e2e/nav.spec.ts
@@ -50,8 +50,8 @@ test.describe('navigation', () => {
 
   test('language switcher swaps locale', async ({ page }) => {
     await page.goto('/en/about/');
-    // The header has a single ES/EN toggle button rendered as a link.
-    const altLink = page.getByRole('link', { name: /^ES$/ });
+    // Use the header's lang-toggle specifically to avoid matching the footer switch.
+    const altLink = page.locator('#lang-toggle');
     await expect(altLink).toBeVisible();
     await altLink.click();
     await expect(page).toHaveURL(/\/es\/acerca\/?$/);
@@ -59,7 +59,7 @@ test.describe('navigation', () => {
 
   test('language switcher preserves docs section', async ({ page }) => {
     await page.goto('/en/docs/vision/');
-    const altLink = page.getByRole('link', { name: /^ES$/ });
+    const altLink = page.locator('#lang-toggle');
     await altLink.click();
     await expect(page).toHaveURL(/\/es\/docs\/vision\/?$/);
   });


### PR DESCRIPTION
## Summary

Implements PR-3 of the [UX revamp design](docs/superpowers/specs/2026-04-26-ux-revamp-design.md) Section 5: real footer with brand strip + 4 link columns + EN/ES + theme switch, plus Breadcrumbs component reading routeTree.

### Footer (`Footer.astro` rewrite)
5-column grid on `lg+` (brand spans 2), 2-col on `md`, single column with `<details>` accordions on `<sm`. Brand strip · Product · Learn · Community · Legal. Bottom strip carries EN/ES segmented switch + theme toggle + version. Gated via `resolveChromeMode` — silent on app-mode pages (observe, explore, profile, etc.) where the bottom bar is the chrome.

### Breadcrumbs (new `Breadcrumbs.astro`)
Reads `routeTree` + `getRouteParent` to build a trail. Doc pages render `Docs › <Section>`. Non-doc deep routes walk via getRouteParent. Silent on single-segment pages and app-mode paths.

### i18n
New `footer.*` keys (tagline, description_short, columns, links) — 951 total keys, 0 EN/ES mismatches.

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 380/380
- [x] `npm run build` — 84 pages
- [x] `npm run test:e2e` — 81/81 passed (fixed 2 strict-mode nav tests after footer added a 2nd EN/ES toggle)
- [ ] Manual smoke on mobile: footer accordions expand/collapse, EN/ES + theme switches work

🤖 Generated with [Claude Code](https://claude.com/claude-code)