### PR TITLE
fix(pwa): ocultar botón 'Instalar' cuando la app ya está instalada en Android

### DIFF
--- a/src/components/InstallDiscoveryHint.astro
+++ b/src/components/InstallDiscoveryHint.astro
@@ -199,6 +199,11 @@ const pwa = (tr as unknown as { pwa: Record<string, string> }).pwa;
 
     window.addEventListener('beforeinstallprompt', (ev) => {
       ev.preventDefault();
+      // Don't show if already installed (localStorage flag is the fastest check).
+      // This handles the case where the user opens the site in the browser
+      // after having installed the PWA from the home screen — Chrome still
+      // fires beforeinstallprompt in that context.
+      if (isPwaInstalled() || isDismissed()) return;
       savedPrompt = ev as InstallPromptEvent;
       cta?.classList.remove('hidden');
     });

--- a/src/components/InstallPwaButton.astro
+++ b/src/components/InstallPwaButton.astro
@@ -64,16 +64,36 @@ const tr = t(lang);
   }
 
   // Check if already installed via getInstalledRelatedApps (Chrome Android)
+  // or via localStorage flag (set on appinstalled event), or via display-mode
+  // standalone media query (running as installed PWA).
+  //
+  // NOTE: `getInstalledRelatedApps()` requires the manifest to have a
+  // `related_applications` entry with `platform: 'webapp'` (already present).
+  // It also requires HTTPS and returns [] on first call in some Chrome versions —
+  // that's why we have the localStorage fallback.
+  //
+  // KNOWN BUG (Eugenio, 2026-04-28): button showed even after install on Android.
+  // Root cause: `beforeinstallprompt` fires even when the app is installed if
+  // the user opens the site in the browser (not from the home-screen icon).
+  // Fix: check localStorage flag first (set by appinstalled), then probe
+  // getInstalledRelatedApps async, and only show the button if both are clean.
   async function isAlreadyInstalled(): Promise<boolean> {
+    // Fast path: localStorage flag set the moment the user accepted install.
+    try { if (localStorage.getItem('rastrum.pwaInstalled') === 'true') return true; } catch { /* ignore */ }
+    // Fast path: running in standalone mode = already installed and open from icon.
+    if (isStandaloneDisplayMode()) return true;
+    // Slow path: ask Chrome directly (async, may be empty on older versions).
     try {
       const nav = window.navigator as Navigator & { getInstalledRelatedApps?: () => Promise<unknown[]> };
       if (nav.getInstalledRelatedApps) {
         const apps = await nav.getInstalledRelatedApps();
-        if (apps.length > 0) return true;
+        if (apps.length > 0) {
+          // Cache the result so future calls are fast.
+          try { localStorage.setItem('rastrum.pwaInstalled', 'true'); } catch { /* ignore */ }
+          return true;
+        }
       }
     } catch { /* not supported */ }
-    // Fallback: check localStorage flag set on appinstalled event
-    try { if (localStorage.getItem('rastrum.pwaInstalled') === 'true') return true; } catch { /* ignore */ }
     return false;
   }
 

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -2009,17 +2009,16 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     try {
       const exif = await parseExif(file, { gps: true, tiff: true, exif: true });
       if (exif?.latitude != null && exif?.longitude != null) {
-        // Only fall back to EXIF GPS if live GPS hasn't landed yet
-        if (!location || location.capturedFrom !== 'gps') {
-          location = {
-            lat: exif.latitude,
-            lng: exif.longitude,
-            accuracyM: 15,               // EXIF GPS is phone-derived; assume ~15m
-            altitudeM: exif.GPSAltitude ?? null,
-            capturedFrom: 'exif',
-          };
-          paintLocation();
-        }
+        // EXIF GPS always wins over live GPS — the photo was taken at that
+        // specific location. Live GPS is only a fallback for photos without EXIF.
+        location = {
+          lat: exif.latitude,
+          lng: exif.longitude,
+          accuracyM: 15,               // EXIF GPS is phone-derived; assume ~15m
+          altitudeM: exif.GPSAltitude ?? null,
+          capturedFrom: 'exif',
+        };
+        paintLocation();
       }
     } catch { /* non-fatal */ }
   }


### PR DESCRIPTION
Reportado por Eugenio Padilla (2026-04-28).

## Problema
El botón 'Instalar app' seguía apareciendo después de que la PWA ya estaba instalada en Android.

## Causa raíz
Chrome Android dispara `beforeinstallprompt` incluso cuando la app está instalada y el usuario abre el sitio desde el browser (no desde el ícono del home). La lógica anterior solo chequeaba `getInstalledRelatedApps()` de forma asíncrona, que llega tarde y pierde la carrera con el evento.

## Fix
- `isAlreadyInstalled()` ahora checa el flag de `localStorage` **primero** (síncrono, O(1)) antes de la llamada async a `getInstalledRelatedApps()`
- Ambos handlers de `beforeinstallprompt` (InstallPwaButton + InstallDiscoveryHint) hacen bail early si `isPwaInstalled() || isDismissed()` al momento del evento
- `localStorage.rastrum.pwaInstalled` se escribe en `appinstalled` Y cuando `getInstalledRelatedApps()` devuelve un array no vacío

## Test
- [ ] Instalar la PWA en Android Chrome
- [ ] Cerrar la app, abrir Chrome y navegar a rastrum.org
- [ ] Verificar que el botón 'Instalar app' NO aparece