### PR TITLE
fix(sync): observaciones guardadas como guest sincronizan al iniciar sesión

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -73,6 +73,12 @@ async function syncOne(record: ObservationRecord): Promise<void> {
   // If the observation was saved while the user was not yet authenticated (guest),
   // try to re-resolve the observer now. If there's an active session, upgrade
   // the record in Dexie so future syncs also pick it up.
+  //
+  // NOTE: syncOutboxInner() also has a guest-upgrade path added in the fix for
+  // the skipped_guest bug (2026-04-28). If this upgrade logic changes, update
+  // both places. The duplication is intentional: syncOutboxInner upgrades before
+  // the loop so the re-fetched record has the right observer_kind; this path
+  // handles edge cases where syncOne is called directly.
   let observerRef = obs.observerRef;
   if (observerRef.kind !== 'user') {
     try {

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -352,6 +352,7 @@ export async function syncOutbox(): Promise<SyncResult> {
 
 async function syncOutboxInner(): Promise<SyncResult> {
   const db = getDB();
+  const supabase = getSupabase();
   // Pending AND error rows both belong in the queue. An 'error' row is one
   // that previously failed (e.g. CORS, network blip); we want manual retry
   // and the auto-retry-on-mount to re-attempt them, not just the never-tried
@@ -372,7 +373,45 @@ async function syncOutboxInner(): Promise<SyncResult> {
   let last_error: string | null = null;
 
   for (const rec of queued) {
-    if (rec.observer_kind === 'guest') { skipped_guest++; continue; }
+    // Guest rows were saved before the user authenticated. Before skipping,
+    // try to upgrade the record to the current authenticated user so it can
+    // be synced. The same upgrade runs inside syncOne() but the guard below
+    // was skipping guest rows before syncOne() ever ran — meaning observations
+    // saved offline before login never synced even after the user logged in.
+    if (rec.observer_kind === 'guest') {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session?.user?.id) {
+          await db.observations.update(rec.id, {
+            observer_kind: 'user',
+            data: { ...(rec.data as Record<string, unknown>), observerRef: { kind: 'user', id: session.user.id } },
+          });
+          // Re-fetch the updated record so syncOne uses the upgraded observer
+          const upgraded = await db.observations.get(rec.id);
+          if (upgraded) {
+            try {
+              await syncOne(upgraded);
+              synced++;
+              emit<SyncRowDetail>(SYNC_EVENTS.rowDone, { observation_id: rec.id });
+            } catch (err) {
+              failed++;
+              const msg = err instanceof Error ? err.message : String(err);
+              last_error = msg;
+              console.warn('[rastrum] syncOne (upgraded guest) failed', rec.id, msg);
+              await db.observations.update(rec.id, {
+                sync_status: 'error', sync_error: msg,
+                sync_attempts: (rec.sync_attempts ?? 0) + 1,
+                updated_at: new Date().toISOString(),
+              });
+              emit<SyncRowDetail>(SYNC_EVENTS.rowFail, { observation_id: rec.id, error: msg });
+            }
+            continue;
+          }
+        }
+      } catch { /* couldn't upgrade, leave as guest for next sync */ }
+      skipped_guest++;
+      continue;
+    }
     try {
       await syncOne(rec);
       synced++;


### PR DESCRIPTION
Bug reportado por Eugenio Padilla 2026-04-28 en prueba real.

## Síntoma
Badge naranja '1 pendiente' visible pero al tocarlo las observaciones no se subían al servidor.

## Causa raíz
`syncOutboxInner()` tenía este guard:
```ts
if (rec.observer_kind === 'guest') { skipped_guest++; continue; }
```

Esto salteaba TODAS las filas guest antes de llegar a `syncOne()`. La lógica de upgrade guest→user sí existía dentro de `syncOne()` pero nunca se ejecutaba porque el guard hacía `continue` primero.

## Fix
Antes de contar como skipped_guest, intentar upgrade:
1. Consultar sesión activa
2. Si hay usuario autenticado → actualizar `observer_kind='user'` en Dexie
3. Re-fetch del registro upgradeado → llamar `syncOne()`
4. Solo si no hay sesión → `skipped_guest++` (comportamiento original)

## Test
- [ ] Guardar observación sin iniciar sesión → badge naranja '1 pendiente'
- [ ] Iniciar sesión con Google
- [ ] Tocar badge → observación sube y aparece en el perfil
- [ ] Contador de observaciones incrementa de 0 a 1