### PR TITLE
fix(sync): corregir errores TypeScript en upgrade guest→user (CI fix)

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -388,9 +388,13 @@ async function syncOutboxInner(): Promise<SyncResult> {
       try {
         const { data: { session } } = await supabase.auth.getSession();
         if (session?.user?.id) {
+          const upgradedData: Observation = {
+            ...(rec.data as Observation),
+            observerRef: { kind: 'user', id: session.user.id },
+          };
           await db.observations.update(rec.id, {
             observer_kind: 'user',
-            data: { ...(rec.data as Record<string, unknown>), observerRef: { kind: 'user', id: session.user.id } },
+            data: upgradedData,
           });
           // Re-fetch the updated record so syncOne uses the upgraded observer
           const upgraded = await db.observations.get(rec.id);


### PR DESCRIPTION
Hotfix post CI failure del PR #55.

## Errores
```
TS2322: Type '{ observerRef: ... }' is not assignable to type 'Observation'
TS2352: Conversion of type 'Observation' to type 'Record<string, unknown>' may be a mistake
```

## Fix
Construir el objeto upgradeado tipado explícitamente como `Observation` en lugar de castear a `Record<string, unknown>`:
```ts
const upgradedData: Observation = {
  ...(rec.data as Observation),
  observerRef: { kind: 'user', id: session.user.id },
};
```

La lógica del fix del PR #55 no cambia — solo el tipado.