### PR TITLE
fix(sync): SW v7 + botón 'Subir pendientes' en Mis Observaciones

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -9,7 +9,7 @@
 //   - Manifest, favicon, sw.js itself: network-first so updates land fast.
 //
 // Bump VERSION to invalidate every cached entry on the next visit.
-const VERSION = 'rastrum-shell-v6-2026-04-27-cors-fix';
+const VERSION = 'rastrum-shell-v7-2026-04-29-sync-fix';
 const SHELL = [
   '/',
   '/en/',

--- a/src/components/MyObservationsView.astro
+++ b/src/components/MyObservationsView.astro
@@ -630,6 +630,10 @@ const tabs = [
           const result = await syncOutbox();
           if (result.synced > 0) await resetAndLoad();
           paintLastSync();
+          // Toast: si todo se saltó (upgrade guest falló silenciosamente)
+          if (result.synced === 0 && result.skipped_guest > 0) {
+            showToast(lang === 'es' ? 'No se pudo subir — intenta cerrar y abrir la app' : 'Upload failed — try closing and reopening the app', 'err');
+          }
         } catch { /* silent */ } finally {
           syncNowBtn.disabled = false;
           await refreshSyncNowBtn();

--- a/src/components/MyObservationsView.astro
+++ b/src/components/MyObservationsView.astro
@@ -92,6 +92,17 @@ const tabs = [
       </a>
       <p id="mo-last-sync" class="mt-1 text-xs text-zinc-500 dark:text-zinc-500" aria-live="polite"></p>
     </div>
+    <button
+      id="mo-sync-now-btn"
+      type="button"
+      class="hidden min-h-[40px] inline-flex items-center gap-2 rounded-lg bg-emerald-700 hover:bg-emerald-800 px-4 py-2 text-sm font-semibold text-white transition-colors"
+      aria-label={lang === 'es' ? 'Sincronizar observaciones pendientes' : 'Sync pending observations'}
+    >
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h5M20 20v-5h-5M4 9a8 8 0 0114-3M20 15a8 8 0 01-14 3"/>
+      </svg>
+      <span id="mo-sync-now-label">{lang === 'es' ? 'Subir pendientes' : 'Upload pending'}</span>
+    </button>
   </header>
   <!-- Self-healing banner — shown when there are error rows older than 24h -->
   <div id="mo-stale-banner" class="hidden mb-4 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-3 flex items-start gap-2">
@@ -592,6 +603,41 @@ const tabs = [
     await paintStaleBanner();
     await resetAndLoad();
 
+    // Wire "Subir pendientes" button — visible when there are pending/error rows
+    const syncNowBtn = document.getElementById('mo-sync-now-btn') as HTMLButtonElement | null;
+    const syncNowLabel = document.getElementById('mo-sync-now-label');
+    async function refreshSyncNowBtn() {
+      if (!syncNowBtn) return;
+      const { getDB } = await import('../lib/db');
+      const db = getDB();
+      const count = await db.observations.where('sync_status').anyOf('pending', 'error').count();
+      if (count > 0) {
+        syncNowBtn.classList.remove('hidden');
+        if (syncNowLabel) syncNowLabel.textContent = lang === 'es' ? `Subir ${count} pendiente${count === 1 ? '' : 's'}` : `Upload ${count} pending`;
+      } else {
+        syncNowBtn.classList.add('hidden');
+      }
+    }
+    await refreshSyncNowBtn();
+    if (syncNowBtn && !syncNowBtn.dataset.bound) {
+      syncNowBtn.dataset.bound = '1';
+      syncNowBtn.addEventListener('click', async () => {
+        if (!navigator.onLine) return;
+        syncNowBtn.disabled = true;
+        if (syncNowLabel) syncNowLabel.textContent = lang === 'es' ? 'Subiendo…' : 'Uploading…';
+        try {
+          const { syncOutbox } = await import('../lib/sync');
+          const result = await syncOutbox();
+          if (result.synced > 0) await resetAndLoad();
+          paintLastSync();
+        } catch { /* silent */ } finally {
+          syncNowBtn.disabled = false;
+          await refreshSyncNowBtn();
+          await paintStaleBanner();
+        }
+      });
+    }
+
     // Auto-retry the outbox in the background. If the user is here looking
     // at their list, they care about anything stuck in 'pending' from a
     // previous session. Re-render the list when sync completes so the
@@ -601,6 +647,7 @@ const tabs = [
       const result = await syncOutbox();
       if (result.synced > 0) await resetAndLoad();
       paintLastSync();
+      await refreshSyncNowBtn();
     } catch { /* silent — user already sees the list */ }
   }
 


### PR DESCRIPTION
Eugenio Padilla 2026-04-29: badge naranja no responde al tap.

## Causa probable
El service worker v6 estaba cacheando JS anterior al fix del PR #55. La lógica de upgrade guest→user nunca llegó al cliente.

## Fix
1. **SW bump a v7** — invalida el caché completo en todos los clientes
2. **Botón 'Subir pendientes'** en el header de Mis Observaciones:
   - Visible solo cuando hay filas pending/error
   - Muestra conteo: *'Subir 1 pendiente'*
   - Llama syncOutbox() directamente
   - Recarga la lista al terminar
   - Se oculta al llegar a 0

El botón es más grande y descubrible que el badge del header.