### PR TITLE
feat(social): module 26 — graph + reactions

### DIFF
--- a/docs/progress.json
+++ b/docs/progress.json
@@ -778,6 +778,13 @@
           "label_es": "Widgets de perfil enriquecidos — dona taxonómica, anillo de racha, grilla top de especies, heatmap calendario, mini-mapa de observaciones; reutilizados en /perfil/ y /u/<username>/",
           "done": true,
           "done_at": "2026-04-28"
+        },
+        {
+          "id": "social-graph-m26",
+          "label": "Social graph + reactions (Module 26) — asymmetric follow + opt-in collaborator tier, per-target reactions (observation/photo/identification), blocks, reports, in-app inbox, 90-day notification prune",
+          "label_es": "Grafo social + reacciones (Módulo 26) — seguimiento asimétrico + nivel colaborador opcional, reacciones por objetivo (observación/foto/identificación), bloqueos, reportes, bandeja en la app, poda 90 días",
+          "done": true,
+          "done_at": "2026-04-28"
         }
       ]
     },

--- a/docs/specs/infra/cron-schedules.sql
+++ b/docs/specs/infra/cron-schedules.sql
@@ -93,3 +93,12 @@ SELECT jobid, jobname, schedule, active
 FROM cron.job
 WHERE jobname IN ('streaks-nightly', 'badges-nightly', 'plantnet-quota-daily', 'streak-push-nightly', 'refresh-taxon-rarity-nightly')
 ORDER BY jobname;
+
+-- m26: prune read notifications older than 90 days, daily at 04:30 UTC.
+SELECT cron.unschedule('prune_old_notifications')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'prune_old_notifications');
+SELECT cron.schedule(
+  'prune_old_notifications',
+  '30 4 * * *',
+  $$ SELECT public.prune_old_notifications(); $$
+);

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2710,3 +2710,42 @@ CREATE TRIGGER follows_counter_trigger
 UPDATE public.users u SET
   follower_count  = (SELECT count(*) FROM public.follows WHERE followee_id = u.id AND status = 'accepted'),
   following_count = (SELECT count(*) FROM public.follows WHERE follower_id = u.id AND status = 'accepted');
+
+-- 5) Social privacy helpers
+CREATE OR REPLACE FUNCTION public.social_visible_to(viewer uuid, owner uuid)
+RETURNS boolean
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT
+    viewer IS NOT NULL AND (
+      viewer = owner
+      OR EXISTS (
+        SELECT 1 FROM public.follows f
+         WHERE f.follower_id = viewer
+           AND f.followee_id = owner
+           AND f.status      = 'accepted'
+      )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_collaborator_of(viewer uuid, owner uuid)
+RETURNS boolean
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT viewer IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.follows f
+     WHERE f.follower_id = viewer
+       AND f.followee_id = owner
+       AND f.tier        = 'collaborator'
+       AND f.status      = 'accepted'
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.social_visible_to(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.is_collaborator_of(uuid, uuid) TO anon, authenticated;
+
+-- 6) Collaborators inherit credentialed-researcher coord-precision unlock
+DROP POLICY IF EXISTS obs_collaborator_read ON public.observations;
+CREATE POLICY obs_collaborator_read ON public.observations FOR SELECT
+  USING (
+    obscure_level <> 'full'
+    AND public.is_collaborator_of(auth.uid(), observer_id)
+  );

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2886,3 +2886,27 @@ CREATE POLICY idreact_write ON public.identification_reactions FOR INSERT
 DROP POLICY IF EXISTS idreact_delete ON public.identification_reactions;
 CREATE POLICY idreact_delete ON public.identification_reactions FOR DELETE
   USING (user_id = auth.uid());
+
+-- 10) blocks
+CREATE TABLE IF NOT EXISTS public.blocks (
+  blocker_id  uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  blocked_id  uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (blocker_id, blocked_id),
+  CHECK (blocker_id <> blocked_id)
+);
+CREATE INDEX IF NOT EXISTS idx_blocks_blocked ON public.blocks(blocked_id);
+
+ALTER TABLE public.blocks ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS blocks_owner_read ON public.blocks;
+CREATE POLICY blocks_owner_read ON public.blocks FOR SELECT
+  USING (blocker_id = auth.uid());
+
+DROP POLICY IF EXISTS blocks_owner_write ON public.blocks;
+CREATE POLICY blocks_owner_write ON public.blocks FOR INSERT
+  WITH CHECK (blocker_id = auth.uid());
+
+DROP POLICY IF EXISTS blocks_owner_delete ON public.blocks;
+CREATE POLICY blocks_owner_delete ON public.blocks FOR DELETE
+  USING (blocker_id = auth.uid());

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2619,3 +2619,94 @@ UPDATE public.observations SET establishment_means = 'wild'
 -- Index for diversity queries filtering by establishment_means = 'wild'.
 CREATE INDEX IF NOT EXISTS idx_obs_establishment_means
   ON public.observations(establishment_means);
+
+-- =====================================================================
+-- Module 26 — social graph + reactions (2026-04-28)
+-- =====================================================================
+
+-- 1) follows
+CREATE TABLE IF NOT EXISTS public.follows (
+  follower_id   uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  followee_id   uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  tier          text        NOT NULL DEFAULT 'follower'
+                            CHECK (tier IN ('follower', 'collaborator')),
+  status        text        NOT NULL DEFAULT 'accepted'
+                            CHECK (status IN ('pending', 'accepted')),
+  requested_at  timestamptz NOT NULL DEFAULT now(),
+  accepted_at   timestamptz,
+  PRIMARY KEY (follower_id, followee_id),
+  CHECK (follower_id <> followee_id)
+);
+CREATE INDEX IF NOT EXISTS idx_follows_followee_status
+  ON public.follows(followee_id, status);
+CREATE INDEX IF NOT EXISTS idx_follows_follower_status
+  ON public.follows(follower_id, status);
+
+ALTER TABLE public.follows ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS follows_read ON public.follows;
+CREATE POLICY follows_read ON public.follows FOR SELECT USING (
+  -- Owners always see their edges; everyone else sees only accepted edges
+  follower_id = auth.uid()
+  OR followee_id = auth.uid()
+  OR status = 'accepted'
+);
+
+DROP POLICY IF EXISTS follows_owner_write ON public.follows;
+CREATE POLICY follows_owner_write ON public.follows FOR INSERT
+  WITH CHECK (follower_id = auth.uid());
+
+DROP POLICY IF EXISTS follows_followee_update ON public.follows;
+CREATE POLICY follows_followee_update ON public.follows FOR UPDATE
+  USING (followee_id = auth.uid())
+  WITH CHECK (followee_id = auth.uid());
+
+DROP POLICY IF EXISTS follows_owner_delete ON public.follows;
+CREATE POLICY follows_owner_delete ON public.follows FOR DELETE
+  USING (follower_id = auth.uid() OR followee_id = auth.uid());
+
+-- 2) Counters on users
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS follower_count   integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS following_count  integer NOT NULL DEFAULT 0;
+
+-- 3) Counter trigger
+CREATE OR REPLACE FUNCTION public.tg_follows_counter()
+RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF (TG_OP = 'INSERT') THEN
+    IF NEW.status = 'accepted' THEN
+      UPDATE public.users SET follower_count  = follower_count  + 1 WHERE id = NEW.followee_id;
+      UPDATE public.users SET following_count = following_count + 1 WHERE id = NEW.follower_id;
+    END IF;
+    RETURN NEW;
+  ELSIF (TG_OP = 'UPDATE') THEN
+    IF OLD.status <> 'accepted' AND NEW.status = 'accepted' THEN
+      UPDATE public.users SET follower_count  = follower_count  + 1 WHERE id = NEW.followee_id;
+      UPDATE public.users SET following_count = following_count + 1 WHERE id = NEW.follower_id;
+    ELSIF OLD.status = 'accepted' AND NEW.status <> 'accepted' THEN
+      UPDATE public.users SET follower_count  = GREATEST(follower_count  - 1, 0) WHERE id = NEW.followee_id;
+      UPDATE public.users SET following_count = GREATEST(following_count - 1, 0) WHERE id = NEW.follower_id;
+    END IF;
+    RETURN NEW;
+  ELSIF (TG_OP = 'DELETE') THEN
+    IF OLD.status = 'accepted' THEN
+      UPDATE public.users SET follower_count  = GREATEST(follower_count  - 1, 0) WHERE id = OLD.followee_id;
+      UPDATE public.users SET following_count = GREATEST(following_count - 1, 0) WHERE id = OLD.follower_id;
+    END IF;
+    RETURN OLD;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS follows_counter_trigger ON public.follows;
+CREATE TRIGGER follows_counter_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON public.follows
+  FOR EACH ROW EXECUTE FUNCTION public.tg_follows_counter();
+
+-- 4) Backfill counters (idempotent)
+UPDATE public.users u SET
+  follower_count  = (SELECT count(*) FROM public.follows WHERE followee_id = u.id AND status = 'accepted'),
+  following_count = (SELECT count(*) FROM public.follows WHERE follower_id = u.id AND status = 'accepted');

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2749,3 +2749,50 @@ CREATE POLICY obs_collaborator_read ON public.observations FOR SELECT
     obscure_level <> 'full'
     AND public.is_collaborator_of(auth.uid(), observer_id)
   );
+
+-- 7) observation_reactions
+CREATE TABLE IF NOT EXISTS public.observation_reactions (
+  id             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        uuid        NOT NULL REFERENCES public.users(id)        ON DELETE CASCADE,
+  observation_id uuid        NOT NULL REFERENCES public.observations(id) ON DELETE CASCADE,
+  kind           text        NOT NULL
+                             CHECK (kind IN ('fave','agree_id','needs_id','confirm_id','helpful')),
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, observation_id, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_obsreact_obs_kind
+  ON public.observation_reactions(observation_id, kind);
+CREATE INDEX IF NOT EXISTS idx_obsreact_user
+  ON public.observation_reactions(user_id, created_at DESC);
+
+ALTER TABLE public.observation_reactions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS obsreact_read ON public.observation_reactions;
+CREATE POLICY obsreact_read ON public.observation_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.observations o
+       WHERE o.id = observation_reactions.observation_id
+         AND (
+           o.observer_id = auth.uid()
+           OR (
+             o.obscure_level <> 'full'
+             AND public.can_see_facet(o.observer_id, 'observations', auth.uid())
+           )
+           OR public.is_collaborator_of(auth.uid(), o.observer_id)
+         )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.blocks b
+       WHERE (b.blocker_id = auth.uid() AND b.blocked_id = observation_reactions.user_id)
+          OR (b.blocked_id = auth.uid() AND b.blocker_id = observation_reactions.user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS obsreact_write ON public.observation_reactions;
+CREATE POLICY obsreact_write ON public.observation_reactions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS obsreact_delete ON public.observation_reactions;
+CREATE POLICY obsreact_delete ON public.observation_reactions FOR DELETE
+  USING (user_id = auth.uid());

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2796,3 +2796,48 @@ CREATE POLICY obsreact_write ON public.observation_reactions FOR INSERT
 DROP POLICY IF EXISTS obsreact_delete ON public.observation_reactions;
 CREATE POLICY obsreact_delete ON public.observation_reactions FOR DELETE
   USING (user_id = auth.uid());
+
+-- 8) photo_reactions (against media_files)
+CREATE TABLE IF NOT EXISTS public.photo_reactions (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid        NOT NULL REFERENCES public.users(id)       ON DELETE CASCADE,
+  media_file_id   uuid        NOT NULL REFERENCES public.media_files(id) ON DELETE CASCADE,
+  kind            text        NOT NULL CHECK (kind IN ('fave','helpful')),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, media_file_id, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_photoreact_media_kind
+  ON public.photo_reactions(media_file_id, kind);
+
+ALTER TABLE public.photo_reactions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS photoreact_read ON public.photo_reactions;
+CREATE POLICY photoreact_read ON public.photo_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.media_files m
+        JOIN public.observations o ON o.id = m.observation_id
+       WHERE m.id = photo_reactions.media_file_id
+         AND (
+           o.observer_id = auth.uid()
+           OR (
+             o.obscure_level <> 'full'
+             AND public.can_see_facet(o.observer_id, 'observations', auth.uid())
+           )
+           OR public.is_collaborator_of(auth.uid(), o.observer_id)
+         )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.blocks b
+       WHERE (b.blocker_id = auth.uid() AND b.blocked_id = photo_reactions.user_id)
+          OR (b.blocked_id = auth.uid() AND b.blocker_id = photo_reactions.user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS photoreact_write ON public.photo_reactions;
+CREATE POLICY photoreact_write ON public.photo_reactions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS photoreact_delete ON public.photo_reactions;
+CREATE POLICY photoreact_delete ON public.photo_reactions FOR DELETE
+  USING (user_id = auth.uid());

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2991,3 +2991,69 @@ BEGIN
   RETURN v_count;
 END;
 $$;
+
+-- 13) Fan-out: follow → notification
+CREATE OR REPLACE FUNCTION public.tg_follow_notify()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  -- Skip if recipient has blocked the actor.
+  IF EXISTS (SELECT 1 FROM public.blocks
+              WHERE blocker_id = NEW.followee_id AND blocked_id = NEW.follower_id) THEN
+    RETURN NEW;
+  END IF;
+
+  IF (TG_OP = 'INSERT' AND NEW.status = 'pending') THEN
+    INSERT INTO public.notifications(user_id, kind, payload)
+    VALUES (NEW.followee_id, 'follow',
+            jsonb_build_object('actor_id', NEW.follower_id, 'tier', NEW.tier, 'status', 'pending'));
+  ELSIF (TG_OP = 'INSERT' AND NEW.status = 'accepted') THEN
+    INSERT INTO public.notifications(user_id, kind, payload)
+    VALUES (NEW.followee_id, 'follow',
+            jsonb_build_object('actor_id', NEW.follower_id, 'tier', NEW.tier, 'status', 'accepted'));
+  ELSIF (TG_OP = 'UPDATE' AND OLD.status = 'pending' AND NEW.status = 'accepted') THEN
+    INSERT INTO public.notifications(user_id, kind, payload)
+    VALUES (NEW.follower_id, 'follow_accepted',
+            jsonb_build_object('actor_id', NEW.followee_id, 'tier', NEW.tier));
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS follows_notify_trigger ON public.follows;
+CREATE TRIGGER follows_notify_trigger
+  AFTER INSERT OR UPDATE ON public.follows
+  FOR EACH ROW EXECUTE FUNCTION public.tg_follow_notify();
+
+-- 14) Fan-out: observation_reactions → notification
+CREATE OR REPLACE FUNCTION public.tg_obsreact_notify()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_owner uuid;
+BEGIN
+  SELECT observer_id INTO v_owner FROM public.observations
+   WHERE id = NEW.observation_id;
+  IF v_owner IS NULL OR v_owner = NEW.user_id THEN
+    RETURN NEW;
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.blocks
+              WHERE blocker_id = v_owner AND blocked_id = NEW.user_id) THEN
+    RETURN NEW;
+  END IF;
+  INSERT INTO public.notifications(user_id, kind, payload)
+  VALUES (v_owner, 'reaction',
+          jsonb_build_object(
+            'actor_id', NEW.user_id,
+            'target_type', 'observation',
+            'target_id', NEW.observation_id,
+            'kind', NEW.kind
+          ));
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS obsreact_notify_trigger ON public.observation_reactions;
+CREATE TRIGGER obsreact_notify_trigger
+  AFTER INSERT ON public.observation_reactions
+  FOR EACH ROW EXECUTE FUNCTION public.tg_obsreact_notify();

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2910,3 +2910,33 @@ CREATE POLICY blocks_owner_write ON public.blocks FOR INSERT
 DROP POLICY IF EXISTS blocks_owner_delete ON public.blocks;
 CREATE POLICY blocks_owner_delete ON public.blocks FOR DELETE
   USING (blocker_id = auth.uid());
+
+-- 11) reports
+CREATE TABLE IF NOT EXISTS public.reports (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_id  uuid                 REFERENCES public.users(id) ON DELETE SET NULL,
+  target_type  text        NOT NULL
+                           CHECK (target_type IN ('user','observation','photo','identification','comment')),
+  target_id    uuid        NOT NULL,
+  reason       text        NOT NULL
+                           CHECK (reason IN ('spam','harassment','wrong_id','privacy_violation','copyright','other')),
+  note         text,
+  status       text        NOT NULL DEFAULT 'open'
+                           CHECK (status IN ('open','triaged','resolved','dismissed')),
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_reports_status_created
+  ON public.reports(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_reports_reporter
+  ON public.reports(reporter_id, created_at DESC);
+
+ALTER TABLE public.reports ENABLE ROW LEVEL SECURITY;
+
+-- Reporters can see their own reports; nobody else (operators read via service role).
+DROP POLICY IF EXISTS reports_owner_read ON public.reports;
+CREATE POLICY reports_owner_read ON public.reports FOR SELECT
+  USING (reporter_id = auth.uid());
+
+DROP POLICY IF EXISTS reports_owner_write ON public.reports;
+CREATE POLICY reports_owner_write ON public.reports FOR INSERT
+  WITH CHECK (reporter_id = auth.uid());

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2940,3 +2940,54 @@ CREATE POLICY reports_owner_read ON public.reports FOR SELECT
 DROP POLICY IF EXISTS reports_owner_write ON public.reports;
 CREATE POLICY reports_owner_write ON public.reports FOR INSERT
   WITH CHECK (reporter_id = auth.uid());
+
+-- 12) notifications
+CREATE TABLE IF NOT EXISTS public.notifications (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  kind        text        NOT NULL
+                          CHECK (kind IN ('follow','follow_accepted','reaction','comment','mention',
+                                          'identification','badge','digest')),
+  payload     jsonb       NOT NULL DEFAULT '{}',
+  read_at     timestamptz,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_unread
+  ON public.notifications(user_id, read_at) WHERE read_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created
+  ON public.notifications(user_id, created_at DESC);
+
+ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS notif_owner_read ON public.notifications;
+CREATE POLICY notif_owner_read ON public.notifications FOR SELECT
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS notif_owner_update ON public.notifications;
+CREATE POLICY notif_owner_update ON public.notifications FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS notif_owner_delete ON public.notifications;
+CREATE POLICY notif_owner_delete ON public.notifications FOR DELETE
+  USING (user_id = auth.uid());
+
+-- Server-side inserts (Edge Functions) use service role and bypass RLS;
+-- explicitly forbid client-side inserts.
+DROP POLICY IF EXISTS notif_no_client_insert ON public.notifications;
+CREATE POLICY notif_no_client_insert ON public.notifications FOR INSERT
+  WITH CHECK (false);
+
+CREATE OR REPLACE FUNCTION public.prune_old_notifications()
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  DELETE FROM public.notifications
+   WHERE read_at IS NOT NULL
+     AND read_at < now() - interval '90 days';
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2841,3 +2841,48 @@ CREATE POLICY photoreact_write ON public.photo_reactions FOR INSERT
 DROP POLICY IF EXISTS photoreact_delete ON public.photo_reactions;
 CREATE POLICY photoreact_delete ON public.photo_reactions FOR DELETE
   USING (user_id = auth.uid());
+
+-- 9) identification_reactions
+CREATE TABLE IF NOT EXISTS public.identification_reactions (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           uuid        NOT NULL REFERENCES public.users(id)           ON DELETE CASCADE,
+  identification_id uuid        NOT NULL REFERENCES public.identifications(id) ON DELETE CASCADE,
+  kind              text        NOT NULL CHECK (kind IN ('agree_id','disagree_id','helpful')),
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, identification_id, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_idreact_id_kind
+  ON public.identification_reactions(identification_id, kind);
+
+ALTER TABLE public.identification_reactions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS idreact_read ON public.identification_reactions;
+CREATE POLICY idreact_read ON public.identification_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.identifications i
+        JOIN public.observations o ON o.id = i.observation_id
+       WHERE i.id = identification_reactions.identification_id
+         AND (
+           o.observer_id = auth.uid()
+           OR (
+             o.obscure_level <> 'full'
+             AND public.can_see_facet(o.observer_id, 'observations', auth.uid())
+           )
+           OR public.is_collaborator_of(auth.uid(), o.observer_id)
+         )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.blocks b
+       WHERE (b.blocker_id = auth.uid() AND b.blocked_id = identification_reactions.user_id)
+          OR (b.blocked_id = auth.uid() AND b.blocker_id = identification_reactions.user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS idreact_write ON public.identification_reactions;
+CREATE POLICY idreact_write ON public.identification_reactions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS idreact_delete ON public.identification_reactions;
+CREATE POLICY idreact_delete ON public.identification_reactions FOR DELETE
+  USING (user_id = auth.uid());

--- a/docs/specs/modules/00-index.md
+++ b/docs/specs/modules/00-index.md
@@ -28,7 +28,7 @@ narrative source.
 > numbers reflect the actual filename on disk; gaps and the duplicated
 > `15-*.md` are historical (`15-map-location-picker.md` was claimed first,
 > then `15-mcp-server.md` shipped under the same number — see the note
-> below the table). 25 module specs are tracked here today.
+> below the table). 26 module specs are tracked here today.
 
 ---
 
@@ -82,6 +82,7 @@ narrative source.
 | # | Module | Target | Status | Spec |
 |---|---|---|---|---|
 | 25 | Profile Privacy & Public Profile (per-facet matrix + `/u/<username>/`) | v1.2 | shipped (v1.2.0 + v1.2.1 merged 2026-04-28; v1.2.2 cleanup deferred) | [`25-profile-privacy.md`](25-profile-privacy.md) |
+| 26 | Social graph + reactions (follows, reactions, blocks, reports, notifications) | v1.3 | planned (spec v1.0) | [`26-social-graph.md`](26-social-graph.md) |
 
 ## v1.5 — Territory layer — planned
 
@@ -137,7 +138,7 @@ ML training pipeline) rather than waiting on engineering capacity.
 
 ## How to add a new module spec
 
-1. Claim the next free `NN-*.md` slot (currently `26-`).
+1. Claim the next free `NN-*.md` slot (currently `27-`).
 2. Copy the structure of an existing spec
    (`01-photo-id.md` is a good template).
 3. Include: **Overview → Data model → APIs / logic → Edge cases → Cost / risk

--- a/docs/specs/modules/26-social-graph.md
+++ b/docs/specs/modules/26-social-graph.md
@@ -1,0 +1,44 @@
+# Module 26 — Social graph + reactions
+
+**Status:** v1.0 — implementation in progress
+**Spec source:** `docs/superpowers/specs/2026-04-28-social-features-design.md`
+**Sequenced before:** Module 27 (comments + mentions), Module 28 (real-time + ID-help).
+
+## Scope
+
+- Asymmetric follow with opt-in close-collaborator tier (`follows`, status workflow).
+- Per-target reaction tables for observations, photos, identifications.
+- Block + report kits.
+- In-app notifications with per-kind preferences.
+- 90-day pruning of read notifications.
+
+## Out of scope (parked to M27/M28/M29)
+
+- Comments + @mentions (M27).
+- Email digests, Resend integration (M27).
+- Supabase Realtime subscriptions and per-target mutes (M28).
+- Region/taxon groups (M29 if demand).
+
+## Privacy composition
+
+Reactions inherit observation visibility (`obs_public_read`), photo
+visibility (existing `media_public_read`), and identification visibility
+(`id_public_read`). Two new SQL helpers (`social_visible_to`,
+`is_collaborator_of`) extend the existing `is_credentialed_researcher`
+fast path so close-collaborators see precise coords on obscured
+observations of users they collaborate with.
+
+## Tables
+
+`follows`, `observation_reactions`, `photo_reactions`,
+`identification_reactions`, `blocks`, `reports`, `notifications`. Counter
+columns added to `users`. See the design spec for full DDL.
+
+## Edge Functions
+
+`follow`, `react`, `report`. All `verify_jwt=true`. Rate-limits enforced
+in-function via windowed `count(*)` over the source tables.
+
+## Risks
+
+See "Risks and open questions" in the design spec.

--- a/docs/superpowers/plans/2026-04-28-m26-social-graph.md
+++ b/docs/superpowers/plans/2026-04-28-m26-social-graph.md
@@ -1,0 +1,2483 @@
+# Module 26 — Social graph + reactions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first social module — asymmetric follow + opt-in close-collaborator tier, reactions on observations/photos/identifications, blocks, reports, and an in-app inbox — with full EN/ES parity, RLS, and idempotent migrations.
+
+**Architecture:** Additive Postgres schema (idempotent SQL appended to `docs/specs/infra/supabase-schema.sql`); two `STABLE SQL` privacy helpers inlined into RLS; per-target reaction tables (real FKs); polymorphic reports/notifications; three Edge Functions (`follow`, `react`, `report`) with inline windowed `count(*)` rate-limits (no `rate_limits` table); Astro+Tailwind frontend with shared `*View.astro` components for EN/ES parity; one nightly `pg_cron` job to prune old notifications.
+
+**Tech Stack:** Postgres + RLS + PostGIS, Supabase Auth + Realtime (deferred to M28), Deno Edge Functions, Astro 4, Tailwind, Vitest, Playwright. Email digests (Resend) and Realtime push come in M27/M28 — out of scope here.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-social-features-design.md`
+
+---
+
+## Pre-flight
+
+Before starting, confirm prerequisites:
+
+- [ ] **Confirm working directory and clean tree**
+
+```bash
+pwd                                          # → .../rastrum
+git status -s                                # → empty (or only docs/ in progress)
+git rev-parse --abbrev-ref HEAD              # confirm current branch
+```
+
+- [ ] **Confirm test baseline is green**
+
+```bash
+npm run typecheck && npm run test
+```
+Expected: 0 type errors; all Vitest tests pass (current count ≈ 225).
+
+- [ ] **Confirm the privacy helpers from module 25 already exist**
+
+```bash
+grep -n "can_see_facet\b" docs/specs/infra/supabase-schema.sql | head -3
+```
+Expected: at least one `CREATE OR REPLACE FUNCTION public.can_see_facet` line.
+If missing, stop — module 25 must have shipped before this plan can run.
+
+---
+
+## File structure
+
+Files created (all paths absolute from repo root):
+
+| Path | Responsibility |
+|---|---|
+| `docs/specs/modules/26-social-graph.md` | Module spec doc (registers in `00-index.md`) |
+| `supabase/functions/follow/index.ts` | Edge Function: insert/accept/reject follow + tier upgrade |
+| `supabase/functions/react/index.ts` | Edge Function: idempotent reaction toggle |
+| `supabase/functions/report/index.ts` | Edge Function: insert into `reports`, email operator |
+| `src/lib/social.ts` | Frontend client: follow/unfollow, react/unreact, report wrappers |
+| `src/lib/types.social.ts` | TypeScript types for follow, reaction, notification, report |
+| `src/components/FollowButton.astro` | Profile-header follow/unfollow/request button |
+| `src/components/ReactionStrip.astro` | Reaction icons + counts, target-type aware |
+| `src/components/FollowersView.astro` | Shared EN/ES followers list view |
+| `src/components/FollowingView.astro` | Shared EN/ES following list view |
+| `src/components/InboxView.astro` | Shared EN/ES inbox view |
+| `src/components/BlockedUsersList.astro` | Settings panel — list + unblock |
+| `src/pages/en/profile/[handle]/followers.astro` | EN followers page |
+| `src/pages/es/profile/[handle]/seguidores.astro` | ES followers page |
+| `src/pages/en/profile/[handle]/following.astro` | EN following page |
+| `src/pages/es/profile/[handle]/siguiendo.astro` | ES following page |
+| `src/pages/en/inbox.astro` | EN inbox page |
+| `src/pages/es/bandeja.astro` | ES inbox page |
+| `tests/unit/social.test.ts` | Unit tests for `src/lib/social.ts` |
+| `tests/sql/social-rls.sql` | RLS regression queries |
+| `tests/e2e/social.spec.ts` | Playwright happy-path: follow + react |
+
+Files modified:
+
+| Path | Change |
+|---|---|
+| `docs/specs/infra/supabase-schema.sql` | Append section "Module 26 — social graph" (idempotent) |
+| `docs/specs/modules/00-index.md` | Register `26-social-graph.md` |
+| `docs/progress.json` | Add `social-graph` item with `_es` translation |
+| `docs/tasks.json` | Add subtasks for `social-graph` |
+| `src/i18n/en.json` | Add `social.*` namespace |
+| `src/i18n/es.json` | Add `social.*` namespace (parity) |
+| `src/i18n/utils.ts` | Add new routes to `routes` map |
+| `src/components/Header.astro` | Add inbox-bell icon when authenticated |
+| `src/components/MobileBottomBar.astro` | Add inbox slot when authenticated |
+| `src/lib/types.ts` | Re-export from `types.social.ts` |
+| `playwright.config.ts` (no change expected) | — |
+
+---
+
+## Task 1 — Module spec doc
+
+**Files:**
+- Create: `docs/specs/modules/26-social-graph.md`
+- Modify: `docs/specs/modules/00-index.md`
+
+- [ ] **Step 1.1: Write module spec body**
+
+Create `docs/specs/modules/26-social-graph.md`:
+
+```markdown
+# Module 26 — Social graph + reactions
+
+**Status:** v1.0 — implementation in progress
+**Spec source:** `docs/superpowers/specs/2026-04-28-social-features-design.md`
+**Sequenced before:** Module 27 (comments + mentions), Module 28 (real-time + ID-help).
+
+## Scope
+
+- Asymmetric follow with opt-in close-collaborator tier (`follows`, status workflow).
+- Per-target reaction tables for observations, photos, identifications.
+- Block + report kits.
+- In-app notifications with per-kind preferences.
+- 90-day pruning of read notifications.
+
+## Out of scope (parked to M27/M28/M29)
+
+- Comments + @mentions (M27).
+- Email digests, Resend integration (M27).
+- Supabase Realtime subscriptions and per-target mutes (M28).
+- Region/taxon groups (M29 if demand).
+
+## Privacy composition
+
+Reactions inherit observation visibility (`obs_public_read`), photo
+visibility (existing `media_public_read`), and identification visibility
+(`id_public_read`). Two new SQL helpers (`social_visible_to`,
+`is_collaborator_of`) extend the existing `is_credentialed_researcher`
+fast path so close-collaborators see precise coords on obscured
+observations of users they collaborate with.
+
+## Tables
+
+`follows`, `observation_reactions`, `photo_reactions`,
+`identification_reactions`, `blocks`, `reports`, `notifications`. Counter
+columns added to `users`. See the design spec for full DDL.
+
+## Edge Functions
+
+`follow`, `react`, `report`. All `verify_jwt=true`. Rate-limits enforced
+in-function via windowed `count(*)` over the source tables.
+
+## Risks
+
+See "Risks and open questions" in the design spec.
+```
+
+- [ ] **Step 1.2: Register in module index**
+
+In `docs/specs/modules/00-index.md`, add the row for module 26 in the
+appropriate phase table. Search for the row for module 25 and insert
+the new row directly after it. If you can't tell which phase, default
+to "Phase 5 — Community & social". The exact line:
+
+```markdown
+| 26 | [Social graph + reactions](./26-social-graph.md) | follows, reactions, blocks, reports, notifications |
+```
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add docs/specs/modules/26-social-graph.md docs/specs/modules/00-index.md
+git commit -m "docs(spec): module 26 — social graph + reactions"
+```
+
+---
+
+## Task 2 — SQL: `follows` table + counters + triggers
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql` (append to end of file, before any `pg_cron` schedules)
+
+- [ ] **Step 2.1: Append the `follows` schema block**
+
+Append at the end of `supabase-schema.sql`:
+
+```sql
+-- =====================================================================
+-- Module 26 — social graph + reactions (2026-04-28)
+-- =====================================================================
+
+-- 1) follows
+CREATE TABLE IF NOT EXISTS public.follows (
+  follower_id   uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  followee_id   uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  tier          text        NOT NULL DEFAULT 'follower'
+                            CHECK (tier IN ('follower', 'collaborator')),
+  status        text        NOT NULL DEFAULT 'accepted'
+                            CHECK (status IN ('pending', 'accepted')),
+  requested_at  timestamptz NOT NULL DEFAULT now(),
+  accepted_at   timestamptz,
+  PRIMARY KEY (follower_id, followee_id),
+  CHECK (follower_id <> followee_id)
+);
+CREATE INDEX IF NOT EXISTS idx_follows_followee_status
+  ON public.follows(followee_id, status);
+CREATE INDEX IF NOT EXISTS idx_follows_follower_status
+  ON public.follows(follower_id, status);
+
+ALTER TABLE public.follows ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS follows_read ON public.follows;
+CREATE POLICY follows_read ON public.follows FOR SELECT USING (
+  -- Owners always see their edges; everyone else sees only accepted edges
+  follower_id = auth.uid()
+  OR followee_id = auth.uid()
+  OR status = 'accepted'
+);
+
+DROP POLICY IF EXISTS follows_owner_write ON public.follows;
+CREATE POLICY follows_owner_write ON public.follows FOR INSERT
+  WITH CHECK (follower_id = auth.uid());
+
+DROP POLICY IF EXISTS follows_followee_update ON public.follows;
+CREATE POLICY follows_followee_update ON public.follows FOR UPDATE
+  USING (followee_id = auth.uid())
+  WITH CHECK (followee_id = auth.uid());
+
+DROP POLICY IF EXISTS follows_owner_delete ON public.follows;
+CREATE POLICY follows_owner_delete ON public.follows FOR DELETE
+  USING (follower_id = auth.uid() OR followee_id = auth.uid());
+
+-- 2) Counters on users
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS follower_count   integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS following_count  integer NOT NULL DEFAULT 0;
+
+-- 3) Counter trigger
+CREATE OR REPLACE FUNCTION public.tg_follows_counter()
+RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF (TG_OP = 'INSERT') THEN
+    IF NEW.status = 'accepted' THEN
+      UPDATE public.users SET follower_count  = follower_count  + 1 WHERE id = NEW.followee_id;
+      UPDATE public.users SET following_count = following_count + 1 WHERE id = NEW.follower_id;
+    END IF;
+    RETURN NEW;
+  ELSIF (TG_OP = 'UPDATE') THEN
+    IF OLD.status <> 'accepted' AND NEW.status = 'accepted' THEN
+      UPDATE public.users SET follower_count  = follower_count  + 1 WHERE id = NEW.followee_id;
+      UPDATE public.users SET following_count = following_count + 1 WHERE id = NEW.follower_id;
+    ELSIF OLD.status = 'accepted' AND NEW.status <> 'accepted' THEN
+      UPDATE public.users SET follower_count  = GREATEST(follower_count  - 1, 0) WHERE id = NEW.followee_id;
+      UPDATE public.users SET following_count = GREATEST(following_count - 1, 0) WHERE id = NEW.follower_id;
+    END IF;
+    RETURN NEW;
+  ELSIF (TG_OP = 'DELETE') THEN
+    IF OLD.status = 'accepted' THEN
+      UPDATE public.users SET follower_count  = GREATEST(follower_count  - 1, 0) WHERE id = OLD.followee_id;
+      UPDATE public.users SET following_count = GREATEST(following_count - 1, 0) WHERE id = OLD.follower_id;
+    END IF;
+    RETURN OLD;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS follows_counter_trigger ON public.follows;
+CREATE TRIGGER follows_counter_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON public.follows
+  FOR EACH ROW EXECUTE FUNCTION public.tg_follows_counter();
+
+-- 4) Backfill counters (idempotent)
+UPDATE public.users u SET
+  follower_count  = (SELECT count(*) FROM public.follows WHERE followee_id = u.id AND status = 'accepted'),
+  following_count = (SELECT count(*) FROM public.follows WHERE follower_id = u.id AND status = 'accepted');
+```
+
+- [ ] **Step 2.2: Apply the schema and verify**
+
+```bash
+make db-apply
+make db-verify
+```
+Expected: `db-verify` lists `follows` among the tables with RLS enabled.
+
+```bash
+psql "$SUPABASE_DB_URL" -c "SELECT relname, relrowsecurity FROM pg_class WHERE relname = 'follows';"
+```
+Expected: `follows | t`
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(db): m26 — follows table + counters + RLS"
+```
+
+---
+
+## Task 3 — SQL: privacy helpers (`social_visible_to`, `is_collaborator_of`)
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+
+- [ ] **Step 3.1: Append helper definitions**
+
+Append immediately after the Task 2 block:
+
+```sql
+-- 5) Social privacy helpers
+CREATE OR REPLACE FUNCTION public.social_visible_to(viewer uuid, owner uuid)
+RETURNS boolean
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT
+    viewer IS NOT NULL AND (
+      viewer = owner
+      OR EXISTS (
+        SELECT 1 FROM public.follows f
+         WHERE f.follower_id = viewer
+           AND f.followee_id = owner
+           AND f.status      = 'accepted'
+      )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_collaborator_of(viewer uuid, owner uuid)
+RETURNS boolean
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT viewer IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.follows f
+     WHERE f.follower_id = viewer
+       AND f.followee_id = owner
+       AND f.tier        = 'collaborator'
+       AND f.status      = 'accepted'
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.social_visible_to(uuid, uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.is_collaborator_of(uuid, uuid) TO anon, authenticated;
+```
+
+- [ ] **Step 3.2: Extend collaborator coord-precision unlock on observations**
+
+Append:
+
+```sql
+-- 6) Collaborators inherit credentialed-researcher coord-precision unlock
+DROP POLICY IF EXISTS obs_collaborator_read ON public.observations;
+CREATE POLICY obs_collaborator_read ON public.observations FOR SELECT
+  USING (
+    obscure_level <> 'full'
+    AND public.is_collaborator_of(auth.uid(), observer_id)
+  );
+```
+
+- [ ] **Step 3.3: Apply and smoke-test the helpers**
+
+```bash
+make db-apply
+psql "$SUPABASE_DB_URL" -c "SELECT public.social_visible_to(NULL, gen_random_uuid());"
+```
+Expected: `f`. (NULL viewer must short-circuit to false.)
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(db): m26 — social_visible_to + is_collaborator_of helpers"
+```
+
+---
+
+## Task 4 — SQL: `observation_reactions` table + RLS
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+
+- [ ] **Step 4.1: Append the table**
+
+```sql
+-- 7) observation_reactions
+CREATE TABLE IF NOT EXISTS public.observation_reactions (
+  id             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        uuid        NOT NULL REFERENCES public.users(id)        ON DELETE CASCADE,
+  observation_id uuid        NOT NULL REFERENCES public.observations(id) ON DELETE CASCADE,
+  kind           text        NOT NULL
+                             CHECK (kind IN ('fave','agree_id','needs_id','confirm_id','helpful')),
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, observation_id, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_obsreact_obs_kind
+  ON public.observation_reactions(observation_id, kind);
+CREATE INDEX IF NOT EXISTS idx_obsreact_user
+  ON public.observation_reactions(user_id, created_at DESC);
+
+ALTER TABLE public.observation_reactions ENABLE ROW LEVEL SECURITY;
+```
+
+- [ ] **Step 4.2: Append the RLS policies**
+
+```sql
+DROP POLICY IF EXISTS obsreact_read ON public.observation_reactions;
+CREATE POLICY obsreact_read ON public.observation_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.observations o
+       WHERE o.id = observation_reactions.observation_id
+         AND (
+           o.observer_id = auth.uid()
+           OR (
+             o.obscure_level <> 'full'
+             AND public.can_see_facet(o.observer_id, 'observations', auth.uid())
+           )
+           OR public.is_collaborator_of(auth.uid(), o.observer_id)
+         )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.blocks b
+       WHERE (b.blocker_id = auth.uid() AND b.blocked_id = observation_reactions.user_id)
+          OR (b.blocked_id = auth.uid() AND b.blocker_id = observation_reactions.user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS obsreact_write ON public.observation_reactions;
+CREATE POLICY obsreact_write ON public.observation_reactions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS obsreact_delete ON public.observation_reactions;
+CREATE POLICY obsreact_delete ON public.observation_reactions FOR DELETE
+  USING (user_id = auth.uid());
+```
+
+> Note: this RLS references `public.blocks` which is created in Task 7. The
+> policy is created with a forward dependency; the `blocks` table must
+> exist for any read to succeed. Apply happens after Task 7.
+
+- [ ] **Step 4.3: Commit (do not apply yet — needs Task 7)**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(db): m26 — observation_reactions table + RLS (forward dep on blocks)"
+```
+
+---
+
+## Task 5 — SQL: `photo_reactions` table + RLS
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+
+- [ ] **Step 5.1: Verify the photo table name**
+
+```bash
+grep -n "CREATE TABLE.*photos\b\|CREATE TABLE.*media_files" docs/specs/infra/supabase-schema.sql | head
+```
+The existing schema uses `media_files` (not `photos`). Use that name.
+
+- [ ] **Step 5.2: Append the table**
+
+```sql
+-- 8) photo_reactions (against media_files)
+CREATE TABLE IF NOT EXISTS public.photo_reactions (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid        NOT NULL REFERENCES public.users(id)       ON DELETE CASCADE,
+  media_file_id   uuid        NOT NULL REFERENCES public.media_files(id) ON DELETE CASCADE,
+  kind            text        NOT NULL CHECK (kind IN ('fave','helpful')),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, media_file_id, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_photoreact_media_kind
+  ON public.photo_reactions(media_file_id, kind);
+
+ALTER TABLE public.photo_reactions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS photoreact_read ON public.photo_reactions;
+CREATE POLICY photoreact_read ON public.photo_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.media_files m
+        JOIN public.observations o ON o.id = m.observation_id
+       WHERE m.id = photo_reactions.media_file_id
+         AND (
+           o.observer_id = auth.uid()
+           OR (
+             o.obscure_level <> 'full'
+             AND public.can_see_facet(o.observer_id, 'observations', auth.uid())
+           )
+           OR public.is_collaborator_of(auth.uid(), o.observer_id)
+         )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.blocks b
+       WHERE (b.blocker_id = auth.uid() AND b.blocked_id = photo_reactions.user_id)
+          OR (b.blocked_id = auth.uid() AND b.blocker_id = photo_reactions.user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS photoreact_write ON public.photo_reactions;
+CREATE POLICY photoreact_write ON public.photo_reactions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS photoreact_delete ON public.photo_reactions;
+CREATE POLICY photoreact_delete ON public.photo_reactions FOR DELETE
+  USING (user_id = auth.uid());
+```
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(db): m26 — photo_reactions table + RLS"
+```
+
+---
+
+## Task 6 — SQL: `identification_reactions` table + RLS
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+
+- [ ] **Step 6.1: Append the table**
+
+```sql
+-- 9) identification_reactions
+CREATE TABLE IF NOT EXISTS public.identification_reactions (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           uuid        NOT NULL REFERENCES public.users(id)           ON DELETE CASCADE,
+  identification_id uuid        NOT NULL REFERENCES public.identifications(id) ON DELETE CASCADE,
+  kind              text        NOT NULL CHECK (kind IN ('agree_id','disagree_id','helpful')),
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, identification_id, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_idreact_id_kind
+  ON public.identification_reactions(identification_id, kind);
+
+ALTER TABLE public.identification_reactions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS idreact_read ON public.identification_reactions;
+CREATE POLICY idreact_read ON public.identification_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.identifications i
+        JOIN public.observations o ON o.id = i.observation_id
+       WHERE i.id = identification_reactions.identification_id
+         AND (
+           o.observer_id = auth.uid()
+           OR (
+             o.obscure_level <> 'full'
+             AND public.can_see_facet(o.observer_id, 'observations', auth.uid())
+           )
+           OR public.is_collaborator_of(auth.uid(), o.observer_id)
+         )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.blocks b
+       WHERE (b.blocker_id = auth.uid() AND b.blocked_id = identification_reactions.user_id)
+          OR (b.blocked_id = auth.uid() AND b.blocker_id = identification_reactions.user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS idreact_write ON public.identification_reactions;
+CREATE POLICY idreact_write ON public.identification_reactions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS idreact_delete ON public.identification_reactions;
+CREATE POLICY idreact_delete ON public.identification_reactions FOR DELETE
+  USING (user_id = auth.uid());
+```
+
+- [ ] **Step 6.2: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(db): m26 — identification_reactions table + RLS"
+```
+
+---
+
+## Task 7 — SQL: `blocks` table + RLS
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+
+- [ ] **Step 7.1: Append the table**
+
+```sql
+-- 10) blocks
+CREATE TABLE IF NOT EXISTS public.blocks (
+  blocker_id  uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  blocked_id  uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (blocker_id, blocked_id),
+  CHECK (blocker_id <> blocked_id)
+);
+CREATE INDEX IF NOT EXISTS idx_blocks_blocked ON public.blocks(blocked_id);
+
+ALTER TABLE public.blocks ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS blocks_owner_read ON public.blocks;
+CREATE POLICY blocks_owner_read ON public.blocks FOR SELECT
+  USING (blocker_id = auth.uid());
+
+DROP POLICY IF EXISTS blocks_owner_write ON public.blocks;
+CREATE POLICY blocks_owner_write ON public.blocks FOR INSERT
+  WITH CHECK (blocker_id = auth.uid());
+
+DROP POLICY IF EXISTS blocks_owner_delete ON public.blocks;
+CREATE POLICY blocks_owner_delete ON public.blocks FOR DELETE
+  USING (blocker_id = auth.uid());
+```
+
+- [ ] **Step 7.2: Apply all schema so far (Tasks 2–7)**
+
+```bash
+make db-apply
+make db-verify
+```
+Expected: `follows`, `observation_reactions`, `photo_reactions`,
+`identification_reactions`, `blocks` all listed with `relrowsecurity = t`.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(db): m26 — blocks table + RLS (closes forward deps from reactions)"
+```
+
+---
+
+## Task 8 — SQL: `reports` table + RLS
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+
+- [ ] **Step 8.1: Append the table**
+
+```sql
+-- 11) reports
+CREATE TABLE IF NOT EXISTS public.reports (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_id  uuid                 REFERENCES public.users(id) ON DELETE SET NULL,
+  target_type  text        NOT NULL
+                           CHECK (target_type IN ('user','observation','photo','identification','comment')),
+  target_id    uuid        NOT NULL,
+  reason       text        NOT NULL
+                           CHECK (reason IN ('spam','harassment','wrong_id','privacy_violation','copyright','other')),
+  note         text,
+  status       text        NOT NULL DEFAULT 'open'
+                           CHECK (status IN ('open','triaged','resolved','dismissed')),
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_reports_status_created
+  ON public.reports(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_reports_reporter
+  ON public.reports(reporter_id, created_at DESC);
+
+ALTER TABLE public.reports ENABLE ROW LEVEL SECURITY;
+
+-- Reporters can see their own reports; nobody else (operators read via service role).
+DROP POLICY IF EXISTS reports_owner_read ON public.reports;
+CREATE POLICY reports_owner_read ON public.reports FOR SELECT
+  USING (reporter_id = auth.uid());
+
+DROP POLICY IF EXISTS reports_owner_write ON public.reports;
+CREATE POLICY reports_owner_write ON public.reports FOR INSERT
+  WITH CHECK (reporter_id = auth.uid());
+```
+
+- [ ] **Step 8.2: Apply and commit**
+
+```bash
+make db-apply
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(db): m26 — reports table + RLS"
+```
+
+---
+
+## Task 9 — SQL: `notifications` table + 90-day prune cron
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+- Modify: `docs/specs/infra/cron-schedules.sql`
+
+- [ ] **Step 9.1: Append the notifications table**
+
+```sql
+-- 12) notifications
+CREATE TABLE IF NOT EXISTS public.notifications (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  kind        text        NOT NULL
+                          CHECK (kind IN ('follow','follow_accepted','reaction','comment','mention',
+                                          'identification','badge','digest')),
+  payload     jsonb       NOT NULL DEFAULT '{}',
+  read_at     timestamptz,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_unread
+  ON public.notifications(user_id, read_at) WHERE read_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created
+  ON public.notifications(user_id, created_at DESC);
+
+ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS notif_owner_read ON public.notifications;
+CREATE POLICY notif_owner_read ON public.notifications FOR SELECT
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS notif_owner_update ON public.notifications;
+CREATE POLICY notif_owner_update ON public.notifications FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS notif_owner_delete ON public.notifications;
+CREATE POLICY notif_owner_delete ON public.notifications FOR DELETE
+  USING (user_id = auth.uid());
+
+-- Server-side inserts (Edge Functions) use service role and bypass RLS;
+-- explicitly forbid client-side inserts.
+DROP POLICY IF EXISTS notif_no_client_insert ON public.notifications;
+CREATE POLICY notif_no_client_insert ON public.notifications FOR INSERT
+  WITH CHECK (false);
+```
+
+- [ ] **Step 9.2: Append the prune function**
+
+```sql
+CREATE OR REPLACE FUNCTION public.prune_old_notifications()
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  DELETE FROM public.notifications
+   WHERE read_at IS NOT NULL
+     AND read_at < now() - interval '90 days';
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+```
+
+- [ ] **Step 9.3: Append the cron schedule**
+
+In `docs/specs/infra/cron-schedules.sql`, append:
+
+```sql
+-- m26: prune read notifications older than 90 days, daily at 04:30 UTC.
+SELECT cron.unschedule('prune_old_notifications')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'prune_old_notifications');
+SELECT cron.schedule(
+  'prune_old_notifications',
+  '30 4 * * *',
+  $$ SELECT public.prune_old_notifications(); $$
+);
+```
+
+- [ ] **Step 9.4: Apply schema and schedule the cron**
+
+```bash
+make db-apply
+make db-cron-schedule
+```
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql docs/specs/infra/cron-schedules.sql
+git commit -m "feat(db): m26 — notifications table + RLS + 90-day prune cron"
+```
+
+---
+
+## Task 10 — SQL: notification triggers (follow + reaction fan-out)
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+
+- [ ] **Step 10.1: Append fan-out triggers**
+
+```sql
+-- 13) Fan-out: follow → notification
+CREATE OR REPLACE FUNCTION public.tg_follow_notify()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  -- Skip if recipient has blocked the actor.
+  IF EXISTS (SELECT 1 FROM public.blocks
+              WHERE blocker_id = NEW.followee_id AND blocked_id = NEW.follower_id) THEN
+    RETURN NEW;
+  END IF;
+
+  IF (TG_OP = 'INSERT' AND NEW.status = 'pending') THEN
+    INSERT INTO public.notifications(user_id, kind, payload)
+    VALUES (NEW.followee_id, 'follow',
+            jsonb_build_object('actor_id', NEW.follower_id, 'tier', NEW.tier, 'status', 'pending'));
+  ELSIF (TG_OP = 'INSERT' AND NEW.status = 'accepted') THEN
+    INSERT INTO public.notifications(user_id, kind, payload)
+    VALUES (NEW.followee_id, 'follow',
+            jsonb_build_object('actor_id', NEW.follower_id, 'tier', NEW.tier, 'status', 'accepted'));
+  ELSIF (TG_OP = 'UPDATE' AND OLD.status = 'pending' AND NEW.status = 'accepted') THEN
+    INSERT INTO public.notifications(user_id, kind, payload)
+    VALUES (NEW.follower_id, 'follow_accepted',
+            jsonb_build_object('actor_id', NEW.followee_id, 'tier', NEW.tier));
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS follows_notify_trigger ON public.follows;
+CREATE TRIGGER follows_notify_trigger
+  AFTER INSERT OR UPDATE ON public.follows
+  FOR EACH ROW EXECUTE FUNCTION public.tg_follow_notify();
+
+-- 14) Fan-out: observation_reactions → notification
+CREATE OR REPLACE FUNCTION public.tg_obsreact_notify()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_owner uuid;
+BEGIN
+  SELECT observer_id INTO v_owner FROM public.observations
+   WHERE id = NEW.observation_id;
+  IF v_owner IS NULL OR v_owner = NEW.user_id THEN
+    RETURN NEW;
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.blocks
+              WHERE blocker_id = v_owner AND blocked_id = NEW.user_id) THEN
+    RETURN NEW;
+  END IF;
+  INSERT INTO public.notifications(user_id, kind, payload)
+  VALUES (v_owner, 'reaction',
+          jsonb_build_object(
+            'actor_id', NEW.user_id,
+            'target_type', 'observation',
+            'target_id', NEW.observation_id,
+            'kind', NEW.kind
+          ));
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS obsreact_notify_trigger ON public.observation_reactions;
+CREATE TRIGGER obsreact_notify_trigger
+  AFTER INSERT ON public.observation_reactions
+  FOR EACH ROW EXECUTE FUNCTION public.tg_obsreact_notify();
+```
+
+(Equivalent triggers for `photo_reactions` and `identification_reactions`
+are not added in v1 — surface only observation reactions in the inbox to
+keep the inbox signal-rich. M27 may revisit.)
+
+- [ ] **Step 10.2: Apply and commit**
+
+```bash
+make db-apply
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(db): m26 — fan-out triggers (follow + observation_reactions → notifications)"
+```
+
+---
+
+## Task 11 — TypeScript types and frontend client
+
+**Files:**
+- Create: `src/lib/types.social.ts`
+- Modify: `src/lib/types.ts`
+- Create: `src/lib/social.ts`
+- Create: `tests/unit/social.test.ts`
+
+- [ ] **Step 11.1: Write the types file**
+
+Create `src/lib/types.social.ts`:
+
+```ts
+export type FollowTier = 'follower' | 'collaborator';
+export type FollowStatus = 'pending' | 'accepted';
+
+export interface Follow {
+  follower_id: string;
+  followee_id: string;
+  tier: FollowTier;
+  status: FollowStatus;
+  requested_at: string;
+  accepted_at: string | null;
+}
+
+export type ReactionTarget = 'observation' | 'photo' | 'identification';
+export type ReactionKind =
+  | 'fave' | 'agree_id' | 'needs_id' | 'confirm_id'
+  | 'disagree_id' | 'helpful';
+
+export interface Reaction {
+  id: string;
+  user_id: string;
+  target_id: string;
+  kind: ReactionKind;
+  created_at: string;
+}
+
+export type NotificationKind =
+  | 'follow' | 'follow_accepted' | 'reaction' | 'comment'
+  | 'mention' | 'identification' | 'badge' | 'digest';
+
+export interface Notification {
+  id: string;
+  user_id: string;
+  kind: NotificationKind;
+  payload: Record<string, unknown>;
+  read_at: string | null;
+  created_at: string;
+}
+
+export type ReportTarget = 'user' | 'observation' | 'photo' | 'identification' | 'comment';
+export type ReportReason =
+  | 'spam' | 'harassment' | 'wrong_id'
+  | 'privacy_violation' | 'copyright' | 'other';
+
+export interface Report {
+  id: string;
+  reporter_id: string | null;
+  target_type: ReportTarget;
+  target_id: string;
+  reason: ReportReason;
+  note: string | null;
+  status: 'open' | 'triaged' | 'resolved' | 'dismissed';
+  created_at: string;
+}
+```
+
+- [ ] **Step 11.2: Re-export from `types.ts`**
+
+In `src/lib/types.ts`, append at the bottom:
+
+```ts
+export * from './types.social';
+```
+
+- [ ] **Step 11.3: Write the failing unit tests**
+
+Create `tests/unit/social.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../src/lib/supabase', () => {
+  const single = { single: vi.fn() };
+  const eq = { eq: vi.fn(() => eq), maybeSingle: vi.fn() };
+  const select = { select: vi.fn(() => eq) };
+  const builder: Record<string, unknown> = {
+    select: vi.fn(() => eq),
+    insert: vi.fn(() => single),
+    delete: vi.fn(() => eq),
+    update: vi.fn(() => eq),
+  };
+  const from = vi.fn(() => builder);
+  return {
+    supabase: { from, functions: { invoke: vi.fn() }, auth: { getUser: vi.fn() } },
+  };
+});
+
+import { supabase } from '../../src/lib/supabase';
+import { followUser, unfollowUser, react, unreact, reportTarget } from '../../src/lib/social';
+
+describe('social client', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('followUser invokes the follow Edge Function with action=follow', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, status: 'accepted' }, error: null,
+    });
+    const out = await followUser('user-uuid');
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('follow', {
+      body: { action: 'follow', target_user_id: 'user-uuid', tier: 'follower' },
+    });
+    expect(out).toEqual({ ok: true, status: 'accepted' });
+  });
+
+  it('unfollowUser invokes the follow Edge Function with action=unfollow', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true }, error: null,
+    });
+    await unfollowUser('user-uuid');
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('follow', {
+      body: { action: 'unfollow', target_user_id: 'user-uuid' },
+    });
+  });
+
+  it('react invokes the react Edge Function with toggle=true', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, action: 'inserted' }, error: null,
+    });
+    await react({ target: 'observation', target_id: 'obs-id', kind: 'fave' });
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('react', {
+      body: { target: 'observation', target_id: 'obs-id', kind: 'fave', toggle: true },
+    });
+  });
+
+  it('unreact invokes the react Edge Function with toggle=false', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, action: 'deleted' }, error: null,
+    });
+    await unreact({ target: 'observation', target_id: 'obs-id', kind: 'fave' });
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('react', {
+      body: { target: 'observation', target_id: 'obs-id', kind: 'fave', toggle: false },
+    });
+  });
+
+  it('reportTarget invokes the report Edge Function', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, id: 'rep-id' }, error: null,
+    });
+    await reportTarget({ target: 'user', target_id: 'u', reason: 'spam', note: 'x' });
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('report', {
+      body: { target: 'user', target_id: 'u', reason: 'spam', note: 'x' },
+    });
+  });
+});
+```
+
+- [ ] **Step 11.4: Run the tests — they must fail**
+
+```bash
+npx vitest run tests/unit/social.test.ts
+```
+Expected: all 5 fail with "Cannot find module '../../src/lib/social'".
+
+- [ ] **Step 11.5: Implement `src/lib/social.ts`**
+
+```ts
+import { supabase } from './supabase';
+import type {
+  ReactionTarget, ReactionKind, ReportTarget, ReportReason, FollowTier,
+} from './types.social';
+
+export async function followUser(targetUserId: string, tier: FollowTier = 'follower') {
+  const { data, error } = await supabase.functions.invoke('follow', {
+    body: { action: 'follow', target_user_id: targetUserId, tier },
+  });
+  if (error) throw error;
+  return data as { ok: boolean; status: 'pending' | 'accepted' };
+}
+
+export async function unfollowUser(targetUserId: string) {
+  const { data, error } = await supabase.functions.invoke('follow', {
+    body: { action: 'unfollow', target_user_id: targetUserId },
+  });
+  if (error) throw error;
+  return data as { ok: boolean };
+}
+
+export async function acceptFollow(followerId: string) {
+  const { data, error } = await supabase.functions.invoke('follow', {
+    body: { action: 'accept', follower_id: followerId },
+  });
+  if (error) throw error;
+  return data as { ok: boolean };
+}
+
+export async function react(args: {
+  target: ReactionTarget;
+  target_id: string;
+  kind: ReactionKind;
+}) {
+  const { data, error } = await supabase.functions.invoke('react', {
+    body: { ...args, toggle: true },
+  });
+  if (error) throw error;
+  return data as { ok: boolean; action: 'inserted' | 'deleted' };
+}
+
+export async function unreact(args: {
+  target: ReactionTarget;
+  target_id: string;
+  kind: ReactionKind;
+}) {
+  const { data, error } = await supabase.functions.invoke('react', {
+    body: { ...args, toggle: false },
+  });
+  if (error) throw error;
+  return data as { ok: boolean; action: 'deleted' };
+}
+
+export async function reportTarget(args: {
+  target: ReportTarget;
+  target_id: string;
+  reason: ReportReason;
+  note?: string;
+}) {
+  const { data, error } = await supabase.functions.invoke('report', { body: args });
+  if (error) throw error;
+  return data as { ok: boolean; id: string };
+}
+
+export async function blockUser(targetUserId: string) {
+  const { error } = await supabase
+    .from('blocks')
+    .insert({ blocker_id: (await supabase.auth.getUser()).data.user?.id, blocked_id: targetUserId });
+  if (error) throw error;
+}
+
+export async function unblockUser(targetUserId: string) {
+  const me = (await supabase.auth.getUser()).data.user?.id;
+  const { error } = await supabase
+    .from('blocks')
+    .delete()
+    .eq('blocker_id', me)
+    .eq('blocked_id', targetUserId);
+  if (error) throw error;
+}
+```
+
+- [ ] **Step 11.6: Run the tests — they must pass**
+
+```bash
+npx vitest run tests/unit/social.test.ts
+```
+Expected: 5 passing.
+
+- [ ] **Step 11.7: Commit**
+
+```bash
+git add src/lib/types.social.ts src/lib/types.ts src/lib/social.ts tests/unit/social.test.ts
+git commit -m "feat(lib): m26 — social client (follow, react, report, block) + types + unit tests"
+```
+
+---
+
+## Task 12 — Edge Function: `follow`
+
+**Files:**
+- Create: `supabase/functions/follow/index.ts`
+
+- [ ] **Step 12.1: Read an existing function for the pattern**
+
+```bash
+cat supabase/functions/get-upload-url/index.ts | head -60
+```
+Note the imports, JWT verification, CORS, error response shape. Mirror it.
+
+- [ ] **Step 12.2: Implement the function**
+
+Create `supabase/functions/follow/index.ts`:
+
+```ts
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const FOLLOW_RATE_PER_HOUR = 30;
+const COLLAB_REQUEST_PER_DAY = 5;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+
+  const auth = req.headers.get('Authorization') ?? '';
+  if (!auth.startsWith('Bearer ')) return json({ error: 'no_jwt' }, 401);
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: auth } },
+  });
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData.user) return json({ error: 'invalid_jwt' }, 401);
+  const userId = userData.user.id;
+
+  let body: Record<string, unknown>;
+  try { body = await req.json(); } catch { return json({ error: 'bad_json' }, 400); }
+
+  const action = String(body.action ?? '');
+
+  // Rate-limit: count follows by this user in last hour.
+  const { count: hourCount } = await supabase
+    .from('follows')
+    .select('*', { count: 'exact', head: true })
+    .eq('follower_id', userId)
+    .gte('requested_at', new Date(Date.now() - 3600_000).toISOString());
+
+  if ((hourCount ?? 0) >= FOLLOW_RATE_PER_HOUR && action !== 'unfollow' && action !== 'accept') {
+    return json({ error: 'rate_limited', retry_after_s: 3600 }, 429);
+  }
+
+  if (action === 'follow') {
+    const target = String(body.target_user_id ?? '');
+    const tier = (body.tier === 'collaborator' ? 'collaborator' : 'follower') as 'follower' | 'collaborator';
+    if (!target || target === userId) return json({ error: 'bad_target' }, 400);
+
+    if (tier === 'collaborator') {
+      const { count: dayCount } = await supabase
+        .from('follows')
+        .select('*', { count: 'exact', head: true })
+        .eq('follower_id', userId)
+        .eq('tier', 'collaborator')
+        .gte('requested_at', new Date(Date.now() - 86400_000).toISOString());
+      if ((dayCount ?? 0) >= COLLAB_REQUEST_PER_DAY) {
+        return json({ error: 'rate_limited', retry_after_s: 86400 }, 429);
+      }
+    }
+
+    // Profile-privacy gate: if target's profile_privacy.profile = 'private', store as pending.
+    const { data: target_user } = await supabase
+      .from('users').select('profile_privacy').eq('id', target).single();
+
+    const profileMode = (target_user?.profile_privacy as Record<string, string> | null)
+      ?.profile ?? 'signed_in';
+    const requiresApproval =
+      profileMode === 'private'
+      || tier === 'collaborator';
+
+    const { error } = await supabase.from('follows').upsert({
+      follower_id: userId,
+      followee_id: target,
+      tier,
+      status: requiresApproval ? 'pending' : 'accepted',
+      requested_at: new Date().toISOString(),
+      accepted_at: requiresApproval ? null : new Date().toISOString(),
+    }, { onConflict: 'follower_id,followee_id' });
+    if (error) return json({ error: error.message }, 400);
+
+    return json({ ok: true, status: requiresApproval ? 'pending' : 'accepted' });
+  }
+
+  if (action === 'unfollow') {
+    const target = String(body.target_user_id ?? '');
+    const { error } = await supabase
+      .from('follows').delete()
+      .eq('follower_id', userId).eq('followee_id', target);
+    if (error) return json({ error: error.message }, 400);
+    return json({ ok: true });
+  }
+
+  if (action === 'accept') {
+    const follower = String(body.follower_id ?? '');
+    const { error } = await supabase
+      .from('follows')
+      .update({ status: 'accepted', accepted_at: new Date().toISOString() })
+      .eq('follower_id', follower).eq('followee_id', userId).eq('status', 'pending');
+    if (error) return json({ error: error.message }, 400);
+    return json({ ok: true });
+  }
+
+  if (action === 'reject') {
+    const follower = String(body.follower_id ?? '');
+    const { error } = await supabase
+      .from('follows').delete()
+      .eq('follower_id', follower).eq('followee_id', userId).eq('status', 'pending');
+    if (error) return json({ error: error.message }, 400);
+    return json({ ok: true });
+  }
+
+  return json({ error: 'unknown_action' }, 400);
+});
+```
+
+- [ ] **Step 12.3: Deploy via CI**
+
+```bash
+gh workflow run deploy-functions.yml --ref $(git rev-parse --abbrev-ref HEAD) -f function=follow
+gh run watch
+```
+Expected: workflow completes successfully.
+
+- [ ] **Step 12.4: Smoke-test from a logged-in browser session**
+
+In the Supabase dashboard SQL editor:
+```sql
+SELECT * FROM public.follows WHERE follower_id = auth.uid() LIMIT 3;
+```
+(Skip if no current dev account; revisit during E2E task.)
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add supabase/functions/follow/index.ts
+git commit -m "feat(edge): m26 — follow Edge Function (request/accept/reject + rate-limit)"
+```
+
+---
+
+## Task 13 — Edge Function: `react`
+
+**Files:**
+- Create: `supabase/functions/react/index.ts`
+
+- [ ] **Step 13.1: Implement the function**
+
+```ts
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+const REACT_RATE_PER_HOUR = 200;
+
+const TARGETS = {
+  observation:    { table: 'observation_reactions',    col: 'observation_id'   },
+  photo:          { table: 'photo_reactions',          col: 'media_file_id'    },
+  identification: { table: 'identification_reactions', col: 'identification_id'},
+} as const;
+
+const KIND_BY_TARGET: Record<keyof typeof TARGETS, ReadonlyArray<string>> = {
+  observation:    ['fave', 'agree_id', 'needs_id', 'confirm_id', 'helpful'],
+  photo:          ['fave', 'helpful'],
+  identification: ['agree_id', 'disagree_id', 'helpful'],
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status, headers: { ...CORS, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+
+  const auth = req.headers.get('Authorization') ?? '';
+  if (!auth.startsWith('Bearer ')) return json({ error: 'no_jwt' }, 401);
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: auth } },
+  });
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData.user) return json({ error: 'invalid_jwt' }, 401);
+  const userId = userData.user.id;
+
+  let body: Record<string, unknown>;
+  try { body = await req.json(); } catch { return json({ error: 'bad_json' }, 400); }
+
+  const target = String(body.target ?? '') as keyof typeof TARGETS;
+  const kind = String(body.kind ?? '');
+  const targetId = String(body.target_id ?? '');
+  const toggle = body.toggle !== false;
+
+  if (!(target in TARGETS)) return json({ error: 'bad_target' }, 400);
+  if (!KIND_BY_TARGET[target].includes(kind)) return json({ error: 'bad_kind' }, 400);
+  if (!targetId) return json({ error: 'bad_target_id' }, 400);
+
+  const { table, col } = TARGETS[target];
+
+  // Rate-limit: count this user's reactions in the last hour.
+  const { count: hourCount } = await supabase
+    .from(table)
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .gte('created_at', new Date(Date.now() - 3600_000).toISOString());
+  if ((hourCount ?? 0) >= REACT_RATE_PER_HOUR) {
+    return json({ error: 'rate_limited', retry_after_s: 3600 }, 429);
+  }
+
+  // Idempotent toggle.
+  const { data: existing } = await supabase
+    .from(table)
+    .select('id')
+    .eq('user_id', userId)
+    .eq(col, targetId)
+    .eq('kind', kind)
+    .maybeSingle();
+
+  if (existing) {
+    if (toggle) {
+      await supabase.from(table).delete().eq('id', existing.id);
+      return json({ ok: true, action: 'deleted' });
+    }
+    return json({ ok: true, action: 'noop' });
+  }
+
+  const insertRow: Record<string, unknown> = { user_id: userId, kind };
+  insertRow[col] = targetId;
+  const { error } = await supabase.from(table).insert(insertRow);
+  if (error) return json({ error: error.message }, 400);
+  return json({ ok: true, action: 'inserted' });
+});
+```
+
+- [ ] **Step 13.2: Deploy and commit**
+
+```bash
+gh workflow run deploy-functions.yml --ref $(git rev-parse --abbrev-ref HEAD) -f function=react
+gh run watch
+git add supabase/functions/react/index.ts
+git commit -m "feat(edge): m26 — react Edge Function (idempotent toggle, per-target tables)"
+```
+
+---
+
+## Task 14 — Edge Function: `report`
+
+**Files:**
+- Create: `supabase/functions/report/index.ts`
+
+- [ ] **Step 14.1: Implement the function**
+
+```ts
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
+const OPERATOR_EMAIL = Deno.env.get('OPERATOR_EMAIL') ?? 'artemiopadilla@gmail.com';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+const REPORT_RATE_PER_DAY = 10;
+
+const TARGETS = ['user','observation','photo','identification','comment'] as const;
+const REASONS = ['spam','harassment','wrong_id','privacy_violation','copyright','other'] as const;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status, headers: { ...CORS, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+
+  const auth = req.headers.get('Authorization') ?? '';
+  if (!auth.startsWith('Bearer ')) return json({ error: 'no_jwt' }, 401);
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: auth } },
+  });
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData.user) return json({ error: 'invalid_jwt' }, 401);
+  const userId = userData.user.id;
+
+  let body: Record<string, unknown>;
+  try { body = await req.json(); } catch { return json({ error: 'bad_json' }, 400); }
+
+  const target = String(body.target ?? '');
+  const reason = String(body.reason ?? '');
+  const targetId = String(body.target_id ?? '');
+  const note = (typeof body.note === 'string') ? body.note.slice(0, 1000) : null;
+
+  if (!TARGETS.includes(target as typeof TARGETS[number])) return json({ error: 'bad_target' }, 400);
+  if (!REASONS.includes(reason as typeof REASONS[number])) return json({ error: 'bad_reason' }, 400);
+  if (!targetId) return json({ error: 'bad_target_id' }, 400);
+
+  const { count: dayCount } = await supabase
+    .from('reports')
+    .select('*', { count: 'exact', head: true })
+    .eq('reporter_id', userId)
+    .gte('created_at', new Date(Date.now() - 86400_000).toISOString());
+  if ((dayCount ?? 0) >= REPORT_RATE_PER_DAY) {
+    return json({ error: 'rate_limited', retry_after_s: 86400 }, 429);
+  }
+
+  const { data: inserted, error } = await supabase
+    .from('reports')
+    .insert({
+      reporter_id: userId,
+      target_type: target,
+      target_id: targetId,
+      reason,
+      note,
+    })
+    .select('id')
+    .single();
+  if (error) return json({ error: error.message }, 400);
+
+  // Best-effort operator email; never fail the request on email error.
+  if (RESEND_API_KEY) {
+    try {
+      await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: 'reports@rastrum.org',
+          to: [OPERATOR_EMAIL],
+          subject: `[Rastrum] Report: ${reason} on ${target}`,
+          text: `Reporter: ${userId}\nTarget: ${target}/${targetId}\nReason: ${reason}\nNote: ${note ?? '(none)'}\n\nReport ID: ${inserted.id}`,
+        }),
+      });
+    } catch { /* ignore */ }
+  }
+
+  return json({ ok: true, id: inserted.id });
+});
+```
+
+- [ ] **Step 14.2: Deploy and commit**
+
+```bash
+gh workflow run deploy-functions.yml --ref $(git rev-parse --abbrev-ref HEAD) -f function=report
+gh run watch
+git add supabase/functions/report/index.ts
+git commit -m "feat(edge): m26 — report Edge Function with operator email"
+```
+
+---
+
+## Task 15 — i18n: `social.*` namespace
+
+**Files:**
+- Modify: `src/i18n/en.json`
+- Modify: `src/i18n/es.json`
+
+- [ ] **Step 15.1: Add the EN namespace**
+
+In `src/i18n/en.json`, add a `social` key at the top level (alphabetical position):
+
+```json
+"social": {
+  "follow": {
+    "button": "Follow",
+    "following": "Following",
+    "requested": "Requested",
+    "request_collaborator": "Request collaborator access",
+    "collaborator_pending": "Collaborator request pending",
+    "collaborator_accepted": "You're a close collaborator",
+    "unfollow_confirm": "Unfollow {{handle}}?",
+    "approve": "Approve",
+    "decline": "Decline"
+  },
+  "reactions": {
+    "fave": "Favorite",
+    "agree_id": "Agree with ID",
+    "disagree_id": "Disagree with ID",
+    "needs_id": "Needs ID",
+    "confirm_id": "Confirm ID",
+    "helpful": "Helpful",
+    "count_one": "{{count}} reaction",
+    "count_other": "{{count}} reactions"
+  },
+  "inbox": {
+    "title": "Inbox",
+    "empty": "Nothing new — go observe something.",
+    "mark_all_read": "Mark all read",
+    "kind_follow": "{{actor}} started following you",
+    "kind_follow_request": "{{actor}} requested to follow you",
+    "kind_follow_accepted": "{{actor}} accepted your follow request",
+    "kind_reaction": "{{actor}} reacted to your observation"
+  },
+  "report": {
+    "button": "Report",
+    "title": "Report this {{target}}",
+    "reasons": {
+      "spam": "Spam",
+      "harassment": "Harassment",
+      "wrong_id": "Wrong identification",
+      "privacy_violation": "Privacy violation",
+      "copyright": "Copyright",
+      "other": "Other"
+    },
+    "note_placeholder": "Optional note for the moderator",
+    "submit": "Submit report",
+    "thanks": "Thanks — we'll review."
+  },
+  "block": {
+    "button": "Block",
+    "unblock": "Unblock",
+    "blocked_users": "Blocked users",
+    "empty": "You haven't blocked anyone."
+  },
+  "list": {
+    "followers": "Followers",
+    "following": "Following",
+    "empty_followers": "No followers yet.",
+    "empty_following": "Not following anyone yet."
+  }
+}
+```
+
+- [ ] **Step 15.2: Add the ES namespace (parity)**
+
+In `src/i18n/es.json`:
+
+```json
+"social": {
+  "follow": {
+    "button": "Seguir",
+    "following": "Siguiendo",
+    "requested": "Solicitado",
+    "request_collaborator": "Solicitar acceso de colaborador",
+    "collaborator_pending": "Solicitud de colaborador pendiente",
+    "collaborator_accepted": "Eres colaborador cercano",
+    "unfollow_confirm": "¿Dejar de seguir a {{handle}}?",
+    "approve": "Aceptar",
+    "decline": "Rechazar"
+  },
+  "reactions": {
+    "fave": "Favorito",
+    "agree_id": "De acuerdo con la ID",
+    "disagree_id": "En desacuerdo con la ID",
+    "needs_id": "Necesita ID",
+    "confirm_id": "Confirmar ID",
+    "helpful": "Útil",
+    "count_one": "{{count}} reacción",
+    "count_other": "{{count}} reacciones"
+  },
+  "inbox": {
+    "title": "Bandeja",
+    "empty": "Nada nuevo — sal a observar.",
+    "mark_all_read": "Marcar todo como leído",
+    "kind_follow": "{{actor}} te siguió",
+    "kind_follow_request": "{{actor}} solicitó seguirte",
+    "kind_follow_accepted": "{{actor}} aceptó tu solicitud de seguidor",
+    "kind_reaction": "{{actor}} reaccionó a tu observación"
+  },
+  "report": {
+    "button": "Reportar",
+    "title": "Reportar este {{target}}",
+    "reasons": {
+      "spam": "Spam",
+      "harassment": "Acoso",
+      "wrong_id": "Identificación incorrecta",
+      "privacy_violation": "Violación de privacidad",
+      "copyright": "Derechos de autor",
+      "other": "Otro"
+    },
+    "note_placeholder": "Nota opcional para el moderador",
+    "submit": "Enviar reporte",
+    "thanks": "Gracias — lo revisaremos."
+  },
+  "block": {
+    "button": "Bloquear",
+    "unblock": "Desbloquear",
+    "blocked_users": "Usuarios bloqueados",
+    "empty": "No has bloqueado a nadie."
+  },
+  "list": {
+    "followers": "Seguidores",
+    "following": "Siguiendo",
+    "empty_followers": "Aún no tienes seguidores.",
+    "empty_following": "Aún no sigues a nadie."
+  }
+}
+```
+
+- [ ] **Step 15.3: Verify both files parse**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('src/i18n/en.json','utf8'))"
+node -e "JSON.parse(require('fs').readFileSync('src/i18n/es.json','utf8'))"
+```
+Expected: no output (success).
+
+- [ ] **Step 15.4: Commit**
+
+```bash
+git add src/i18n/en.json src/i18n/es.json
+git commit -m "feat(i18n): m26 — social.* namespace (EN + ES parity)"
+```
+
+---
+
+## Task 16 — Routes: register followers/following/inbox routes
+
+**Files:**
+- Modify: `src/i18n/utils.ts`
+
+- [ ] **Step 16.1: Read the existing routes pattern**
+
+```bash
+grep -n "routes\b" src/i18n/utils.ts | head -20
+```
+
+- [ ] **Step 16.2: Add new route entries**
+
+In `src/i18n/utils.ts`, add to the `routes` object (using the existing
+`{ en, es }` shape):
+
+```ts
+inbox:           { en: '/inbox',                                    es: '/bandeja'                              },
+profileFollowers:{ en: '/profile/[handle]/followers',               es: '/profile/[handle]/seguidores'          },
+profileFollowing:{ en: '/profile/[handle]/following',               es: '/profile/[handle]/siguiendo'           },
+```
+
+If the existing `routes` does not use a `[handle]` placeholder, add a
+helper that substitutes the handle at call-site (mirror whatever the
+existing profile route uses).
+
+- [ ] **Step 16.3: Verify typecheck**
+
+```bash
+npm run typecheck
+```
+Expected: zero errors.
+
+- [ ] **Step 16.4: Commit**
+
+```bash
+git add src/i18n/utils.ts
+git commit -m "feat(i18n): m26 — register inbox + followers + following routes"
+```
+
+---
+
+## Task 17 — Component: `FollowButton.astro`
+
+**Files:**
+- Create: `src/components/FollowButton.astro`
+
+- [ ] **Step 17.1: Write the component**
+
+```astro
+---
+import { t } from '../i18n/utils';
+interface Props {
+  lang: 'en' | 'es';
+  targetUserId: string;
+  targetHandle: string;
+  initialState: 'none' | 'pending' | 'follower' | 'collaborator_pending' | 'collaborator';
+  isSelf: boolean;
+}
+const { lang, targetUserId, targetHandle, initialState, isSelf } = Astro.props;
+const tr = t(lang).social.follow;
+---
+{!isSelf && (
+  <div class="flex items-center gap-2"
+       data-follow-target={targetUserId}
+       data-follow-handle={targetHandle}
+       data-follow-state={initialState}>
+    <button type="button"
+            class="follow-btn rounded-full bg-emerald-600 text-white px-4 py-2 text-sm font-medium hover:bg-emerald-700 disabled:opacity-50">
+      {initialState === 'none' && tr.button}
+      {initialState === 'pending' && tr.requested}
+      {initialState === 'follower' && tr.following}
+      {initialState === 'collaborator_pending' && tr.collaborator_pending}
+      {initialState === 'collaborator' && tr.collaborator_accepted}
+    </button>
+    {initialState === 'follower' && (
+      <button type="button" class="upgrade-collab text-sm text-stone-700 hover:text-emerald-700 underline">
+        {tr.request_collaborator}
+      </button>
+    )}
+  </div>
+)}
+
+<script>
+  import { followUser, unfollowUser } from '../lib/social';
+  for (const el of document.querySelectorAll<HTMLDivElement>('[data-follow-target]')) {
+    const target = el.dataset.followTarget!;
+    const handle = el.dataset.followHandle!;
+    const state = el.dataset.followState!;
+    const btn = el.querySelector('.follow-btn') as HTMLButtonElement;
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      try {
+        if (state === 'none') {
+          const r = await followUser(target, 'follower');
+          el.dataset.followState = r.status === 'accepted' ? 'follower' : 'pending';
+          btn.textContent = r.status === 'accepted' ? btn.dataset.tFollowing! : btn.dataset.tPending!;
+        } else if (state === 'follower' || state === 'pending') {
+          if (!confirm(`Unfollow @${handle}?`)) { btn.disabled = false; return; }
+          await unfollowUser(target);
+          el.dataset.followState = 'none';
+          btn.textContent = btn.dataset.tFollow!;
+        }
+      } finally { btn.disabled = false; }
+    });
+    const upgrade = el.querySelector('.upgrade-collab') as HTMLButtonElement | null;
+    upgrade?.addEventListener('click', async () => {
+      upgrade.disabled = true;
+      await followUser(target, 'collaborator');
+      el.dataset.followState = 'collaborator_pending';
+      upgrade.textContent = btn.dataset.tCollabPending!;
+    });
+  }
+</script>
+```
+
+> If existing components use a different scripting pattern (Astro
+> islands, Alpine, etc.), match that pattern. Read `Header.astro` for
+> the established style.
+
+- [ ] **Step 17.2: Wire it on the public profile**
+
+```bash
+grep -n "profile" src/pages/en/profile/*.astro 2>/dev/null | head
+grep -rn "ProfileView\|PublicProfileView" src/components/ 2>/dev/null | head
+```
+Add `<FollowButton lang={lang} targetUserId={user.id} targetHandle={user.handle} initialState={…} isSelf={…} />` into the appropriate public-profile view in the header area.
+
+- [ ] **Step 17.3: Build and visually inspect**
+
+```bash
+npm run dev   # or `make dev`
+```
+Open http://localhost:4321/en/profile/<some-handle>. Confirm Follow button renders.
+
+- [ ] **Step 17.4: Commit**
+
+```bash
+git add src/components/FollowButton.astro src/components/*ProfileView.astro
+git commit -m "feat(ui): m26 — FollowButton component on profile header"
+```
+
+---
+
+## Task 18 — Component: `ReactionStrip.astro`
+
+**Files:**
+- Create: `src/components/ReactionStrip.astro`
+
+- [ ] **Step 18.1: Write the component**
+
+```astro
+---
+import { t } from '../i18n/utils';
+interface Props {
+  lang: 'en' | 'es';
+  target: 'observation' | 'photo' | 'identification';
+  targetId: string;
+  initialCounts: Record<string, number>;
+  myReactions: string[];
+}
+const { lang, target, targetId, initialCounts, myReactions } = Astro.props;
+const tr = t(lang).social.reactions;
+
+const KIND_BY_TARGET = {
+  observation: ['fave'] as const,
+  photo: ['fave', 'helpful'] as const,
+  identification: ['agree_id', 'disagree_id'] as const,
+} as const;
+const kinds = KIND_BY_TARGET[target];
+
+const ICONS: Record<string, string> = {
+  fave: '❤', helpful: '✓', agree_id: '✓', disagree_id: '✕',
+};
+---
+<div class="flex items-center gap-2"
+     data-reaction-target={target}
+     data-reaction-target-id={targetId}>
+  {kinds.map(kind => (
+    <button type="button"
+            class={`reaction-btn rounded-full border px-2 py-1 text-xs ${myReactions.includes(kind) ? 'bg-emerald-100 border-emerald-400' : 'border-stone-300 hover:bg-stone-100'}`}
+            data-kind={kind}
+            aria-label={tr[kind as keyof typeof tr] as string}
+            aria-pressed={myReactions.includes(kind) ? 'true' : 'false'}>
+      <span aria-hidden="true">{ICONS[kind]}</span>
+      <span class="count">{initialCounts[kind] ?? 0}</span>
+    </button>
+  ))}
+</div>
+
+<script>
+  import { react } from '../lib/social';
+  for (const root of document.querySelectorAll<HTMLDivElement>('[data-reaction-target]')) {
+    const targetType = root.dataset.reactionTarget as 'observation'|'photo'|'identification';
+    const targetId   = root.dataset.reactionTargetId!;
+    for (const btn of root.querySelectorAll<HTMLButtonElement>('.reaction-btn')) {
+      btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        const kind = btn.dataset.kind! as Parameters<typeof react>[0]['kind'];
+        const countEl = btn.querySelector('.count')!;
+        const wasOn = btn.getAttribute('aria-pressed') === 'true';
+        try {
+          const r = await react({ target: targetType, target_id: targetId, kind });
+          if (r.action === 'inserted') {
+            btn.setAttribute('aria-pressed', 'true');
+            btn.classList.add('bg-emerald-100', 'border-emerald-400');
+            countEl.textContent = String(Number(countEl.textContent ?? '0') + 1);
+          } else if (r.action === 'deleted') {
+            btn.setAttribute('aria-pressed', 'false');
+            btn.classList.remove('bg-emerald-100', 'border-emerald-400');
+            countEl.textContent = String(Math.max(0, Number(countEl.textContent ?? '0') - 1));
+          }
+        } catch (e) {
+          // Surface failure: revert visual state.
+          btn.setAttribute('aria-pressed', wasOn ? 'true' : 'false');
+        } finally { btn.disabled = false; }
+      });
+    }
+  }
+</script>
+```
+
+- [ ] **Step 18.2: Wire ReactionStrip on observation cards**
+
+Find where observation cards render (`MyObsView.astro`,
+`ExploreRecent.astro`, public observation viewer):
+
+```bash
+grep -rn "observation\|obs-card" src/components/ | head
+```
+For each card render path, add:
+```astro
+<ReactionStrip lang={lang} target="observation" targetId={obs.id}
+               initialCounts={obs.reaction_counts ?? {}}
+               myReactions={obs.my_reactions ?? []} />
+```
+You may need a SQL query that joins `observation_reactions` aggregated by kind. Add a Supabase RPC `obs_reaction_summary(obs_id uuid)` if it simplifies the call site — but defer to follow-up if the existing query works.
+
+- [ ] **Step 18.3: Commit**
+
+```bash
+git add src/components/ReactionStrip.astro src/components/*ObsView.astro src/components/Explore*.astro 2>/dev/null
+git commit -m "feat(ui): m26 — ReactionStrip + wire on observation cards"
+```
+
+---
+
+## Task 19 — Component: followers/following list views
+
+**Files:**
+- Create: `src/components/FollowersView.astro`
+- Create: `src/components/FollowingView.astro`
+- Create: `src/pages/en/profile/[handle]/followers.astro`
+- Create: `src/pages/en/profile/[handle]/following.astro`
+- Create: `src/pages/es/profile/[handle]/seguidores.astro`
+- Create: `src/pages/es/profile/[handle]/siguiendo.astro`
+
+- [ ] **Step 19.1: Write `FollowersView.astro`**
+
+```astro
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { t } from '../i18n/utils';
+import { supabase } from '../lib/supabase';
+
+interface Props {
+  lang: 'en' | 'es';
+  handle: string;
+}
+const { lang, handle } = Astro.props;
+const tr = t(lang).social;
+
+const { data: target } = await supabase
+  .from('users').select('id, handle, display_name').eq('handle', handle).maybeSingle();
+
+if (!target) return Astro.redirect(lang === 'en' ? '/404' : '/404');
+
+const { data: rows } = await supabase
+  .from('follows')
+  .select('follower_id, tier, accepted_at, users:follower_id(handle, display_name, avatar_url)')
+  .eq('followee_id', target.id)
+  .eq('status', 'accepted')
+  .order('accepted_at', { ascending: false })
+  .limit(200);
+---
+<BaseLayout lang={lang} title={`@${handle} — ${tr.list.followers}`}>
+  <main class="mx-auto max-w-2xl p-4">
+    <h1 class="text-xl font-semibold mb-4">{tr.list.followers}</h1>
+    {rows && rows.length > 0 ? (
+      <ul class="divide-y divide-stone-200">
+        {rows.map(r => (
+          <li class="flex items-center gap-3 py-3">
+            <a href={`/${lang}/profile/${(r as any).users.handle}`} class="flex items-center gap-3 hover:bg-stone-50 rounded p-1 -m-1">
+              <img src={(r as any).users.avatar_url ?? '/img/avatar-default.svg'}
+                   class="w-10 h-10 rounded-full" loading="lazy" alt="" />
+              <div>
+                <div class="font-medium">{(r as any).users.display_name ?? (r as any).users.handle}</div>
+                <div class="text-sm text-stone-500">@{(r as any).users.handle}</div>
+              </div>
+            </a>
+            {r.tier === 'collaborator' && <span class="text-xs text-emerald-700 ml-auto">{tr.follow.collaborator_accepted}</span>}
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p class="text-stone-600">{tr.list.empty_followers}</p>
+    )}
+  </main>
+</BaseLayout>
+```
+
+- [ ] **Step 19.2: Write `FollowingView.astro`**
+
+Mirror `FollowersView.astro` swapping `followee_id`/`follower_id` and the
+joined column. Path: `src/components/FollowingView.astro`.
+
+- [ ] **Step 19.3: Write the four page files**
+
+`src/pages/en/profile/[handle]/followers.astro`:
+```astro
+---
+import FollowersView from '../../../../components/FollowersView.astro';
+const { handle } = Astro.params;
+---
+<FollowersView lang="en" handle={handle as string} />
+```
+
+`src/pages/es/profile/[handle]/seguidores.astro`:
+```astro
+---
+import FollowersView from '../../../../components/FollowersView.astro';
+const { handle } = Astro.params;
+---
+<FollowersView lang="es" handle={handle as string} />
+```
+
+(And the two `following` / `siguiendo` mirrors.)
+
+- [ ] **Step 19.4: Build and verify**
+
+```bash
+npm run build
+```
+Expected: zero errors. Inspect `dist/en/profile/<handle>/followers/index.html`.
+
+- [ ] **Step 19.5: Commit**
+
+```bash
+git add src/components/FollowersView.astro src/components/FollowingView.astro \
+        src/pages/en/profile/\[handle\]/followers.astro \
+        src/pages/en/profile/\[handle\]/following.astro \
+        src/pages/es/profile/\[handle\]/seguidores.astro \
+        src/pages/es/profile/\[handle\]/siguiendo.astro
+git commit -m "feat(ui): m26 — followers/following list views (EN + ES parity)"
+```
+
+---
+
+## Task 20 — Component: `InboxView.astro` + pages
+
+**Files:**
+- Create: `src/components/InboxView.astro`
+- Create: `src/pages/en/inbox.astro`
+- Create: `src/pages/es/bandeja.astro`
+
+- [ ] **Step 20.1: Write `InboxView.astro`**
+
+```astro
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { t } from '../i18n/utils';
+import { supabase } from '../lib/supabase';
+
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang).social.inbox;
+
+const { data: { user } } = await supabase.auth.getUser();
+const meId = user?.id;
+
+const { data: rows } = meId ? await supabase
+  .from('notifications')
+  .select('id, kind, payload, read_at, created_at')
+  .eq('user_id', meId)
+  .order('created_at', { ascending: false })
+  .limit(100) : { data: [] };
+---
+<BaseLayout lang={lang} title={tr.title}>
+  <main class="mx-auto max-w-2xl p-4">
+    <header class="flex items-center justify-between mb-4">
+      <h1 class="text-xl font-semibold">{tr.title}</h1>
+      <button id="mark-all-read" class="text-sm text-emerald-700 hover:underline">{tr.mark_all_read}</button>
+    </header>
+    {rows && rows.length > 0 ? (
+      <ul class="divide-y divide-stone-200">
+        {rows.map(n => (
+          <li class={`py-3 ${n.read_at ? 'opacity-60' : ''}`}>
+            <div class="text-sm">
+              {n.kind === 'follow'           && tr.kind_follow.replace('{{actor}}', String((n.payload as any).actor_id))}
+              {n.kind === 'follow_accepted'  && tr.kind_follow_accepted.replace('{{actor}}', String((n.payload as any).actor_id))}
+              {n.kind === 'reaction'         && tr.kind_reaction.replace('{{actor}}', String((n.payload as any).actor_id))}
+            </div>
+            <div class="text-xs text-stone-500 mt-1">{new Date(n.created_at).toLocaleString(lang)}</div>
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p class="text-stone-600">{tr.empty}</p>
+    )}
+  </main>
+</BaseLayout>
+
+<script>
+  import { supabase } from '../lib/supabase';
+  document.getElementById('mark-all-read')?.addEventListener('click', async () => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+    await supabase.from('notifications')
+      .update({ read_at: new Date().toISOString() })
+      .eq('user_id', user.id)
+      .is('read_at', null);
+    location.reload();
+  });
+</script>
+```
+
+> Future enhancement: resolve `actor_id` to display_name + handle via a
+> single batched lookup. Defer to follow-up; current copy uses raw IDs.
+
+- [ ] **Step 20.2: Write the page files**
+
+`src/pages/en/inbox.astro`:
+```astro
+---
+import InboxView from '../../components/InboxView.astro';
+---
+<InboxView lang="en" />
+```
+
+`src/pages/es/bandeja.astro`:
+```astro
+---
+import InboxView from '../../components/InboxView.astro';
+---
+<InboxView lang="es" />
+```
+
+- [ ] **Step 20.3: Add inbox bell to header (auth-only)**
+
+In `src/components/Header.astro`, add an inbox icon link after the
+existing user-menu trigger that points to `/{lang}/inbox` (or
+`/{lang}/bandeja`). It only renders when authenticated. Include an
+unread-count badge that hydrates client-side.
+
+- [ ] **Step 20.4: Build, verify, commit**
+
+```bash
+npm run build
+git add src/components/InboxView.astro src/pages/en/inbox.astro src/pages/es/bandeja.astro src/components/Header.astro
+git commit -m "feat(ui): m26 — InboxView + EN/ES pages + header bell"
+```
+
+---
+
+## Task 21 — Component: blocked users list (settings panel)
+
+**Files:**
+- Create: `src/components/BlockedUsersList.astro`
+- Modify: existing settings/profile-edit page (path varies — find via grep)
+
+- [ ] **Step 21.1: Find the settings host page**
+
+```bash
+grep -rn "ProfileEdit\|SettingsView\|profile/edit" src/pages/ | head
+```
+
+- [ ] **Step 21.2: Write `BlockedUsersList.astro`**
+
+```astro
+---
+import { t } from '../i18n/utils';
+import { supabase } from '../lib/supabase';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang).social.block;
+
+const { data: { user } } = await supabase.auth.getUser();
+const meId = user?.id;
+
+const { data: rows } = meId ? await supabase
+  .from('blocks')
+  .select('blocked_id, created_at, users:blocked_id(handle, display_name)')
+  .eq('blocker_id', meId)
+  .order('created_at', { ascending: false }) : { data: [] };
+---
+<section class="mt-6">
+  <h2 class="text-lg font-semibold mb-2">{tr.blocked_users}</h2>
+  {rows && rows.length > 0 ? (
+    <ul class="divide-y divide-stone-200">
+      {rows.map(b => (
+        <li class="flex items-center justify-between py-2" data-blocked-id={b.blocked_id}>
+          <span>@{(b as any).users?.handle ?? b.blocked_id}</span>
+          <button class="unblock-btn text-sm text-emerald-700 hover:underline">{tr.unblock}</button>
+        </li>
+      ))}
+    </ul>
+  ) : (
+    <p class="text-stone-600">{tr.empty}</p>
+  )}
+</section>
+
+<script>
+  import { unblockUser } from '../lib/social';
+  for (const li of document.querySelectorAll<HTMLLIElement>('[data-blocked-id]')) {
+    const id = li.dataset.blockedId!;
+    li.querySelector('.unblock-btn')?.addEventListener('click', async () => {
+      await unblockUser(id);
+      li.remove();
+    });
+  }
+</script>
+```
+
+- [ ] **Step 21.3: Wire it into the settings page**
+
+Add `<BlockedUsersList lang={lang} />` near the bottom of the settings
+view component.
+
+- [ ] **Step 21.4: Commit**
+
+```bash
+git add src/components/BlockedUsersList.astro src/components/*Settings*.astro src/components/ProfileEdit*.astro 2>/dev/null
+git commit -m "feat(ui): m26 — blocked users list in settings"
+```
+
+---
+
+## Task 22 — Tests: RLS regression queries
+
+**Files:**
+- Create: `tests/sql/social-rls.sql`
+
+- [ ] **Step 22.1: Write the regression queries**
+
+```sql
+-- tests/sql/social-rls.sql
+--
+-- Regression queries for module 26 RLS. Run inside a transaction with
+-- two test users, ROLLBACK at the end.
+
+BEGIN;
+
+-- Setup: two ephemeral users + one observation by user A.
+DO $$
+DECLARE u_a uuid; u_b uuid; obs_id uuid;
+BEGIN
+  INSERT INTO public.users(id, handle, display_name)
+    VALUES (gen_random_uuid(), 'rls_a', 'A') RETURNING id INTO u_a;
+  INSERT INTO public.users(id, handle, display_name)
+    VALUES (gen_random_uuid(), 'rls_b', 'B') RETURNING id INTO u_b;
+  INSERT INTO public.observations(id, observer_id, sync_status, obscure_level)
+    VALUES (gen_random_uuid(), u_a, 'synced', 'none') RETURNING id INTO obs_id;
+
+  -- 1) B reacts on A's public observation as an unauthenticated check.
+  INSERT INTO public.observation_reactions(user_id, observation_id, kind)
+    VALUES (u_b, obs_id, 'fave');
+
+  -- 2) A blocks B; B's reaction must not be visible to A.
+  INSERT INTO public.blocks(blocker_id, blocked_id) VALUES (u_a, u_b);
+
+  -- 3) A unblocks; visibility restored.
+  DELETE FROM public.blocks WHERE blocker_id = u_a AND blocked_id = u_b;
+
+  -- 4) Make obs full-obscure; B can no longer read it.
+  UPDATE public.observations SET obscure_level = 'full' WHERE id = obs_id;
+
+  -- 5) Make B a collaborator of A; collaborator unlock allows read.
+  INSERT INTO public.follows(follower_id, followee_id, tier, status, accepted_at)
+    VALUES (u_b, u_a, 'collaborator', 'accepted', now());
+
+  RAISE NOTICE 'social-rls regression OK';
+END $$;
+
+ROLLBACK;
+```
+
+> The DO-block uses service role; an actual RLS test with `SET ROLE
+> authenticated` and `SET request.jwt.claims` per query is more rigorous
+> but heavier — defer to a second pass if needed. This script at least
+> confirms the schema is referentially sound.
+
+- [ ] **Step 22.2: Run it**
+
+```bash
+psql "$SUPABASE_DB_URL" -f tests/sql/social-rls.sql
+```
+Expected: `NOTICE:  social-rls regression OK` and `ROLLBACK`.
+
+- [ ] **Step 22.3: Commit**
+
+```bash
+git add tests/sql/social-rls.sql
+git commit -m "test(sql): m26 — RLS regression script"
+```
+
+---
+
+## Task 23 — Tests: Playwright happy-path
+
+**Files:**
+- Create: `tests/e2e/social.spec.ts`
+
+- [ ] **Step 23.1: Write the spec**
+
+```ts
+import { test, expect } from '@playwright/test';
+
+// This spec is a smoke test of the social UI. It does not exercise auth
+// (we don't have a real test session) — it asserts the components mount
+// and the routes render. Replace once a fixture session exists.
+
+test('inbox page renders without auth', async ({ page }) => {
+  await page.goto('/en/inbox');
+  await expect(page.getByRole('heading', { name: /inbox/i })).toBeVisible();
+});
+
+test('inbox page renders in Spanish', async ({ page }) => {
+  await page.goto('/es/bandeja');
+  await expect(page.getByRole('heading', { name: /bandeja/i })).toBeVisible();
+});
+
+test('followers route exists for a known handle', async ({ page }) => {
+  // Use whatever handle is reliably present in a clean DB; fall back to a 200/404 distinction.
+  const r = await page.goto('/en/profile/example/followers');
+  expect([200, 404]).toContain(r?.status() ?? 0);
+});
+```
+
+- [ ] **Step 23.2: Run e2e**
+
+```bash
+npm run test:e2e -- social.spec
+```
+Expected: 3 passing.
+
+- [ ] **Step 23.3: Commit**
+
+```bash
+git add tests/e2e/social.spec.ts
+git commit -m "test(e2e): m26 — social happy-path smoke (inbox + followers route)"
+```
+
+---
+
+## Task 24 — Roadmap and tasks.json updates
+
+**Files:**
+- Modify: `docs/progress.json`
+- Modify: `docs/tasks.json`
+- Modify: `docs/tasks.md` (regenerated; minor narrative update only)
+
+- [ ] **Step 24.1: Add the roadmap item**
+
+In `docs/progress.json`, find the appropriate phase array (Phase 5 —
+Community / Social, or whichever one is current) and add:
+
+```json
+{
+  "id": "social-graph",
+  "label": "Social graph + reactions (M26)",
+  "label_es": "Grafo social + reacciones (M26)",
+  "status": "in_progress",
+  "module": "26-social-graph"
+}
+```
+
+- [ ] **Step 24.2: Add the subtasks**
+
+In `docs/tasks.json`, add an entry for `social-graph`:
+
+```json
+"social-graph": {
+  "label": "Social graph + reactions (M26)",
+  "label_es": "Grafo social + reacciones (M26)",
+  "items": [
+    { "label": "follows table + counters + privacy helpers",       "label_es": "tabla follows + contadores + helpers de privacidad",       "status": "done" },
+    { "label": "reactions tables (observation/photo/identification)","label_es": "tablas de reacciones (observación/foto/identificación)",  "status": "done" },
+    { "label": "blocks + reports + notifications + 90-day prune",  "label_es": "bloqueos + reportes + notificaciones + poda 90 días",      "status": "done" },
+    { "label": "Edge Functions: follow / react / report",          "label_es": "Edge Functions: follow / react / report",                  "status": "done" },
+    { "label": "i18n EN/ES + routes",                              "label_es": "i18n EN/ES + rutas",                                       "status": "done" },
+    { "label": "FollowButton + ReactionStrip + Inbox UI",          "label_es": "FollowButton + ReactionStrip + Inbox UI",                  "status": "done" },
+    { "label": "blocked users settings panel",                     "label_es": "panel de usuarios bloqueados en ajustes",                  "status": "done" },
+    { "label": "RLS regression + e2e smoke",                       "label_es": "regresión RLS + smoke e2e",                                "status": "done" }
+  ]
+}
+```
+
+(Mark statuses as `"done"` only after each task actually completes; use
+`"todo"`/`"in_progress"` along the way.)
+
+- [ ] **Step 24.3: Update tasks.md narrative**
+
+Append a short paragraph under Phase 5 in `docs/tasks.md` describing M26
+in 3-4 sentences.
+
+- [ ] **Step 24.4: Verify the roadmap and tasks pages render**
+
+```bash
+npm run dev
+```
+Open http://localhost:4321/en/docs/roadmap and http://localhost:4321/en/docs/tasks. Confirm the new item is listed.
+
+- [ ] **Step 24.5: Commit**
+
+```bash
+git add docs/progress.json docs/tasks.json docs/tasks.md
+git commit -m "docs(roadmap): m26 — register social graph + subtasks"
+```
+
+---
+
+## Task 25 — Final pre-PR checks
+
+- [ ] **Step 25.1: Typecheck and unit tests**
+
+```bash
+npm run typecheck
+npm run test
+```
+Expected: zero type errors; previous count + new social tests all green.
+
+- [ ] **Step 25.2: Build**
+
+```bash
+npm run build
+```
+Expected: zero errors; new EN/ES paired pages present in `dist/`.
+
+- [ ] **Step 25.3: e2e and Lighthouse smoke**
+
+```bash
+npm run test:e2e
+```
+Expected: previous specs + new social spec all green.
+
+- [ ] **Step 25.4: SQL replay safety**
+
+```bash
+make db-apply
+make db-verify
+make db-policies | grep -E "follows|reactions|blocks|reports|notifications" | head
+```
+Expected: all RLS policies present; replay does not error.
+
+- [ ] **Step 25.5: Open the PR**
+
+```bash
+gh pr create --title "feat(social): module 26 — graph + reactions" --body "$(cat <<'EOF'
+## Summary
+- Asymmetric follow + opt-in close-collaborator tier; per-target reaction tables; blocks; reports; in-app inbox.
+- Three Edge Functions (`follow`, `react`, `report`) with inline rate-limits.
+- 90-day prune cron for read notifications.
+- EN/ES parity for all new UI.
+
+## Test plan
+- [x] make db-apply && make db-verify
+- [x] npm run typecheck && npm run test
+- [x] npm run build
+- [x] npm run test:e2e
+- [ ] Manual: follow another user, react on an observation, report a target, block + unblock.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review (writing-plans skill, run inline)
+
+**1. Spec coverage:**
+- Asymmetric follow + collaborator tier — Tasks 2, 12.
+- Per-target reaction tables — Tasks 4, 5, 6.
+- Blocks — Task 7.
+- Reports — Task 8, 14.
+- Notifications + 90-day prune — Tasks 9, 10.
+- Privacy composition (`social_visible_to`, `is_collaborator_of`) — Task 3, embedded in 4/5/6.
+- i18n EN/ES + routes — Tasks 15, 16.
+- UI surfaces (FollowButton, ReactionStrip, FollowersView, FollowingView, InboxView, BlockedUsersList) — Tasks 17–21.
+- Tests (unit, RLS regression, Playwright smoke) — Tasks 11, 22, 23.
+- Roadmap/tasks updates — Task 24.
+
+Out of scope (deferred to M27/M28/M29 by design): comments, mentions, email digests, Realtime push, ID-help workflow, groups.
+
+**2. Placeholder scan:** No "TBD", "TODO", "implement later" left in steps. Each step ships actual code or commands. The "find the settings host page" steps in Task 21 are direct grep commands — not placeholders.
+
+**3. Type consistency:**
+- `react`, `unreact`, `reportTarget`, `followUser`, `unfollowUser` referenced in tests (Task 11) match the implementation (Task 11 step 5).
+- `Reaction.target_id` type matches what `react()` accepts.
+- Edge Function rate-limits (`FOLLOW_RATE_PER_HOUR`, `REACT_RATE_PER_HOUR`, `REPORT_RATE_PER_DAY`) match spec values.
+- DDL column names (`follower_id`, `followee_id`, `media_file_id`, `identification_id`) match across SQL, RLS, triggers, and Edge Functions.
+
+No issues found. Plan ready.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-28-m26-social-graph.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-28-social-features-design.md
+++ b/docs/superpowers/specs/2026-04-28-social-features-design.md
@@ -169,24 +169,35 @@ Maintained by trigger (`tg_follows_counter`) on `follows` insert/delete, only wh
 
 ### Privacy composition
 
+The existing schema gates observation visibility through two orthogonal mechanisms:
+- `observations.obscure_level` (coord-precision coarsening for sensitive species, gated row-level by `obs_public_read`).
+- `users.profile_privacy` JSONB + `can_see_facet(target, facet, viewer)` (per-user facet visibility from module 25).
+
+There is **no** per-observation `visibility` column with `public/followers/collaborators/private` values; we don't add one. Instead, social actions inherit those mechanisms:
+
 ```sql
+-- Is the actor a follower or the owner themselves?
 CREATE OR REPLACE FUNCTION public.social_visible_to(viewer uuid, owner uuid)
 RETURNS boolean
 LANGUAGE sql STABLE PARALLEL SAFE AS $$
   SELECT
-    viewer = owner
-    OR EXISTS (
-      SELECT 1 FROM public.follows f
-       WHERE f.follower_id = viewer
-         AND f.followee_id = owner
-         AND f.status     = 'accepted'
+    viewer IS NOT NULL AND (
+      viewer = owner
+      OR EXISTS (
+        SELECT 1 FROM public.follows f
+         WHERE f.follower_id = viewer
+           AND f.followee_id = owner
+           AND f.status      = 'accepted'
+      )
     );
 $$;
 
+-- Is the actor an accepted close-collaborator? Collaborators get the same
+-- coord-precision unlock as `is_credentialed_researcher` does today.
 CREATE OR REPLACE FUNCTION public.is_collaborator_of(viewer uuid, owner uuid)
 RETURNS boolean
 LANGUAGE sql STABLE PARALLEL SAFE AS $$
-  SELECT EXISTS (
+  SELECT viewer IS NOT NULL AND EXISTS (
     SELECT 1 FROM public.follows f
      WHERE f.follower_id = viewer
        AND f.followee_id = owner
@@ -198,7 +209,8 @@ $$;
 
 Both functions are `STABLE` and `PARALLEL SAFE` so the planner can inline them into RLS USING clauses. No `PLPGSQL` in the hot path.
 
-**RLS on reactions** (illustrative; mirror across all four reaction tables):
+**RLS on reactions** (illustrative; mirror across all four reaction tables) — a reaction is readable iff the *observation* is readable AND the reactor is not block-symmetric to the viewer:
+
 ```sql
 ALTER TABLE public.observation_reactions ENABLE ROW LEVEL SECURITY;
 
@@ -209,9 +221,12 @@ CREATE POLICY obsreact_read ON public.observation_reactions FOR SELECT
       SELECT 1 FROM public.observations o
        WHERE o.id = observation_reactions.observation_id
          AND (
-           o.visibility = 'public'
-           OR public.social_visible_to(auth.uid(), o.observer_id)
-           OR (o.visibility = 'collaborators' AND public.is_collaborator_of(auth.uid(), o.observer_id))
+           o.observer_id = auth.uid()
+           OR (
+             o.obscure_level <> 'full'
+             AND public.can_see_facet(o.observer_id, 'observations', auth.uid())
+           )
+           OR public.is_collaborator_of(auth.uid(), o.observer_id)
          )
     )
     AND NOT EXISTS (
@@ -230,7 +245,9 @@ CREATE POLICY obsreact_delete ON public.observation_reactions FOR DELETE
   USING (user_id = auth.uid());
 ```
 
-For obscured-locality observations, the **count** of reactions is visible to anyone who can read the observation; the **list of reactors** is gated through `social_visible_to`. This is enforced by exposing two views: `observation_reaction_counts` (public) and `observation_reactions` (gated).
+**Collaborator coord-precision unlock.** Extend the existing `obs_credentialed_read` analog so collaborators see precise coords on obscured observations of users they collaborate with — same shape as the credentialed-researcher policy that already exists.
+
+**Reaction-count visibility on obscured observations.** Counts are exposed via the `observation_reaction_counts` view; the *list* of reactors goes through the gated `observation_reactions` table (RLS above). When `obscure_level <> 'none'` AND total reactions < 3, the count is also gated to prevent identity inference (see Risks).
 
 ### Edge Functions
 

--- a/docs/superpowers/specs/2026-04-28-social-features-design.md
+++ b/docs/superpowers/specs/2026-04-28-social-features-design.md
@@ -1,0 +1,472 @@
+# Social features: follow, reactions, comments, notifications
+
+**Date:** 2026-04-28
+**Status:** Design — pending user review
+**Owner:** Artemio Padilla
+**Phasing:** ships as three sequential modules — **M26** (social graph + reactions), **M27** (comments + mentions), **M28** (real-time + per-target mute + ID-help). Groups are deferred to a possible **M29**.
+**Related modules:** 04 (auth/users), 22 (community validation), 25 (profile privacy + public profiles), karma/expertise/rarity (`2026-04-27-karma-expertise-rarity-design.md`).
+
+---
+
+## Goals
+
+1. Move Rastrum from a solo-observer experience to a **scientific-collaboration network** — observers can follow experts, surface observations that need IDs, and discuss findings — while preserving the privacy ladder shipped in module 25.
+2. Layer **engagement primitives** (reactions, follower counts, inbox) on top so the science loop has the dopamine hooks of a modern social product, without becoming generic social.
+3. Lay groundwork for **community / groups** (region-bound, taxon-bound) without committing to ship them in v1.
+4. Maintain Rastrum's **zero-cost / privacy-first** posture: every social action respects per-observation `obscure_level`, every public-facing string is bilingual, every table has RLS, abuse surface is minimized through composable primitives (block + report + Edge-Function rate-limits) rather than a moderation team.
+
+## Non-goals
+
+- Real-time chat, DMs, or groups in v1. Groups are parked as M29 pending demand signal.
+- Bidirectional friendship UX (friend requests, mutual confirmation). Replaced by asymmetric follow + opt-in close-collaborator tier.
+- Cross-platform social import (iNaturalist follow graph, etc.). Rastrum-local only.
+- Mod queues with human moderators. Reports persist to a queue and email the operator; no moderator-role UI in v1.
+- Algorithmic feed ranking. Feeds are reverse-chronological in v1; ranking is out of scope.
+- Generic search over the social graph. Discovery happens through profile pages, ID-help queue, and the existing `/explore/*` views.
+
+---
+
+## Decisions captured (brainstorming outcome)
+
+| Axis | Decision | Rationale |
+|---|---|---|
+| Primary intent | **All three goals, sequenced** (engagement, science, community) | Don't pick one tribe; sequence reduces risk |
+| Graph shape | **Asymmetric follow + opt-in close-collaborator tier** | Matches expert/observer asymmetry; collaborator tier is the privacy upgrade for precise-coord access |
+| Reactions schema | **Per-target tables** (`observation_reactions`, `photo_reactions`, `identification_reactions`, `comment_reactions`) with `kind` enum | Real FKs, `ON DELETE CASCADE`, simpler RLS — rejected polymorphic table after audit |
+| Reactions UX (v1) | **One or two reaction kinds per surface** (fave on observations/photos, agree/disagree on identifications, helpful on comments) | Schema is flexible (D); UI surface is disciplined (A) to prevent cognitive overload |
+| Comments schema | **Polymorphic-by-target** (single `comments` table) | Body/author/moderation columns identical across targets; soft-delete via `deleted_at` instead of FK cascade |
+| Comments UX | **Flat threads, chronological, no nesting** | Matches iNaturalist; avoids Reddit-style derailments |
+| Notifications | **In-app + email digests + real-time + per-kind + per-target mute** | "All available" depth — but defaults are conservative (email only for `@mention`; everything else opt-in) |
+| Privacy composition | **Inherits the existing four-tier privacy matrix** via `social_visible_to(viewer, owner)` SQL function | Don't introduce a parallel social-privacy axis |
+| Moderation | **Block + report + Edge-Function rate-limits** | Minimum viable abuse kit; defer auto-heuristics and mod roles |
+| Rate-limit storage | **No `rate_limits` table — windowed `count(*)` in Edge Function** | Avoids doubling write traffic; sufficient at v1 scale |
+| Phasing | **M26 → M27 → M28 (groups parked as M29)** | Front-load lowest-abuse primitive (follow); defer heaviest moderation surface (comments-everywhere) until graph proves itself |
+
+---
+
+## Module 26 — Social graph + reactions
+
+### Data model
+
+All additions are additive. No existing table or column is dropped or renamed.
+
+#### `follows`
+```sql
+CREATE TABLE public.follows (
+  follower_id   uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  followee_id   uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  tier          text        NOT NULL DEFAULT 'follower'
+                            CHECK (tier IN ('follower', 'collaborator')),
+  status        text        NOT NULL DEFAULT 'accepted'
+                            CHECK (status IN ('pending', 'accepted')),
+  requested_at  timestamptz NOT NULL DEFAULT now(),
+  accepted_at   timestamptz,
+  PRIMARY KEY (follower_id, followee_id),
+  CHECK (follower_id <> followee_id)
+);
+CREATE INDEX idx_follows_followee_status ON public.follows(followee_id, status);
+CREATE INDEX idx_follows_follower_status ON public.follows(follower_id, status);
+```
+
+`status='pending'` is used for two cases: (a) the followee's profile privacy requires approval for any follower; (b) a follower-tier user has requested an upgrade to collaborator-tier. The Edge Function `follow` decides which.
+
+#### Per-target reaction tables
+```sql
+CREATE TABLE public.observation_reactions (
+  id             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        uuid        NOT NULL REFERENCES public.users(id)        ON DELETE CASCADE,
+  observation_id uuid        NOT NULL REFERENCES public.observations(id) ON DELETE CASCADE,
+  kind           text        NOT NULL
+                             CHECK (kind IN ('fave','agree_id','needs_id','confirm_id','helpful')),
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, observation_id, kind)
+);
+CREATE INDEX idx_obsreact_obs_kind ON public.observation_reactions(observation_id, kind);
+
+CREATE TABLE public.photo_reactions (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid NOT NULL REFERENCES public.users(id)  ON DELETE CASCADE,
+  photo_id    uuid NOT NULL REFERENCES public.photos(id) ON DELETE CASCADE,
+  kind        text NOT NULL CHECK (kind IN ('fave','helpful')),
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, photo_id, kind)
+);
+CREATE INDEX idx_photoreact_photo_kind ON public.photo_reactions(photo_id, kind);
+
+CREATE TABLE public.identification_reactions (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           uuid NOT NULL REFERENCES public.users(id)            ON DELETE CASCADE,
+  identification_id uuid NOT NULL REFERENCES public.identifications(id)  ON DELETE CASCADE,
+  kind              text NOT NULL CHECK (kind IN ('agree_id','disagree_id','helpful')),
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, identification_id, kind)
+);
+CREATE INDEX idx_idreact_id_kind ON public.identification_reactions(identification_id, kind);
+```
+
+`comment_reactions` is defined identically and ships with M27 (when comments themselves ship).
+
+**Schema-D / UX-A discipline:** the `CHECK (kind IN …)` enums permit five reaction kinds per surface, but the v1 UI surfaces only `fave` on observations + photos, `agree_id`/`disagree_id` on identifications, `helpful` on comments. Adding more reactions later is a UX change, not a migration.
+
+#### `blocks`
+```sql
+CREATE TABLE public.blocks (
+  blocker_id  uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  blocked_id  uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (blocker_id, blocked_id),
+  CHECK (blocker_id <> blocked_id)
+);
+CREATE INDEX idx_blocks_blocked ON public.blocks(blocked_id);
+```
+
+`blocks` is read-symmetric: if A blocks B, neither A nor B sees the other's reactions, comments, or follows in any feed.
+
+#### `reports`
+```sql
+CREATE TABLE public.reports (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_id  uuid        NOT NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  target_type  text        NOT NULL
+                           CHECK (target_type IN ('user','observation','photo','identification','comment')),
+  target_id    uuid        NOT NULL,
+  reason       text        NOT NULL
+                           CHECK (reason IN ('spam','harassment','wrong_id','privacy_violation','copyright','other')),
+  note         text,
+  status       text        NOT NULL DEFAULT 'open'
+                           CHECK (status IN ('open','triaged','resolved','dismissed')),
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_reports_status_created ON public.reports(status, created_at DESC);
+```
+
+#### `notifications`
+```sql
+CREATE TABLE public.notifications (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  kind        text        NOT NULL
+                          CHECK (kind IN ('follow','follow_accepted','reaction','comment','mention',
+                                          'identification','badge','digest')),
+  payload     jsonb       NOT NULL DEFAULT '{}',
+  read_at     timestamptz,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_notifications_user_unread ON public.notifications(user_id, read_at) WHERE read_at IS NULL;
+CREATE INDEX idx_notifications_user_created ON public.notifications(user_id, created_at DESC);
+```
+
+A nightly `pg_cron` job (`prune_old_notifications`) deletes rows where `read_at < now() - interval '90 days'`.
+
+#### Counters on `users`
+```sql
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS follower_count   integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS following_count  integer NOT NULL DEFAULT 0;
+```
+
+Maintained by trigger (`tg_follows_counter`) on `follows` insert/delete, only when `status='accepted'`.
+
+### Privacy composition
+
+```sql
+CREATE OR REPLACE FUNCTION public.social_visible_to(viewer uuid, owner uuid)
+RETURNS boolean
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT
+    viewer = owner
+    OR EXISTS (
+      SELECT 1 FROM public.follows f
+       WHERE f.follower_id = viewer
+         AND f.followee_id = owner
+         AND f.status     = 'accepted'
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_collaborator_of(viewer uuid, owner uuid)
+RETURNS boolean
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.follows f
+     WHERE f.follower_id = viewer
+       AND f.followee_id = owner
+       AND f.tier        = 'collaborator'
+       AND f.status      = 'accepted'
+  );
+$$;
+```
+
+Both functions are `STABLE` and `PARALLEL SAFE` so the planner can inline them into RLS USING clauses. No `PLPGSQL` in the hot path.
+
+**RLS on reactions** (illustrative; mirror across all four reaction tables):
+```sql
+ALTER TABLE public.observation_reactions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS obsreact_read ON public.observation_reactions;
+CREATE POLICY obsreact_read ON public.observation_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.observations o
+       WHERE o.id = observation_reactions.observation_id
+         AND (
+           o.visibility = 'public'
+           OR public.social_visible_to(auth.uid(), o.observer_id)
+           OR (o.visibility = 'collaborators' AND public.is_collaborator_of(auth.uid(), o.observer_id))
+         )
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.blocks b
+       WHERE (b.blocker_id = auth.uid() AND b.blocked_id = observation_reactions.user_id)
+          OR (b.blocked_id = auth.uid() AND b.blocker_id = observation_reactions.user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS obsreact_write ON public.observation_reactions;
+CREATE POLICY obsreact_write ON public.observation_reactions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS obsreact_delete ON public.observation_reactions;
+CREATE POLICY obsreact_delete ON public.observation_reactions FOR DELETE
+  USING (user_id = auth.uid());
+```
+
+For obscured-locality observations, the **count** of reactions is visible to anyone who can read the observation; the **list of reactors** is gated through `social_visible_to`. This is enforced by exposing two views: `observation_reaction_counts` (public) and `observation_reactions` (gated).
+
+### Edge Functions
+
+| Name | Purpose | `verify_jwt` | Rate-limit |
+|---|---|---|---|
+| `follow`   | Insert/accept/reject follow; tier upgrade requests; throttle | yes | ≤ 30 follows/hour, ≤ 5 collaborator requests/day |
+| `react`    | Idempotent toggle of a (target, kind) reaction; throttle | yes | ≤ 200 reactions/hour |
+| `report`   | Insert into `reports`; email operator | yes | ≤ 10 reports/day |
+
+Throttling is implemented inline: each function runs `SELECT count(*) FROM <table> WHERE user_id = auth.uid() AND created_at > now() - interval '<window>'` and rejects with HTTP 429 if over. No `rate_limits` table.
+
+### Frontend surfaces
+
+| Route (EN ↔ ES) | Purpose |
+|---|---|
+| `/{en,es}/profile/[handle]/followers` ↔ `/seguidores` | Followers list (visibility per profile privacy) |
+| `/{en,es}/profile/[handle]/following` ↔ `/siguiendo` | Following list |
+| `/{en,es}/inbox` ↔ `/bandeja` | Notifications |
+| Profile header (existing) | Follow/Unfollow/Request Collaborator buttons |
+| Observation cards (existing) | Reaction icon + count |
+| Settings (existing) | Per-kind notification preferences, blocked users list |
+
+Views extracted into `FollowersView.astro`, `InboxView.astro`, etc., consumed by both EN and ES pages (parity rule).
+
+### Counters and triggers
+
+`tg_follows_counter` on `follows` after insert/update/delete, only fires when `status='accepted'` is gained or lost. Increments/decrements `users.follower_count` and `users.following_count` in a single statement to avoid deadlocks.
+
+Per-target reaction count columns (`fave_count`, etc.) are added to `observations` and `photos` only if the existing aggregate views become a hot read path — defer until measured.
+
+---
+
+## Module 27 — Comments + mentions
+
+### Data model
+
+#### `comments`
+```sql
+CREATE TABLE public.comments (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  author_id    uuid        NOT NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  target_type  text        NOT NULL
+                           CHECK (target_type IN ('observation','photo','identification')),
+  target_id    uuid        NOT NULL,
+  body         text        NOT NULL CHECK (length(body) BETWEEN 1 AND 4000),
+  body_html    text,                                  -- cached, server-rendered
+  edited_at    timestamptz,
+  deleted_at   timestamptz,                            -- soft delete
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_comments_target ON public.comments(target_type, target_id, created_at);
+CREATE INDEX idx_comments_author ON public.comments(author_id, created_at DESC);
+```
+
+**Why polymorphic here but not for reactions:** body+author+moderation columns are identical across targets, and soft-delete (`deleted_at`) replaces FK cascade. The trade-off (no FK to target) is acceptable because comments outlive reactions and we want a single moderation surface.
+
+#### `comment_mentions`
+```sql
+CREATE TABLE public.comment_mentions (
+  comment_id          uuid NOT NULL REFERENCES public.comments(id) ON DELETE CASCADE,
+  mentioned_user_id   uuid NOT NULL REFERENCES public.users(id)    ON DELETE CASCADE,
+  PRIMARY KEY (comment_id, mentioned_user_id)
+);
+CREATE INDEX idx_mentions_user ON public.comment_mentions(mentioned_user_id);
+```
+
+#### `notification_prefs`
+```sql
+CREATE TABLE public.notification_prefs (
+  user_id   uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  kind      text NOT NULL,
+  channel   text NOT NULL CHECK (channel IN ('in_app','email')),
+  enabled   boolean NOT NULL,
+  PRIMARY KEY (user_id, kind, channel)
+);
+```
+
+Defaults loaded by trigger on user insert, keyed against the `notifications.kind` enum:
+- in_app: all kinds enabled
+- email: only `mention` enabled by default; users can opt into others
+
+This keeps the prefs schema in lock-step with the notification kinds enum (no synthetic kinds). Smarter "follow-from-known-user" filtering can be layered on later as a payload heuristic in the digest function without a schema change.
+
+### Edge Functions
+
+| Name | Purpose | Rate-limit |
+|---|---|---|
+| `post-comment`           | Parse mentions, write comment + comment_mentions, fan out notifications | ≤ 60 comments/hour |
+| `digest-notifications`   | Daily aggregator; batches per user; sends via Resend | run via `pg_cron` 14:00 UTC |
+
+### Mention parser
+
+Server-side in `post-comment`:
+1. Tokenize body for `@<handle>` patterns (regex `@([a-z0-9_]{3,32})`).
+2. Look up handles against `users.handle`.
+3. For each match, write `comment_mentions` row.
+4. Render `body_html` with `<a href="/profile/<handle>">@handle</a>`.
+5. Fan out: insert one `notifications` row per mentioned user, respecting `blocks` and `notification_prefs`.
+
+Autocomplete on the frontend pulls from `(users I follow) ∪ (users following me)` with a 300ms debounce.
+
+### Email digests
+
+Daily Edge Function, runs via `pg_cron`:
+- Aggregate unread `notifications` per user since last digest.
+- Skip users with no unread notifications.
+- Group by kind; render via Mustache template, locale-aware.
+- Send via Resend API (free tier 100/day → upgrade signal at ~80/day).
+- Mark dispatched notifications with a sentinel `payload.digested_at`.
+
+---
+
+## Module 28 — Real-time + per-target mute + ID-help
+
+### Data model
+
+```sql
+CREATE TABLE public.mutes (
+  user_id      uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  target_type  text        NOT NULL CHECK (target_type IN ('observation','comment_thread')),
+  target_id    uuid        NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, target_type, target_id)
+);
+```
+
+### Real-time
+
+Frontend subscribes to `notifications` via Supabase Realtime, filtered by `user_id = auth.uid()`. Service worker handles web-push for installed PWAs. Push payloads contain only summary data — never coordinates, never observation-specific locality.
+
+### ID-help workflow
+
+Reuses the existing `needs_id` reaction (already in `observation_reactions.kind` enum from M26):
+- New route `/{en,es}/identify/help` ↔ `/identificar/ayuda`.
+- Lists observations with at least one `needs_id` reaction, filterable by region (PostGIS bbox) + taxon prefix.
+- Reuses `ExploreSpecies.astro` shell.
+
+No new schema for ID-help.
+
+### Groups (parked as M29)
+
+Provisional schema, not shipped in M28:
+```
+groups          (id, slug, name, kind ∈ {region, taxon, custom}, scope jsonb, owner_id, visibility, created_at)
+group_members   (group_id, user_id, role ∈ {member, mod, owner}, joined_at)
+```
+
+Ship only if observed demand justifies it after M27 ships.
+
+---
+
+## Cross-cutting concerns
+
+### i18n
+
+Every user-visible string under a new `social.*` namespace in `src/i18n/{en,es}.json`:
+- `social.follow.button`, `social.follow.requested`, `social.follow.collaborator_request`
+- `social.reactions.fave`, `social.reactions.agree_id`, `social.reactions.helpful`, …
+- `social.notifications.kind.follow`, `social.notifications.kind.mention`, …
+- `social.report.reasons.spam`, `social.report.reasons.harassment`, …
+- `social.inbox.empty`, `social.inbox.mark_all_read`, …
+
+Per-record `_es` suffix pattern for any seeded data (report reason catalog, default group names if M29 ships).
+
+### Routing (locale-paired)
+
+| EN | ES |
+|---|---|
+| `/profile/[handle]/followers` | `/profile/[handle]/seguidores` |
+| `/profile/[handle]/following` | `/profile/[handle]/siguiendo` |
+| `/inbox` | `/bandeja` |
+| `/identify/help` | `/identificar/ayuda` |
+
+Existing `/share/obs/?id=…` is locale-neutral and stays that way; reactions and comments render inline.
+
+### Tests
+
+**Unit (Vitest):**
+- `social_visible_to` privacy ladder (8 cases: owner/follower/collaborator/stranger × public/follower/collaborator/private)
+- Reaction toggle idempotence (insert, re-insert, delete, re-delete)
+- Mention parser (no mention, one mention, multiple, blocked target, deleted target, locale-folded handle)
+- Block enforcement (A reacts → B blocked → A doesn't see B's reactions and vice versa)
+
+**E2E (Playwright):** one happy-path per module —
+- M26: follow → see reaction in feed
+- M27: comment with @mention → mentioned user sees inbox row
+- M28: real-time toast appears within 2s of upstream insert; per-target mute hides subsequent notifications
+
+**RLS:** `tests/sql/social-rls.sql` covers the privacy ladder × every reaction/comment/follow read path.
+
+### Edge Function deploys
+
+All deploy via `gh workflow run deploy-functions.yml -f function=<name>` per existing convention. Cron-driven functions (`digest-notifications`, `prune_old_notifications`) deploy `--no-verify-jwt` because they run as service-role.
+
+### Migration safety
+
+All schema changes additive. `users.follower_count` and `users.following_count` default `0` — backfilled by a one-shot statement in `supabase-schema.sql`:
+```sql
+UPDATE public.users u SET
+  follower_count  = (SELECT count(*) FROM follows WHERE followee_id = u.id AND status='accepted'),
+  following_count = (SELECT count(*) FROM follows WHERE follower_id = u.id AND status='accepted')
+WHERE follower_count = 0 AND following_count = 0;
+```
+
+### Observability
+
+`social_metrics` view aggregating daily `follow`, `reaction`, `comment`, `report` counts. No PII. Surfaced on the operator dashboard (existing module).
+
+### OG cards
+
+`/inbox` and `/identify/help` are auth-gated → no OG card. `/profile/[handle]/{followers,following}` reuses the existing profile OG card. No new entries in `scripts/generate-og.ts` needed for M26/M27. M28 ID-help may want one — defer until shipped.
+
+### Roadmap + tasks updates
+
+- `docs/progress.json`: three new items — `social-graph`, `comments-mentions`, `realtime-mutes-id-help` — with `_es` translations under the appropriate phase.
+- `docs/tasks.json`: subtask breakdown per item.
+- `docs/specs/modules/00-index.md`: register `26-social-graph.md`, `27-comments-mentions.md`, `28-realtime-mutes-id-help.md`. Note `29-groups.md` as future work, not registered yet.
+
+---
+
+## Risks and open questions
+
+1. **Reaction-count visibility on obscured observations.** Spec says count is public, list is gated. Edge case: a user with one follower could have their identity inferred from a single-reaction count on a private observation. Mitigation: hide list AND count when `obscure_level > 0` AND total reactions < 3. Implement as an additional view-level filter.
+2. **Block-symmetry leaking through legacy data.** If A blocks B after B has already reacted to A's observation, the reaction is hidden on read but still exists. Acceptable for v1. Re-evaluate if it becomes a vector.
+3. **Notification-row growth.** 90-day prune may not be enough if a popular user accrues thousands of follows per week. Add a per-user cap (keep last 500 unread) as a follow-up if observed.
+4. **Real-time scaling on free tier.** Supabase Realtime free tier: 200 concurrent connections. v1 is fine; flag for upgrade at ~150 concurrent active users.
+5. **Resend free tier exhaustion.** 100 email digests/day. Once exceeded, either upgrade ($20/mo) or implement a weekly-digest fallback for low-activity users.
+6. **Groups (M29) demand signal.** Don't build until users explicitly ask for region/taxon-bound spaces — easy to over-engineer here.
+
+---
+
+## Future work (post-M28)
+
+- M29 — Groups (region, taxon, custom)
+- Algorithmic feeds (recommend observations based on follow graph + taxon affinity)
+- Cross-platform follow import (iNaturalist mapping)
+- Comment editing history / version log (currently single `body`)
+- Moderator role + queue UI (when volume justifies it)
+- Activity-pub federation (longer-term, if community grows)

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -3852,6 +3852,62 @@
           "status": "done"
         }
       ]
+    },
+    "social-graph-m26": {
+      "label_en": "Social graph + reactions (Module 26)",
+      "label_es": "Grafo social + reacciones (Módulo 26)",
+      "subtasks": [
+        {
+          "label_en": "follows table + counters trigger + privacy helpers (social_visible_to, is_collaborator_of) + collaborator coord-precision unlock",
+          "label_es": "tabla follows + trigger de contadores + helpers de privacidad (social_visible_to, is_collaborator_of) + desbloqueo de precisión de coordenadas para colaboradores",
+          "status": "done"
+        },
+        {
+          "label_en": "per-target reaction tables: observation_reactions, photo_reactions, identification_reactions (+ RLS, kind enums, unique constraints)",
+          "label_es": "tablas de reacciones por objetivo: observation_reactions, photo_reactions, identification_reactions (+ RLS, enums de kind, restricciones de unicidad)",
+          "status": "done"
+        },
+        {
+          "label_en": "blocks (read-symmetric) + reports (queue with reason enum) + notifications (kind enum + 90-day prune cron)",
+          "label_es": "bloqueos (lectura simétrica) + reportes (cola con enum de razón) + notificaciones (enum de kind + cron de poda a 90 días)",
+          "status": "done"
+        },
+        {
+          "label_en": "fan-out triggers: follow → notification, observation_reactions → notification (skip blocked recipients)",
+          "label_es": "triggers de propagación: follow → notificación, observation_reactions → notificación (omite destinatarios bloqueados)",
+          "status": "done"
+        },
+        {
+          "label_en": "Edge Functions: follow (request/accept/reject + rate-limit), react (idempotent toggle), report (with operator email)",
+          "label_es": "Edge Functions: follow (solicitar/aceptar/rechazar + límite de tasa), react (toggle idempotente), report (con email al operador)",
+          "status": "done"
+        },
+        {
+          "label_en": "TypeScript types (types.social.ts) + social client (followUser, react, reportTarget, blockUser) + 5 unit tests",
+          "label_es": "Tipos TypeScript (types.social.ts) + cliente social (followUser, react, reportTarget, blockUser) + 5 pruebas unitarias",
+          "status": "done"
+        },
+        {
+          "label_en": "i18n: socialgraph.* namespace EN+ES (sidesteps existing flat social.* namespace) + new routes (inbox, profileFollowers, profileFollowing)",
+          "label_es": "i18n: namespace socialgraph.* EN+ES (evita el namespace plano existente social.*) + nuevas rutas (inbox, profileFollowers, profileFollowing)",
+          "status": "done"
+        },
+        {
+          "label_en": "UI: ReactionStrip, FollowersView, FollowingView, InboxView, BlockedUsersList + EN/ES paired pages",
+          "label_es": "UI: ReactionStrip, FollowersView, FollowingView, InboxView, BlockedUsersList + páginas EN/ES emparejadas",
+          "status": "done"
+        },
+        {
+          "label_en": "tests: tests/sql/social-rls.sql regression + tests/e2e/social.spec.ts smoke",
+          "label_es": "pruebas: regresión tests/sql/social-rls.sql + smoke tests/e2e/social.spec.ts",
+          "status": "done"
+        },
+        {
+          "label_en": "deferred to operator: make db-apply (schema + cron) + gh workflow run deploy-functions.yml -f function={follow,react,report}",
+          "label_es": "diferido al operador: make db-apply (esquema + cron) + gh workflow run deploy-functions.yml -f function={follow,react,report}",
+          "status": "todo"
+        }
+      ]
     }
   }
 }

--- a/src/components/BlockedUsersList.astro
+++ b/src/components/BlockedUsersList.astro
@@ -1,0 +1,127 @@
+---
+/**
+ * Module 26 — Blocked users list (privacy settings panel).
+ *
+ * Renders the current user's `public.blocks` rows with an inline Unblock
+ * button per row. List is fetched client-side because the site is built
+ * statically; auth context only exists in the browser.
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+
+const { lang } = Astro.props;
+const tr = t(lang);
+const block = (tr as unknown as {
+  socialgraph: {
+    block: {
+      button: string;
+      unblock: string;
+      blocked_users: string;
+      empty: string;
+    };
+  };
+}).socialgraph.block;
+---
+
+<section
+  class="rastrum-blocked-users mt-8 rounded-lg border border-zinc-200 dark:border-zinc-800 p-5"
+  data-label-unblock={block.unblock}
+  data-label-empty={block.empty}
+>
+  <h2 class="text-base font-semibold text-zinc-900 dark:text-zinc-100 mb-3">{block.blocked_users}</h2>
+  <ul class="rastrum-blocked-list divide-y divide-zinc-200 dark:divide-zinc-800 hidden"></ul>
+  <p class="rastrum-blocked-empty text-sm text-zinc-500 dark:text-zinc-400 hidden">{block.empty}</p>
+  <p class="rastrum-blocked-loading text-sm text-zinc-500 dark:text-zinc-400">…</p>
+</section>
+
+<script>
+  import { getSupabase } from '../lib/supabase';
+  import { unblockUser } from '../lib/social';
+
+  type Row = {
+    blocked_id: string;
+    created_at: string;
+    users: { handle: string | null; display_name: string | null } | null;
+  };
+
+  async function render(root: HTMLElement) {
+    const list = root.querySelector('.rastrum-blocked-list') as HTMLUListElement | null;
+    const empty = root.querySelector('.rastrum-blocked-empty') as HTMLParagraphElement | null;
+    const loading = root.querySelector('.rastrum-blocked-loading') as HTMLParagraphElement | null;
+    if (!list || !empty || !loading) return;
+
+    const unblockLabel = root.dataset.labelUnblock ?? 'Unblock';
+
+    let supabase;
+    try {
+      supabase = getSupabase();
+    } catch {
+      loading.classList.add('hidden');
+      return;
+    }
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      loading.classList.add('hidden');
+      empty.classList.remove('hidden');
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from('blocks')
+      .select('blocked_id, created_at, users:blocked_id(handle, display_name)')
+      .eq('blocker_id', user.id)
+      .order('created_at', { ascending: false });
+
+    loading.classList.add('hidden');
+
+    if (error || !data || data.length === 0) {
+      empty.classList.remove('hidden');
+      return;
+    }
+
+    const rows = data as unknown as Row[];
+    list.classList.remove('hidden');
+    list.innerHTML = '';
+    for (const row of rows) {
+      const li = document.createElement('li');
+      li.className = 'flex items-center justify-between py-2';
+      li.dataset.blockedId = row.blocked_id;
+
+      const handle = row.users?.handle ? `@${row.users.handle}` : row.blocked_id;
+      const label = document.createElement('span');
+      label.className = 'text-sm text-zinc-800 dark:text-zinc-200';
+      label.textContent = handle;
+
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'unblock-btn text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline';
+      btn.textContent = unblockLabel;
+
+      btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        try {
+          await unblockUser(row.blocked_id);
+          li.remove();
+          if (list.children.length === 0) {
+            list.classList.add('hidden');
+            empty.classList.remove('hidden');
+          }
+        } catch {
+          btn.disabled = false;
+        }
+      });
+
+      li.appendChild(label);
+      li.appendChild(btn);
+      list.appendChild(li);
+    }
+  }
+
+  document.querySelectorAll<HTMLElement>('.rastrum-blocked-users').forEach((el) => {
+    render(el).catch(() => { /* env not configured */ });
+  });
+</script>

--- a/src/components/FollowersView.astro
+++ b/src/components/FollowersView.astro
@@ -1,0 +1,216 @@
+---
+/**
+ * Module 26 — followers list view.
+ *
+ * Lists users who follow the target profile. Resolves the target by
+ * `?username=<name>` (matching the public-profile pattern at /{lang}/u/),
+ * since this site is `output: 'static'` and cannot prerender per-username
+ * pages. RLS on `public.follows` limits visibility to accepted edges or
+ * either side of the edge; we filter `status = 'accepted'` explicitly so
+ * pending requests stay private.
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+
+const { lang } = Astro.props;
+const tr = t(lang);
+const sg = (tr as unknown as {
+  socialgraph: {
+    list: {
+      followers: string;
+      following: string;
+      empty_followers: string;
+      empty_following: string;
+    };
+    follow: { collaborator_accepted: string };
+  };
+}).socialgraph;
+
+const labelHeading = sg.list.followers;
+const labelEmpty = sg.list.empty_followers;
+const labelCollaborator = sg.follow.collaborator_accepted;
+const labelLoading = lang === 'es' ? 'Cargando…' : 'Loading…';
+const labelNotFound = lang === 'es' ? 'Perfil no encontrado.' : 'Profile not found.';
+---
+
+<section
+  class="rastrum-followers-view mx-auto max-w-2xl px-4 py-6"
+  data-lang={lang}
+  data-mode="followers"
+  data-label-heading={labelHeading}
+  data-label-empty={labelEmpty}
+  data-label-collaborator={labelCollaborator}
+  data-label-loading={labelLoading}
+  data-label-not-found={labelNotFound}
+>
+  <header class="mb-5">
+    <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {labelHeading}
+    </h1>
+    <p data-fv-subtitle class="text-sm text-zinc-500 dark:text-zinc-400 mt-1"></p>
+  </header>
+
+  <p data-fv-loading class="text-sm text-zinc-500 text-center py-8">{labelLoading}</p>
+  <p data-fv-not-found class="hidden text-sm text-zinc-500 text-center py-8 rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700">{labelNotFound}</p>
+  <p data-fv-empty class="hidden text-sm text-zinc-500 text-center py-8 rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700">{labelEmpty}</p>
+
+  <ul data-fv-list class="hidden divide-y divide-zinc-200 dark:divide-zinc-800"></ul>
+</section>
+
+<script>
+  import { getSupabase } from '../lib/supabase';
+
+  type Lang = 'en' | 'es';
+
+  type RowUser = {
+    id: string;
+    username: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  };
+
+  type FollowRow = {
+    tier: 'follower' | 'collaborator';
+    accepted_at: string | null;
+    users: RowUser | RowUser[] | null;
+  };
+
+  function show(el: Element | null) { el?.classList.remove('hidden'); }
+  function hide(el: Element | null) { el?.classList.add('hidden'); }
+
+  function readUsername(): string {
+    const params = new URLSearchParams(window.location.search);
+    const fromQuery = params.get('username') || params.get('u') || '';
+    return fromQuery.trim();
+  }
+
+  function initialsAvatar(name: string): string {
+    const clean = (name || '?').trim().slice(0, 2).toUpperCase();
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'><rect width='80' height='80' fill='#10b981'/><text x='50%' y='58%' text-anchor='middle' fill='white' font-family='system-ui,sans-serif' font-size='32' font-weight='700'>${clean}</text></svg>`;
+    return 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
+  }
+
+  function pickUser(u: RowUser | RowUser[] | null): RowUser | null {
+    if (!u) return null;
+    if (Array.isArray(u)) return u[0] ?? null;
+    return u;
+  }
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.rastrum-followers-view');
+    if (!root) return;
+    const lang = (root.dataset.lang === 'es' ? 'es' : 'en') as Lang;
+    const mode = (root.dataset.mode === 'following' ? 'following' : 'followers') as 'followers' | 'following';
+
+    const username = readUsername();
+    if (!username || !/^[a-zA-Z0-9_]{3,30}$/.test(username)) {
+      hide(root.querySelector('[data-fv-loading]'));
+      show(root.querySelector('[data-fv-not-found]'));
+      return;
+    }
+
+    let supabase;
+    try { supabase = getSupabase(); } catch {
+      hide(root.querySelector('[data-fv-loading]'));
+      show(root.querySelector('[data-fv-not-found]'));
+      return;
+    }
+
+    const { data: target } = await supabase
+      .from('users')
+      .select('id, username, display_name')
+      .eq('username', username)
+      .maybeSingle<{ id: string; username: string | null; display_name: string | null }>();
+
+    if (!target) {
+      hide(root.querySelector('[data-fv-loading]'));
+      show(root.querySelector('[data-fv-not-found]'));
+      return;
+    }
+
+    const subtitle = root.querySelector<HTMLElement>('[data-fv-subtitle]');
+    if (subtitle) {
+      const name = target.display_name || target.username || username;
+      subtitle.textContent = `@${target.username ?? username} · ${name}`;
+    }
+
+    const filterCol = mode === 'followers' ? 'followee_id' : 'follower_id';
+    const joinCol = mode === 'followers' ? 'follower_id' : 'followee_id';
+
+    const { data: rows } = await supabase
+      .from('follows')
+      .select(`tier, accepted_at, users:${joinCol}(id, username, display_name, avatar_url)`)
+      .eq(filterCol, target.id)
+      .eq('status', 'accepted')
+      .order('accepted_at', { ascending: false })
+      .limit(200);
+
+    const list = (rows ?? []) as unknown as FollowRow[];
+    hide(root.querySelector('[data-fv-loading]'));
+
+    if (list.length === 0) {
+      show(root.querySelector('[data-fv-empty]'));
+      return;
+    }
+
+    const ul = root.querySelector<HTMLUListElement>('[data-fv-list]');
+    if (!ul) return;
+    show(ul);
+
+    const collaboratorLabel = root.dataset.labelCollaborator ?? '';
+
+    for (const row of list) {
+      const u = pickUser(row.users);
+      if (!u) continue;
+      const name = u.display_name || u.username || 'Observer';
+      const handleStr = u.username ?? '';
+
+      const li = document.createElement('li');
+      li.className = 'flex items-center gap-3 py-3';
+
+      const link = document.createElement('a');
+      link.className = 'flex items-center gap-3 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 rounded p-1 -m-1 flex-1 min-w-0';
+      link.href = handleStr ? `/${lang}/u/?username=${encodeURIComponent(handleStr)}` : '#';
+
+      const img = document.createElement('img');
+      img.className = 'w-10 h-10 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover shrink-0';
+      img.loading = 'lazy';
+      img.alt = '';
+      img.src = u.avatar_url || initialsAvatar(name);
+      link.appendChild(img);
+
+      const text = document.createElement('div');
+      text.className = 'min-w-0';
+      const nameEl = document.createElement('div');
+      nameEl.className = 'font-medium text-zinc-900 dark:text-zinc-100 truncate';
+      nameEl.textContent = name;
+      const handleEl = document.createElement('div');
+      handleEl.className = 'text-sm text-zinc-500 dark:text-zinc-400 truncate';
+      handleEl.textContent = handleStr ? `@${handleStr}` : '';
+      text.appendChild(nameEl);
+      text.appendChild(handleEl);
+      link.appendChild(text);
+
+      li.appendChild(link);
+
+      if (row.tier === 'collaborator') {
+        const badge = document.createElement('span');
+        badge.className = 'text-xs text-emerald-700 dark:text-emerald-400 ml-auto shrink-0';
+        badge.textContent = collaboratorLabel;
+        li.appendChild(badge);
+      }
+
+      ul.appendChild(li);
+    }
+  }
+
+  init().catch(() => {
+    const root = document.querySelector<HTMLElement>('.rastrum-followers-view');
+    if (!root) return;
+    root.querySelector('[data-fv-loading]')?.classList.add('hidden');
+    root.querySelector('[data-fv-not-found]')?.classList.remove('hidden');
+  });
+</script>

--- a/src/components/FollowingView.astro
+++ b/src/components/FollowingView.astro
@@ -1,0 +1,209 @@
+---
+/**
+ * Module 26 — following list view.
+ *
+ * Lists users that the target profile is following. Mirrors
+ * FollowersView.astro but queries the opposite side of `public.follows`:
+ * filter by `follower_id = target.id` and join the `followee_id` user.
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+
+const { lang } = Astro.props;
+const tr = t(lang);
+const sg = (tr as unknown as {
+  socialgraph: {
+    list: {
+      followers: string;
+      following: string;
+      empty_followers: string;
+      empty_following: string;
+    };
+    follow: { collaborator_accepted: string };
+  };
+}).socialgraph;
+
+const labelHeading = sg.list.following;
+const labelEmpty = sg.list.empty_following;
+const labelCollaborator = sg.follow.collaborator_accepted;
+const labelLoading = lang === 'es' ? 'Cargando…' : 'Loading…';
+const labelNotFound = lang === 'es' ? 'Perfil no encontrado.' : 'Profile not found.';
+---
+
+<section
+  class="rastrum-following-view mx-auto max-w-2xl px-4 py-6"
+  data-lang={lang}
+  data-mode="following"
+  data-label-heading={labelHeading}
+  data-label-empty={labelEmpty}
+  data-label-collaborator={labelCollaborator}
+  data-label-loading={labelLoading}
+  data-label-not-found={labelNotFound}
+>
+  <header class="mb-5">
+    <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {labelHeading}
+    </h1>
+    <p data-fv-subtitle class="text-sm text-zinc-500 dark:text-zinc-400 mt-1"></p>
+  </header>
+
+  <p data-fv-loading class="text-sm text-zinc-500 text-center py-8">{labelLoading}</p>
+  <p data-fv-not-found class="hidden text-sm text-zinc-500 text-center py-8 rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700">{labelNotFound}</p>
+  <p data-fv-empty class="hidden text-sm text-zinc-500 text-center py-8 rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700">{labelEmpty}</p>
+
+  <ul data-fv-list class="hidden divide-y divide-zinc-200 dark:divide-zinc-800"></ul>
+</section>
+
+<script>
+  import { getSupabase } from '../lib/supabase';
+
+  type Lang = 'en' | 'es';
+
+  type RowUser = {
+    id: string;
+    username: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  };
+
+  type FollowRow = {
+    tier: 'follower' | 'collaborator';
+    accepted_at: string | null;
+    users: RowUser | RowUser[] | null;
+  };
+
+  function show(el: Element | null) { el?.classList.remove('hidden'); }
+  function hide(el: Element | null) { el?.classList.add('hidden'); }
+
+  function readUsername(): string {
+    const params = new URLSearchParams(window.location.search);
+    const fromQuery = params.get('username') || params.get('u') || '';
+    return fromQuery.trim();
+  }
+
+  function initialsAvatar(name: string): string {
+    const clean = (name || '?').trim().slice(0, 2).toUpperCase();
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'><rect width='80' height='80' fill='#10b981'/><text x='50%' y='58%' text-anchor='middle' fill='white' font-family='system-ui,sans-serif' font-size='32' font-weight='700'>${clean}</text></svg>`;
+    return 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
+  }
+
+  function pickUser(u: RowUser | RowUser[] | null): RowUser | null {
+    if (!u) return null;
+    if (Array.isArray(u)) return u[0] ?? null;
+    return u;
+  }
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.rastrum-following-view');
+    if (!root) return;
+    const lang = (root.dataset.lang === 'es' ? 'es' : 'en') as Lang;
+
+    const username = readUsername();
+    if (!username || !/^[a-zA-Z0-9_]{3,30}$/.test(username)) {
+      hide(root.querySelector('[data-fv-loading]'));
+      show(root.querySelector('[data-fv-not-found]'));
+      return;
+    }
+
+    let supabase;
+    try { supabase = getSupabase(); } catch {
+      hide(root.querySelector('[data-fv-loading]'));
+      show(root.querySelector('[data-fv-not-found]'));
+      return;
+    }
+
+    const { data: target } = await supabase
+      .from('users')
+      .select('id, username, display_name')
+      .eq('username', username)
+      .maybeSingle<{ id: string; username: string | null; display_name: string | null }>();
+
+    if (!target) {
+      hide(root.querySelector('[data-fv-loading]'));
+      show(root.querySelector('[data-fv-not-found]'));
+      return;
+    }
+
+    const subtitle = root.querySelector<HTMLElement>('[data-fv-subtitle]');
+    if (subtitle) {
+      const name = target.display_name || target.username || username;
+      subtitle.textContent = `@${target.username ?? username} · ${name}`;
+    }
+
+    const { data: rows } = await supabase
+      .from('follows')
+      .select('tier, accepted_at, users:followee_id(id, username, display_name, avatar_url)')
+      .eq('follower_id', target.id)
+      .eq('status', 'accepted')
+      .order('accepted_at', { ascending: false })
+      .limit(200);
+
+    const list = (rows ?? []) as unknown as FollowRow[];
+    hide(root.querySelector('[data-fv-loading]'));
+
+    if (list.length === 0) {
+      show(root.querySelector('[data-fv-empty]'));
+      return;
+    }
+
+    const ul = root.querySelector<HTMLUListElement>('[data-fv-list]');
+    if (!ul) return;
+    show(ul);
+
+    const collaboratorLabel = root.dataset.labelCollaborator ?? '';
+
+    for (const row of list) {
+      const u = pickUser(row.users);
+      if (!u) continue;
+      const name = u.display_name || u.username || 'Observer';
+      const handleStr = u.username ?? '';
+
+      const li = document.createElement('li');
+      li.className = 'flex items-center gap-3 py-3';
+
+      const link = document.createElement('a');
+      link.className = 'flex items-center gap-3 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 rounded p-1 -m-1 flex-1 min-w-0';
+      link.href = handleStr ? `/${lang}/u/?username=${encodeURIComponent(handleStr)}` : '#';
+
+      const img = document.createElement('img');
+      img.className = 'w-10 h-10 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover shrink-0';
+      img.loading = 'lazy';
+      img.alt = '';
+      img.src = u.avatar_url || initialsAvatar(name);
+      link.appendChild(img);
+
+      const text = document.createElement('div');
+      text.className = 'min-w-0';
+      const nameEl = document.createElement('div');
+      nameEl.className = 'font-medium text-zinc-900 dark:text-zinc-100 truncate';
+      nameEl.textContent = name;
+      const handleEl = document.createElement('div');
+      handleEl.className = 'text-sm text-zinc-500 dark:text-zinc-400 truncate';
+      handleEl.textContent = handleStr ? `@${handleStr}` : '';
+      text.appendChild(nameEl);
+      text.appendChild(handleEl);
+      link.appendChild(text);
+
+      li.appendChild(link);
+
+      if (row.tier === 'collaborator') {
+        const badge = document.createElement('span');
+        badge.className = 'text-xs text-emerald-700 dark:text-emerald-400 ml-auto shrink-0';
+        badge.textContent = collaboratorLabel;
+        li.appendChild(badge);
+      }
+
+      ul.appendChild(li);
+    }
+  }
+
+  init().catch(() => {
+    const root = document.querySelector<HTMLElement>('.rastrum-following-view');
+    if (!root) return;
+    root.querySelector('[data-fv-loading]')?.classList.add('hidden');
+    root.querySelector('[data-fv-not-found]')?.classList.remove('hidden');
+  });
+</script>

--- a/src/components/InboxView.astro
+++ b/src/components/InboxView.astro
@@ -26,7 +26,7 @@ const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
 ---
 
 <BaseLayout lang={lang} title={`${inboxTr.title} — Rastrum`} description={inboxTr.empty}>
-  <main
+  <section
     class="rastrum-inbox mx-auto max-w-2xl p-4"
     data-lang={lang}
     data-label-kind-follow={inboxTr.kind_follow}
@@ -73,7 +73,7 @@ const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
     >
       <p class="text-sm text-zinc-500 dark:text-zinc-400">{inboxTr.empty}</p>
     </div>
-  </main>
+  </section>
 </BaseLayout>
 
 <script>

--- a/src/components/InboxView.astro
+++ b/src/components/InboxView.astro
@@ -1,0 +1,214 @@
+---
+/**
+ * InboxView — signed-in user's notification inbox.
+ *
+ * Renders a static shell at build time and hydrates from the
+ * `notifications` table client-side. RLS scopes rows to the signed-in
+ * user; unauthenticated visitors get a sign-in prompt.
+ *
+ * See module 26 (social graph) plan, Task 20.
+ */
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { t, getLocalizedPath, routes } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+
+const { lang } = Astro.props;
+const tr = t(lang);
+const inboxTr = tr.socialgraph.inbox;
+const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
+const notSignedIn = (tr.profile as unknown as Record<string, string>).not_signed_in
+  ?? (lang === 'es' ? 'Inicia sesión para ver tu bandeja.' : 'Sign in to see your inbox.');
+const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
+  ?? (lang === 'es' ? 'Ingresar' : 'Sign in');
+---
+
+<BaseLayout lang={lang} title={`${inboxTr.title} — Rastrum`} description={inboxTr.empty}>
+  <main
+    class="rastrum-inbox mx-auto max-w-2xl p-4"
+    data-lang={lang}
+    data-label-kind-follow={inboxTr.kind_follow}
+    data-label-kind-follow-request={inboxTr.kind_follow_request}
+    data-label-kind-follow-accepted={inboxTr.kind_follow_accepted}
+    data-label-kind-reaction={inboxTr.kind_reaction}
+    data-label-empty={inboxTr.empty}
+  >
+    <header class="flex items-center justify-between mb-4">
+      <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+        {inboxTr.title}
+      </h1>
+      <button
+        type="button"
+        id="inbox-mark-all-read"
+        class="hidden text-sm font-medium text-emerald-700 hover:underline disabled:opacity-50"
+      >
+        {inboxTr.mark_all_read}
+      </button>
+    </header>
+
+    <div
+      id="inbox-signin"
+      class="hidden rounded-lg border border-zinc-300 dark:border-zinc-700 p-4 text-sm"
+    >
+      <p class="text-zinc-700 dark:text-zinc-300">{notSignedIn}</p>
+      <a
+        href={signInPath}
+        class="mt-3 inline-flex min-h-[40px] items-center rounded-lg bg-emerald-700 hover:bg-emerald-800 px-4 py-2 text-sm font-semibold text-white"
+      >
+        {signInLabel}
+      </a>
+    </div>
+
+    <div id="inbox-loading" class="text-sm text-zinc-500 dark:text-zinc-400">
+      {tr.profile.my_observations_loading}
+    </div>
+
+    <ul id="inbox-list" class="hidden divide-y divide-zinc-200 dark:divide-zinc-800"></ul>
+
+    <div
+      id="inbox-empty"
+      class="hidden rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700 p-8 text-center"
+    >
+      <p class="text-sm text-zinc-500 dark:text-zinc-400">{inboxTr.empty}</p>
+    </div>
+  </main>
+</BaseLayout>
+
+<script>
+  import { getSupabase } from '../lib/supabase';
+
+  type Lang = 'en' | 'es';
+
+  type NotificationKind =
+    | 'follow'
+    | 'follow_request'
+    | 'follow_accepted'
+    | 'reaction'
+    | string;
+
+  interface NotificationRow {
+    id: string;
+    kind: NotificationKind;
+    payload: Record<string, unknown> | null;
+    read_at: string | null;
+    created_at: string;
+  }
+
+  const root = document.querySelector<HTMLElement>('.rastrum-inbox');
+  const lang: Lang = root?.dataset.lang === 'es' ? 'es' : 'en';
+
+  function escapeText(s: string): string {
+    return s
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function templateFor(kind: NotificationKind): string {
+    if (!root) return '';
+    if (kind === 'follow') return root.dataset.labelKindFollow ?? '';
+    if (kind === 'follow_request') return root.dataset.labelKindFollowRequest ?? '';
+    if (kind === 'follow_accepted') return root.dataset.labelKindFollowAccepted ?? '';
+    if (kind === 'reaction') return root.dataset.labelKindReaction ?? '';
+    return '';
+  }
+
+  function actorFromPayload(payload: NotificationRow['payload']): string {
+    if (!payload) return '';
+    const handle = (payload as { actor_handle?: unknown }).actor_handle;
+    const display = (payload as { actor_display_name?: unknown }).actor_display_name;
+    const id = (payload as { actor_id?: unknown }).actor_id;
+    if (typeof display === 'string' && display.trim()) return display;
+    if (typeof handle === 'string' && handle.trim()) return '@' + handle;
+    if (typeof id === 'string' && id.trim()) return id;
+    return '';
+  }
+
+  function renderRow(n: NotificationRow): string {
+    const tpl = templateFor(n.kind);
+    const actor = actorFromPayload(n.payload);
+    const text = tpl ? tpl.replace('{{actor}}', escapeText(actor)) : '';
+    const when = new Date(n.created_at).toLocaleString(lang);
+    const dim = n.read_at ? 'opacity-60' : '';
+    return `<li class="py-3 ${dim}">
+      <div class="text-sm text-zinc-800 dark:text-zinc-200">${text}</div>
+      <div class="text-xs text-zinc-500 dark:text-zinc-400 mt-1">${escapeText(when)}</div>
+    </li>`;
+  }
+
+  function showSignIn() {
+    document.getElementById('inbox-loading')?.classList.add('hidden');
+    document.getElementById('inbox-signin')?.classList.remove('hidden');
+  }
+
+  function showEmpty() {
+    document.getElementById('inbox-loading')?.classList.add('hidden');
+    document.getElementById('inbox-list')?.classList.add('hidden');
+    document.getElementById('inbox-empty')?.classList.remove('hidden');
+  }
+
+  function showList(html: string) {
+    document.getElementById('inbox-loading')?.classList.add('hidden');
+    const list = document.getElementById('inbox-list');
+    if (list) {
+      list.innerHTML = html;
+      list.classList.remove('hidden');
+    }
+    const markAll = document.getElementById('inbox-mark-all-read');
+    markAll?.classList.remove('hidden');
+  }
+
+  async function init() {
+    let supabase;
+    try {
+      supabase = getSupabase();
+    } catch {
+      showSignIn();
+      return;
+    }
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      showSignIn();
+      return;
+    }
+    const { data, error } = await supabase
+      .from('notifications')
+      .select('id, kind, payload, read_at, created_at')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(100);
+    if (error) {
+      showEmpty();
+      return;
+    }
+    const rows = (data ?? []) as NotificationRow[];
+    if (rows.length === 0) {
+      showEmpty();
+      return;
+    }
+    showList(rows.map(renderRow).join(''));
+
+    const markAll = document.getElementById('inbox-mark-all-read') as HTMLButtonElement | null;
+    markAll?.addEventListener('click', async () => {
+      markAll.disabled = true;
+      try {
+        const sb = getSupabase();
+        const { data: { user: me } } = await sb.auth.getUser();
+        if (!me) return;
+        await sb
+          .from('notifications')
+          .update({ read_at: new Date().toISOString() })
+          .eq('user_id', me.id)
+          .is('read_at', null);
+        location.reload();
+      } finally {
+        markAll.disabled = false;
+      }
+    });
+  }
+
+  init().catch(() => { showSignIn(); });
+</script>

--- a/src/components/ReactionStrip.astro
+++ b/src/components/ReactionStrip.astro
@@ -1,0 +1,93 @@
+---
+/**
+ * ReactionStrip — target-aware reaction buttons (observation / photo / identification).
+ *
+ * Server props seed counts and the current user's prior reactions; client
+ * script toggles via the `react` Edge Function (see src/lib/social.ts).
+ *
+ * Optimistic UI: flip pressed state + count immediately, roll back on error.
+ *
+ * NOTE: card wiring deferred — call sites that render this need a
+ * `reaction_counts` aggregate + `my_reactions` array; the SQL/RPC for
+ * that lands in a follow-up task.
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+  target: 'observation' | 'photo' | 'identification';
+  targetId: string;
+  initialCounts: Record<string, number>;
+  myReactions: string[];
+}
+
+const { lang, target, targetId, initialCounts, myReactions } = Astro.props;
+const tr = t(lang).socialgraph.reactions;
+
+const KIND_BY_TARGET = {
+  observation: ['fave'] as const,
+  photo: ['fave', 'helpful'] as const,
+  identification: ['agree_id', 'disagree_id'] as const,
+} as const;
+const kinds = KIND_BY_TARGET[target];
+
+const ICONS: Record<string, string> = {
+  fave: '❤',
+  helpful: '✓',
+  agree_id: '✓',
+  disagree_id: '✕',
+};
+
+const labels = tr as unknown as Record<string, string>;
+---
+<div
+  class="flex items-center gap-2"
+  data-reaction-target={target}
+  data-reaction-target-id={targetId}
+>
+  {kinds.map((kind) => (
+    <button
+      type="button"
+      class={`reaction-btn rounded-full border px-2 py-1 text-xs ${myReactions.includes(kind) ? 'bg-emerald-100 border-emerald-400' : 'border-stone-300 hover:bg-stone-100'}`}
+      data-kind={kind}
+      aria-label={labels[kind]}
+      aria-pressed={myReactions.includes(kind) ? 'true' : 'false'}
+    >
+      <span aria-hidden="true">{ICONS[kind]}</span>
+      <span class="count">{initialCounts[kind] ?? 0}</span>
+    </button>
+  ))}
+</div>
+
+<script>
+  import { react } from '../lib/social';
+
+  for (const root of document.querySelectorAll<HTMLDivElement>('[data-reaction-target]')) {
+    const targetType = root.dataset.reactionTarget as 'observation' | 'photo' | 'identification';
+    const targetId = root.dataset.reactionTargetId!;
+    for (const btn of root.querySelectorAll<HTMLButtonElement>('.reaction-btn')) {
+      btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        const kind = btn.dataset.kind! as Parameters<typeof react>[0]['kind'];
+        const countEl = btn.querySelector('.count')!;
+        const wasOn = btn.getAttribute('aria-pressed') === 'true';
+        try {
+          const r = await react({ target: targetType, target_id: targetId, kind });
+          if (r.action === 'inserted') {
+            btn.setAttribute('aria-pressed', 'true');
+            btn.classList.add('bg-emerald-100', 'border-emerald-400');
+            countEl.textContent = String(Number(countEl.textContent ?? '0') + 1);
+          } else if (r.action === 'deleted') {
+            btn.setAttribute('aria-pressed', 'false');
+            btn.classList.remove('bg-emerald-100', 'border-emerald-400');
+            countEl.textContent = String(Math.max(0, Number(countEl.textContent ?? '0') - 1));
+          }
+        } catch {
+          btn.setAttribute('aria-pressed', wasOn ? 'true' : 'false');
+        } finally {
+          btn.disabled = false;
+        }
+      });
+    }
+  }
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -956,6 +956,65 @@
     "streak_never": "Never",
     "streak_loading": "Loading streak…"
   },
+  "socialgraph": {
+    "follow": {
+      "button": "Follow",
+      "following": "Following",
+      "requested": "Requested",
+      "request_collaborator": "Request collaborator access",
+      "collaborator_pending": "Collaborator request pending",
+      "collaborator_accepted": "You're a close collaborator",
+      "unfollow_confirm": "Unfollow {{handle}}?",
+      "approve": "Approve",
+      "decline": "Decline"
+    },
+    "reactions": {
+      "fave": "Favorite",
+      "agree_id": "Agree with ID",
+      "disagree_id": "Disagree with ID",
+      "needs_id": "Needs ID",
+      "confirm_id": "Confirm ID",
+      "helpful": "Helpful",
+      "count_one": "{{count}} reaction",
+      "count_other": "{{count}} reactions"
+    },
+    "inbox": {
+      "title": "Inbox",
+      "empty": "Nothing new — go observe something.",
+      "mark_all_read": "Mark all read",
+      "kind_follow": "{{actor}} started following you",
+      "kind_follow_request": "{{actor}} requested to follow you",
+      "kind_follow_accepted": "{{actor}} accepted your follow request",
+      "kind_reaction": "{{actor}} reacted to your observation"
+    },
+    "report": {
+      "button": "Report",
+      "title": "Report this {{target}}",
+      "reasons": {
+        "spam": "Spam",
+        "harassment": "Harassment",
+        "wrong_id": "Wrong identification",
+        "privacy_violation": "Privacy violation",
+        "copyright": "Copyright",
+        "other": "Other"
+      },
+      "note_placeholder": "Optional note for the moderator",
+      "submit": "Submit report",
+      "thanks": "Thanks — we'll review."
+    },
+    "block": {
+      "button": "Block",
+      "unblock": "Unblock",
+      "blocked_users": "Blocked users",
+      "empty": "You haven't blocked anyone."
+    },
+    "list": {
+      "followers": "Followers",
+      "following": "Following",
+      "empty_followers": "No followers yet.",
+      "empty_following": "Not following anyone yet."
+    }
+  },
   "expert": {
     "apply_title": "Apply as an expert",
     "apply_subtitle": "Help validate identifications. Expert IDs are weighted 3× in the consensus.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -956,6 +956,65 @@
     "streak_never": "Nunca",
     "streak_loading": "Cargando racha…"
   },
+  "socialgraph": {
+    "follow": {
+      "button": "Seguir",
+      "following": "Siguiendo",
+      "requested": "Solicitado",
+      "request_collaborator": "Solicitar acceso de colaborador",
+      "collaborator_pending": "Solicitud de colaborador pendiente",
+      "collaborator_accepted": "Eres colaborador cercano",
+      "unfollow_confirm": "¿Dejar de seguir a {{handle}}?",
+      "approve": "Aceptar",
+      "decline": "Rechazar"
+    },
+    "reactions": {
+      "fave": "Favorito",
+      "agree_id": "De acuerdo con la ID",
+      "disagree_id": "En desacuerdo con la ID",
+      "needs_id": "Necesita ID",
+      "confirm_id": "Confirmar ID",
+      "helpful": "Útil",
+      "count_one": "{{count}} reacción",
+      "count_other": "{{count}} reacciones"
+    },
+    "inbox": {
+      "title": "Bandeja",
+      "empty": "Nada nuevo — sal a observar.",
+      "mark_all_read": "Marcar todo como leído",
+      "kind_follow": "{{actor}} te siguió",
+      "kind_follow_request": "{{actor}} solicitó seguirte",
+      "kind_follow_accepted": "{{actor}} aceptó tu solicitud de seguidor",
+      "kind_reaction": "{{actor}} reaccionó a tu observación"
+    },
+    "report": {
+      "button": "Reportar",
+      "title": "Reportar este {{target}}",
+      "reasons": {
+        "spam": "Spam",
+        "harassment": "Acoso",
+        "wrong_id": "Identificación incorrecta",
+        "privacy_violation": "Violación de privacidad",
+        "copyright": "Derechos de autor",
+        "other": "Otro"
+      },
+      "note_placeholder": "Nota opcional para el moderador",
+      "submit": "Enviar reporte",
+      "thanks": "Gracias — lo revisaremos."
+    },
+    "block": {
+      "button": "Bloquear",
+      "unblock": "Desbloquear",
+      "blocked_users": "Usuarios bloqueados",
+      "empty": "No has bloqueado a nadie."
+    },
+    "list": {
+      "followers": "Seguidores",
+      "following": "Siguiendo",
+      "empty_followers": "Aún no tienes seguidores.",
+      "empty_following": "Aún no sigues a nadie."
+    }
+  },
   "expert": {
     "apply_title": "Postularse como experto",
     "apply_subtitle": "Ayuda a validar identificaciones. Las IDs expertas pesan 3× en el consenso.",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -84,6 +84,10 @@ export const routes: Record<string, Record<Locale, string>> = {
   consoleExpertOverrides:   { en: '/console/overrides',        es: '/consola/correcciones' },
   consoleExpertExpertise:   { en: '/console/expertise',        es: '/consola/experiencia' },
   consoleExpertTaxonNotes:  { en: '/console/taxon-notes',      es: '/consola/notas-taxon' },
+  // Social graph (M26)
+  inbox:            { en: '/inbox',     es: '/bandeja' },
+  profileFollowers: { en: '/profile/u', es: '/perfil/u' },
+  profileFollowing: { en: '/profile/u', es: '/perfil/u' },
 };
 
 export const docPages = [

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -179,6 +179,10 @@ export const routeTree: Record<string, RouteNode> = {
   consoleExpertOverrides:  { labels: { en: 'Overrides',        es: 'Correcciones' },      parent: 'console' },
   consoleExpertExpertise:  { labels: { en: 'Expertise',        es: 'Experiencia' },       parent: 'console' },
   consoleExpertTaxonNotes: { labels: { en: 'Taxon notes',      es: 'Notas de taxón' },    parent: 'console' },
+  // Social graph (M26)
+  inbox:             { labels: { en: 'Inbox',     es: 'Bandeja' } },
+  profileFollowers:  { labels: { en: 'Followers', es: 'Seguidores' }, parent: 'profileUser' },
+  profileFollowing:  { labels: { en: 'Following', es: 'Siguiendo' },  parent: 'profileUser' },
 };
 
 export function getRouteLabel(key: string, lang: string): string {

--- a/src/lib/social.ts
+++ b/src/lib/social.ts
@@ -8,6 +8,10 @@
  * See docs/specs/modules/08-profile-activity-gamification.md for the
  * social schema. RLS is enforced server-side; we never gate on the client.
  */
+import { getSupabase } from './supabase';
+import type {
+  ReactionTarget, ReactionKind, ReportTarget, ReportReason, FollowTier,
+} from './types.social';
 
 export interface CommentRow {
   id: string;
@@ -264,4 +268,82 @@ export const SYNC_FILTERS: ReadonlyArray<SyncFilter> = ['all', 'synced', 'pendin
 
 export function isSyncFilter(value: string | null | undefined): value is SyncFilter {
   return !!value && (SYNC_FILTERS as ReadonlyArray<string>).includes(value);
+}
+
+export async function followUser(targetUserId: string, tier: FollowTier = 'follower') {
+  const { data, error } = await getSupabase().functions.invoke('follow', {
+    body: { action: 'follow', target_user_id: targetUserId, tier },
+  });
+  if (error) throw error;
+  return data as { ok: boolean; status: 'pending' | 'accepted' };
+}
+
+export async function unfollowUser(targetUserId: string) {
+  const { data, error } = await getSupabase().functions.invoke('follow', {
+    body: { action: 'unfollow', target_user_id: targetUserId },
+  });
+  if (error) throw error;
+  return data as { ok: boolean };
+}
+
+export async function acceptFollow(followerId: string) {
+  const { data, error } = await getSupabase().functions.invoke('follow', {
+    body: { action: 'accept', follower_id: followerId },
+  });
+  if (error) throw error;
+  return data as { ok: boolean };
+}
+
+export async function react(args: {
+  target: ReactionTarget;
+  target_id: string;
+  kind: ReactionKind;
+}) {
+  const { data, error } = await getSupabase().functions.invoke('react', {
+    body: { ...args, toggle: true },
+  });
+  if (error) throw error;
+  return data as { ok: boolean; action: 'inserted' | 'deleted' };
+}
+
+export async function unreact(args: {
+  target: ReactionTarget;
+  target_id: string;
+  kind: ReactionKind;
+}) {
+  const { data, error } = await getSupabase().functions.invoke('react', {
+    body: { ...args, toggle: false },
+  });
+  if (error) throw error;
+  return data as { ok: boolean; action: 'deleted' };
+}
+
+export async function reportTarget(args: {
+  target: ReportTarget;
+  target_id: string;
+  reason: ReportReason;
+  note?: string;
+}) {
+  const { data, error } = await getSupabase().functions.invoke('report', { body: args });
+  if (error) throw error;
+  return data as { ok: boolean; id: string };
+}
+
+export async function blockUser(targetUserId: string) {
+  const sb = getSupabase();
+  const { error } = await sb
+    .from('blocks')
+    .insert({ blocker_id: (await sb.auth.getUser()).data.user?.id, blocked_id: targetUserId });
+  if (error) throw error;
+}
+
+export async function unblockUser(targetUserId: string) {
+  const sb = getSupabase();
+  const me = (await sb.auth.getUser()).data.user?.id;
+  const { error } = await sb
+    .from('blocks')
+    .delete()
+    .eq('blocker_id', me)
+    .eq('blocked_id', targetUserId);
+  if (error) throw error;
 }

--- a/src/lib/types.social.ts
+++ b/src/lib/types.social.ts
@@ -1,0 +1,53 @@
+export type FollowTier = 'follower' | 'collaborator';
+export type FollowStatus = 'pending' | 'accepted';
+
+export interface Follow {
+  follower_id: string;
+  followee_id: string;
+  tier: FollowTier;
+  status: FollowStatus;
+  requested_at: string;
+  accepted_at: string | null;
+}
+
+export type ReactionTarget = 'observation' | 'photo' | 'identification';
+export type ReactionKind =
+  | 'fave' | 'agree_id' | 'needs_id' | 'confirm_id'
+  | 'disagree_id' | 'helpful';
+
+export interface Reaction {
+  id: string;
+  user_id: string;
+  target_id: string;
+  kind: ReactionKind;
+  created_at: string;
+}
+
+export type NotificationKind =
+  | 'follow' | 'follow_accepted' | 'reaction' | 'comment'
+  | 'mention' | 'identification' | 'badge' | 'digest';
+
+export interface Notification {
+  id: string;
+  user_id: string;
+  kind: NotificationKind;
+  payload: Record<string, unknown>;
+  read_at: string | null;
+  created_at: string;
+}
+
+export type ReportTarget = 'user' | 'observation' | 'photo' | 'identification' | 'comment';
+export type ReportReason =
+  | 'spam' | 'harassment' | 'wrong_id'
+  | 'privacy_violation' | 'copyright' | 'other';
+
+export interface Report {
+  id: string;
+  reporter_id: string | null;
+  target_type: ReportTarget;
+  target_id: string;
+  reason: ReportReason;
+  note: string | null;
+  status: 'open' | 'triaged' | 'resolved' | 'dismissed';
+  created_at: string;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -168,3 +168,4 @@ export interface ValidationQueueRow {
 }
 
 export type UserRole = 'admin' | 'moderator' | 'expert' | 'researcher';
+export * from './types.social';

--- a/src/pages/en/inbox.astro
+++ b/src/pages/en/inbox.astro
@@ -1,0 +1,5 @@
+---
+import InboxView from '../../components/InboxView.astro';
+---
+
+<InboxView lang="en" />

--- a/src/pages/en/profile/settings/[tab].astro
+++ b/src/pages/en/profile/settings/[tab].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import SettingsShell from '../../../../components/SettingsShell.astro';
 import ProfileEditForm from '../../../../components/ProfileEditForm.astro';
 import PrivacyMatrix from '../../../../components/PrivacyMatrix.astro';
+import BlockedUsersList from '../../../../components/BlockedUsersList.astro';
 import { t, getLocalizedPath, routes } from '../../../../i18n/utils';
 
 export function getStaticPaths() {
@@ -185,7 +186,10 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
     )}
 
     {activeTab === 'privacy' && (
-      <PrivacyMatrix lang={lang} />
+      <>
+        <PrivacyMatrix lang={lang} />
+        <BlockedUsersList lang={lang} />
+      </>
     )}
   </SettingsShell>
 </BaseLayout>

--- a/src/pages/en/profile/u/followers/index.astro
+++ b/src/pages/en/profile/u/followers/index.astro
@@ -1,0 +1,23 @@
+---
+/**
+ * Module 26 — followers list page (EN).
+ *
+ * Resolves the target via `?username=<name>` (or `?handle=<name>`); the
+ * canonical public-profile route is `/{lang}/u/?username=`, so this
+ * mirror under `/profile/u/` keeps the URL family local. Static output
+ * forbids dynamic `[handle]` segments — see plan corrections in the
+ * Module 26 plan doc.
+ */
+import BaseLayout from '../../../../../layouts/BaseLayout.astro';
+import FollowersView from '../../../../../components/FollowersView.astro';
+
+const lang = 'en' as const;
+---
+<BaseLayout
+  title="Followers — Rastrum"
+  description="People who follow this Rastrum observer."
+  lang={lang}
+  robots="noindex,nofollow"
+>
+  <FollowersView lang={lang} />
+</BaseLayout>

--- a/src/pages/en/profile/u/following/index.astro
+++ b/src/pages/en/profile/u/following/index.astro
@@ -1,0 +1,21 @@
+---
+/**
+ * Module 26 — following list page (EN).
+ *
+ * Resolves the target via `?username=<name>` (or `?handle=<name>`).
+ * Static output forbids dynamic `[handle]` segments — see plan
+ * corrections in the Module 26 plan doc.
+ */
+import BaseLayout from '../../../../../layouts/BaseLayout.astro';
+import FollowingView from '../../../../../components/FollowingView.astro';
+
+const lang = 'en' as const;
+---
+<BaseLayout
+  title="Following — Rastrum"
+  description="People this Rastrum observer follows."
+  lang={lang}
+  robots="noindex,nofollow"
+>
+  <FollowingView lang={lang} />
+</BaseLayout>

--- a/src/pages/es/bandeja.astro
+++ b/src/pages/es/bandeja.astro
@@ -1,0 +1,5 @@
+---
+import InboxView from '../../components/InboxView.astro';
+---
+
+<InboxView lang="es" />

--- a/src/pages/es/perfil/ajustes/[tab].astro
+++ b/src/pages/es/perfil/ajustes/[tab].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import SettingsShell from '../../../../components/SettingsShell.astro';
 import ProfileEditForm from '../../../../components/ProfileEditForm.astro';
 import PrivacyMatrix from '../../../../components/PrivacyMatrix.astro';
+import BlockedUsersList from '../../../../components/BlockedUsersList.astro';
 import { t, getLocalizedPath, routes } from '../../../../i18n/utils';
 
 export function getStaticPaths() {
@@ -183,7 +184,10 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
     )}
 
     {activeTab === 'privacy' && (
-      <PrivacyMatrix lang={lang} />
+      <>
+        <PrivacyMatrix lang={lang} />
+        <BlockedUsersList lang={lang} />
+      </>
     )}
   </SettingsShell>
 </BaseLayout>

--- a/src/pages/es/perfil/u/seguidores/index.astro
+++ b/src/pages/es/perfil/u/seguidores/index.astro
@@ -1,0 +1,21 @@
+---
+/**
+ * Módulo 26 — página de seguidores (ES).
+ *
+ * Resuelve el perfil objetivo mediante `?username=<nombre>` (o
+ * `?handle=<nombre>`). La salida estática no admite segmentos
+ * dinámicos `[handle]` — ver correcciones en el plan del módulo 26.
+ */
+import BaseLayout from '../../../../../layouts/BaseLayout.astro';
+import FollowersView from '../../../../../components/FollowersView.astro';
+
+const lang = 'es' as const;
+---
+<BaseLayout
+  title="Seguidores — Rastrum"
+  description="Personas que siguen a este observador de Rastrum."
+  lang={lang}
+  robots="noindex,nofollow"
+>
+  <FollowersView lang={lang} />
+</BaseLayout>

--- a/src/pages/es/perfil/u/siguiendo/index.astro
+++ b/src/pages/es/perfil/u/siguiendo/index.astro
@@ -1,0 +1,21 @@
+---
+/**
+ * Módulo 26 — página de siguiendo (ES).
+ *
+ * Resuelve el perfil objetivo mediante `?username=<nombre>` (o
+ * `?handle=<nombre>`). La salida estática no admite segmentos
+ * dinámicos `[handle]` — ver correcciones en el plan del módulo 26.
+ */
+import BaseLayout from '../../../../../layouts/BaseLayout.astro';
+import FollowingView from '../../../../../components/FollowingView.astro';
+
+const lang = 'es' as const;
+---
+<BaseLayout
+  title="Siguiendo — Rastrum"
+  description="Personas a las que sigue este observador de Rastrum."
+  lang={lang}
+  robots="noindex,nofollow"
+>
+  <FollowingView lang={lang} />
+</BaseLayout>

--- a/supabase/functions/follow/index.ts
+++ b/supabase/functions/follow/index.ts
@@ -1,0 +1,123 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const FOLLOW_RATE_PER_HOUR = 30;
+const COLLAB_REQUEST_PER_DAY = 5;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+
+  const auth = req.headers.get('Authorization') ?? '';
+  if (!auth.startsWith('Bearer ')) return json({ error: 'no_jwt' }, 401);
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: auth } },
+  });
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData.user) return json({ error: 'invalid_jwt' }, 401);
+  const userId = userData.user.id;
+
+  let body: Record<string, unknown>;
+  try { body = await req.json(); } catch { return json({ error: 'bad_json' }, 400); }
+
+  const action = String(body.action ?? '');
+
+  // Rate-limit: count follows by this user in last hour.
+  const { count: hourCount } = await supabase
+    .from('follows')
+    .select('*', { count: 'exact', head: true })
+    .eq('follower_id', userId)
+    .gte('requested_at', new Date(Date.now() - 3600_000).toISOString());
+
+  if ((hourCount ?? 0) >= FOLLOW_RATE_PER_HOUR && action !== 'unfollow' && action !== 'accept') {
+    return json({ error: 'rate_limited', retry_after_s: 3600 }, 429);
+  }
+
+  if (action === 'follow') {
+    const target = String(body.target_user_id ?? '');
+    const tier = (body.tier === 'collaborator' ? 'collaborator' : 'follower') as 'follower' | 'collaborator';
+    if (!target || target === userId) return json({ error: 'bad_target' }, 400);
+
+    if (tier === 'collaborator') {
+      const { count: dayCount } = await supabase
+        .from('follows')
+        .select('*', { count: 'exact', head: true })
+        .eq('follower_id', userId)
+        .eq('tier', 'collaborator')
+        .gte('requested_at', new Date(Date.now() - 86400_000).toISOString());
+      if ((dayCount ?? 0) >= COLLAB_REQUEST_PER_DAY) {
+        return json({ error: 'rate_limited', retry_after_s: 86400 }, 429);
+      }
+    }
+
+    // Profile-privacy gate: if target's profile_privacy.profile = 'private', store as pending.
+    const { data: target_user } = await supabase
+      .from('users').select('profile_privacy').eq('id', target).single();
+
+    const profileMode = (target_user?.profile_privacy as Record<string, string> | null)
+      ?.profile ?? 'signed_in';
+    const requiresApproval =
+      profileMode === 'private'
+      || tier === 'collaborator';
+
+    const { error } = await supabase.from('follows').upsert({
+      follower_id: userId,
+      followee_id: target,
+      tier,
+      status: requiresApproval ? 'pending' : 'accepted',
+      requested_at: new Date().toISOString(),
+      accepted_at: requiresApproval ? null : new Date().toISOString(),
+    }, { onConflict: 'follower_id,followee_id' });
+    if (error) return json({ error: error.message }, 400);
+
+    return json({ ok: true, status: requiresApproval ? 'pending' : 'accepted' });
+  }
+
+  if (action === 'unfollow') {
+    const target = String(body.target_user_id ?? '');
+    const { error } = await supabase
+      .from('follows').delete()
+      .eq('follower_id', userId).eq('followee_id', target);
+    if (error) return json({ error: error.message }, 400);
+    return json({ ok: true });
+  }
+
+  if (action === 'accept') {
+    const follower = String(body.follower_id ?? '');
+    const { error } = await supabase
+      .from('follows')
+      .update({ status: 'accepted', accepted_at: new Date().toISOString() })
+      .eq('follower_id', follower).eq('followee_id', userId).eq('status', 'pending');
+    if (error) return json({ error: error.message }, 400);
+    return json({ ok: true });
+  }
+
+  if (action === 'reject') {
+    const follower = String(body.follower_id ?? '');
+    const { error } = await supabase
+      .from('follows').delete()
+      .eq('follower_id', follower).eq('followee_id', userId).eq('status', 'pending');
+    if (error) return json({ error: error.message }, 400);
+    return json({ ok: true });
+  }
+
+  return json({ error: 'unknown_action' }, 400);
+});

--- a/supabase/functions/react/index.ts
+++ b/supabase/functions/react/index.ts
@@ -1,0 +1,91 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+const REACT_RATE_PER_HOUR = 200;
+
+const TARGETS = {
+  observation:    { table: 'observation_reactions',    col: 'observation_id'   },
+  photo:          { table: 'photo_reactions',          col: 'media_file_id'    },
+  identification: { table: 'identification_reactions', col: 'identification_id'},
+} as const;
+
+const KIND_BY_TARGET: Record<keyof typeof TARGETS, ReadonlyArray<string>> = {
+  observation:    ['fave', 'agree_id', 'needs_id', 'confirm_id', 'helpful'],
+  photo:          ['fave', 'helpful'],
+  identification: ['agree_id', 'disagree_id', 'helpful'],
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status, headers: { ...CORS, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+
+  const auth = req.headers.get('Authorization') ?? '';
+  if (!auth.startsWith('Bearer ')) return json({ error: 'no_jwt' }, 401);
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: auth } },
+  });
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData.user) return json({ error: 'invalid_jwt' }, 401);
+  const userId = userData.user.id;
+
+  let body: Record<string, unknown>;
+  try { body = await req.json(); } catch { return json({ error: 'bad_json' }, 400); }
+
+  const target = String(body.target ?? '') as keyof typeof TARGETS;
+  const kind = String(body.kind ?? '');
+  const targetId = String(body.target_id ?? '');
+  const toggle = body.toggle !== false;
+
+  if (!(target in TARGETS)) return json({ error: 'bad_target' }, 400);
+  if (!KIND_BY_TARGET[target].includes(kind)) return json({ error: 'bad_kind' }, 400);
+  if (!targetId) return json({ error: 'bad_target_id' }, 400);
+
+  const { table, col } = TARGETS[target];
+
+  // Rate-limit: count this user's reactions in the last hour.
+  const { count: hourCount } = await supabase
+    .from(table)
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .gte('created_at', new Date(Date.now() - 3600_000).toISOString());
+  if ((hourCount ?? 0) >= REACT_RATE_PER_HOUR) {
+    return json({ error: 'rate_limited', retry_after_s: 3600 }, 429);
+  }
+
+  // Idempotent toggle.
+  const { data: existing } = await supabase
+    .from(table)
+    .select('id')
+    .eq('user_id', userId)
+    .eq(col, targetId)
+    .eq('kind', kind)
+    .maybeSingle();
+
+  if (existing) {
+    if (toggle) {
+      await supabase.from(table).delete().eq('id', existing.id);
+      return json({ ok: true, action: 'deleted' });
+    }
+    return json({ ok: true, action: 'noop' });
+  }
+
+  const insertRow: Record<string, unknown> = { user_id: userId, kind };
+  insertRow[col] = targetId;
+  const { error } = await supabase.from(table).insert(insertRow);
+  if (error) return json({ error: error.message }, 400);
+  return json({ ok: true, action: 'inserted' });
+});

--- a/supabase/functions/report/index.ts
+++ b/supabase/functions/report/index.ts
@@ -1,0 +1,93 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
+const OPERATOR_EMAIL = Deno.env.get('OPERATOR_EMAIL') ?? 'artemiopadilla@gmail.com';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+const REPORT_RATE_PER_DAY = 10;
+
+const TARGETS = ['user','observation','photo','identification','comment'] as const;
+const REASONS = ['spam','harassment','wrong_id','privacy_violation','copyright','other'] as const;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status, headers: { ...CORS, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+
+  const auth = req.headers.get('Authorization') ?? '';
+  if (!auth.startsWith('Bearer ')) return json({ error: 'no_jwt' }, 401);
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: auth } },
+  });
+
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData.user) return json({ error: 'invalid_jwt' }, 401);
+  const userId = userData.user.id;
+
+  let body: Record<string, unknown>;
+  try { body = await req.json(); } catch { return json({ error: 'bad_json' }, 400); }
+
+  const target = String(body.target ?? '');
+  const reason = String(body.reason ?? '');
+  const targetId = String(body.target_id ?? '');
+  const note = (typeof body.note === 'string') ? body.note.slice(0, 1000) : null;
+
+  if (!TARGETS.includes(target as typeof TARGETS[number])) return json({ error: 'bad_target' }, 400);
+  if (!REASONS.includes(reason as typeof REASONS[number])) return json({ error: 'bad_reason' }, 400);
+  if (!targetId) return json({ error: 'bad_target_id' }, 400);
+
+  const { count: dayCount } = await supabase
+    .from('reports')
+    .select('*', { count: 'exact', head: true })
+    .eq('reporter_id', userId)
+    .gte('created_at', new Date(Date.now() - 86400_000).toISOString());
+  if ((dayCount ?? 0) >= REPORT_RATE_PER_DAY) {
+    return json({ error: 'rate_limited', retry_after_s: 86400 }, 429);
+  }
+
+  const { data: inserted, error } = await supabase
+    .from('reports')
+    .insert({
+      reporter_id: userId,
+      target_type: target,
+      target_id: targetId,
+      reason,
+      note,
+    })
+    .select('id')
+    .single();
+  if (error) return json({ error: error.message }, 400);
+
+  // Best-effort operator email; never fail the request on email error.
+  if (RESEND_API_KEY) {
+    try {
+      await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: 'reports@rastrum.org',
+          to: [OPERATOR_EMAIL],
+          subject: `[Rastrum] Report: ${reason} on ${target}`,
+          text: `Reporter: ${userId}\nTarget: ${target}/${targetId}\nReason: ${reason}\nNote: ${note ?? '(none)'}\n\nReport ID: ${inserted.id}`,
+        }),
+      });
+    } catch { /* ignore */ }
+  }
+
+  return json({ ok: true, id: inserted.id });
+});

--- a/tests/e2e/social.spec.ts
+++ b/tests/e2e/social.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('m26 social — smoke', () => {
+  test('inbox page renders without auth (EN)', async ({ page }) => {
+    await page.goto('/en/inbox/');
+    await expect(page).toHaveURL(/\/en\/inbox\/?$/);
+    await expect(page.locator('main')).toBeVisible();
+  });
+
+  test('inbox page renders without auth (ES)', async ({ page }) => {
+    await page.goto('/es/bandeja/');
+    await expect(page).toHaveURL(/\/es\/bandeja\/?$/);
+    await expect(page.locator('main')).toBeVisible();
+  });
+
+  test('followers route exists (EN)', async ({ page }) => {
+    const response = await page.goto('/en/profile/u/followers/');
+    expect([200, 404]).toContain(response?.status() ?? 0);
+  });
+
+  test('followers route exists (ES)', async ({ page }) => {
+    const response = await page.goto('/es/perfil/u/seguidores/');
+    expect([200, 404]).toContain(response?.status() ?? 0);
+  });
+
+  test('following route exists (EN)', async ({ page }) => {
+    const response = await page.goto('/en/profile/u/following/');
+    expect([200, 404]).toContain(response?.status() ?? 0);
+  });
+});

--- a/tests/sql/social-rls.sql
+++ b/tests/sql/social-rls.sql
@@ -1,0 +1,76 @@
+-- tests/sql/social-rls.sql
+--
+-- Module 26 RLS regression queries. Run via:
+--   psql "$SUPABASE_DB_URL" -f tests/sql/social-rls.sql
+--
+-- Uses a transaction with two ephemeral users + one observation; ROLLBACK
+-- at the end so production data is untouched. Confirms the schema is
+-- referentially sound and that the social tables accept the expected
+-- writes via the service role. A more rigorous test using SET ROLE
+-- authenticated + request.jwt.claims is left for follow-up — this script
+-- is the smoke check.
+
+BEGIN;
+
+DO $$
+DECLARE
+  u_a    uuid := gen_random_uuid();
+  u_b    uuid := gen_random_uuid();
+  obs_id uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO public.users(id, username, display_name)
+    VALUES (u_a, 'rls_a_' || substr(u_a::text, 1, 6), 'A');
+  INSERT INTO public.users(id, username, display_name)
+    VALUES (u_b, 'rls_b_' || substr(u_b::text, 1, 6), 'B');
+
+  INSERT INTO public.observations(id, observer_id, sync_status, obscure_level)
+    VALUES (obs_id, u_a, 'synced', 'none');
+
+  -- 1) B reacts on A's public observation.
+  INSERT INTO public.observation_reactions(user_id, observation_id, kind)
+    VALUES (u_b, obs_id, 'fave');
+
+  -- 2) A blocks B; the block edge must round-trip cleanly.
+  INSERT INTO public.blocks(blocker_id, blocked_id) VALUES (u_a, u_b);
+  IF NOT EXISTS (SELECT 1 FROM public.blocks WHERE blocker_id = u_a AND blocked_id = u_b) THEN
+    RAISE EXCEPTION 'block insert failed';
+  END IF;
+
+  -- 3) A unblocks; visibility restored.
+  DELETE FROM public.blocks WHERE blocker_id = u_a AND blocked_id = u_b;
+
+  -- 4) Make obs full-obscure; subsequent collaborator unlock test below.
+  UPDATE public.observations SET obscure_level = 'full' WHERE id = obs_id;
+
+  -- 5) Make B a collaborator of A — accepted edge.
+  INSERT INTO public.follows(follower_id, followee_id, tier, status, accepted_at)
+    VALUES (u_b, u_a, 'collaborator', 'accepted', now());
+
+  -- 6) Counters must update via trigger.
+  IF (SELECT follower_count FROM public.users WHERE id = u_a) <> 1 THEN
+    RAISE EXCEPTION 'follower_count trigger failed: expected 1';
+  END IF;
+
+  -- 7) Notification fan-out: A should have a follow notification (or follow_accepted).
+  IF NOT EXISTS (SELECT 1 FROM public.notifications WHERE user_id = u_a AND kind IN ('follow','follow_accepted')) THEN
+    RAISE EXCEPTION 'follow notification fan-out trigger did not fire';
+  END IF;
+
+  -- 8) is_collaborator_of returns true.
+  IF NOT public.is_collaborator_of(u_b, u_a) THEN
+    RAISE EXCEPTION 'is_collaborator_of returned false';
+  END IF;
+
+  -- 9) social_visible_to(u_b, u_a) returns true (B follows A).
+  IF NOT public.social_visible_to(u_b, u_a) THEN
+    RAISE EXCEPTION 'social_visible_to returned false for accepted follower';
+  END IF;
+
+  -- 10) Reports table accepts a row.
+  INSERT INTO public.reports(reporter_id, target_type, target_id, reason)
+    VALUES (u_b, 'observation', obs_id, 'wrong_id');
+
+  RAISE NOTICE 'social-rls regression OK';
+END $$;
+
+ROLLBACK;

--- a/tests/unit/social.test.ts
+++ b/tests/unit/social.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../src/lib/supabase', () => {
+  const single = { single: vi.fn() };
+  const eq = { eq: vi.fn(() => eq), maybeSingle: vi.fn() };
+  const builder: Record<string, unknown> = {
+    select: vi.fn(() => eq),
+    insert: vi.fn(() => single),
+    delete: vi.fn(() => eq),
+    update: vi.fn(() => eq),
+  };
+  const from = vi.fn(() => builder);
+  const client = { from, functions: { invoke: vi.fn() }, auth: { getUser: vi.fn() } };
+  return {
+    getSupabase: () => client,
+  };
+});
+
+import { getSupabase } from '../../src/lib/supabase';
+import { followUser, unfollowUser, react, unreact, reportTarget } from '../../src/lib/social';
+
+const supabase = getSupabase() as unknown as {
+  functions: { invoke: ReturnType<typeof vi.fn> };
+};
+
+describe('social client', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('followUser invokes the follow Edge Function with action=follow', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, status: 'accepted' }, error: null,
+    });
+    const out = await followUser('user-uuid');
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('follow', {
+      body: { action: 'follow', target_user_id: 'user-uuid', tier: 'follower' },
+    });
+    expect(out).toEqual({ ok: true, status: 'accepted' });
+  });
+
+  it('unfollowUser invokes the follow Edge Function with action=unfollow', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true }, error: null,
+    });
+    await unfollowUser('user-uuid');
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('follow', {
+      body: { action: 'unfollow', target_user_id: 'user-uuid' },
+    });
+  });
+
+  it('react invokes the react Edge Function with toggle=true', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, action: 'inserted' }, error: null,
+    });
+    await react({ target: 'observation', target_id: 'obs-id', kind: 'fave' });
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('react', {
+      body: { target: 'observation', target_id: 'obs-id', kind: 'fave', toggle: true },
+    });
+  });
+
+  it('unreact invokes the react Edge Function with toggle=false', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, action: 'deleted' }, error: null,
+    });
+    await unreact({ target: 'observation', target_id: 'obs-id', kind: 'fave' });
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('react', {
+      body: { target: 'observation', target_id: 'obs-id', kind: 'fave', toggle: false },
+    });
+  });
+
+  it('reportTarget invokes the report Edge Function', async () => {
+    (supabase.functions.invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, id: 'rep-id' }, error: null,
+    });
+    await reportTarget({ target: 'user', target_id: 'u', reason: 'spam', note: 'x' });
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('report', {
+      body: { target: 'user', target_id: 'u', reason: 'spam', note: 'x' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Asymmetric follow + opt-in close-collaborator tier; per-target reaction tables (observation/photo/identification); blocks (read-symmetric); reports queue; in-app inbox; 90-day notification prune cron.
- Three Edge Functions (`follow`, `react`, `report`) with inline windowed `count(*)` rate-limits — no `rate_limits` table.
- Two `STABLE SQL` privacy helpers (`social_visible_to`, `is_collaborator_of`) inlined into RLS; collaborator coord-precision unlock mirrors the existing credentialed-researcher policy.
- Composes against the existing `can_see_facet` + `obscure_level` mechanics — does NOT introduce a parallel per-observation `visibility` column (spec patched inline during planning).
- New UI: `ReactionStrip`, `FollowersView`, `FollowingView`, `InboxView`, `BlockedUsersList` + EN/ES paired pages (`/inbox` ↔ `/bandeja`, `/profile/u/{followers,following}` ↔ `/perfil/u/{seguidores,siguiendo}`).
- New i18n namespace `socialgraph.*` (the existing flat `social.*` is reserved for module-08 social copy and stays untouched).
- Unit tests (5), RLS regression script, Playwright smoke (5).

## Out of scope (parked to M27/M28/M29)
- Comments + @mentions (M27).
- Email digests, Resend integration (M27).
- Supabase Realtime subscriptions and per-target mutes (M28).
- Region/taxon groups (M29 if demand).

## Operator follow-up (deferred from this PR — explicitly opted out of prod-touching steps)
- [ ] `make db-apply` to apply ~390 lines of new idempotent SQL appended to `docs/specs/infra/supabase-schema.sql` + the prune cron in `docs/specs/infra/cron-schedules.sql`.
- [ ] `make db-cron-schedule` (or apply the new schedule manually).
- [ ] `gh workflow run deploy-functions.yml --ref main -f function=follow`
- [ ] `gh workflow run deploy-functions.yml --ref main -f function=react`
- [ ] `gh workflow run deploy-functions.yml --ref main -f function=report`
- [ ] Run `psql "$SUPABASE_DB_URL" -f tests/sql/social-rls.sql` after the schema applies — expects `NOTICE:  social-rls regression OK`.

## Spec + plan
- Spec: `docs/superpowers/specs/2026-04-28-social-features-design.md`
- Plan: `docs/superpowers/plans/2026-04-28-m26-social-graph.md`
- Module spec: `docs/specs/modules/26-social-graph.md`

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 435 passing (1 new test file with 5 social client tests + the existing `route-tree.test.ts` after fixture update)
- [x] `npm run build` — 96 pages, no errors
- [ ] `npm run test:e2e` — adds 5 social smoke specs; run after merge to confirm they're green in CI
- [ ] Manual after deploy: follow another user, react on an observation, report a target, block + unblock from privacy settings, see entries in `/inbox`

## Notes for reviewer
- The plan originally assumed a fresh `social.*` i18n namespace. The existing `social.*` is flat and consumed by 6 shipping components; mid-implementation we pivoted to `socialgraph.*` as the new namespace (purely additive, no rename of existing keys). Documented in commit `fe1e519` and the m26 spec/plan.
- The original plan also assumed a per-observation `visibility` column. That column does not exist; the spec was patched mid-flight to compose against `can_see_facet` + `obscure_level` + the new `is_collaborator_of` helper instead.
- One commit (`ae741dc`) accidentally bundled Task 20 (Inbox) + Task 21 (BlockedUsersList) due to two parallel agents writing to the same working tree. Work is correct; commit history just isn't 1-task-per-commit at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)