### PR TITLE
feat(observe): establishment_means — origen del organismo (silvestre / cultivada / doméstica)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2595,3 +2595,27 @@ WHERE
 GROUP BY o.observer_id, i.taxon_id, t.scientific_name, t.kingdom, tr.bucket;
 
 GRANT SELECT ON public.profile_pokedex TO anon, authenticated;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- Module 27 — Establishment Means (organism origin)
+-- Requested by Eugenio Padilla, 2026-04-28.
+-- Darwin Core: establishmentMeans / occurrenceStatus field.
+-- ═════════════════════════════════════════════════════════════════════
+
+ALTER TABLE public.observations
+  ADD COLUMN IF NOT EXISTS establishment_means text NOT NULL DEFAULT 'wild'
+    CHECK (establishment_means IN ('wild','cultivated','captive','uncertain'));
+
+COMMENT ON COLUMN public.observations.establishment_means IS
+  'Darwin Core establishmentMeans. wild=native wild individual; '
+  'cultivated=planted/cultivated plant or managed population; '
+  'captive=domestic animal, zoo, aquarium; uncertain=observer not sure.';
+
+-- Backfill existing rows (all pre-existing observations assumed wild —
+-- the only reasonable default for a biodiversity app in the field).
+UPDATE public.observations SET establishment_means = 'wild'
+  WHERE establishment_means IS DISTINCT FROM 'wild';
+
+-- Index for diversity queries filtering by establishment_means = 'wild'.
+CREATE INDEX IF NOT EXISTS idx_obs_establishment_means
+  ON public.observations(establishment_means);

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -46,6 +46,8 @@ const habitats = [
 const habitatLabels = (tr.observe as any).habitat_options as Record<string,string> | undefined;
 const weathers = ['sunny','cloudy','overcast','light_rain','heavy_rain','fog','storm'];
 const weatherLabels = (tr.observe as any).weather_options as Record<string,string> | undefined;
+const establishmentMeans = ['wild','cultivated','captive','uncertain'] as const;
+const establishmentLabels = (tr.observe as any).establishment_means_options as Record<string,string> | undefined;
 
 // Pull strings into typed local consts so JSX never needs an inline
 // `Record<…>` cast (Astro/esbuild parses the angle brackets as a tag).
@@ -416,6 +418,29 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
           <option value="">{tr.observe.weather_placeholder}</option>
           {weathers.map(w => <option value={w}>{weatherLabels?.[w] ?? w.replace(/_/g, ' ')}</option>)}
         </select>
+      </div>
+    </div>
+
+    <!-- Establishment means (organism origin) -->
+    <div data-identify-hide>
+      <label for="obs-establishment" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+        {observeStrings.establishment_means}
+      </label>
+      <div class="flex flex-wrap gap-2">
+        {establishmentMeans.map((v) => (
+          <label class="cursor-pointer">
+            <input
+              type="radio"
+              name="establishment_means"
+              value={v}
+              class="peer sr-only"
+              checked={v === 'wild'}
+            />
+            <span class="inline-flex items-center rounded-full border border-zinc-300 dark:border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-700 dark:text-zinc-300 peer-checked:bg-emerald-700 peer-checked:text-white peer-checked:border-emerald-700 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors">
+              {establishmentLabels?.[v] ?? v}
+            </span>
+          </label>
+        ))}
       </div>
     </div>
 
@@ -2253,6 +2278,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       },
       habitat: ((form.elements.namedItem('habitat') as HTMLSelectElement).value || null) as Observation['habitat'],
       weather: ((form.elements.namedItem('weather') as HTMLSelectElement).value || null) as Observation['weather'],
+      establishmentMeans: (form.querySelector<HTMLInputElement>('input[name="establishment_means"]:checked')?.value ?? 'wild') as 'wild' | 'cultivated' | 'captive' | 'uncertain',
       evidenceType: ((form.elements.namedItem('evidence_type') as HTMLSelectElement).value || 'direct_sighting') as Observation['evidenceType'],
       notes: ((form.elements.namedItem('notes') as HTMLTextAreaElement).value || null),
       asDraft,
@@ -2660,6 +2686,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       time: new Date().toISOString(),
       habitat: (form.elements.namedItem('habitat') as HTMLSelectElement | null)?.value || null,
       weather: (form.elements.namedItem('weather') as HTMLSelectElement | null)?.value || null,
+      establishment_means: form.querySelector<HTMLInputElement>('input[name="establishment_means"]:checked')?.value ?? 'wild',
       evidence_type: (form.elements.namedItem('evidence_type') as HTMLSelectElement | null)?.value || null,
       behavior_tags: null,
       count: null,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -442,6 +442,14 @@
     "habitat_placeholder": "Select habitat (optional)",
     "weather": "Weather",
     "weather_placeholder": "Select weather (optional)",
+    "establishment_means": "Organism origin",
+    "establishment_means_placeholder": "Select origin (optional)",
+    "establishment_means_options": {
+      "wild": "🌿 Wild",
+      "cultivated": "🌱 Cultivated / planted",
+      "captive": "🏠 Domestic / captive",
+      "uncertain": "❓ Not sure"
+    },
     "notes": "Notes",
     "notes_placeholder": "Behaviour, context, anything the form doesn't capture",
     "submit": "Save observation",
@@ -1189,56 +1197,56 @@
     "rank_in_region": "rank {n} in {region}"
   },
   "validation": {
-    "queue_title":              "Validation queue",
-    "queue_subtitle":           "{n} observations need help",
-    "queue_empty":              "No observations waiting for validation. Nice work!",
-    "queue_error":              "Could not load the queue.",
-    "queue_loading":            "Loading…",
-    "queue_filter_kingdom":     "Kingdom",
-    "queue_filter_status":      "Status",
-    "queue_filter_all":         "All",
-    "queue_filter_no_id":       "No identification",
-    "queue_filter_low_conf":    "Low confidence",
-    "queue_filter_pending":     "Awaiting validation",
-    "suggest_id":               "Suggest identification",
-    "confirm_id":               "Confirm {name}",
-    "suggest_different":        "Suggest another",
-    "votes_count_one":          "1 suggestion",
-    "votes_count_other":        "{n} suggestions",
-    "experts_count":            "{n} {kingdom} expert(s)",
-    "research_grade":           "Research grade",
-    "research_grade_promoted":  "Identification promoted to research grade!",
-    "pending_validation":       "Waiting for community validation",
-    "cannot_vote_own":          "You can't validate your own observations",
-    "tie_warning":              "Two suggestions are tied — a tiebreaker vote is needed.",
-    "expert_note_placeholder":  "Notes (optional)",
-    "confidence_high":          "High",
-    "confidence_medium":        "Medium",
-    "confidence_low":           "Low",
-    "confidence_label":         "Your confidence",
-    "scientific_name_label":    "Scientific name",
+    "queue_title": "Validation queue",
+    "queue_subtitle": "{n} observations need help",
+    "queue_empty": "No observations waiting for validation. Nice work!",
+    "queue_error": "Could not load the queue.",
+    "queue_loading": "Loading…",
+    "queue_filter_kingdom": "Kingdom",
+    "queue_filter_status": "Status",
+    "queue_filter_all": "All",
+    "queue_filter_no_id": "No identification",
+    "queue_filter_low_conf": "Low confidence",
+    "queue_filter_pending": "Awaiting validation",
+    "suggest_id": "Suggest identification",
+    "confirm_id": "Confirm {name}",
+    "suggest_different": "Suggest another",
+    "votes_count_one": "1 suggestion",
+    "votes_count_other": "{n} suggestions",
+    "experts_count": "{n} {kingdom} expert(s)",
+    "research_grade": "Research grade",
+    "research_grade_promoted": "Identification promoted to research grade!",
+    "pending_validation": "Waiting for community validation",
+    "cannot_vote_own": "You can't validate your own observations",
+    "tie_warning": "Two suggestions are tied — a tiebreaker vote is needed.",
+    "expert_note_placeholder": "Notes (optional)",
+    "confidence_high": "High",
+    "confidence_medium": "Medium",
+    "confidence_low": "Low",
+    "confidence_label": "Your confidence",
+    "scientific_name_label": "Scientific name",
     "scientific_name_placeholder": "Start typing, e.g. Quercus oleoides",
-    "validate_signin_prompt":   "Sign in to suggest an identification",
-    "validate_signin_btn":      "Sign in",
-    "research_grade_title":     "Research grade — community-confirmed",
-    "submit_target_tpl":        "Suggestion for {name}'s observation",
-    "nav_validate_label":       "Validate",
-    "submission_received":      "Suggestion received.",
-    "submit_suggestion":        "Submit suggestion",
-    "submitting":               "Submitting…",
-    "cancel":                   "Cancel",
-    "current_id_label":         "Current identification",
-    "no_id_yet":                "Unidentified",
-    "by_observer":              "By {name}",
-    "no_taxon_match":           "No species found with that name. Make sure you're typing the full scientific name.",
-    "submit_failed":            "Could not submit suggestion: {error}",
-    "dashboard_title":          "My validations",
-    "dashboard_subtitle":       "Suggestions you've made and their impact.",
-    "dashboard_empty":          "You haven't validated any observations yet. Visit the queue to start.",
-    "stat_suggestions":         "Suggestions made",
-    "stat_research_grade":      "Reached research grade",
-    "stat_kingdoms":            "Kingdoms validated",
-    "go_to_queue":              "Open the queue",
+    "validate_signin_prompt": "Sign in to suggest an identification",
+    "validate_signin_btn": "Sign in",
+    "research_grade_title": "Research grade — community-confirmed",
+    "submit_target_tpl": "Suggestion for {name}'s observation",
+    "nav_validate_label": "Validate",
+    "submission_received": "Suggestion received.",
+    "submit_suggestion": "Submit suggestion",
+    "submitting": "Submitting…",
+    "cancel": "Cancel",
+    "current_id_label": "Current identification",
+    "no_id_yet": "Unidentified",
+    "by_observer": "By {name}",
+    "no_taxon_match": "No species found with that name. Make sure you're typing the full scientific name.",
+    "submit_failed": "Could not submit suggestion: {error}",
+    "dashboard_title": "My validations",
+    "dashboard_subtitle": "Suggestions you've made and their impact.",
+    "dashboard_empty": "You haven't validated any observations yet. Visit the queue to start.",
+    "stat_suggestions": "Suggestions made",
+    "stat_research_grade": "Reached research grade",
+    "stat_kingdoms": "Kingdoms validated",
+    "go_to_queue": "Open the queue",
     "karma_microcopy_loading": "Loading vote weight…",
     "karma_microcopy_unavailable": "Vote weighting will be visible after first save."
   },
@@ -1358,25 +1366,82 @@
     "save_failed_toast": "Could not save — try again",
     "owner_only_badge": "Only you see this",
     "facet": {
-      "profile":          { "label": "Public profile",          "description": "Whether the profile page is reachable at all." },
-      "real_name":        { "label": "Display name",            "description": "Your display name when it differs from your username." },
-      "bio":              { "label": "Bio",                     "description": "The bio you wrote on your profile." },
-      "location":         { "label": "Region",                  "description": "Your primary region (state or country) — never your precise address." },
-      "stats_counts":     { "label": "Stats counts",            "description": "Total observations, research-grade count, kingdoms validated." },
-      "observation_map":  { "label": "Observation map",         "description": "Map of your observations. Sensitive species are still coarsened to ~11 km." },
-      "calendar_heatmap": { "label": "Activity calendar",       "description": "12-month grid showing days you observed." },
-      "taxonomic_donut":  { "label": "Taxonomic breakdown",     "description": "Donut of which kingdoms or phyla you mostly observe." },
-      "top_species":      { "label": "Top species",             "description": "Grid of your most-observed species with thumbnails." },
-      "streak":           { "label": "Streak",                  "description": "Current and longest day streak." },
-      "badges":           { "label": "Badges",                  "description": "The badges you have unlocked." },
-      "activity_feed":    { "label": "Activity feed",           "description": "Chronological feed of your observations, IDs, and suggestions." },
-      "validation_rep":   { "label": "Validation reputation",   "description": "Your accepted-IDs and research-grade-promoted counts. Anchor of the credentialed-researcher signal." },
-      "obs_list":         { "label": "Observation list",        "description": "Browse-all-observations link to your full history." },
-      "watchlist":        { "label": "Watchlist",               "description": "Taxa you are watching." },
-      "goals":            { "label": "Goals",                   "description": "Monthly observation goals and progress." },
-      "karma_total":      { "label": "Karma score",             "description": "Your karma score and trust signal." },
-      "expertise":        { "label": "Expertise",               "description": "Per-taxon expertise scores derived from validation outcomes." },
-      "pokedex":          { "label": "Pokédex",                 "description": "Grid of every taxon you have observed, with rarity buckets." }
+      "profile": {
+        "label": "Public profile",
+        "description": "Whether the profile page is reachable at all."
+      },
+      "real_name": {
+        "label": "Display name",
+        "description": "Your display name when it differs from your username."
+      },
+      "bio": {
+        "label": "Bio",
+        "description": "The bio you wrote on your profile."
+      },
+      "location": {
+        "label": "Region",
+        "description": "Your primary region (state or country) — never your precise address."
+      },
+      "stats_counts": {
+        "label": "Stats counts",
+        "description": "Total observations, research-grade count, kingdoms validated."
+      },
+      "observation_map": {
+        "label": "Observation map",
+        "description": "Map of your observations. Sensitive species are still coarsened to ~11 km."
+      },
+      "calendar_heatmap": {
+        "label": "Activity calendar",
+        "description": "12-month grid showing days you observed."
+      },
+      "taxonomic_donut": {
+        "label": "Taxonomic breakdown",
+        "description": "Donut of which kingdoms or phyla you mostly observe."
+      },
+      "top_species": {
+        "label": "Top species",
+        "description": "Grid of your most-observed species with thumbnails."
+      },
+      "streak": {
+        "label": "Streak",
+        "description": "Current and longest day streak."
+      },
+      "badges": {
+        "label": "Badges",
+        "description": "The badges you have unlocked."
+      },
+      "activity_feed": {
+        "label": "Activity feed",
+        "description": "Chronological feed of your observations, IDs, and suggestions."
+      },
+      "validation_rep": {
+        "label": "Validation reputation",
+        "description": "Your accepted-IDs and research-grade-promoted counts. Anchor of the credentialed-researcher signal."
+      },
+      "obs_list": {
+        "label": "Observation list",
+        "description": "Browse-all-observations link to your full history."
+      },
+      "watchlist": {
+        "label": "Watchlist",
+        "description": "Taxa you are watching."
+      },
+      "goals": {
+        "label": "Goals",
+        "description": "Monthly observation goals and progress."
+      },
+      "karma_total": {
+        "label": "Karma score",
+        "description": "Your karma score and trust signal."
+      },
+      "expertise": {
+        "label": "Expertise",
+        "description": "Per-taxon expertise scores derived from validation outcomes."
+      },
+      "pokedex": {
+        "label": "Pokédex",
+        "description": "Grid of every taxon you have observed, with rarity buckets."
+      }
     }
   },
   "console": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -442,6 +442,14 @@
     "habitat_placeholder": "Selecciona hábitat (opcional)",
     "weather": "Clima",
     "weather_placeholder": "Selecciona clima (opcional)",
+    "establishment_means": "Origen del organismo",
+    "establishment_means_placeholder": "Selecciona origen (opcional)",
+    "establishment_means_options": {
+      "wild": "🌿 Silvestre",
+      "cultivated": "🌱 Cultivada / plantada",
+      "captive": "🏠 Doméstica / cautiverio",
+      "uncertain": "❓ No sé"
+    },
     "notes": "Notas",
     "notes_placeholder": "Comportamiento, contexto, lo que el formulario no capture",
     "submit": "Guardar observación",
@@ -1189,56 +1197,56 @@
     "rank_in_region": "ranking {n} en {region}"
   },
   "validation": {
-    "queue_title":              "Cola de validación",
-    "queue_subtitle":           "{n} observaciones necesitan ayuda",
-    "queue_empty":              "No hay observaciones esperando validación. ¡Buen trabajo!",
-    "queue_error":              "No se pudo cargar la cola.",
-    "queue_loading":            "Cargando…",
-    "queue_filter_kingdom":     "Reino",
-    "queue_filter_status":      "Estado",
-    "queue_filter_all":         "Todas",
-    "queue_filter_no_id":       "Sin identificación",
-    "queue_filter_low_conf":    "Baja confianza",
-    "queue_filter_pending":     "Esperando validación",
-    "suggest_id":               "Sugerir identificación",
-    "confirm_id":               "Confirmar {name}",
-    "suggest_different":        "Sugerir otra",
-    "votes_count_one":          "1 sugerencia",
-    "votes_count_other":        "{n} sugerencias",
-    "experts_count":            "{n} experto(s) en {kingdom}",
-    "research_grade":           "Grado de investigación",
-    "research_grade_promoted":  "¡Identificación promovida a grado investigación!",
-    "pending_validation":       "Esperando validación de la comunidad",
-    "cannot_vote_own":          "No puedes validar tus propias observaciones",
-    "tie_warning":              "Dos sugerencias empatadas — se necesita un voto desempate.",
-    "expert_note_placeholder":  "Notas (opcional)",
-    "confidence_high":          "Alta",
-    "confidence_medium":        "Media",
-    "confidence_low":           "Baja",
-    "confidence_label":         "Tu confianza",
-    "scientific_name_label":    "Nombre científico",
+    "queue_title": "Cola de validación",
+    "queue_subtitle": "{n} observaciones necesitan ayuda",
+    "queue_empty": "No hay observaciones esperando validación. ¡Buen trabajo!",
+    "queue_error": "No se pudo cargar la cola.",
+    "queue_loading": "Cargando…",
+    "queue_filter_kingdom": "Reino",
+    "queue_filter_status": "Estado",
+    "queue_filter_all": "Todas",
+    "queue_filter_no_id": "Sin identificación",
+    "queue_filter_low_conf": "Baja confianza",
+    "queue_filter_pending": "Esperando validación",
+    "suggest_id": "Sugerir identificación",
+    "confirm_id": "Confirmar {name}",
+    "suggest_different": "Sugerir otra",
+    "votes_count_one": "1 sugerencia",
+    "votes_count_other": "{n} sugerencias",
+    "experts_count": "{n} experto(s) en {kingdom}",
+    "research_grade": "Grado de investigación",
+    "research_grade_promoted": "¡Identificación promovida a grado investigación!",
+    "pending_validation": "Esperando validación de la comunidad",
+    "cannot_vote_own": "No puedes validar tus propias observaciones",
+    "tie_warning": "Dos sugerencias empatadas — se necesita un voto desempate.",
+    "expert_note_placeholder": "Notas (opcional)",
+    "confidence_high": "Alta",
+    "confidence_medium": "Media",
+    "confidence_low": "Baja",
+    "confidence_label": "Tu confianza",
+    "scientific_name_label": "Nombre científico",
     "scientific_name_placeholder": "Empieza a escribir, p. ej. Quercus oleoides",
-    "validate_signin_prompt":   "Inicia sesión para sugerir una identificación",
-    "validate_signin_btn":      "Iniciar sesión",
-    "research_grade_title":     "Grado investigación — confirmado por la comunidad",
-    "submit_target_tpl":        "Sugerencia para la observación de {name}",
-    "nav_validate_label":       "Validar",
-    "submission_received":      "Sugerencia recibida.",
-    "submit_suggestion":        "Enviar sugerencia",
-    "submitting":               "Enviando…",
-    "cancel":                   "Cancelar",
-    "current_id_label":         "Identificación actual",
-    "no_id_yet":                "Sin identificar",
-    "by_observer":              "Por {name}",
-    "no_taxon_match":           "No se encontró ninguna especie con ese nombre. Asegúrate de escribir el nombre científico completo.",
-    "submit_failed":            "No se pudo enviar la sugerencia: {error}",
-    "dashboard_title":          "Mis validaciones",
-    "dashboard_subtitle":       "Sugerencias que has hecho y su impacto.",
-    "dashboard_empty":          "Aún no has validado ninguna observación. Visita la cola de validación para empezar.",
-    "stat_suggestions":         "Sugerencias hechas",
-    "stat_research_grade":      "Llegaron a grado investigación",
-    "stat_kingdoms":            "Reinos validados",
-    "go_to_queue":              "Ir a la cola",
+    "validate_signin_prompt": "Inicia sesión para sugerir una identificación",
+    "validate_signin_btn": "Iniciar sesión",
+    "research_grade_title": "Grado investigación — confirmado por la comunidad",
+    "submit_target_tpl": "Sugerencia para la observación de {name}",
+    "nav_validate_label": "Validar",
+    "submission_received": "Sugerencia recibida.",
+    "submit_suggestion": "Enviar sugerencia",
+    "submitting": "Enviando…",
+    "cancel": "Cancelar",
+    "current_id_label": "Identificación actual",
+    "no_id_yet": "Sin identificar",
+    "by_observer": "Por {name}",
+    "no_taxon_match": "No se encontró ninguna especie con ese nombre. Asegúrate de escribir el nombre científico completo.",
+    "submit_failed": "No se pudo enviar la sugerencia: {error}",
+    "dashboard_title": "Mis validaciones",
+    "dashboard_subtitle": "Sugerencias que has hecho y su impacto.",
+    "dashboard_empty": "Aún no has validado ninguna observación. Visita la cola de validación para empezar.",
+    "stat_suggestions": "Sugerencias hechas",
+    "stat_research_grade": "Llegaron a grado investigación",
+    "stat_kingdoms": "Reinos validados",
+    "go_to_queue": "Ir a la cola",
     "karma_microcopy_loading": "Cargando peso de voto…",
     "karma_microcopy_unavailable": "El peso de tu voto aparecerá tras tu primera guardada."
   },
@@ -1358,25 +1366,82 @@
     "save_failed_toast": "No se pudo guardar — intenta de nuevo",
     "owner_only_badge": "Solo lo ves tú",
     "facet": {
-      "profile":          { "label": "Perfil público",               "description": "Si la página de perfil está accesible." },
-      "real_name":        { "label": "Nombre visible",                "description": "Tu nombre visible cuando difiere de tu usuario." },
-      "bio":              { "label": "Biografía",                    "description": "La biografía que escribiste en tu perfil." },
-      "location":         { "label": "Región",                       "description": "Tu región principal (estado o país) — nunca tu dirección precisa." },
-      "stats_counts":     { "label": "Conteos",                      "description": "Total de observaciones, conteo grado-investigación, reinos validados." },
-      "observation_map":  { "label": "Mapa de observaciones",         "description": "Mapa de tus observaciones. Especies sensibles se siguen aproximando a ~11 km." },
-      "calendar_heatmap": { "label": "Calendario de actividad",       "description": "Cuadrícula de 12 meses con los días en que observaste." },
-      "taxonomic_donut":  { "label": "Desglose taxonómico",           "description": "Donut con los reinos o filos que más observas." },
-      "top_species":      { "label": "Especies destacadas",           "description": "Cuadrícula con tus especies más observadas y miniaturas." },
-      "streak":           { "label": "Racha",                        "description": "Racha actual y más larga." },
-      "badges":           { "label": "Insignias",                    "description": "Insignias que has desbloqueado." },
-      "activity_feed":    { "label": "Feed de actividad",             "description": "Cronología de tus observaciones, IDs y sugerencias." },
-      "validation_rep":   { "label": "Reputación de validación",       "description": "Conteo de IDs aceptadas y promovidas a grado-investigación. Anclaje del perfil de investigador credenciado." },
-      "obs_list":         { "label": "Lista de observaciones",         "description": "Enlace para explorar todo tu historial de observaciones." },
-      "watchlist":        { "label": "Seguimiento",                   "description": "Taxones que estás siguiendo." },
-      "goals":            { "label": "Metas",                         "description": "Metas mensuales de observación y progreso." },
-      "karma_total":      { "label": "Karma",                         "description": "Tu puntaje de karma y señal de confianza." },
-      "expertise":        { "label": "Experiencia",                   "description": "Puntajes de experiencia por taxón derivados de validaciones." },
-      "pokedex":          { "label": "Pokédex",                       "description": "Cuadrícula de cada taxón observado, con cubetas de rareza." }
+      "profile": {
+        "label": "Perfil público",
+        "description": "Si la página de perfil está accesible."
+      },
+      "real_name": {
+        "label": "Nombre visible",
+        "description": "Tu nombre visible cuando difiere de tu usuario."
+      },
+      "bio": {
+        "label": "Biografía",
+        "description": "La biografía que escribiste en tu perfil."
+      },
+      "location": {
+        "label": "Región",
+        "description": "Tu región principal (estado o país) — nunca tu dirección precisa."
+      },
+      "stats_counts": {
+        "label": "Conteos",
+        "description": "Total de observaciones, conteo grado-investigación, reinos validados."
+      },
+      "observation_map": {
+        "label": "Mapa de observaciones",
+        "description": "Mapa de tus observaciones. Especies sensibles se siguen aproximando a ~11 km."
+      },
+      "calendar_heatmap": {
+        "label": "Calendario de actividad",
+        "description": "Cuadrícula de 12 meses con los días en que observaste."
+      },
+      "taxonomic_donut": {
+        "label": "Desglose taxonómico",
+        "description": "Donut con los reinos o filos que más observas."
+      },
+      "top_species": {
+        "label": "Especies destacadas",
+        "description": "Cuadrícula con tus especies más observadas y miniaturas."
+      },
+      "streak": {
+        "label": "Racha",
+        "description": "Racha actual y más larga."
+      },
+      "badges": {
+        "label": "Insignias",
+        "description": "Insignias que has desbloqueado."
+      },
+      "activity_feed": {
+        "label": "Feed de actividad",
+        "description": "Cronología de tus observaciones, IDs y sugerencias."
+      },
+      "validation_rep": {
+        "label": "Reputación de validación",
+        "description": "Conteo de IDs aceptadas y promovidas a grado-investigación. Anclaje del perfil de investigador credenciado."
+      },
+      "obs_list": {
+        "label": "Lista de observaciones",
+        "description": "Enlace para explorar todo tu historial de observaciones."
+      },
+      "watchlist": {
+        "label": "Seguimiento",
+        "description": "Taxones que estás siguiendo."
+      },
+      "goals": {
+        "label": "Metas",
+        "description": "Metas mensuales de observación y progreso."
+      },
+      "karma_total": {
+        "label": "Karma",
+        "description": "Tu puntaje de karma y señal de confianza."
+      },
+      "expertise": {
+        "label": "Experiencia",
+        "description": "Puntajes de experiencia por taxón derivados de validaciones."
+      },
+      "pokedex": {
+        "label": "Pokédex",
+        "description": "Cuadrícula de cada taxón observado, con cubetas de rareza."
+      }
     }
   },
   "console": {

--- a/supabase/functions/export-dwca/index.ts
+++ b/supabase/functions/export-dwca/index.ts
@@ -105,7 +105,7 @@ const OCCURRENCE_COLUMNS = [
   'decimalLatitude','decimalLongitude','geodeticDatum','coordinateUncertaintyInMeters',
   'scientificName','taxonRank','kingdom',
   'identificationQualifier','identifiedBy','occurrenceStatus',
-  'license','rightsHolder','stateProvince','habitat',
+  'license','rightsHolder','stateProvince','habitat','establishmentMeans',
   'informationWithheld','dataGeneralizations',
 ] as const;
 
@@ -127,6 +127,7 @@ const OCCURRENCE_TERMS: Record<typeof OCCURRENCE_COLUMNS[number], string> = {
   rightsHolder:                  'http://purl.org/dc/terms/rightsHolder',
   stateProvince:                 'http://rs.tdwg.org/dwc/terms/stateProvince',
   habitat:                       'http://rs.tdwg.org/dwc/terms/habitat',
+  establishmentMeans:            'http://rs.tdwg.org/dwc/terms/establishmentMeans',
   informationWithheld:           'http://rs.tdwg.org/dwc/terms/informationWithheld',
   dataGeneralizations:           'http://rs.tdwg.org/dwc/terms/dataGeneralizations',
 };
@@ -351,7 +352,7 @@ serve(async (req) => {
   const db = createClient(SUPABASE_URL, SERVICE_ROLE);
 
   let q = db.from('observations').select(`
-    id, observed_at, accuracy_m, obscure_level, state_province, habitat, location,
+    id, observed_at, accuracy_m, obscure_level, state_province, habitat, establishment_means, location,
     primary_taxon_id, observer_id,
     taxa:primary_taxon_id(kingdom, family, scientific_name),
     identifications!inner(scientific_name, confidence, source, is_primary, is_research_grade),
@@ -414,6 +415,7 @@ serve(async (req) => {
       rightsHolder: o.users?.display_name || o.users?.username || '',
       stateProvince: o.state_province ?? '',
       habitat: o.habitat?.replace(/_/g, ' ') ?? '',
+      establishmentMeans: (o as unknown as { establishment_means?: string }).establishment_means ?? 'wild',
       informationWithheld: withheld ? `Precise location withheld: sensitive species (${o.obscure_level})` : '',
       dataGeneralizations: withheld ? `Coordinates rounded (${o.obscure_level})` : '',
     });


### PR DESCRIPTION
Cierra #44. Solicitado por Eugenio Padilla.

## Qué hace

Agrega el campo **origen del organismo** al formulario de observación y al schema.

### UI — selector de pills en ObservationForm

```
🌿 Silvestre     (default)
🌱 Cultivada / plantada
🏠 Doméstica / cautiverio
❓ No sé
```

Aparece debajo de Hábitat/Clima. Default `wild` para compatibilidad con observaciones existentes.

### Schema

```sql
ALTER TABLE public.observations
  ADD COLUMN establishment_means text NOT NULL DEFAULT 'wild'
    CHECK (establishment_means IN ('wild','cultivated','captive','uncertain'));
```

- Backfill de todos los registros existentes a `'wild'`
- Índice `idx_obs_establishment_means` para queries de diversidad (Módulo 24 filtrará `= 'wild'` por defecto)

### Darwin Core export

Campo `establishmentMeans` añadido al ZIP export, mapeado a `http://rs.tdwg.org/dwc/terms/establishmentMeans`.

## Operador (post-merge)

```bash
psql "$SUPABASE_DB_URL" -f docs/specs/infra/supabase-schema.sql
gh workflow run deploy-functions.yml --ref main -f function=export-dwca
```

## Test plan

- [x] `npm run build` — 98 páginas, limpio
- [ ] Verificar pills en /observe, default Silvestre
- [ ] Verificar que el valor se guarda al subir observación
- [ ] Verificar columna `establishmentMeans` en export DwC