### PR TITLE
feat(profile): leyendas de expertise regional — 'Top identificador de Fabaceae en Oaxaca'

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3057,3 +3057,80 @@ DROP TRIGGER IF EXISTS obsreact_notify_trigger ON public.observation_reactions;
 CREATE TRIGGER obsreact_notify_trigger
   AFTER INSERT ON public.observation_reactions
   FOR EACH ROW EXECUTE FUNCTION public.tg_obsreact_notify();
+
+-- ═════════════════════════════════════════════════════════════════════
+-- Module 27 — Expertise Legends (regional rankings)
+-- Issue #47 — "Top identificador de Fabaceae en Oaxaca"
+-- ═════════════════════════════════════════════════════════════════════
+
+-- View: user_expertise_regional
+-- Computes per-user, per-taxon, per-region score and rank.
+-- Region = state_province of the observations the user has made for that taxon.
+-- Only covers users with profile_public=true AND gamification_opt_in=true.
+CREATE OR REPLACE VIEW public.user_expertise_regional AS
+SELECT
+  ue.user_id,
+  ue.taxon_id,
+  t.scientific_name                              AS taxon_name,
+  COALESCE(t.family, t.scientific_name)          AS taxon_family,
+  t.taxon_rank,
+  COALESCE(o.state_province, 'México')           AS region,
+  ue.score,
+  rank() OVER (
+    PARTITION BY ue.taxon_id, COALESCE(o.state_province, 'México')
+    ORDER BY ue.score DESC
+  )                                              AS region_rank,
+  rank() OVER (
+    PARTITION BY ue.taxon_id
+    ORDER BY ue.score DESC
+  )                                              AS national_rank
+FROM public.user_expertise ue
+JOIN public.taxa t ON t.id = ue.taxon_id
+LEFT JOIN LATERAL (
+  SELECT DISTINCT state_province
+  FROM public.observations
+  WHERE observer_id = ue.user_id
+    AND primary_taxon_id = ue.taxon_id
+    AND state_province IS NOT NULL
+  LIMIT 1
+) o ON true
+JOIN public.users u ON u.id = ue.user_id
+WHERE u.profile_public = true
+  AND u.gamification_opt_in = true
+  AND ue.score > 0;
+
+GRANT SELECT ON public.user_expertise_regional TO anon, authenticated;
+
+-- Function: top_expertise_legend(user_id)
+-- Returns the single highest-ranked legend for a user (for badge display).
+CREATE OR REPLACE FUNCTION public.top_expertise_legend(p_user_id uuid)
+RETURNS TABLE (
+  taxon_name   text,
+  taxon_family text,
+  taxon_rank   text,
+  region       text,
+  score        numeric,
+  region_rank  bigint,
+  tier         text   -- 'legend' | 'expert' | 'reference' | 'active'
+)
+LANGUAGE sql STABLE SECURITY INVOKER AS $$
+  SELECT
+    taxon_name,
+    taxon_family,
+    taxon_rank,
+    region,
+    score,
+    region_rank,
+    CASE
+      WHEN region_rank = 1  THEN 'legend'
+      WHEN region_rank <= 3 THEN 'expert'
+      WHEN region_rank <= 10 THEN 'reference'
+      ELSE 'active'
+    END AS tier
+  FROM public.user_expertise_regional
+  WHERE user_id = p_user_id
+  ORDER BY region_rank ASC, score DESC
+  LIMIT 1;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.top_expertise_legend(uuid) TO anon, authenticated;

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3087,11 +3087,13 @@ SELECT
 FROM public.user_expertise ue
 JOIN public.taxa t ON t.id = ue.taxon_id
 LEFT JOIN LATERAL (
-  SELECT DISTINCT state_province
+  SELECT state_province
   FROM public.observations
   WHERE observer_id = ue.user_id
     AND primary_taxon_id = ue.taxon_id
     AND state_province IS NOT NULL
+  GROUP BY state_province
+  ORDER BY COUNT(*) DESC
   LIMIT 1
 ) o ON true
 JOIN public.users u ON u.id = ue.user_id

--- a/src/components/ExpertiseCoverageGrid.astro
+++ b/src/components/ExpertiseCoverageGrid.astro
@@ -1,0 +1,80 @@
+---
+/**
+ * ExpertiseCoverageGrid — grid de familias taxonómicas coloreado por tier.
+ *
+ * Muestra hasta 50 taxones ordenados por score descendente.
+ * Cada celda indica el nombre del taxón, la región, y el rango regional.
+ *
+ * Usage: <ExpertiseCoverageGrid lang="es" userId={userId} />
+ */
+interface Props {
+  lang: 'en' | 'es';
+  userId?: string;
+}
+
+const { lang, userId = '' } = Astro.props;
+const title = lang === 'es' ? 'Territorios dominados' : 'Expertise coverage';
+const emptyMsg = lang === 'es'
+  ? 'Aún no hay expertise registrado. Las identificaciones validadas por la comunidad generan expertise automáticamente.'
+  : 'No expertise recorded yet. Community-validated identifications generate expertise automatically.';
+---
+
+<section class="mt-6">
+  <h3 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider mb-3">
+    {title}
+  </h3>
+  <div
+    id="expertise-coverage-grid"
+    class="grid grid-cols-2 sm:grid-cols-3 gap-2"
+    data-user-id={userId}
+    data-lang={lang}
+    data-empty={emptyMsg}
+  >
+    <p class="col-span-full text-xs text-zinc-400">{lang === 'es' ? 'Cargando…' : 'Loading…'}</p>
+  </div>
+</section>
+
+<script>
+  import { getExpertiseCoverage, legendTitle, tierColors } from '../lib/expertise-legends';
+  import { getSupabase } from '../lib/supabase';
+
+  async function init() {
+    const grid = document.getElementById('expertise-coverage-grid');
+    if (!grid) return;
+
+    const lang = (grid.dataset.lang ?? 'es') as 'en' | 'es';
+    let userId = grid.dataset.userId ?? '';
+    const emptyMsg = grid.dataset.empty ?? '';
+
+    if (!userId) {
+      const { data } = await getSupabase().auth.getUser();
+      userId = data.user?.id ?? '';
+    }
+    if (!userId) { grid.innerHTML = `<p class="col-span-full text-xs text-zinc-400">${emptyMsg}</p>`; return; }
+
+    const rows = await getExpertiseCoverage(userId);
+    if (rows.length === 0) {
+      grid.innerHTML = `<p class="col-span-full text-xs text-zinc-400">${emptyMsg}</p>`;
+      return;
+    }
+
+    grid.innerHTML = rows.map(r => {
+      const c = tierColors(r.tier);
+      const rankBadge = r.region_rank <= 10
+        ? `<span class="ml-auto text-[10px] font-bold ${c.text} opacity-80">#${r.region_rank}</span>`
+        : '';
+      const regionLine = `<span class="text-[10px] ${c.text} opacity-60 truncate">${r.region}</span>`;
+      return `
+        <div class="flex flex-col gap-0.5 rounded-lg border ${c.border} ${c.bg} px-3 py-2">
+          <div class="flex items-center gap-1">
+            <span class="text-xs font-semibold ${c.text} truncate flex-1">${r.taxon_family}</span>
+            ${rankBadge}
+          </div>
+          ${regionLine}
+        </div>
+      `;
+    }).join('');
+  }
+
+  init();
+</script>

--- a/src/components/ExpertiseLegendBadge.astro
+++ b/src/components/ExpertiseLegendBadge.astro
@@ -1,0 +1,69 @@
+---
+/**
+ * ExpertiseLegendBadge — muestra el badge de leyenda regional en el perfil.
+ *
+ * Llama a top_expertise_legend(userId) y renderiza el título dinámico:
+ *   "🥇 Top identificador de Fabaceae en Oaxaca"
+ *
+ * Si el usuario no tiene expertise registrado, no renderiza nada.
+ *
+ * Usage: <ExpertiseLegendBadge lang="es" userId={userId} />
+ * o: sin userId → carga dinámicamente desde JS con el auth.uid()
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+  userId?: string;
+  class?: string;
+}
+
+const { lang, userId = '', class: extraClass = '' } = Astro.props;
+---
+
+<div
+  id="expertise-legend-badge"
+  class={`hidden ${extraClass}`}
+  data-user-id={userId}
+  data-lang={lang}
+  aria-live="polite"
+>
+  <!-- Populated by client script -->
+</div>
+
+<script>
+  import { getTopLegend, legendTitle, tierColors, tierLabel } from '../lib/expertise-legends';
+  import { getSupabase } from '../lib/supabase';
+
+  async function init() {
+    const el = document.getElementById('expertise-legend-badge');
+    if (!el) return;
+
+    const lang = (el.dataset.lang ?? 'es') as 'en' | 'es';
+    let userId = el.dataset.userId ?? '';
+
+    // If no userId provided, use current auth user
+    if (!userId) {
+      const { data } = await getSupabase().auth.getUser();
+      userId = data.user?.id ?? '';
+    }
+    if (!userId) return;
+
+    const legend = await getTopLegend(userId);
+    if (!legend) return;
+
+    const colors = tierColors(legend.tier);
+    const title  = legendTitle(legend, lang);
+    const rlabel = tierLabel(legend.tier, lang);
+
+    el.innerHTML = `
+      <div class="inline-flex items-center gap-2 rounded-full border ${colors.border} ${colors.bg} px-3 py-1">
+        <span class="text-xs font-semibold ${colors.text}">${title}</span>
+        ${legend.region_rank <= 3 ? `<span class="text-[10px] ${colors.text} opacity-70">#${legend.region_rank}</span>` : ''}
+      </div>
+    `;
+    el.classList.remove('hidden');
+  }
+
+  init();
+</script>

--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -1,6 +1,8 @@
 ---
 import { t, getLocalizedPath, routes, type Locale } from '../i18n/utils';
 import StreakCard from './StreakCard.astro';
+import ExpertiseLegendBadge from './ExpertiseLegendBadge.astro';
+import ExpertiseCoverageGrid from './ExpertiseCoverageGrid.astro';
 import Skeleton from './Skeleton.astro';
 import PrivacyIntroBanner from './PrivacyIntroBanner.astro';
 import ProfileObservationMap from './profile/ProfileObservationMap.astro';
@@ -118,6 +120,8 @@ const k = (tr as unknown as { karma: Record<string, string> }).karma;
     <ProfileTopSpeciesGrid lang={lang} viewer="self" />
     <ProfileStreakRing lang={lang} viewer="self" />
     <ProfileKarmaSection lang={lang} viewer="self" />
+    <ExpertiseLegendBadge lang={lang} class="mb-2" />
+    <ExpertiseCoverageGrid lang={lang} />
     <ProfilePokedexLink lang={lang} viewer="self" />
     <ProfileBadgesGrid lang={lang} viewer="self" />
     <ProfileActivityTimeline lang={lang} viewer="self" />

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -17,6 +17,8 @@
 import { t } from '../i18n/utils';
 import FollowButton from './FollowButton.astro';
 import ShareButton from './ShareButton.astro';
+import ExpertiseLegendBadge from './ExpertiseLegendBadge.astro';
+import ExpertiseCoverageGrid from './ExpertiseCoverageGrid.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -138,6 +140,9 @@ const pm = pmTree.privacy;
       </a>
       <p data-pp-pokedex-owner-only data-owner-only-badge class="hidden mt-2 text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400"></p>
     </section>
+
+    <!-- Expertise legends (Module 27) — wired after profile loads -->
+    <div id="pp-expertise-mount" class="mb-8"></div>
   </article>
 </div>
 
@@ -264,6 +269,33 @@ const pm = pmTree.privacy;
       shareProfBtn.dataset.shareTitle = `${name} — Rastrum`;
       shareProfBtn.dataset.shareText  = `Perfil de ${name} en Rastrum`;
       shareProfBtn.dataset.shareUrl   = window.location.href;
+    }
+
+    // Wire expertise legend badge + coverage grid for this profile
+    const expertiseMount = document.getElementById('pp-expertise-mount');
+    if (expertiseMount && profile.id && (isOwner || facets.expertise !== false)) {
+      expertiseMount.innerHTML = `
+        <div id="expertise-legend-badge" class="hidden mb-2" data-user-id="${profile.id}" data-lang="${lang}" aria-live="polite"></div>
+        <div id="expertise-coverage-grid" class="grid grid-cols-2 sm:grid-cols-3 gap-2" data-user-id="${profile.id}" data-lang="${lang}" data-empty=""></div>
+      `;
+      // Dynamically import and run the expertise helpers
+      const { getTopLegend, getExpertiseCoverage, legendTitle, tierColors } = await import('../lib/expertise-legends');
+      const legend = await getTopLegend(profile.id);
+      const badgeEl = document.getElementById('expertise-legend-badge');
+      if (legend && badgeEl) {
+        const c = tierColors(legend.tier);
+        const t = legendTitle(legend, lang as 'en' | 'es');
+        badgeEl.innerHTML = `<div class="inline-flex items-center gap-2 rounded-full border ${c.border} ${c.bg} px-3 py-1"><span class="text-xs font-semibold ${c.text}">${t}</span>${legend.region_rank <= 3 ? `<span class="text-[10px] ${c.text} opacity-70">#${legend.region_rank}</span>` : ''}</div>`;
+        badgeEl.classList.remove('hidden');
+      }
+      const rows = await getExpertiseCoverage(profile.id);
+      const coverageEl = document.getElementById('expertise-coverage-grid');
+      if (coverageEl && rows.length > 0) {
+        coverageEl.innerHTML = rows.map(r => {
+          const c = tierColors(r.tier);
+          return `<div class="flex flex-col gap-0.5 rounded-lg border ${c.border} ${c.bg} px-3 py-2"><div class="flex items-center gap-1"><span class="text-xs font-semibold ${c.text} truncate flex-1">${r.taxon_family}</span>${r.region_rank <= 10 ? `<span class="text-[10px] font-bold ${c.text} opacity-80">#${r.region_rank}</span>` : ''}</div><span class="text-[10px] ${c.text} opacity-60 truncate">${r.region}</span></div>`;
+        }).join('');
+      }
     }
     if (isOwner && facets.real_name === false) {
       const badge = root.querySelector<HTMLElement>('[data-pp-name-owner-only]');

--- a/src/lib/expertise-legends.ts
+++ b/src/lib/expertise-legends.ts
@@ -1,0 +1,108 @@
+/**
+ * expertise-legends.ts — helpers for regional expertise rankings.
+ *
+ * Wraps the `user_expertise_regional` view and `top_expertise_legend()`
+ * SQL function introduced in Module 27.
+ */
+import { getSupabase } from './supabase';
+
+export type ExpertiseTier = 'legend' | 'expert' | 'reference' | 'active';
+
+export interface ExpertiseLegend {
+  taxon_name:   string;
+  taxon_family: string;
+  taxon_rank:   string;
+  region:       string;
+  score:        number;
+  region_rank:  number;
+  tier:         ExpertiseTier;
+}
+
+export interface ExpertiseCoverageRow {
+  taxon_name:   string;
+  taxon_family: string;
+  taxon_rank:   string;
+  region:       string;
+  score:        number;
+  region_rank:  number;
+  national_rank: number;
+  tier:         ExpertiseTier;
+}
+
+/** Human-readable rank label. EN/ES. */
+export function tierLabel(tier: ExpertiseTier, lang: 'en' | 'es'): string {
+  const labels: Record<ExpertiseTier, Record<'en' | 'es', string>> = {
+    legend:    { en: '🥇 Regional legend', es: '🥇 Leyenda regional' },
+    expert:    { en: '🥈 Regional expert',  es: '🥈 Experto regional' },
+    reference: { en: '🥉 Reference',        es: '🥉 Referente' },
+    active:    { en: '⭐ Active identifier', es: '⭐ Identificador activo' },
+  };
+  return labels[tier][lang];
+}
+
+/** Badge title shown on profile, e.g. "Top identificador de Fabaceae en Oaxaca" */
+export function legendTitle(leg: ExpertiseLegend, lang: 'en' | 'es'): string {
+  if (lang === 'es') {
+    if (leg.region_rank === 1)   return `Top identificador de ${leg.taxon_family} en ${leg.region}`;
+    if (leg.region_rank <= 3)    return `Experto en ${leg.taxon_family} — ${leg.region}`;
+    if (leg.region_rank <= 10)   return `Referente en ${leg.taxon_family} — ${leg.region}`;
+    return `Identificador activo en ${leg.taxon_family}`;
+  }
+  if (leg.region_rank === 1)   return `Top identifier for ${leg.taxon_family} in ${leg.region}`;
+  if (leg.region_rank <= 3)    return `Expert in ${leg.taxon_family} — ${leg.region}`;
+  if (leg.region_rank <= 10)   return `Reference for ${leg.taxon_family} — ${leg.region}`;
+  return `Active identifier for ${leg.taxon_family}`;
+}
+
+/** Tier color classes for Tailwind. */
+export function tierColors(tier: ExpertiseTier): { bg: string; text: string; border: string } {
+  const map: Record<ExpertiseTier, { bg: string; text: string; border: string }> = {
+    legend:    { bg: 'bg-yellow-50 dark:bg-yellow-900/20',  text: 'text-yellow-800 dark:text-yellow-300',  border: 'border-yellow-400' },
+    expert:    { bg: 'bg-zinc-100 dark:bg-zinc-800',        text: 'text-zinc-700 dark:text-zinc-200',       border: 'border-zinc-400' },
+    reference: { bg: 'bg-amber-50 dark:bg-amber-900/20',    text: 'text-amber-800 dark:text-amber-300',     border: 'border-amber-400' },
+    active:    { bg: 'bg-emerald-50 dark:bg-emerald-900/20',text: 'text-emerald-800 dark:text-emerald-300', border: 'border-emerald-400' },
+  };
+  return map[tier];
+}
+
+/** Fetch the single top legend for a user (for the profile badge). */
+export async function getTopLegend(userId: string): Promise<ExpertiseLegend | null> {
+  const { data, error } = await getSupabase()
+    .rpc('top_expertise_legend', { p_user_id: userId });
+  if (error || !data || data.length === 0) return null;
+  const row = data[0];
+  return {
+    taxon_name:   row.taxon_name,
+    taxon_family: row.taxon_family,
+    taxon_rank:   row.taxon_rank,
+    region:       row.region,
+    score:        Number(row.score),
+    region_rank:  Number(row.region_rank),
+    tier:         row.tier as ExpertiseTier,
+  };
+}
+
+/** Fetch all expertise rows for a user (for the coverage grid). */
+export async function getExpertiseCoverage(userId: string): Promise<ExpertiseCoverageRow[]> {
+  const { data, error } = await getSupabase()
+    .from('user_expertise_regional')
+    .select('taxon_name,taxon_family,taxon_rank,region,score,region_rank,national_rank')
+    .eq('user_id', userId)
+    .order('score', { ascending: false })
+    .limit(50);
+  if (error || !data) return [];
+  return data.map(r => ({
+    taxon_name:    r.taxon_name,
+    taxon_family:  r.taxon_family,
+    taxon_rank:    r.taxon_rank,
+    region:        r.region,
+    score:         Number(r.score),
+    region_rank:   Number(r.region_rank),
+    national_rank: Number(r.national_rank),
+    tier: (
+      Number(r.region_rank) === 1  ? 'legend' :
+      Number(r.region_rank) <= 3   ? 'expert' :
+      Number(r.region_rank) <= 10  ? 'reference' : 'active'
+    ) as ExpertiseTier,
+  }));
+}


### PR DESCRIPTION
Cierra #47.

## Qué hace

Muestra títulos dinámicos en el perfil basados en el expertise acumulado por taxón + región.

**Ejemplos:**
- 🥇 *Top identificador de Fabaceae en Oaxaca*
- 🥈 *Experto en Quercus — Sierra Juárez*
- 🥉 *Referente en carnívoros — México*

## Componentes

### SQL (supabase-schema.sql)
- **Vista `user_expertise_regional`** — cruza `user_expertise` con `observations.state_province` para calcular rango regional y nacional
- **Función `top_expertise_legend(user_id)`** — devuelve la leyenda top con tier

### TypeScript (`src/lib/expertise-legends.ts`)
- `getTopLegend()` / `getExpertiseCoverage()`
- `legendTitle()` — genera el título dinámico en EN/ES
- `tierColors()` — colores por tier (oro/plata/bronce/verde)

### UI
- **`ExpertiseLegendBadge`** — badge pill en el perfil
- **`ExpertiseCoverageGrid`** — grid de familias coloreado por tier ("Territorios dominados")

### Tiers
| Rank regional | Tier |
|---|---|
| #1 | 🥇 Leyenda regional |
| #2–3 | 🥈 Experto regional |
| #4–10 | 🥉 Referente |
| resto | ⭐ Identificador activo |

## Operador (post-merge)
```bash
psql "$SUPABASE_DB_URL" -f docs/specs/infra/supabase-schema.sql
```

## Test
- [ ] Usuario con expertise en Fabaceae de Oaxaca → badge muestra 'Top identificador de Fabaceae en Oaxaca'
- [ ] Grid muestra familias coloreadas con rango regional
- [ ] Perfil público respeta privacy matrix facet `expertise`