### PR TITLE
fix(observe): EXIF GPS gana sobre ambas pasadas del GPS en vivo

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -2067,20 +2067,25 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       // First pass: quick low-accuracy fix (coarse network location)
       navigator.geolocation.getCurrentPosition(
         (pos) => {
-          location = {
-            lat: pos.coords.latitude,
-            lng: pos.coords.longitude,
-            accuracyM: pos.coords.accuracy,
-            altitudeM: pos.coords.altitude,
-            capturedFrom: 'gps',
-          };
-          paintLocation();
+          // Never overwrite EXIF coords — the photo was taken at that
+          // specific location. GPS in-page is only a fallback for photos
+          // without EXIF (or when no photo has been uploaded yet).
+          if (location?.capturedFrom !== 'exif') {
+            location = {
+              lat: pos.coords.latitude,
+              lng: pos.coords.longitude,
+              accuracyM: pos.coords.accuracy,
+              altitudeM: pos.coords.altitude,
+              capturedFrom: 'gps',
+            };
+            paintLocation();
+          }
           // Second pass: refine with high-accuracy GPS (up to 30s).
           // If the refine fails we silently keep the coarse fix — only
           // show an error if BOTH passes failed (handled below).
           navigator.geolocation.getCurrentPosition(
             (pos2) => {
-              if (pos2.coords.accuracy < (location?.accuracyM ?? 9999)) {
+              if (location?.capturedFrom !== 'exif' && pos2.coords.accuracy < (location?.accuracyM ?? 9999)) {
                 location = {
                   lat: pos2.coords.latitude,
                   lng: pos2.coords.longitude,


### PR DESCRIPTION
Fix incompleto identificado por Nyx post-merge de PR #48.

## Problema real

`getLiveGPS()` se llama en page load y tiene **dos pasadas**:
1. Primera pasada rápida (GPS de red, ~1s)
2. Segunda pasada de alta precisión (GPS real, hasta 30s)

Ambas sobreescribían `location` incondicionalmente — sin checar si ya había EXIF cargado. En campo con buena señal, la segunda pasada llegaba 2-30 segundos después y pisaba las coordenadas de la foto.

## Fix

Guard `location?.capturedFrom !== 'exif'` en **ambas** asignaciones de `getLiveGPS()`:

```ts
// Primera pasada
if (location?.capturedFrom !== 'exif') {
  location = { ...gpsCoords, capturedFrom: 'gps' };
  paintLocation();
}

// Segunda pasada  
if (location?.capturedFrom !== 'exif' && pos2.coords.accuracy < ...) {
  location = { ...gpsCoords, capturedFrom: 'gps' };
}
```

Si hay EXIF → GPS ignorado en ambas pasadas.
Si no hay EXIF (foto sin metadatos, cámara in-app) → GPS sigue siendo la fuente, comportamiento sin cambio.

## Test
- [ ] Subir foto con EXIF GPS de otra ubicación → coordenadas deben ser las del EXIF, no la ubicación actual
- [ ] Esperar 30s → las coordenadas NO deben cambiar
- [ ] Subir foto sin EXIF (screenshot, cámara in-app) → GPS en vivo debe funcionar normalmente