### PR TITLE
feat(share): FAB global de compartir en todas las páginas (PWA only)

### DIFF
--- a/src/components/GlobalShareFab.astro
+++ b/src/components/GlobalShareFab.astro
@@ -38,7 +38,7 @@ const toastMsg = lang === 'es' ? '🔗 Link copiado' : '🔗 Link copied';
   aria-label={label}
   title={label}
   data-toast={toastMsg}
-  class="hidden fixed bottom-20 right-4 sm:bottom-6 z-40 w-11 h-11 rounded-full bg-emerald-700 hover:bg-emerald-800 active:bg-emerald-900 text-white shadow-lg flex items-center justify-center transition-colors"
+  class="hidden fixed bottom-[calc(5rem+env(safe-area-inset-bottom)+3.75rem)] sm:bottom-20 right-4 z-40 w-11 h-11 rounded-full bg-emerald-700 hover:bg-emerald-800 active:bg-emerald-900 text-white shadow-lg flex items-center justify-center transition-colors"
 >
   <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
     <path stroke-linecap="round" stroke-linejoin="round"
@@ -49,7 +49,7 @@ const toastMsg = lang === 'es' ? '🔗 Link copiado' : '🔗 Link copied';
 <!-- Toast -->
 <div
   id="global-share-toast"
-  class="hidden fixed bottom-36 sm:bottom-20 right-4 z-50 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
+  class="hidden fixed bottom-6 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
   aria-live="polite"
 ></div>
 

--- a/src/components/GlobalShareFab.astro
+++ b/src/components/GlobalShareFab.astro
@@ -1,0 +1,106 @@
+---
+/**
+ * GlobalShareFab — Floating Action Button de compartir presente en todas las
+ * páginas del sitio. Solo visible en modo PWA standalone (cuando el chrome del
+ * browser está oculto y el usuario no puede copiar la URL desde la barra).
+ *
+ * Comportamiento:
+ * - Solo aparece en display-mode: standalone (PWA instalada)
+ * - Excluido en el formulario de observación (/observe, /observar) —
+ *   ya tiene demasiados elementos en pantalla
+ * - Posición: esquina inferior derecha, sobre el footer nativo
+ * - Web Share API nativa en Android/iOS; fallback a clipboard en desktop
+ * - Toast de confirmación en el fallback
+ *
+ * No se muestra en desktop browser normal (no standalone) para no competir
+ * con la barra de dirección del browser.
+ */
+interface Props {
+  lang: 'en' | 'es';
+  currentPath: string;
+}
+
+const { lang, currentPath } = Astro.props;
+
+// Exclude pages that have their own share UI or too much chrome
+const excluded = ['/observe', '/observar', '/identify', '/identificar'];
+const isExcluded = excluded.some(p => currentPath.includes(p));
+if (isExcluded) return;
+
+const label = lang === 'es' ? 'Compartir esta página' : 'Share this page';
+const toastMsg = lang === 'es' ? '🔗 Link copiado' : '🔗 Link copied';
+---
+
+<!-- FAB only shown when running as installed PWA (display-mode: standalone) -->
+<button
+  id="global-share-fab"
+  type="button"
+  aria-label={label}
+  title={label}
+  data-toast={toastMsg}
+  class="hidden fixed bottom-20 right-4 sm:bottom-6 z-40 w-11 h-11 rounded-full bg-emerald-700 hover:bg-emerald-800 active:bg-emerald-900 text-white shadow-lg flex items-center justify-center transition-colors"
+>
+  <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round"
+      d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+  </svg>
+</button>
+
+<!-- Toast -->
+<div
+  id="global-share-toast"
+  class="hidden fixed bottom-36 sm:bottom-20 right-4 z-50 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
+  aria-live="polite"
+></div>
+
+<script>
+  (function () {
+    const fab   = document.getElementById('global-share-fab');
+    const toast = document.getElementById('global-share-toast');
+    if (!fab || !toast) return;
+
+    // Only show in PWA standalone mode
+    const isStandalone =
+      window.matchMedia?.('(display-mode: standalone)').matches ||
+      (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+
+    if (!isStandalone) return;
+
+    fab.classList.remove('hidden');
+    fab.classList.add('flex');
+
+    fab.addEventListener('click', async () => {
+      const url   = window.location.href;
+      const title = document.title;
+      const msg   = fab.dataset.toast ?? '🔗 Link copied';
+
+      function showToast() {
+        toast.textContent = msg;
+        toast.classList.remove('hidden');
+        setTimeout(() => toast.classList.add('hidden'), 2500);
+      }
+
+      if (navigator.share) {
+        try {
+          await navigator.share({ title, url });
+          return;
+        } catch (e) {
+          if ((e as Error).name === 'AbortError') return;
+          // fall through to clipboard
+        }
+      }
+
+      try {
+        await navigator.clipboard.writeText(url);
+      } catch {
+        const inp = document.createElement('input');
+        inp.value = url;
+        document.body.appendChild(inp);
+        inp.select();
+        document.execCommand('copy');
+        document.body.removeChild(inp);
+      }
+      showToast();
+    });
+  })();
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ import InstallPwaButton from '../components/InstallPwaButton.astro';
 import InstallDiscoveryHint from '../components/InstallDiscoveryHint.astro';
 import OnboardingTour from '../components/OnboardingTour.astro';
 import ReportIssueButton from '../components/ReportIssueButton.astro';
+import GlobalShareFab from '../components/GlobalShareFab.astro';
 import SwUpdateToast from '../components/SwUpdateToast.astro';
 import OfflineBanner from '../components/OfflineBanner.astro';
 import { getAlternateUrl } from '../i18n/utils';
@@ -156,6 +157,7 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <CommandPalette lang={lang} />
     <InstallPwaButton lang={installLang} />
     <ReportIssueButton lang={lang} />
+    <GlobalShareFab lang={lang} currentPath={currentPath} />
     <OnboardingTour lang={installLang} />
     <SwUpdateToast lang={lang} />
   </body>


### PR DESCRIPTION
## Problema
En modo PWA standalone el browser chrome está oculto — no hay barra de dirección para copiar la URL. El botón de compartir del PR #50 solo cubría observaciones y perfiles. Docs, mapa, explorar, especies no tenían forma de compartir.

## Solución
`GlobalShareFab.astro` integrado en `BaseLayout.astro` — presente en **todas las páginas**.

## Comportamiento
- **Solo aparece en display-mode: standalone** (PWA instalada). En el browser normal, la barra de dirección es suficiente — el FAB no aparece.
- **Android/iOS** → Web Share API nativa (sheet del OS: WhatsApp, etc.)
- **Desktop/fallback** → copia URL al portapapeles + toast
- **Excluido** en `/observe` y `/observar` — el formulario de observación ya tiene demasiado chrome

## UI
- Botón circular esmeralda, esquina inferior derecha
- `bottom-20` en móvil (sobre el footer nativo), `bottom-6` en desktop
- Ícono de share estándar (tres círculos conectados)

## Test
- [ ] Instalar la PWA en Android → navegar a /docs/financiamiento → tap FAB → abre sheet nativo
- [ ] Ir a /explorar/ → tap FAB → comparte URL correcta
- [ ] Abrir en Chrome browser normal (no standalone) → FAB no aparece
- [ ] Ir al formulario de observación → FAB no aparece