### PR TITLE
fix(auth): redirigir desde login si hay sesión y robustecer cerrar sesión

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -269,7 +269,7 @@ const docColumns = [
 <!-- Auth status: keeps the existing avatar-swap behavior -->
 <script>
   import { getSupabase } from '../lib/supabase';
-  import { signOut } from '../lib/auth';
+  import { signOut, SUPABASE_AUTH_STORAGE_KEY, HEADER_AVATAR_CACHE_KEY, HEADER_AVATAR_NAME_KEY } from '../lib/auth';
   import { getUserRoles } from '../lib/user-roles';
   import type { UserProfile } from '../lib/types';
 
@@ -286,8 +286,8 @@ const docColumns = [
     return 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
   }
 
-  const AVATAR_CACHE_KEY = 'rastrum.headerAvatar';
-  const AVATAR_NAME_KEY  = 'rastrum.headerName';
+  const AVATAR_CACHE_KEY = HEADER_AVATAR_CACHE_KEY;
+  const AVATAR_NAME_KEY  = HEADER_AVATAR_NAME_KEY;
   function paintCachedAvatar() {
     if (!avatarImg) return;
     try {
@@ -368,7 +368,7 @@ const docColumns = [
     try {
       localStorage.removeItem(AVATAR_CACHE_KEY);
       localStorage.removeItem(AVATAR_NAME_KEY);
-      localStorage.removeItem('rastrum-auth-v1');
+      localStorage.removeItem(SUPABASE_AUTH_STORAGE_KEY);
     } catch { /* ignore */ }
     window.location.replace(window.location.pathname.startsWith('/es/') ? '/es/' : '/en/');
   });

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -363,5 +363,13 @@ const docColumns = [
 
   avatarBtn?.addEventListener('click', (e) => { e.stopPropagation(); avatarMenu?.classList.toggle('hidden'); });
   document.addEventListener('click', () => avatarMenu?.classList.add('hidden'));
-  signOutBtn?.addEventListener('click', async () => { await signOut(); window.location.reload(); });
+  signOutBtn?.addEventListener('click', async () => {
+    try { await signOut(); } catch { /* dead refresh token — fall through to local cleanup */ }
+    try {
+      localStorage.removeItem(AVATAR_CACHE_KEY);
+      localStorage.removeItem(AVATAR_NAME_KEY);
+      localStorage.removeItem('rastrum-auth-v1');
+    } catch { /* ignore */ }
+    window.location.replace(window.location.pathname.startsWith('/es/') ? '/es/' : '/en/');
+  });
 </script>

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -179,7 +179,15 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
     } catch { /* env not set */ }
   })();
 
-  signOutBtn?.addEventListener('click', async () => { await signOut(); window.location.reload(); });
+  signOutBtn?.addEventListener('click', async () => {
+    try { await signOut(); } catch { /* dead refresh token — fall through to local cleanup */ }
+    try {
+      localStorage.removeItem('rastrum.headerAvatar');
+      localStorage.removeItem('rastrum.headerName');
+      localStorage.removeItem('rastrum-auth-v1');
+    } catch { /* ignore */ }
+    window.location.replace(window.location.pathname.startsWith('/es/') ? '/es/' : '/en/');
+  });
 
   themeBtn?.addEventListener('click', () => {
     const dark = document.documentElement.classList.toggle('dark');

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -123,7 +123,7 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
 
 <script>
   import { getSupabase } from '../lib/supabase';
-  import { signOut } from '../lib/auth';
+  import { signOut, SUPABASE_AUTH_STORAGE_KEY, HEADER_AVATAR_CACHE_KEY, HEADER_AVATAR_NAME_KEY } from '../lib/auth';
   import { getUserRoles } from '../lib/user-roles';
 
   const drawer   = document.getElementById('mobile-drawer');
@@ -182,9 +182,9 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
   signOutBtn?.addEventListener('click', async () => {
     try { await signOut(); } catch { /* dead refresh token — fall through to local cleanup */ }
     try {
-      localStorage.removeItem('rastrum.headerAvatar');
-      localStorage.removeItem('rastrum.headerName');
-      localStorage.removeItem('rastrum-auth-v1');
+      localStorage.removeItem(HEADER_AVATAR_CACHE_KEY);
+      localStorage.removeItem(HEADER_AVATAR_NAME_KEY);
+      localStorage.removeItem(SUPABASE_AUTH_STORAGE_KEY);
     } catch { /* ignore */ }
     window.location.replace(window.location.pathname.startsWith('/es/') ? '/es/' : '/en/');
   });

--- a/src/components/PrivacyMatrix.astro
+++ b/src/components/PrivacyMatrix.astro
@@ -180,6 +180,7 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
 
 <script>
   import { getSupabase } from '../lib/supabase';
+  import { SUPABASE_AUTH_STORAGE_KEY } from '../lib/auth';
   import {
     applyPreset,
     detectPreset,
@@ -368,7 +369,7 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
   function readAccessToken(): string {
     if (typeof localStorage === 'undefined') return '';
     try {
-      const raw = localStorage.getItem('rastrum-auth-v1');
+      const raw = localStorage.getItem(SUPABASE_AUTH_STORAGE_KEY);
       if (!raw) return '';
       const parsed = JSON.parse(raw) as { access_token?: string; currentSession?: { access_token?: string } };
       return parsed.access_token ?? parsed.currentSession?.access_token ?? '';

--- a/src/components/SignInForm.astro
+++ b/src/components/SignInForm.astro
@@ -97,6 +97,18 @@ const tr = t(lang);
     verifyPasskey,
     passkeySupported,
   } from '../lib/auth';
+  import { getSupabase } from '../lib/supabase';
+
+  // If the user already has a valid session, skip the form entirely.
+  (async () => {
+    try {
+      const { data: { session } } = await getSupabase().auth.getSession();
+      if (session?.user) {
+        const isEsPath = window.location.pathname.startsWith('/es/');
+        window.location.replace(isEsPath ? '/es/' : '/en/');
+      }
+    } catch { /* env not set or storage unavailable — show the form */ }
+  })();
 
   const googleBtn  = document.getElementById('google-btn') as HTMLButtonElement | null;
   const githubBtn  = document.getElementById('github-btn') as HTMLButtonElement | null;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,13 @@
 import { getSupabase } from './supabase';
 import type { Provider } from '@supabase/supabase-js';
 
+// ─────────────────────────── Storage key constants ───────────────────────────
+// Centralised here so any change propagates automatically to Header,
+// MobileDrawer, PrivacyMatrix and any future consumer.
+export const SUPABASE_AUTH_STORAGE_KEY = 'rastrum-auth-v1';
+export const HEADER_AVATAR_CACHE_KEY   = 'rastrum.headerAvatar';
+export const HEADER_AVATAR_NAME_KEY    = 'rastrum.headerName';
+
 const callbackUrl = () =>
   (typeof window !== 'undefined' ? window.location.origin : '') + '/auth/callback/';
 


### PR DESCRIPTION
## Summary
- **SignInForm**: redirige a `/{lang}/` si `auth.getSession()` devuelve un usuario válido. Antes el formulario aparecía igual cuando el cliente ya estaba autenticado, dejando el avatar logueado pintado encima del login.
- **Header / MobileDrawer**: el handler de "Cerrar sesión" ahora envuelve `auth.signOut()` en un try/catch (el refresh token muerto hacía que el `await` rechazara y nunca se llegara al `reload`), limpia explícitamente el avatar cacheado (`rastrum.headerAvatar`, `rastrum.headerName`) y la sesión Supabase (`rastrum-auth-v1`) de `localStorage`, y usa `location.replace` al home del idioma activo.

## Repro
1. Tener una sesión Supabase con refresh token expirado/inválido en `localStorage`.
2. Visitar `/es/ingresar/`: aparece el formulario de login con el avatar y menú de cuenta visibles en el header.
3. Click en "Cerrar sesión" → no pasa nada (la promesa rechazaba antes del reload).

Con esta PR, (2) redirige al home y (3) limpia el estado local y navega.

## Test plan
- [ ] `npm run typecheck` pasa (verificado local).
- [ ] Login válido → /sign-in y /ingresar redirigen al home del idioma.
- [ ] Logout desde el header (desktop) limpia avatar + sesión y navega al home.
- [ ] Logout desde el drawer (mobile) hace lo mismo.
- [ ] Con `localStorage['rastrum-auth-v1']` corrupto, logout sigue funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)