### PR TITLE
fix(home): CTA principal lleva a Observar en lugar de Identificar

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -66,7 +66,7 @@
   "home": {
     "hero_title": "Identify any living thing — anywhere",
     "hero_subtitle": "Rastrum exists to make every living thing identifiable by anyone, anywhere — even without cell signal, even without formal training, even in the languages that field guides forgot.",
-    "cta": "Start Identifying",
+    "cta": "Record Observation",
     "how_title": "How It Works",
     "how_steps": [
       {
@@ -110,7 +110,9 @@
       }
     ],
     "docs_cta": "Read the Docs",
-    "github_cta": "View on GitHub"
+    "github_cta": "View on GitHub",
+    "cta_identify": "Quick ID",
+    "cta_subtitle": "Save with GPS, photo and habitat"
   },
   "identify": {
     "title": "Identify a Species",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -66,7 +66,7 @@
   "home": {
     "hero_title": "Identifica cualquier ser vivo — donde sea",
     "hero_subtitle": "Rastrum existe para hacer que cada ser vivo sea identificable por cualquier persona, en cualquier lugar — incluso sin señal celular, sin formación académica, incluso en los idiomas que las guías de campo olvidaron.",
-    "cta": "Comenzar a Identificar",
+    "cta": "Registrar Observación",
     "how_title": "Cómo Funciona",
     "how_steps": [
       {
@@ -110,7 +110,9 @@
       }
     ],
     "docs_cta": "Leer la Documentación",
-    "github_cta": "Ver en GitHub"
+    "github_cta": "Ver en GitHub",
+    "cta_identify": "Identificación rápida",
+    "cta_subtitle": "Guarda con GPS, foto y hábitat"
   },
   "identify": {
     "title": "Identificar una Especie",

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -16,11 +16,20 @@ const tr = t(lang);
       {tr.home.hero_subtitle}
     </p>
     <div class="flex flex-wrap justify-center gap-3">
+      <!-- Primary CTA: Observe (save with GPS + share) -->
+      <a
+        href={getLocalizedPath(lang, routes.observe[lang] + '/')}
+        class="inline-flex flex-col items-center px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
+      >
+        <span>{tr.home.cta}</span>
+        <span class="text-xs font-normal opacity-80">{tr.home.cta_subtitle}</span>
+      </a>
+      <!-- Secondary CTA: Quick identify (no save) -->
       <a
         href={getLocalizedPath(lang, routes.identify[lang] + '/')}
-        class="inline-block px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
+        class="inline-block px-6 py-3 border border-zinc-300 dark:border-zinc-700 hover:border-emerald-500/50 text-zinc-700 dark:text-zinc-300 font-medium rounded-lg transition-colors"
       >
-        {tr.home.cta}
+        {tr.home.cta_identify}
       </a>
       <a
         href={getDocPath(lang)}

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -16,11 +16,20 @@ const tr = t(lang);
       {tr.home.hero_subtitle}
     </p>
     <div class="flex flex-wrap justify-center gap-3">
+      <!-- CTA principal: Observar (guarda con GPS + compartir) -->
+      <a
+        href={getLocalizedPath(lang, routes.observe[lang] + '/')}
+        class="inline-flex flex-col items-center px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
+      >
+        <span>{tr.home.cta}</span>
+        <span class="text-xs font-normal opacity-80">{tr.home.cta_subtitle}</span>
+      </a>
+      <!-- CTA secundario: Identificación rápida (sin guardar) -->
       <a
         href={getLocalizedPath(lang, routes.identify[lang] + '/')}
-        class="inline-block px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
+        class="inline-block px-6 py-3 border border-zinc-300 dark:border-zinc-700 hover:border-emerald-500/50 text-zinc-700 dark:text-zinc-300 font-medium rounded-lg transition-colors"
       >
-        {tr.home.cta}
+        {tr.home.cta_identify}
       </a>
       <a
         href={getDocPath(lang)}


### PR DESCRIPTION
Feedback de Eugenio Padilla 2026-04-28.

## Problema
El botón principal de la home ('Comenzar a Identificar') llevaba a `/identificar` — el flujo de identificación rápida que no guarda nada ni permite compartir la observación. Un naturalista de campo que quiere registrar una especie con GPS y compartirla no encontraba el flujo correcto.

## Fix
- **CTA principal (verde):** 'Registrar Observación' → `/observar`
  - Subtítulo: 'Guarda con GPS, foto y hábitat'
- **CTA secundario (borde):** 'Identificación rápida' → `/identificar`
  - Para el flujo de solo saber qué es una especie sin guardar

## EN
- Primary: 'Record Observation' → `/observe`
- Secondary: 'Quick ID' → `/identify`