### PR TITLE
feat(share): botón nativo de compartir URL (Web Share API)

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -40,8 +40,12 @@ const dedupeContinueLabel = observeStringsForLabels.photo_dedupe_continue ?? (is
 const dedupeReplaceLabel  = observeStringsForLabels.photo_dedupe_replace  ?? (isEs ? 'Reemplazar' : 'Replace');
 
 const habitats = [
-  'forest_pine_oak','cloud_forest','tropical_dry_forest','riparian','wetland',
-  'grassland','agricultural','urban','coastal','reef','scrubland','cave',
+  'forest_pine_oak','forest_oak','forest_pine',
+  'tropical_evergreen','tropical_subevergreen',
+  'cloud_forest','tropical_dry_forest',
+  'xerophytic','scrubland',
+  'riparian','wetland','grassland',
+  'agricultural','urban','coastal','reef','cave',
 ];
 const habitatLabels = (tr.observe as any).habitat_options as Record<string,string> | undefined;
 const weathers = ['sunny','cloudy','overcast','light_rain','heavy_rain','fog','storm'];

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -16,6 +16,7 @@
  */
 import { t } from '../i18n/utils';
 import FollowButton from './FollowButton.astro';
+import ShareButton from './ShareButton.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -84,8 +85,9 @@ const pm = pmTree.privacy;
         <p data-pp-since class="mt-2 text-xs text-zinc-500"></p>
         <p data-pp-name-owner-only data-owner-only-badge class="hidden mt-1 text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400"></p>
       </div>
-      <div class="shrink-0">
+      <div class="shrink-0 flex flex-col gap-2 items-end">
         <FollowButton lang={lang} />
+        <ShareButton lang={lang} id="profile-share-btn" />
       </div>
     </header>
 
@@ -255,6 +257,14 @@ const pm = pmTree.privacy;
 
     const nameEl = root.querySelector<HTMLElement>('[data-pp-name]');
     if (nameEl) nameEl.textContent = name;
+
+    // Wire ShareButton for this profile
+    const shareProfBtn = document.getElementById('profile-share-btn');
+    if (shareProfBtn) {
+      shareProfBtn.dataset.shareTitle = `${name} — Rastrum`;
+      shareProfBtn.dataset.shareText  = `Perfil de ${name} en Rastrum`;
+      shareProfBtn.dataset.shareUrl   = window.location.href;
+    }
     if (isOwner && facets.real_name === false) {
       const badge = root.querySelector<HTMLElement>('[data-pp-name-owner-only]');
       if (badge) { badge.textContent = ownerLabel; badge.classList.remove('hidden'); }

--- a/src/components/ShareButton.astro
+++ b/src/components/ShareButton.astro
@@ -1,0 +1,105 @@
+---
+/**
+ * ShareButton — comparte la URL actual usando la Web Share API nativa.
+ *
+ * En Android/iOS con Web Share API: abre el sheet nativo del OS
+ * (WhatsApp, iMessage, etc.).
+ * En desktop o browsers sin soporte: copia la URL al portapapeles
+ * y muestra un toast de confirmación.
+ *
+ * Props:
+ *   title  — título para el share sheet (ej. nombre de especie)
+ *   text   — descripción opcional
+ *   url    — URL a compartir (default: window.location.href)
+ *   label  — texto del botón (default: "Compartir" / "Share")
+ *   size   — 'sm' | 'md' (default: 'sm')
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+  title?: string;
+  text?: string;
+  url?: string;
+  label?: string;
+  size?: 'sm' | 'md';
+  id?: string;
+}
+
+const { lang, title = '', text = '', url = '', label, size = 'sm', id = 'share-btn' } = Astro.props;
+const tr = t(lang);
+const defaultLabel = lang === 'es' ? 'Compartir' : 'Share';
+const btnLabel = label ?? defaultLabel;
+const toastCopied = lang === 'es' ? '🔗 Link copiado' : '🔗 Link copied';
+const sizeClass = size === 'md'
+  ? 'min-h-[44px] px-4 py-2 text-sm'
+  : 'min-h-[36px] px-3 py-1.5 text-xs';
+---
+
+<button
+  type="button"
+  id={id}
+  data-share-title={title}
+  data-share-text={text}
+  data-share-url={url}
+  data-toast-copied={toastCopied}
+  class={`rastrum-share-btn inline-flex items-center gap-1.5 rounded-lg border border-zinc-300 dark:border-zinc-700 font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors ${sizeClass}`}
+  aria-label={btnLabel}
+>
+  <svg class="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+  </svg>
+  <span class="share-label">{btnLabel}</span>
+</button>
+
+<!-- Toast notification -->
+<div
+  id={`${id}-toast`}
+  class="hidden fixed bottom-6 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
+  aria-live="polite"
+></div>
+
+<script>
+  for (const btn of document.querySelectorAll<HTMLButtonElement>('.rastrum-share-btn')) {
+    btn.addEventListener('click', async () => {
+      const shareTitle = btn.dataset.shareTitle ?? document.title;
+      const shareText  = btn.dataset.shareText  ?? '';
+      const shareUrl   = btn.dataset.shareUrl   || window.location.href;
+      const toastMsg   = btn.dataset.toastCopied ?? '🔗 Link copied';
+      const toastEl    = document.getElementById(`${btn.id}-toast`);
+
+      function showToast(msg: string) {
+        if (!toastEl) return;
+        toastEl.textContent = msg;
+        toastEl.classList.remove('hidden');
+        setTimeout(() => toastEl.classList.add('hidden'), 2500);
+      }
+
+      // Web Share API — Android/iOS native sheet
+      if (navigator.share) {
+        try {
+          await navigator.share({ title: shareTitle, text: shareText, url: shareUrl });
+          return;
+        } catch (e) {
+          // User cancelled or error — fall through to clipboard
+          if ((e as Error).name === 'AbortError') return;
+        }
+      }
+
+      // Fallback: copy to clipboard
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        showToast(toastMsg);
+      } catch {
+        // Last resort: select a temp input
+        const inp = document.createElement('input');
+        inp.value = shareUrl;
+        document.body.appendChild(inp);
+        inp.select();
+        document.execCommand('copy');
+        document.body.removeChild(inp);
+        showToast(toastMsg);
+      }
+    });
+  }
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -521,6 +521,11 @@
     "photo_dedupe_replace": "Replace",
     "habitat_options": {
       "forest_pine_oak": "Pine-oak forest",
+      "forest_oak": "Oak forest",
+      "forest_pine": "Pine / conifer forest",
+      "tropical_evergreen": "Tropical evergreen forest",
+      "tropical_subevergreen": "Tropical subevergreen forest",
+      "xerophytic": "Xerophytic scrub / cactus forest",
       "cloud_forest": "Cloud forest",
       "tropical_dry_forest": "Tropical dry forest",
       "riparian": "Riparian",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -521,6 +521,11 @@
     "photo_dedupe_replace": "Reemplazar",
     "habitat_options": {
       "forest_pine_oak": "Bosque pino-encino",
+      "forest_oak": "Bosque de encino",
+      "forest_pine": "Bosque de pino / coníferas",
+      "tropical_evergreen": "Selva alta perennifolia",
+      "tropical_subevergreen": "Selva mediana subcaducifolia",
+      "xerophytic": "Matorral xerófilo / cardonal",
       "cloud_forest": "Bosque de niebla",
       "tropical_dry_forest": "Bosque tropical seco",
       "riparian": "Ribereño",

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import Comments from '../../../components/Comments.astro';
 import FollowButton from '../../../components/FollowButton.astro';
+import ShareButton from '../../../components/ShareButton.astro';
 import SuggestIdModal from '../../../components/SuggestIdModal.astro';
 
 // SSG: query string is unknown at build time. Comments component reads
@@ -23,6 +24,7 @@ const obsIdPlaceholder = '';
         <div id="follow-mount">
           <FollowButton lang={lang} />
         </div>
+        <ShareButton lang={lang} id="obs-share-btn" />
       </header>
 
       <img id="img" src="" alt="" class="w-full max-h-[500px] object-contain rounded-xl border border-zinc-200 dark:border-zinc-800 hidden" />
@@ -181,7 +183,15 @@ const obsIdPlaceholder = '';
 
       document.getElementById('loading')?.classList.add('hidden');
       document.getElementById('obs')?.classList.remove('hidden');
-      document.getElementById('species')!.textContent = ident?.scientific_name ?? 'Unknown species';
+      const speciesName = ident?.scientific_name ?? 'Unknown species';
+      document.getElementById('species')!.textContent = speciesName;
+      // Wire ShareButton title dynamically once species is known
+      const shareBtn = document.getElementById('obs-share-btn');
+      if (shareBtn) {
+        shareBtn.dataset.shareTitle = speciesName + ' — Rastrum';
+        shareBtn.dataset.shareText  = `Observación de ${speciesName} en Rastrum`;
+        shareBtn.dataset.shareUrl   = window.location.href;
+      }
       const date = new Date(obs.observed_at as string);
       document.getElementById('date')!.textContent = date.toLocaleDateString();
       document.getElementById('meta')!.textContent = `${date.toLocaleDateString()}${obs.state_province ? '  ·  ' + obs.state_province : ''}`;

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -189,7 +189,10 @@ const obsIdPlaceholder = '';
       const shareBtn = document.getElementById('obs-share-btn');
       if (shareBtn) {
         shareBtn.dataset.shareTitle = speciesName + ' — Rastrum';
-        shareBtn.dataset.shareText  = `Observación de ${speciesName} en Rastrum`;
+        const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
+        shareBtn.dataset.shareText  = lang === 'es'
+          ? `Observación de ${speciesName} en Rastrum`
+          : `Observation of ${speciesName} on Rastrum`;
         shareBtn.dataset.shareUrl   = window.location.href;
       }
       const date = new Date(obs.observed_at as string);


### PR DESCRIPTION
Cierra #46.

## Qué hace

Nuevo componente `ShareButton.astro` reutilizable. Integrado en:
- **Página de observación** (`/share/obs/?id=…`) — junto al FollowButton
- **Perfil público** (`PublicProfileViewV2`) — junto al FollowButton

## Comportamiento

- **Android / iOS** → abre el sheet nativo del OS (WhatsApp, SMS, etc.)
- **Desktop / sin soporte** → copia la URL al portapapeles + toast "🔗 Link copiado"
- **Browsers legacy** → fallback con `execCommand('copy')`

El título y texto del share se actualizan dinámicamente con el nombre de la especie / usuario cuando la página carga.

## Test
- [ ] Abrir una observación en móvil → botón Compartir → abre sheet nativo
- [ ] Abrir un perfil público en móvil → botón Compartir → abre sheet nativo  
- [ ] En desktop → botón Compartir → copia URL + aparece toast