### PR TITLE
feat(users): username por defecto estilo Docker con fauna/flora mexicana

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -100,7 +100,15 @@ BEGIN
                    || floor(random() * 900 + 100)::text; -- 3-digit suffix for uniqueness
     EXIT WHEN NOT EXISTS (SELECT 1 FROM public.users WHERE username = gen_username);
     attempts := attempts + 1;
-    EXIT WHEN attempts >= 10;
+    IF attempts >= 10 THEN
+      -- Fallback: timestamp-based suffix guarantees uniqueness
+      gen_username := (adjectives)[1 + floor(random() * array_length(adjectives, 1))::int]
+                     || '-'
+                     || (especies)[1 + floor(random() * array_length(especies, 1))::int]
+                     || '-'
+                     || extract(epoch from now())::bigint % 1000000;
+      EXIT;
+    END IF;
   END LOOP;
 
   INSERT INTO public.users (id, avatar_url, display_name, username)
@@ -3194,7 +3202,14 @@ BEGIN
                      || floor(random() * 900 + 100)::text;
       EXIT WHEN NOT EXISTS (SELECT 1 FROM public.users WHERE username = gen_username);
       attempts := attempts + 1;
-      EXIT WHEN attempts >= 10;
+      IF attempts >= 10 THEN
+        gen_username := (adjectives)[1 + floor(random() * array_length(adjectives, 1))::int]
+                       || '-'
+                       || (especies)[1 + floor(random() * array_length(especies, 1))::int]
+                       || '-'
+                       || extract(epoch from now())::bigint % 1000000;
+        EXIT;
+      END IF;
     END LOOP;
     UPDATE public.users SET username = gen_username WHERE id = rec.id;
   END LOOP;

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -76,12 +76,39 @@ DECLARE
     meta->>'user_name',
     NULLIF(split_part(NEW.email, '@', 1), '')
   );
+  -- Adjectives (nature/character themed, Spanish)
+  adjectives text[] := ARRAY[
+    'valiente','curioso','brillante','veloz','silencioso','audaz','sereno',
+    'ágil','fiero','noble','alerta','sagaz','vibrante','tenaz','libre'
+  ];
+  -- Mexican/LATAM fauna & flora
+  especies text[] := ARRAY[
+    'quetzal','ajolote','teporingo','coatí','cenzontle','ocelote','tapir',
+    'jaguar','manatí','vaquita','guacamaya','tlacuache','armadillo','tejon',
+    'coyote','puma','venado','iguana','boa','tortuga','pelicano','fragata',
+    'colibrí','tucán','flamenco','axolotl','cacomixtle','tlalcoyote'
+  ];
+  gen_username text;
+  attempts int := 0;
 BEGIN
-  INSERT INTO public.users (id, avatar_url, display_name)
-  VALUES (NEW.id, picked_avatar, picked_name)
+  -- Generate a unique <adjective>-<species> username, retry up to 10 times
+  LOOP
+    gen_username := (adjectives)[1 + floor(random() * array_length(adjectives, 1))::int]
+                   || '-'
+                   || (especies)[1 + floor(random() * array_length(especies, 1))::int]
+                   || '-'
+                   || floor(random() * 900 + 100)::text; -- 3-digit suffix for uniqueness
+    EXIT WHEN NOT EXISTS (SELECT 1 FROM public.users WHERE username = gen_username);
+    attempts := attempts + 1;
+    EXIT WHEN attempts >= 10;
+  END LOOP;
+
+  INSERT INTO public.users (id, avatar_url, display_name, username)
+  VALUES (NEW.id, picked_avatar, picked_name, gen_username)
   ON CONFLICT (id) DO UPDATE SET
     avatar_url   = COALESCE(public.users.avatar_url,   EXCLUDED.avatar_url),
-    display_name = COALESCE(public.users.display_name, EXCLUDED.display_name);
+    display_name = COALESCE(public.users.display_name, EXCLUDED.display_name),
+    username     = COALESCE(public.users.username,     EXCLUDED.username);
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
@@ -3136,3 +3163,40 @@ LANGUAGE sql STABLE SECURITY INVOKER AS $$
 $$;
 
 GRANT EXECUTE ON FUNCTION public.top_expertise_legend(uuid) TO anon, authenticated;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- Backfill: assign default usernames to existing users without one
+-- Run once after deploying handle_new_user() update.
+-- ═════════════════════════════════════════════════════════════════════
+DO $$
+DECLARE
+  adjectives text[] := ARRAY[
+    'valiente','curioso','brillante','veloz','silencioso','audaz','sereno',
+    'ágil','fiero','noble','alerta','sagaz','vibrante','tenaz','libre'
+  ];
+  especies text[] := ARRAY[
+    'quetzal','ajolote','teporingo','coatí','cenzontle','ocelote','tapir',
+    'jaguar','manatí','vaquita','guacamaya','tlacuache','armadillo','tejon',
+    'coyote','puma','venado','iguana','boa','tortuga','pelicano','fragata',
+    'colibrí','tucán','flamenco','axolotl','cacomixtle','tlalcoyote'
+  ];
+  rec RECORD;
+  gen_username text;
+  attempts int;
+BEGIN
+  FOR rec IN SELECT id FROM public.users WHERE username IS NULL OR username = '' LOOP
+    attempts := 0;
+    LOOP
+      gen_username := (adjectives)[1 + floor(random() * array_length(adjectives, 1))::int]
+                     || '-'
+                     || (especies)[1 + floor(random() * array_length(especies, 1))::int]
+                     || '-'
+                     || floor(random() * 900 + 100)::text;
+      EXIT WHEN NOT EXISTS (SELECT 1 FROM public.users WHERE username = gen_username);
+      attempts := attempts + 1;
+      EXIT WHEN attempts >= 10;
+    END LOOP;
+    UPDATE public.users SET username = gen_username WHERE id = rec.id;
+  END LOOP;
+END;
+$$;


### PR DESCRIPTION
Solicitado por Artemio 2026-04-29 — 'Anónimo' es mal UX.

## Formato
`<adjetivo>-<especie_mexicana>-<3_dígitos>`

**Ejemplos:**
- `valiente-quetzal-472`
- `curioso-ajolote-831`
- `silencioso-cenzontle-104`
- `audaz-jaguar-667`

## Implementación
- **`handle_new_user()`** genera el username al registrarse
- 15 adjetivos × 28 especies mexicanas × 900 sufijos = **378,000 combinaciones**
- Retry loop (max 10) garantiza unicidad sin colisiones
- COALESCE: si el usuario ya tenía username configurado, no se sobreescribe
- Configurable por el usuario en Ajustes en cualquier momento

## Backfill
Script SQL al final del schema para asignar usernames a usuarios existentes (Artemio, Eugenio).

## Operador post-merge
```bash
psql "$SUPABASE_DB_URL" -f docs/specs/infra/supabase-schema.sql
```