### PR TITLE
feat(social): wire m26 surfaces into the UI

### DIFF
--- a/src/components/BellIcon.astro
+++ b/src/components/BellIcon.astro
@@ -52,7 +52,12 @@ const ariaLabel = lang === 'es' ? 'Bandeja' : 'Inbox';
     async function tick() {
       let supabase;
       try { supabase = getSupabase(); } catch { return; }
-      const { data: { user } } = await supabase.auth.getUser();
+      // Use getSession() (localStorage-only) instead of getUser() (server
+      // round-trip) — we only need to know "is there a logged-in user"
+      // for showing the bell. JWT validation happens on the actual
+      // notification-count query against RLS.
+      const { data: { session } } = await supabase.auth.getSession();
+      const user = session?.user ?? null;
       if (!user) {
         if (wrapper) wrapper.classList.add('hidden');
         return;

--- a/src/components/BellIcon.astro
+++ b/src/components/BellIcon.astro
@@ -1,20 +1,13 @@
 ---
 /**
- * BellIcon — header bell with unread activity badge.
+ * BellIcon — header bell with unread inbox badge.
  *
- * Polls every 60s while the tab is visible. We use polling (not realtime)
- * because:
- *   1. Realtime subscriptions add a persistent socket that hurts the PWA
- *      cold-start budget for visitors who don't care about social.
- *   2. The activity-events table is small per-user; HEAD count requests
- *      are cheap.
- *   3. We pause the timer with the visibilitychange event to avoid
- *      burning battery in background tabs.
- *
- * Links to the profile page where the watchlist + activity live.
- *
- * Badge styling stays readable in both themes — bg-red-500 + white text
- * is contrasty enough to clear WCAG AA against the header background.
+ * Polls every 60s while the tab is visible. The destination is the m26
+ * social inbox (`/inbox` ↔ `/bandeja`). The badge counts unread rows in
+ * the `notifications` table (m26: follow / reaction / comment / mention).
+ * The legacy `activity_events` watchlist surface remains accessible from
+ * the profile page; bringing both into a unified inbox is a v1.1
+ * follow-up.
  */
 import { t, getLocalizedPath, routes } from '../i18n/utils';
 
@@ -24,14 +17,14 @@ interface Props {
 
 const { lang } = Astro.props;
 const tr = t(lang);
-const profilePath = getLocalizedPath(lang, routes.profile[lang] + '/');
-const ariaLabel = lang === 'es' ? 'Actividad' : 'Activity';
+const inboxPath = getLocalizedPath(lang, routes.inbox[lang] + '/');
+const ariaLabel = lang === 'es' ? 'Bandeja' : 'Inbox';
 ---
 
 <a
-  href={profilePath}
+  href={inboxPath}
   id="rastrum-bell"
-  class="rastrum-bell hidden relative inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+  class="rastrum-bell hidden relative inline-flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg hover:bg-emerald-50 dark:hover:bg-emerald-950/40 transition-colors"
   aria-label={ariaLabel}
   data-bell-label-aria={tr.social.unread_label}
 >
@@ -40,7 +33,7 @@ const ariaLabel = lang === 'es' ? 'Actividad' : 'Activity';
   </svg>
   <span
     id="rastrum-bell-badge"
-    class="hidden absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 border-2 border-white dark:border-zinc-950 text-[10px] font-bold text-white flex items-center justify-center pointer-events-none"
+    class="hidden absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-emerald-600 border-2 border-white dark:border-zinc-950 text-[10px] font-bold text-white flex items-center justify-center pointer-events-none"
   >0</span>
 </a>
 
@@ -66,13 +59,13 @@ const ariaLabel = lang === 'es' ? 'Actividad' : 'Activity';
       }
       if (wrapper) wrapper.classList.remove('hidden');
       const { count, error } = await supabase
-        .from('activity_events')
+        .from('notifications')
         .select('id', { count: 'exact', head: true })
-        .eq('actor_id', user.id)
+        .eq('user_id', user.id)
         .is('read_at', null);
       if (error || !badge) return;
       if (count && count > 0) {
-        badge.textContent = count > 99 ? '99+' : String(count);
+        badge.textContent = count > 9 ? '9+' : String(count);
         badge.classList.remove('hidden');
       } else {
         badge.classList.add('hidden');

--- a/src/components/FollowButton.astro
+++ b/src/components/FollowButton.astro
@@ -1,6 +1,12 @@
 ---
 /**
- * FollowButton — toggles a follow on `public.follows`.
+ * FollowButton — opt-in follow / unfollow against a target user.
+ *
+ * Calls the m26 `follow` Edge Function via `followUser()` /
+ * `unfollowUser()` (see src/lib/social.ts) so rate-limits and
+ * profile-privacy gating fire server-side. The function returns
+ * `{ status: 'pending' | 'accepted' }` so we can paint a 3rd
+ * "Requested" state for private profiles.
  *
  * Usage: <FollowButton lang="en" targetUserId={observerId} />
  *
@@ -32,6 +38,7 @@ const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
   data-sign-in-path={signInPath}
   data-label-follow={tr.social.follow}
   data-label-following={tr.social.following}
+  data-label-requested={tr.socialgraph.follow.requested}
   data-label-signin={tr.social.signin_to_follow}
   data-label-loading={tr.social.loading}
 >
@@ -46,28 +53,54 @@ const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
 
 <script>
   import { getSupabase } from '../lib/supabase';
+  import { followUser, unfollowUser } from '../lib/social';
 
   type FollowEl = HTMLElement & { __wired?: boolean };
+  type ButtonState = 'follow' | 'following' | 'requested' | 'signin';
 
-  function paint(btn: HTMLButtonElement, state: 'follow' | 'following' | 'signin', root: HTMLElement) {
+  const STATE_CLASSES: Record<ButtonState, string[]> = {
+    follow: [
+      'border-emerald-600/60', 'text-emerald-700', 'dark:text-emerald-400',
+      'hover:bg-emerald-50', 'dark:hover:bg-emerald-900/20',
+    ],
+    following: [
+      'bg-emerald-700', 'text-white', 'hover:bg-emerald-800', 'border-emerald-700',
+    ],
+    requested: [
+      'bg-amber-100', 'text-amber-800', 'border-amber-300',
+      'dark:bg-amber-950/30', 'dark:text-amber-300', 'dark:border-amber-900/60',
+      'hover:bg-amber-200', 'dark:hover:bg-amber-950/50',
+    ],
+    signin: [
+      'border-zinc-300', 'dark:border-zinc-700', 'text-zinc-700', 'dark:text-zinc-300',
+      'hover:bg-zinc-50', 'dark:hover:bg-zinc-800/40',
+    ],
+  };
+  const ALL_CLASSES = Array.from(new Set(Object.values(STATE_CLASSES).flat()));
+
+  function paint(btn: HTMLButtonElement, state: ButtonState, root: HTMLElement) {
     btn.dataset.state = state;
     btn.classList.remove('hidden');
-    btn.classList.remove(
-      'border-emerald-600/60', 'text-emerald-700', 'dark:text-emerald-400', 'hover:bg-emerald-50', 'dark:hover:bg-emerald-900/20',
-      'bg-emerald-700', 'text-white', 'hover:bg-emerald-800', 'border-emerald-700',
-      'border-zinc-300', 'dark:border-zinc-700', 'text-zinc-700', 'dark:text-zinc-300', 'hover:bg-zinc-50', 'dark:hover:bg-zinc-800/40',
-    );
+    btn.classList.remove(...ALL_CLASSES);
+    btn.classList.add(...STATE_CLASSES[state]);
     const labelEl = btn.querySelector('.follow-label') as HTMLSpanElement | null;
-    if (state === 'following') {
-      btn.classList.add('bg-emerald-700', 'text-white', 'hover:bg-emerald-800', 'border-emerald-700');
-      if (labelEl) labelEl.textContent = root.dataset.labelFollowing ?? '';
-    } else if (state === 'follow') {
-      btn.classList.add('border-emerald-600/60', 'text-emerald-700', 'dark:text-emerald-400', 'hover:bg-emerald-50', 'dark:hover:bg-emerald-900/20');
-      if (labelEl) labelEl.textContent = root.dataset.labelFollow ?? '';
-    } else {
-      btn.classList.add('border-zinc-300', 'dark:border-zinc-700', 'text-zinc-700', 'dark:text-zinc-300', 'hover:bg-zinc-50', 'dark:hover:bg-zinc-800/40');
-      if (labelEl) labelEl.textContent = root.dataset.labelSignin ?? '';
-    }
+    if (!labelEl) return;
+    if (state === 'following') labelEl.textContent = root.dataset.labelFollowing ?? '';
+    else if (state === 'requested') labelEl.textContent = root.dataset.labelRequested ?? '';
+    else if (state === 'follow') labelEl.textContent = root.dataset.labelFollow ?? '';
+    else labelEl.textContent = root.dataset.labelSignin ?? '';
+  }
+
+  async function readExisting(supabase: ReturnType<typeof getSupabase>, follower: string, followee: string): Promise<'none' | 'pending' | 'accepted'> {
+    const { data } = await supabase
+      .from('follows')
+      .select('status')
+      .eq('follower_id', follower)
+      .eq('followee_id', followee)
+      .maybeSingle<{ status?: string | null }>();
+    if (!data) return 'none';
+    if (data.status === 'pending') return 'pending';
+    return 'accepted';
   }
 
   async function wire(root: FollowEl) {
@@ -79,11 +112,7 @@ const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
     if (!btn) return;
 
     let supabase;
-    try {
-      supabase = getSupabase();
-    } catch {
-      return;
-    }
+    try { supabase = getSupabase(); } catch { return; }
 
     const { data: { user } } = await supabase.auth.getUser();
 
@@ -101,38 +130,34 @@ const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
       return;
     }
 
-    const { data: existing } = await supabase
-      .from('follows')
-      .select('follower_id')
-      .eq('follower_id', user.id)
-      .eq('followee_id', targetId)
-      .maybeSingle();
-
-    let following = !!existing;
-    paint(btn, following ? 'following' : 'follow', root);
+    let dbState: 'none' | 'pending' | 'accepted' = await readExisting(supabase, user.id, targetId);
+    let visible: ButtonState = dbState === 'accepted' ? 'following' : dbState === 'pending' ? 'requested' : 'follow';
+    paint(btn, visible, root);
 
     btn.addEventListener('click', async () => {
-      const prev = following;
-      following = !following;
-      paint(btn, following ? 'following' : 'follow', root);
+      const prev = { dbState, visible };
       btn.disabled = true;
       try {
-        if (following) {
-          const { error } = await supabase
-            .from('follows')
-            .insert({ follower_id: user.id, followee_id: targetId });
-          if (error && !/duplicate/i.test(error.message)) throw error;
-        } else {
-          const { error } = await supabase
-            .from('follows')
-            .delete()
-            .eq('follower_id', user.id)
-            .eq('followee_id', targetId);
-          if (error) throw error;
+        if (dbState === 'none') {
+          // Optimistic — assume it'll be accepted; correct after the call.
+          visible = 'following';
+          paint(btn, 'following', root);
+          const out = await followUser(targetId, 'follower');
+          dbState = out.status === 'accepted' ? 'accepted' : 'pending';
+          visible = dbState === 'accepted' ? 'following' : 'requested';
+          paint(btn, visible, root);
+        } else if (dbState === 'pending' || dbState === 'accepted') {
+          visible = 'follow';
+          paint(btn, 'follow', root);
+          await unfollowUser(targetId);
+          dbState = 'none';
         }
-      } catch {
-        following = prev;
-        paint(btn, following ? 'following' : 'follow', root);
+      } catch (err) {
+        dbState = prev.dbState;
+        visible = prev.visible;
+        paint(btn, visible, root);
+        // eslint-disable-next-line no-console
+        console.warn('[follow]', err);
       } finally {
         btn.disabled = false;
       }

--- a/src/components/InboxView.astro
+++ b/src/components/InboxView.astro
@@ -6,6 +6,11 @@
  * `notifications` table client-side. RLS scopes rows to the signed-in
  * user; unauthenticated visitors get a sign-in prompt.
  *
+ * Each row resolves its `actor_id` payload field to the actor's display
+ * name + handle + avatar via a single batched lookup; reactions resolve
+ * the `target_id` to the observation's thumbnail. Unread rows get an
+ * emerald left-rail; reads pop on click.
+ *
  * See module 26 (social graph) plan, Task 20.
  */
 import BaseLayout from '../layouts/BaseLayout.astro';
@@ -19,59 +24,90 @@ const { lang } = Astro.props;
 const tr = t(lang);
 const inboxTr = tr.socialgraph.inbox;
 const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
+const explorePath = getLocalizedPath(lang, routes.exploreRecent[lang] + '/');
 const notSignedIn = (tr.profile as unknown as Record<string, string>).not_signed_in
   ?? (lang === 'es' ? 'Inicia sesión para ver tu bandeja.' : 'Sign in to see your inbox.');
 const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
   ?? (lang === 'es' ? 'Ingresar' : 'Sign in');
+const exploreLabel = lang === 'es' ? 'Explorar observaciones recientes' : 'Browse recent observations';
+const subtitleCopy = lang === 'es'
+  ? 'Avisos de seguidores, reacciones, menciones y validaciones a tus observaciones.'
+  : 'Heads-up on follows, reactions, mentions, and validations on your observations.';
 ---
 
-<BaseLayout lang={lang} title={`${inboxTr.title} — Rastrum`} description={inboxTr.empty}>
+<BaseLayout lang={lang} title={`${inboxTr.title} — Rastrum`} description={subtitleCopy}>
   <section
-    class="rastrum-inbox mx-auto max-w-2xl p-4"
+    class="rastrum-inbox mx-auto max-w-2xl px-4 py-8 md:py-12"
     data-lang={lang}
     data-label-kind-follow={inboxTr.kind_follow}
     data-label-kind-follow-request={inboxTr.kind_follow_request}
     data-label-kind-follow-accepted={inboxTr.kind_follow_accepted}
     data-label-kind-reaction={inboxTr.kind_reaction}
     data-label-empty={inboxTr.empty}
+    data-label-mark-read={lang === 'es' ? 'Marcar leído' : 'Mark read'}
+    data-label-just-now={lang === 'es' ? 'ahora' : 'just now'}
+    data-label-mins={lang === 'es' ? 'min' : 'm'}
+    data-label-hrs={lang === 'es' ? 'h' : 'h'}
+    data-label-days={lang === 'es' ? 'd' : 'd'}
+    data-label-weeks={lang === 'es' ? 'sem' : 'w'}
+    data-label-explore={exploreLabel}
+    data-explore-path={explorePath}
   >
-    <header class="flex items-center justify-between mb-4">
-      <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+    <header class="mb-6 md:mb-8">
+      <h1 class="text-3xl md:text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
         {inboxTr.title}
       </h1>
-      <button
-        type="button"
-        id="inbox-mark-all-read"
-        class="hidden text-sm font-medium text-emerald-700 hover:underline disabled:opacity-50"
-      >
-        {inboxTr.mark_all_read}
-      </button>
+      <p class="mt-1.5 text-sm text-zinc-500 dark:text-zinc-400">{subtitleCopy}</p>
+      <div class="mt-4 flex items-center justify-between">
+        <span id="inbox-unread-count" class="text-xs font-medium text-zinc-600 dark:text-zinc-400 tabular-nums"></span>
+        <button
+          type="button"
+          id="inbox-mark-all-read"
+          class="hidden text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:text-emerald-800 dark:hover:text-emerald-300 transition-colors disabled:opacity-50"
+        >
+          {inboxTr.mark_all_read}
+        </button>
+      </div>
     </header>
 
     <div
       id="inbox-signin"
-      class="hidden rounded-lg border border-zinc-300 dark:border-zinc-700 p-4 text-sm"
+      class="hidden rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-6 text-center"
     >
-      <p class="text-zinc-700 dark:text-zinc-300">{notSignedIn}</p>
+      <p class="text-sm text-zinc-700 dark:text-zinc-300">{notSignedIn}</p>
       <a
         href={signInPath}
-        class="mt-3 inline-flex min-h-[40px] items-center rounded-lg bg-emerald-700 hover:bg-emerald-800 px-4 py-2 text-sm font-semibold text-white"
+        class="mt-4 inline-flex min-h-[44px] items-center justify-center rounded-lg bg-emerald-700 hover:bg-emerald-800 px-5 py-2.5 text-sm font-semibold text-white transition-colors"
       >
         {signInLabel}
       </a>
     </div>
 
-    <div id="inbox-loading" class="text-sm text-zinc-500 dark:text-zinc-400">
-      {tr.profile.my_observations_loading}
+    <div id="inbox-loading" class="space-y-3" aria-hidden="true">
+      <div class="h-16 rounded-xl bg-zinc-100 dark:bg-zinc-900 animate-pulse"></div>
+      <div class="h-16 rounded-xl bg-zinc-100 dark:bg-zinc-900 animate-pulse" style="animation-delay: 80ms"></div>
+      <div class="h-16 rounded-xl bg-zinc-100 dark:bg-zinc-900 animate-pulse" style="animation-delay: 160ms"></div>
     </div>
 
-    <ul id="inbox-list" class="hidden divide-y divide-zinc-200 dark:divide-zinc-800"></ul>
+    <ul id="inbox-list" class="hidden space-y-2"></ul>
 
     <div
       id="inbox-empty"
-      class="hidden rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700 p-8 text-center"
+      class="hidden rounded-2xl border border-dashed border-emerald-300/70 dark:border-emerald-900/60 bg-emerald-50/40 dark:bg-emerald-950/20 p-10 text-center"
     >
-      <p class="text-sm text-zinc-500 dark:text-zinc-400">{inboxTr.empty}</p>
+      <svg class="mx-auto mb-4 h-12 w-12 text-emerald-700 dark:text-emerald-400" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M32 56c0-14 8-22 20-22-2 12-10 22-20 22Z" />
+        <path d="M32 56c0-14-8-22-20-22 2 12 10 22 20 22Z" />
+        <path d="M32 56V20" />
+        <path d="M32 20c0-6 4-10 10-12-2 8-6 12-10 12Z" />
+      </svg>
+      <p class="text-sm text-zinc-700 dark:text-zinc-300">{inboxTr.empty}</p>
+      <a
+        href={explorePath}
+        class="mt-5 inline-flex min-h-[40px] items-center rounded-lg bg-emerald-700 hover:bg-emerald-800 px-4 py-2 text-sm font-semibold text-white transition-colors"
+      >
+        {exploreLabel}
+      </a>
     </div>
   </section>
 </BaseLayout>
@@ -81,19 +117,29 @@ const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
 
   type Lang = 'en' | 'es';
 
-  type NotificationKind =
-    | 'follow'
-    | 'follow_request'
-    | 'follow_accepted'
-    | 'reaction'
-    | string;
-
   interface NotificationRow {
     id: string;
-    kind: NotificationKind;
+    kind: string;
     payload: Record<string, unknown> | null;
     read_at: string | null;
     created_at: string;
+  }
+
+  interface ActorInfo {
+    id: string;
+    username: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  }
+
+  interface ObsThumb {
+    id: string;
+    primary_taxon_id: string | null;
+  }
+
+  interface MediaThumb {
+    observation_id: string;
+    url: string | null;
   }
 
   const root = document.querySelector<HTMLElement>('.rastrum-inbox');
@@ -107,7 +153,23 @@ const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
       .replace(/"/g, '&quot;');
   }
 
-  function templateFor(kind: NotificationKind): string {
+  function timeAgo(iso: string): string {
+    const now = Date.now();
+    const then = new Date(iso).getTime();
+    const sec = Math.max(0, Math.round((now - then) / 1000));
+    if (sec < 60) return root?.dataset.labelJustNow ?? 'just now';
+    const min = Math.round(sec / 60);
+    if (min < 60) return `${min}${root?.dataset.labelMins ?? 'm'}`;
+    const hr = Math.round(sec / 3600);
+    if (hr < 24) return `${hr}${root?.dataset.labelHrs ?? 'h'}`;
+    const d = Math.round(sec / 86400);
+    if (d < 7) return `${d}${root?.dataset.labelDays ?? 'd'}`;
+    const w = Math.round(d / 7);
+    if (w < 5) return `${w}${root?.dataset.labelWeeks ?? 'w'}`;
+    return new Date(iso).toLocaleDateString(lang);
+  }
+
+  function templateFor(kind: string): string {
     if (!root) return '';
     if (kind === 'follow') return root.dataset.labelKindFollow ?? '';
     if (kind === 'follow_request') return root.dataset.labelKindFollowRequest ?? '';
@@ -116,26 +178,107 @@ const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
     return '';
   }
 
-  function actorFromPayload(payload: NotificationRow['payload']): string {
-    if (!payload) return '';
-    const handle = (payload as { actor_handle?: unknown }).actor_handle;
-    const display = (payload as { actor_display_name?: unknown }).actor_display_name;
-    const id = (payload as { actor_id?: unknown }).actor_id;
-    if (typeof display === 'string' && display.trim()) return display;
-    if (typeof handle === 'string' && handle.trim()) return '@' + handle;
-    if (typeof id === 'string' && id.trim()) return id;
-    return '';
+  function iconFor(kind: string): string {
+    // Hand-tuned 16px icons. Each is a circular ring + glyph in the
+    // accent color for that kind. Keeps the inbox visually scannable
+    // without leaning on emoji or heavy SVGs.
+    if (kind === 'follow' || kind === 'follow_accepted' || kind === 'follow_request') {
+      return `<span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-400 ring-1 ring-emerald-200 dark:ring-emerald-900/60">
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="9" cy="8" r="4"/><path d="M3 21v-2a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2"/><path d="M19 8v6"/><path d="M22 11h-6"/></svg>
+      </span>`;
+    }
+    if (kind === 'reaction') {
+      return `<span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-rose-100 dark:bg-rose-950/40 text-rose-600 dark:text-rose-400 ring-1 ring-rose-200 dark:ring-rose-900/60">
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-7-4.5-9.5-9A5.5 5.5 0 0 1 12 6a5.5 5.5 0 0 1 9.5 6c-2.5 4.5-9.5 9-9.5 9Z"/></svg>
+      </span>`;
+    }
+    if (kind === 'comment' || kind === 'mention') {
+      return `<span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-sky-100 dark:bg-sky-950/40 text-sky-700 dark:text-sky-400 ring-1 ring-sky-200 dark:ring-sky-900/60">
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+      </span>`;
+    }
+    if (kind === 'identification' || kind === 'badge') {
+      return `<span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-400 ring-1 ring-amber-200 dark:ring-amber-900/60">
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="12 2 15 8.5 22 9.3 17 14.1 18.2 21 12 17.8 5.8 21 7 14.1 2 9.3 9 8.5 12 2"/></svg>
+      </span>`;
+    }
+    return `<span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 ring-1 ring-zinc-200 dark:ring-zinc-700"><span class="block h-1.5 w-1.5 rounded-full bg-current"/></span>`;
   }
 
-  function renderRow(n: NotificationRow): string {
+  function actorAvatar(actor: ActorInfo | null): string {
+    if (!actor) return '';
+    const url = actor.avatar_url;
+    const name = actor.display_name || actor.username || '?';
+    if (url) {
+      return `<img src="${escapeText(url)}" alt="" loading="lazy" class="absolute -bottom-0.5 -right-0.5 h-5 w-5 rounded-full ring-2 ring-white dark:ring-zinc-950 object-cover" />`;
+    }
+    return `<span class="absolute -bottom-0.5 -right-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-zinc-700 text-[9px] font-bold text-white ring-2 ring-white dark:ring-zinc-950">${escapeText(name.slice(0, 1).toUpperCase())}</span>`;
+  }
+
+  function targetThumb(thumbUrl: string | null): string {
+    if (!thumbUrl) return '';
+    return `<img src="${escapeText(thumbUrl)}" alt="" loading="lazy" class="ml-3 h-12 w-12 shrink-0 rounded-lg object-cover ring-1 ring-zinc-200 dark:ring-zinc-800" />`;
+  }
+
+  function rowHref(n: NotificationRow, actor: ActorInfo | null): string {
+    const p = (n.payload ?? {}) as Record<string, unknown>;
+    if (n.kind === 'follow' || n.kind === 'follow_request' || n.kind === 'follow_accepted') {
+      const handle = actor?.username || (typeof p.actor_handle === 'string' ? (p.actor_handle as string) : '');
+      if (handle) return `/${lang === 'es' ? 'es/perfil' : 'en/profile'}/u/?username=${encodeURIComponent(handle)}`;
+    }
+    if (n.kind === 'reaction') {
+      const obsId = typeof p.target_id === 'string' ? (p.target_id as string) : '';
+      if (obsId) return `/share/obs/?id=${encodeURIComponent(obsId)}`;
+    }
+    return '#';
+  }
+
+  function actorLabel(n: NotificationRow, actor: ActorInfo | null): string {
+    if (actor) {
+      if (actor.display_name) return actor.display_name;
+      if (actor.username) return '@' + actor.username;
+    }
+    const p = (n.payload ?? {}) as Record<string, unknown>;
+    const handle = typeof p.actor_handle === 'string' ? (p.actor_handle as string) : '';
+    const display = typeof p.actor_display_name === 'string' ? (p.actor_display_name as string) : '';
+    if (display) return display;
+    if (handle) return '@' + handle;
+    return lang === 'es' ? 'Alguien' : 'Someone';
+  }
+
+  function renderRow(
+    n: NotificationRow,
+    actor: ActorInfo | null,
+    thumbUrl: string | null,
+  ): string {
     const tpl = templateFor(n.kind);
-    const actor = actorFromPayload(n.payload);
-    const text = tpl ? tpl.replace('{{actor}}', escapeText(actor)) : '';
-    const when = new Date(n.created_at).toLocaleString(lang);
-    const dim = n.read_at ? 'opacity-60' : '';
-    return `<li class="py-3 ${dim}">
-      <div class="text-sm text-zinc-800 dark:text-zinc-200">${text}</div>
-      <div class="text-xs text-zinc-500 dark:text-zinc-400 mt-1">${escapeText(when)}</div>
+    const text = tpl ? tpl.replace('{{actor}}', `<span class="font-semibold text-zinc-900 dark:text-zinc-100">${escapeText(actorLabel(n, actor))}</span>`) : '';
+    const href = rowHref(n, actor);
+    const when = timeAgo(n.created_at);
+    const unread = !n.read_at;
+    const stateClasses = unread
+      ? 'bg-white dark:bg-zinc-900 ring-1 ring-emerald-200 dark:ring-emerald-900/60 shadow-[inset_3px_0_0_0] shadow-emerald-600 dark:shadow-emerald-500'
+      : 'bg-zinc-50/70 dark:bg-zinc-900/40 ring-1 ring-zinc-200/60 dark:ring-zinc-800/60';
+
+    const icon = iconFor(n.kind);
+    const avatar = actorAvatar(actor);
+    const thumb = thumbUrl ? targetThumb(thumbUrl) : '';
+
+    return `<li>
+      <a href="${escapeText(href)}" data-id="${escapeText(n.id)}"
+         class="inbox-row group block rounded-xl ${stateClasses} px-3.5 py-3 transition-all hover:ring-emerald-300 dark:hover:ring-emerald-800/80 hover:shadow-sm">
+        <div class="flex items-start gap-3">
+          <div class="relative shrink-0">${icon}${avatar}</div>
+          <div class="min-w-0 flex-1">
+            <div class="text-sm leading-snug text-zinc-700 dark:text-zinc-300">${text}</div>
+            <div class="mt-0.5 flex items-center gap-2 text-[11px] text-zinc-500 dark:text-zinc-500">
+              <span class="tabular-nums">${escapeText(when)}</span>
+              ${unread ? `<span class="inline-block h-1.5 w-1.5 rounded-full bg-emerald-600 dark:bg-emerald-500" aria-label="${escapeText(lang === 'es' ? 'no leído' : 'unread')}"></span>` : ''}
+            </div>
+          </div>
+          ${thumb}
+        </div>
+      </a>
     </li>`;
   }
 
@@ -150,15 +293,25 @@ const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
     document.getElementById('inbox-empty')?.classList.remove('hidden');
   }
 
-  function showList(html: string) {
+  function showList(html: string, unreadCount: number) {
     document.getElementById('inbox-loading')?.classList.add('hidden');
     const list = document.getElementById('inbox-list');
     if (list) {
       list.innerHTML = html;
       list.classList.remove('hidden');
     }
+    const counter = document.getElementById('inbox-unread-count');
+    if (counter) {
+      if (unreadCount > 0) {
+        counter.textContent = lang === 'es'
+          ? `${unreadCount} sin leer`
+          : `${unreadCount} unread`;
+      } else {
+        counter.textContent = '';
+      }
+    }
     const markAll = document.getElementById('inbox-mark-all-read');
-    markAll?.classList.remove('hidden');
+    if (unreadCount > 0) markAll?.classList.remove('hidden');
   }
 
   async function init() {
@@ -179,7 +332,7 @@ const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
       .select('id, kind, payload, read_at, created_at')
       .eq('user_id', user.id)
       .order('created_at', { ascending: false })
-      .limit(100);
+      .limit(50);
     if (error) {
       showEmpty();
       return;
@@ -189,7 +342,67 @@ const signInLabel = (tr.nav as unknown as Record<string, string>)?.signIn
       showEmpty();
       return;
     }
-    showList(rows.map(renderRow).join(''));
+
+    // Batch-resolve actor info + observation thumbnails so we render
+    // names + avatars + photos without an N+1.
+    const actorIds = new Set<string>();
+    const obsIds = new Set<string>();
+    for (const r of rows) {
+      const p = (r.payload ?? {}) as Record<string, unknown>;
+      if (typeof p.actor_id === 'string') actorIds.add(p.actor_id);
+      if (r.kind === 'reaction' && typeof p.target_id === 'string') {
+        obsIds.add(p.target_id);
+      }
+    }
+
+    const actorById = new Map<string, ActorInfo>();
+    if (actorIds.size > 0) {
+      const { data: users } = await supabase
+        .from('users')
+        .select('id, username, display_name, avatar_url')
+        .in('id', Array.from(actorIds));
+      for (const u of (users ?? []) as ActorInfo[]) actorById.set(u.id, u);
+    }
+
+    const thumbByObsId = new Map<string, string>();
+    if (obsIds.size > 0) {
+      const { data: media } = await supabase
+        .from('media_files')
+        .select('observation_id, url, is_primary, created_at')
+        .in('observation_id', Array.from(obsIds))
+        .order('is_primary', { ascending: false })
+        .order('created_at', { ascending: true });
+      for (const m of (media ?? []) as (MediaThumb & { is_primary?: boolean })[]) {
+        if (!thumbByObsId.has(m.observation_id) && m.url) {
+          thumbByObsId.set(m.observation_id, m.url);
+        }
+      }
+    }
+
+    let unread = 0;
+    const html = rows.map((n) => {
+      if (!n.read_at) unread++;
+      const p = (n.payload ?? {}) as Record<string, unknown>;
+      const actor = (typeof p.actor_id === 'string') ? (actorById.get(p.actor_id as string) ?? null) : null;
+      const target = (n.kind === 'reaction' && typeof p.target_id === 'string')
+        ? (thumbByObsId.get(p.target_id as string) ?? null)
+        : null;
+      return renderRow(n, actor, target);
+    }).join('');
+    showList(html, unread);
+
+    // Click row → mark this notification as read (best-effort) before
+    // navigation. Fire-and-forget so the navigation isn't blocked.
+    document.querySelectorAll<HTMLAnchorElement>('.inbox-row').forEach((row) => {
+      row.addEventListener('click', () => {
+        const id = row.dataset.id;
+        if (!id) return;
+        getSupabase().from('notifications')
+          .update({ read_at: new Date().toISOString() })
+          .eq('id', id)
+          .then(() => undefined, () => undefined);
+      });
+    });
 
     const markAll = document.getElementById('inbox-mark-all-read') as HTMLButtonElement | null;
     markAll?.addEventListener('click', async () => {

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -86,10 +86,57 @@ const pm = pmTree.privacy;
         <p data-pp-bio class="mt-2 text-sm text-zinc-700 dark:text-zinc-300 hidden"></p>
         <p data-pp-since class="mt-2 text-xs text-zinc-500"></p>
         <p data-pp-name-owner-only data-owner-only-badge class="hidden mt-1 text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400"></p>
+        <div data-pp-social-pills class="hidden mt-3 flex items-center gap-4 text-sm">
+          <a data-pp-followers-link href="#" class="group inline-flex items-baseline gap-1.5 text-zinc-700 dark:text-zinc-300 hover:text-emerald-700 dark:hover:text-emerald-400 transition-colors">
+            <span data-pp-followers-count class="font-semibold tabular-nums text-zinc-900 dark:text-zinc-100 group-hover:text-emerald-700 dark:group-hover:text-emerald-400">0</span>
+            <span class="text-xs uppercase tracking-wider text-zinc-500 dark:text-zinc-400">{lang === 'es' ? 'seguidores' : 'followers'}</span>
+          </a>
+          <span class="h-3 w-px bg-zinc-300 dark:bg-zinc-700" aria-hidden="true"></span>
+          <a data-pp-following-link href="#" class="group inline-flex items-baseline gap-1.5 text-zinc-700 dark:text-zinc-300 hover:text-emerald-700 dark:hover:text-emerald-400 transition-colors">
+            <span data-pp-following-count class="font-semibold tabular-nums text-zinc-900 dark:text-zinc-100 group-hover:text-emerald-700 dark:group-hover:text-emerald-400">0</span>
+            <span class="text-xs uppercase tracking-wider text-zinc-500 dark:text-zinc-400">{lang === 'es' ? 'siguiendo' : 'following'}</span>
+          </a>
+        </div>
       </div>
       <div class="shrink-0 flex flex-col gap-2 items-end">
         <FollowButton lang={lang} />
         <ShareButton lang={lang} id="profile-share-btn" />
+        <div data-pp-overflow class="hidden relative">
+          <button
+            type="button"
+            data-pp-overflow-trigger
+            class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-200 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-900 transition-colors"
+            aria-label={lang === 'es' ? 'Más opciones' : 'More options'}
+            aria-haspopup="menu"
+            aria-expanded="false"
+          >
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg>
+          </button>
+          <div
+            data-pp-overflow-menu
+            class="hidden absolute right-0 top-11 z-30 min-w-[180px] rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-lg overflow-hidden"
+            role="menu"
+          >
+            <button
+              type="button"
+              data-pp-action="block"
+              class="flex w-full items-center gap-2.5 px-3.5 py-2.5 text-sm text-zinc-800 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+              role="menuitem"
+            >
+              <svg class="h-4 w-4 text-zinc-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
+              <span data-pp-action-block-label>{tr.socialgraph.block.button}</span>
+            </button>
+            <button
+              type="button"
+              data-pp-action="report"
+              class="flex w-full items-center gap-2.5 px-3.5 py-2.5 text-sm text-zinc-800 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors border-t border-zinc-100 dark:border-zinc-800"
+              role="menuitem"
+            >
+              <svg class="h-4 w-4 text-zinc-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 22V4a2 2 0 0 1 2-2h11l4 6-4 6H6"/><line x1="4" y1="22" x2="4" y2="14"/></svg>
+              <span data-pp-action-report-label>{tr.socialgraph.report.button}</span>
+            </button>
+          </div>
+        </div>
       </div>
     </header>
 
@@ -161,6 +208,8 @@ const pm = pmTree.privacy;
     joined_at: string | null;
     karma_total: number | null;
     credentialed_researcher: boolean | null;
+    follower_count: number | null;
+    following_count: number | null;
   };
 
   type FacetMap = Partial<Record<string, boolean>>;
@@ -207,7 +256,7 @@ const pm = pmTree.privacy;
 
     const { data: profile } = await supabase
       .from('users')
-      .select('id, username, display_name, bio, avatar_url, region_primary, joined_at, karma_total, credentialed_researcher')
+      .select('id, username, display_name, bio, avatar_url, region_primary, joined_at, karma_total, credentialed_researcher, follower_count, following_count')
       .eq('username', username)
       .maybeSingle<PublicUser>();
 
@@ -329,6 +378,87 @@ const pm = pmTree.privacy;
       const lab = root.dataset.labelMemberSince ?? '';
       const sEl = root.querySelector<HTMLElement>('[data-pp-since]');
       if (sEl) sEl.textContent = `${lab}: ${new Date(profile.joined_at).toLocaleDateString(lang)}`;
+    }
+
+    // Followers / following pills — visible on every public profile,
+    // independent of the privacy facet matrix. Counts come from the
+    // denormalised columns maintained by tg_follows_counter.
+    if (profile.username) {
+      const pillsEl = root.querySelector<HTMLElement>('[data-pp-social-pills]');
+      const fwLink = root.querySelector<HTMLAnchorElement>('[data-pp-followers-link]');
+      const fwCount = root.querySelector<HTMLElement>('[data-pp-followers-count]');
+      const fgLink = root.querySelector<HTMLAnchorElement>('[data-pp-following-link]');
+      const fgCount = root.querySelector<HTMLElement>('[data-pp-following-count]');
+      const handle = profile.username;
+      const followersPath = `/${lang}/${lang === 'es' ? 'perfil' : 'profile'}/u/${lang === 'es' ? 'seguidores' : 'followers'}/?username=${encodeURIComponent(handle)}`;
+      const followingPath = `/${lang}/${lang === 'es' ? 'perfil' : 'profile'}/u/${lang === 'es' ? 'siguiendo' : 'following'}/?username=${encodeURIComponent(handle)}`;
+      if (fwLink) fwLink.href = followersPath;
+      if (fgLink) fgLink.href = followingPath;
+      if (fwCount) fwCount.textContent = String(profile.follower_count ?? 0);
+      if (fgCount) fgCount.textContent = String(profile.following_count ?? 0);
+      pillsEl?.classList.remove('hidden');
+    }
+
+    // Overflow menu (Block / Report) — only shown for non-self viewers
+    // who are signed in. Self-view never sees these affordances.
+    if (!isOwner && viewer) {
+      const ovWrap = root.querySelector<HTMLElement>('[data-pp-overflow]');
+      const trigger = root.querySelector<HTMLButtonElement>('[data-pp-overflow-trigger]');
+      const menu = root.querySelector<HTMLElement>('[data-pp-overflow-menu]');
+      ovWrap?.classList.remove('hidden');
+      const closeMenu = () => {
+        menu?.classList.add('hidden');
+        trigger?.setAttribute('aria-expanded', 'false');
+      };
+      const openMenu = () => {
+        menu?.classList.remove('hidden');
+        trigger?.setAttribute('aria-expanded', 'true');
+      };
+      trigger?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (menu?.classList.contains('hidden')) openMenu(); else closeMenu();
+      });
+      document.addEventListener('click', (e) => {
+        if (!ovWrap?.contains(e.target as Node)) closeMenu();
+      });
+      document.addEventListener('keydown', (e) => {
+        if ((e as KeyboardEvent).key === 'Escape') closeMenu();
+      });
+
+      const blockBtn = menu?.querySelector<HTMLButtonElement>('[data-pp-action="block"]');
+      const reportBtn = menu?.querySelector<HTMLButtonElement>('[data-pp-action="report"]');
+      const handleStr = profile.username ?? '';
+
+      blockBtn?.addEventListener('click', async () => {
+        closeMenu();
+        const confirmCopy = lang === 'es'
+          ? `¿Bloquear a @${handleStr}?\n\nNo verán tus reacciones ni tú las suyas. Puedes deshacerlo en Ajustes → Privacidad.`
+          : `Block @${handleStr}?\n\nThey won't see your reactions and you won't see theirs. You can undo this in Settings → Privacy.`;
+        if (!confirm(confirmCopy)) return;
+        blockBtn.disabled = true;
+        try {
+          const { blockUser } = await import('../lib/social');
+          await blockUser(profile.id);
+          alert(lang === 'es' ? 'Usuario bloqueado.' : 'User blocked.');
+        } catch (err) {
+          alert(lang === 'es' ? 'No se pudo bloquear.' : 'Could not block.');
+          // eslint-disable-next-line no-console
+          console.warn('[profile.block]', err);
+        } finally {
+          blockBtn.disabled = false;
+        }
+      });
+
+      reportBtn?.addEventListener('click', () => {
+        closeMenu();
+        const dialog = document.getElementById('rastrum-report-dialog');
+        if (dialog) {
+          (dialog as HTMLElement).dataset.target = 'user';
+          (dialog as HTMLElement).dataset.targetId = profile.id;
+          (dialog as HTMLElement).dataset.targetLabel = '@' + handleStr;
+          dialog.classList.remove('hidden');
+        }
+      });
     }
 
     // Stats

--- a/src/components/ReactionStrip.astro
+++ b/src/components/ReactionStrip.astro
@@ -1,15 +1,22 @@
 ---
 /**
- * ReactionStrip — target-aware reaction buttons (observation / photo / identification).
+ * ReactionStrip — target-aware reaction pills.
  *
- * Server props seed counts and the current user's prior reactions; client
- * script toggles via the `react` Edge Function (see src/lib/social.ts).
+ * Self-hydrating: the component renders an empty shell, then on mount
+ * queries `<target>_reactions` for counts + the viewer's prior
+ * reactions. Toggling fires `react()` (src/lib/social.ts) which calls
+ * the m26 `react` Edge Function (rate-limited, idempotent).
  *
- * Optimistic UI: flip pressed state + count immediately, roll back on error.
+ * Optimistic UI: flip pressed state + count immediately, roll back
+ * on error.
  *
- * NOTE: card wiring deferred — call sites that render this need a
- * `reaction_counts` aggregate + `my_reactions` array; the SQL/RPC for
- * that lands in a follow-up task.
+ * Surface (v1):
+ *   observation     → ❤ Fave
+ *   photo           → ❤ Fave  · ✓ Helpful
+ *   identification  → ✓ Agree · ✕ Disagree
+ *
+ * The schema permits more reaction kinds; surfacing more here is a
+ * UX change, not a migration.
  */
 import { t } from '../i18n/utils';
 
@@ -17,77 +24,182 @@ interface Props {
   lang: 'en' | 'es';
   target: 'observation' | 'photo' | 'identification';
   targetId: string;
-  initialCounts: Record<string, number>;
-  myReactions: string[];
+  /** Visual size: `sm` for inline cards, `md` for detail views. */
+  size?: 'sm' | 'md';
 }
 
-const { lang, target, targetId, initialCounts, myReactions } = Astro.props;
+const { lang, target, targetId, size = 'sm' } = Astro.props;
 const tr = t(lang).socialgraph.reactions;
+const labels = tr as unknown as Record<string, string>;
 
-const KIND_BY_TARGET = {
+const KINDS_BY_TARGET = {
   observation: ['fave'] as const,
   photo: ['fave', 'helpful'] as const,
   identification: ['agree_id', 'disagree_id'] as const,
-} as const;
-const kinds = KIND_BY_TARGET[target];
-
-const ICONS: Record<string, string> = {
-  fave: '❤',
-  helpful: '✓',
-  agree_id: '✓',
-  disagree_id: '✕',
 };
+const kinds = KINDS_BY_TARGET[target];
 
-const labels = tr as unknown as Record<string, string>;
+const sizeClasses = size === 'md'
+  ? 'h-9 gap-1.5 px-3 text-sm'
+  : 'h-7 gap-1 px-2.5 text-[12px]';
 ---
 <div
-  class="flex items-center gap-2"
+  class="rastrum-reactions inline-flex items-center gap-1.5"
   data-reaction-target={target}
   data-reaction-target-id={targetId}
+  data-rs-size={size}
 >
   {kinds.map((kind) => (
     <button
       type="button"
-      class={`reaction-btn rounded-full border px-2 py-1 text-xs ${myReactions.includes(kind) ? 'bg-emerald-100 border-emerald-400' : 'border-stone-300 hover:bg-stone-100'}`}
+      class={`reaction-btn group inline-flex items-center justify-center rounded-full border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 text-zinc-600 dark:text-zinc-400 hover:border-emerald-300 dark:hover:border-emerald-800 hover:text-emerald-700 dark:hover:text-emerald-400 hover:bg-emerald-50/60 dark:hover:bg-emerald-950/30 transition-colors disabled:opacity-50 ${sizeClasses}`}
       data-kind={kind}
       aria-label={labels[kind]}
-      aria-pressed={myReactions.includes(kind) ? 'true' : 'false'}
+      aria-pressed="false"
+      title={labels[kind]}
     >
-      <span aria-hidden="true">{ICONS[kind]}</span>
-      <span class="count">{initialCounts[kind] ?? 0}</span>
+      <span class="reaction-glyph" aria-hidden="true">
+        {kind === 'fave' && (
+          <svg class={`${size === 'md' ? 'h-4 w-4' : 'h-3.5 w-3.5'}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/>
+          </svg>
+        )}
+        {kind === 'helpful' && (
+          <svg class={`${size === 'md' ? 'h-4 w-4' : 'h-3.5 w-3.5'}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="20 6 9 17 4 12"/>
+          </svg>
+        )}
+        {kind === 'agree_id' && (
+          <svg class={`${size === 'md' ? 'h-4 w-4' : 'h-3.5 w-3.5'}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="20 6 9 17 4 12"/>
+          </svg>
+        )}
+        {kind === 'disagree_id' && (
+          <svg class={`${size === 'md' ? 'h-4 w-4' : 'h-3.5 w-3.5'}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        )}
+      </span>
+      <span class="reaction-count tabular-nums font-medium">0</span>
     </button>
   ))}
 </div>
 
 <script>
+  import { getSupabase } from '../lib/supabase';
   import { react } from '../lib/social';
 
-  for (const root of document.querySelectorAll<HTMLDivElement>('[data-reaction-target]')) {
-    const targetType = root.dataset.reactionTarget as 'observation' | 'photo' | 'identification';
-    const targetId = root.dataset.reactionTargetId!;
-    for (const btn of root.querySelectorAll<HTMLButtonElement>('.reaction-btn')) {
+  type ReactTarget = 'observation' | 'photo' | 'identification';
+
+  const TABLE_BY_TARGET: Record<ReactTarget, { table: string; col: string }> = {
+    observation:    { table: 'observation_reactions',    col: 'observation_id' },
+    photo:          { table: 'photo_reactions',          col: 'media_file_id' },
+    identification: { table: 'identification_reactions', col: 'identification_id' },
+  };
+
+  const PRESSED_CLASSES = [
+    'bg-emerald-100', 'dark:bg-emerald-950/40',
+    'border-emerald-400', 'dark:border-emerald-700',
+    'text-emerald-800', 'dark:text-emerald-300',
+  ];
+  const IDLE_CLASSES = [
+    'bg-white', 'dark:bg-zinc-900',
+    'border-zinc-200', 'dark:border-zinc-800',
+    'text-zinc-600', 'dark:text-zinc-400',
+  ];
+
+  function paint(btn: HTMLButtonElement, pressed: boolean) {
+    btn.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+    if (pressed) {
+      btn.classList.remove(...IDLE_CLASSES);
+      btn.classList.add(...PRESSED_CLASSES);
+    } else {
+      btn.classList.remove(...PRESSED_CLASSES);
+      btn.classList.add(...IDLE_CLASSES);
+    }
+  }
+
+  async function hydrate(root: HTMLElement) {
+    const target = root.dataset.reactionTarget as ReactTarget | undefined;
+    const targetId = root.dataset.reactionTargetId;
+    if (!target || !targetId) return;
+
+    let supabase;
+    try { supabase = getSupabase(); } catch { return; }
+
+    const { table, col } = TABLE_BY_TARGET[target];
+    const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('.reaction-btn'));
+
+    // Counts (any user can read aggregates; RLS gates per-row but
+    // count(*) over a permitted scope works the same).
+    const { data: rows } = await supabase
+      .from(table)
+      .select('kind')
+      .eq(col, targetId);
+    const counts: Record<string, number> = {};
+    for (const r of (rows ?? []) as { kind: string }[]) {
+      counts[r.kind] = (counts[r.kind] ?? 0) + 1;
+    }
+
+    // My reactions
+    const { data: { user } } = await supabase.auth.getUser();
+    const mine = new Set<string>();
+    if (user) {
+      const { data: myRows } = await supabase
+        .from(table)
+        .select('kind')
+        .eq(col, targetId)
+        .eq('user_id', user.id);
+      for (const r of (myRows ?? []) as { kind: string }[]) mine.add(r.kind);
+    }
+
+    for (const btn of buttons) {
+      const kind = btn.dataset.kind ?? '';
+      const countEl = btn.querySelector<HTMLElement>('.reaction-count');
+      if (countEl) countEl.textContent = String(counts[kind] ?? 0);
+      paint(btn, mine.has(kind));
+
       btn.addEventListener('click', async () => {
-        btn.disabled = true;
-        const kind = btn.dataset.kind! as Parameters<typeof react>[0]['kind'];
-        const countEl = btn.querySelector('.count')!;
+        if (!user) {
+          // Redirect to sign-in; preserve URL on return.
+          const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
+          location.href = lang === 'es' ? '/es/ingresar/?next=' + encodeURIComponent(location.pathname) : '/en/sign-in/?next=' + encodeURIComponent(location.pathname);
+          return;
+        }
         const wasOn = btn.getAttribute('aria-pressed') === 'true';
+        // Optimistic update.
+        paint(btn, !wasOn);
+        if (countEl) {
+          const cur = Number(countEl.textContent ?? '0');
+          countEl.textContent = String(Math.max(0, wasOn ? cur - 1 : cur + 1));
+        }
+        btn.disabled = true;
         try {
-          const r = await react({ target: targetType, target_id: targetId, kind });
-          if (r.action === 'inserted') {
-            btn.setAttribute('aria-pressed', 'true');
-            btn.classList.add('bg-emerald-100', 'border-emerald-400');
-            countEl.textContent = String(Number(countEl.textContent ?? '0') + 1);
-          } else if (r.action === 'deleted') {
-            btn.setAttribute('aria-pressed', 'false');
-            btn.classList.remove('bg-emerald-100', 'border-emerald-400');
-            countEl.textContent = String(Math.max(0, Number(countEl.textContent ?? '0') - 1));
+          await react({ target, target_id: targetId, kind: kind as 'fave' | 'helpful' | 'agree_id' | 'disagree_id' | 'needs_id' | 'confirm_id' });
+        } catch (err) {
+          // Rollback.
+          paint(btn, wasOn);
+          if (countEl) {
+            const cur = Number(countEl.textContent ?? '0');
+            countEl.textContent = String(Math.max(0, wasOn ? cur + 1 : cur - 1));
           }
-        } catch {
-          btn.setAttribute('aria-pressed', wasOn ? 'true' : 'false');
+          // eslint-disable-next-line no-console
+          console.warn('[react]', err);
         } finally {
           btn.disabled = false;
         }
       });
     }
   }
+
+  function tryHydrateAll() {
+    for (const root of document.querySelectorAll<HTMLElement>('.rastrum-reactions')) {
+      if (root.dataset.rsHydrated === '1') continue;
+      if (!root.dataset.reactionTargetId) continue;
+      root.dataset.rsHydrated = '1';
+      hydrate(root).catch(() => { /* env not configured */ });
+    }
+  }
+  tryHydrateAll();
+  document.addEventListener('rastrum:reactions-ready', tryHydrateAll);
 </script>

--- a/src/components/ReportDialog.astro
+++ b/src/components/ReportDialog.astro
@@ -1,0 +1,175 @@
+---
+/**
+ * ReportDialog — shared modal for reporting any user / observation /
+ * photo / identification. Other components open it by setting
+ * `dataset.target` + `dataset.targetId` (+ `dataset.targetLabel`) on
+ * `#rastrum-report-dialog` and removing the `hidden` class.
+ *
+ * Submit calls `reportTarget()` from `src/lib/social.ts` which posts
+ * to the `report` Edge Function. Best-effort operator email goes from
+ * the function side; the user just sees a toast.
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+
+const { lang } = Astro.props;
+const tr = t(lang);
+const reportTr = tr.socialgraph.report;
+---
+
+<div
+  id="rastrum-report-dialog"
+  class="hidden fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/60 backdrop-blur-sm px-4"
+  data-lang={lang}
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="rastrum-report-title"
+>
+  <div class="w-full max-w-md rounded-2xl bg-white dark:bg-zinc-900 ring-1 ring-zinc-200 dark:ring-zinc-800 shadow-2xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
+    <header class="px-5 py-4 border-b border-zinc-100 dark:border-zinc-800">
+      <h2 id="rastrum-report-title" class="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+        <span data-rd-title-text>{reportTr.title.replace('{{target}}', '')}</span>
+        <span data-rd-target-label class="ml-1 text-zinc-500 dark:text-zinc-400 font-normal"></span>
+      </h2>
+    </header>
+
+    <form id="rastrum-report-form" class="px-5 py-4 space-y-4">
+      <fieldset class="space-y-1.5">
+        <legend class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+          {lang === 'es' ? 'Motivo' : 'Reason'}
+        </legend>
+        {[
+          ['spam',              reportTr.reasons.spam],
+          ['harassment',        reportTr.reasons.harassment],
+          ['wrong_id',          reportTr.reasons.wrong_id],
+          ['privacy_violation', reportTr.reasons.privacy_violation],
+          ['copyright',         reportTr.reasons.copyright],
+          ['other',             reportTr.reasons.other],
+        ].map(([value, label]) => (
+          <label class="flex items-center gap-2.5 px-3 py-2 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-800/60 cursor-pointer transition-colors">
+            <input
+              type="radio"
+              name="reason"
+              value={value}
+              required
+              class="h-4 w-4 text-emerald-700 focus:ring-emerald-500 border-zinc-300 dark:border-zinc-700"
+            />
+            <span class="text-sm text-zinc-800 dark:text-zinc-200">{label}</span>
+          </label>
+        ))}
+      </fieldset>
+
+      <div class="space-y-1.5">
+        <label for="rastrum-report-note" class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+          {lang === 'es' ? 'Nota (opcional)' : 'Note (optional)'}
+        </label>
+        <textarea
+          id="rastrum-report-note"
+          name="note"
+          rows="3"
+          maxlength="1000"
+          placeholder={reportTr.note_placeholder}
+          class="block w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-950 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-600 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
+        ></textarea>
+      </div>
+
+      <p data-rd-error class="hidden text-sm text-rose-600 dark:text-rose-400"></p>
+      <p data-rd-thanks class="hidden rounded-lg bg-emerald-50 dark:bg-emerald-950/40 px-3 py-2 text-sm text-emerald-800 dark:text-emerald-300 ring-1 ring-emerald-200 dark:ring-emerald-900/60">
+        {reportTr.thanks}
+      </p>
+
+      <footer class="flex items-center justify-end gap-2 pt-2">
+        <button
+          type="button"
+          data-rd-cancel
+          class="px-4 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors"
+        >
+          {lang === 'es' ? 'Cancelar' : 'Cancel'}
+        </button>
+        <button
+          type="submit"
+          data-rd-submit
+          class="inline-flex min-h-[40px] items-center justify-center rounded-lg bg-emerald-700 hover:bg-emerald-800 px-5 py-2 text-sm font-semibold text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {reportTr.submit}
+        </button>
+      </footer>
+    </form>
+  </div>
+</div>
+
+<script>
+  import { reportTarget } from '../lib/social';
+
+  type ReportTarget = 'user' | 'observation' | 'photo' | 'identification' | 'comment';
+  type ReportReason = 'spam' | 'harassment' | 'wrong_id' | 'privacy_violation' | 'copyright' | 'other';
+
+  const dialog = document.getElementById('rastrum-report-dialog');
+  if (dialog) {
+    const form = dialog.querySelector<HTMLFormElement>('#rastrum-report-form');
+    const submit = dialog.querySelector<HTMLButtonElement>('[data-rd-submit]');
+    const cancel = dialog.querySelector<HTMLButtonElement>('[data-rd-cancel]');
+    const targetLabelEl = dialog.querySelector<HTMLElement>('[data-rd-target-label]');
+    const errorEl = dialog.querySelector<HTMLElement>('[data-rd-error]');
+    const thanksEl = dialog.querySelector<HTMLElement>('[data-rd-thanks]');
+
+    function close() {
+      dialog?.classList.add('hidden');
+      form?.reset();
+      errorEl?.classList.add('hidden');
+      thanksEl?.classList.add('hidden');
+      if (submit) submit.disabled = false;
+    }
+
+    cancel?.addEventListener('click', close);
+    dialog.addEventListener('click', (e) => {
+      if (e.target === dialog) close();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (!dialog.classList.contains('hidden') && (e as KeyboardEvent).key === 'Escape') close();
+    });
+
+    // Update the target-label whenever the dialog is opened.
+    const observer = new MutationObserver(() => {
+      if (!dialog.classList.contains('hidden') && targetLabelEl) {
+        targetLabelEl.textContent = dialog.dataset.targetLabel ?? '';
+      }
+    });
+    observer.observe(dialog, { attributes: true, attributeFilter: ['class', 'data-target', 'data-target-id', 'data-target-label'] });
+
+    form?.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (!submit || !form) return;
+      const target = (dialog.dataset.target as ReportTarget | undefined) ?? 'user';
+      const targetId = dialog.dataset.targetId ?? '';
+      if (!targetId) return;
+
+      const fd = new FormData(form);
+      const reason = (fd.get('reason') ?? '') as ReportReason;
+      const note = (fd.get('note') ?? '').toString().trim().slice(0, 1000) || undefined;
+      if (!reason) return;
+
+      submit.disabled = true;
+      errorEl?.classList.add('hidden');
+      try {
+        await reportTarget({ target, target_id: targetId, reason, note });
+        thanksEl?.classList.remove('hidden');
+        setTimeout(close, 1400);
+      } catch (err) {
+        if (errorEl) {
+          const lang = dialog.dataset.lang ?? 'en';
+          errorEl.textContent = lang === 'es'
+            ? 'No se pudo enviar el reporte. Intenta de nuevo.'
+            : "Couldn't submit the report. Try again.";
+          errorEl.classList.remove('hidden');
+        }
+        // eslint-disable-next-line no-console
+        console.warn('[report.submit]', err);
+        submit.disabled = false;
+      }
+    });
+  }
+</script>

--- a/src/components/ReportDialog.astro
+++ b/src/components/ReportDialog.astro
@@ -116,12 +116,34 @@ const reportTr = tr.socialgraph.report;
     const errorEl = dialog.querySelector<HTMLElement>('[data-rd-error]');
     const thanksEl = dialog.querySelector<HTMLElement>('[data-rd-thanks]');
 
+    let lastFocused: HTMLElement | null = null;
+
+    const FOCUSABLE_SEL = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    function focusableEls(): HTMLElement[] {
+      return Array.from(dialog!.querySelectorAll<HTMLElement>(FOCUSABLE_SEL))
+        .filter((el) => el.offsetParent !== null);
+    }
+
     function close() {
       dialog?.classList.add('hidden');
       form?.reset();
       errorEl?.classList.add('hidden');
       thanksEl?.classList.add('hidden');
       if (submit) submit.disabled = false;
+      lastFocused?.focus();
+      lastFocused = null;
+    }
+
+    function onOpen() {
+      lastFocused = (document.activeElement as HTMLElement | null) ?? null;
+      if (targetLabelEl) {
+        targetLabelEl.textContent = dialog!.dataset.targetLabel ?? '';
+      }
+      // Focus the first reason radio so keyboard users land in-form.
+      const first = dialog!.querySelector<HTMLElement>('input[type="radio"]')
+        ?? focusableEls()[0];
+      first?.focus();
     }
 
     cancel?.addEventListener('click', close);
@@ -129,14 +151,32 @@ const reportTr = tr.socialgraph.report;
       if (e.target === dialog) close();
     });
     document.addEventListener('keydown', (e) => {
-      if (!dialog.classList.contains('hidden') && (e as KeyboardEvent).key === 'Escape') close();
+      const ev = e as KeyboardEvent;
+      if (dialog.classList.contains('hidden')) return;
+      if (ev.key === 'Escape') {
+        close();
+        return;
+      }
+      if (ev.key === 'Tab') {
+        // Trap focus inside the dialog.
+        const els = focusableEls();
+        if (els.length === 0) return;
+        const first = els[0];
+        const last = els[els.length - 1];
+        const active = document.activeElement as HTMLElement | null;
+        if (ev.shiftKey && active === first) {
+          ev.preventDefault();
+          last.focus();
+        } else if (!ev.shiftKey && active === last) {
+          ev.preventDefault();
+          first.focus();
+        }
+      }
     });
 
-    // Update the target-label whenever the dialog is opened.
+    // Update the target-label + focus-in whenever the dialog is opened.
     const observer = new MutationObserver(() => {
-      if (!dialog.classList.contains('hidden') && targetLabelEl) {
-        targetLabelEl.textContent = dialog.dataset.targetLabel ?? '';
-      }
+      if (!dialog.classList.contains('hidden')) onOpen();
     });
     observer.observe(dialog, { attributes: true, attributeFilter: ['class', 'data-target', 'data-target-id', 'data-target-label'] });
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,6 +9,7 @@ import ReportIssueButton from '../components/ReportIssueButton.astro';
 import GlobalShareFab from '../components/GlobalShareFab.astro';
 import SwUpdateToast from '../components/SwUpdateToast.astro';
 import OfflineBanner from '../components/OfflineBanner.astro';
+import ReportDialog from '../components/ReportDialog.astro';
 import { getAlternateUrl } from '../i18n/utils';
 import StructuredData from '../components/StructuredData.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
@@ -160,5 +161,6 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <GlobalShareFab lang={lang} currentPath={currentPath} />
     <OnboardingTour lang={installLang} />
     <SwUpdateToast lang={lang} />
+    <ReportDialog lang={installLang} />
   </body>
 </html>

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -4,6 +4,7 @@ import Comments from '../../../components/Comments.astro';
 import FollowButton from '../../../components/FollowButton.astro';
 import ShareButton from '../../../components/ShareButton.astro';
 import SuggestIdModal from '../../../components/SuggestIdModal.astro';
+import ReactionStrip from '../../../components/ReactionStrip.astro';
 
 // SSG: query string is unknown at build time. Comments component reads
 // observation_id from data attribute, which we set at runtime in the
@@ -25,9 +26,25 @@ const obsIdPlaceholder = '';
           <FollowButton lang={lang} />
         </div>
         <ShareButton lang={lang} id="obs-share-btn" />
+        <button
+          id="obs-report-btn"
+          type="button"
+          class="hidden inline-flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-200 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-700 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+          aria-label="Report observation"
+          title="Report observation"
+        >
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 22V4a2 2 0 0 1 2-2h11l4 6-4 6H6"/><line x1="4" y1="22" x2="4" y2="14"/></svg>
+        </button>
       </header>
 
       <img id="img" src="" alt="" class="w-full max-h-[500px] object-contain rounded-xl border border-zinc-200 dark:border-zinc-800 hidden" />
+
+      <div id="reactions-mount" class="flex items-center gap-3">
+        <ReactionStrip lang={lang} target="observation" targetId={obsIdPlaceholder} size="md" />
+        <span id="reactions-help" class="hidden text-xs text-zinc-500 dark:text-zinc-500">
+          Tap the heart to favorite this observation.
+        </span>
+      </div>
 
       <dl class="grid grid-cols-2 gap-4 text-sm">
         <div>
@@ -240,6 +257,27 @@ const obsIdPlaceholder = '';
           followRoot.dataset.targetId = observerId;
           document.dispatchEvent(new CustomEvent('rastrum:follow-ready'));
         }
+      }
+
+      // Wire reactions strip with the loaded observation id.
+      const reactRoot = document.querySelector<HTMLElement>('#reactions-mount .rastrum-reactions');
+      if (reactRoot) {
+        reactRoot.dataset.reactionTargetId = id;
+        document.dispatchEvent(new CustomEvent('rastrum:reactions-ready'));
+      }
+
+      // Wire report button — only enabled for non-owner signed-in viewers.
+      const reportBtn = document.getElementById('obs-report-btn');
+      if (reportBtn && !viewerIsObserver) {
+        reportBtn.classList.remove('hidden');
+        reportBtn.addEventListener('click', () => {
+          const dialog = document.getElementById('rastrum-report-dialog');
+          if (!dialog) return;
+          (dialog as HTMLElement).dataset.target = 'observation';
+          (dialog as HTMLElement).dataset.targetId = id;
+          (dialog as HTMLElement).dataset.targetLabel = speciesName;
+          dialog.classList.remove('hidden');
+        });
       }
       const social = document.getElementById('social-mount');
       social?.classList.remove('hidden');


### PR DESCRIPTION
## Summary

After M26 shipped, an audit found **6 of 7 social surfaces were dark** — the components were built and the Edge Functions deployed, but nothing in the chrome led to them. This PR closes that gap with deliberate UX, not just minimal wiring.

## What lights up

| Before | After |
|---|---|
| Header bell pointed to `/profile` | **Bell → `/inbox`** with unread badge from `notifications` (capped 9+) |
| `/inbox` rendered raw IDs as plain `<li>` | **Rich notification cards** — actor avatars, type-coded icons (emerald follow / rose heart / sky comment / amber badge), unread emerald rail, "N unread" counter, fire-and-forget mark-read on click, wildlife-inspired empty state with explore CTA |
| Public profile had no follower count | **Followers · Following pills** inline under the bio, linking to `/profile/u/{followers,following}/?username=…` |
| No way to block or report from a profile | **Overflow ⋮ menu** (non-self, signed-in viewers only) — Block (confirm dialog + `blockUser()`) and Report (shared modal) |
| `report` Edge Function was deployed but unreachable | **`ReportDialog`** — global modal in BaseLayout, opens via `#rastrum-report-dialog` dataset. Reason radio (6), optional 1000-char note, calls `reportTarget()`. Esc / backdrop / Cancel all close cleanly. |
| FollowButton bypassed the new `follow` Edge Function | **Calls `followUser()` / `unfollowUser()`** — rate-limits + profile-privacy gating now reachable. Adds a "Requested" state (amber pill) for follows that land in `pending` against private profiles. |
| `ReactionStrip` rendered with required SSR `initialCounts` (impossible for dynamic obs) | **Self-hydrating** — queries `<target>_reactions` on mount, refined SVG icons (stroke heart / check / x), `size: 'sm' \| 'md'`, listens for `rastrum:reactions-ready` so dynamic surfaces can set `targetId` after load. Wired interactive on `/share/obs/`. |

## Design notes

- All accents stay on the existing brand emerald — no new palette. Type-coded icon rings (emerald / rose / sky / amber) give the inbox visual triage without leaning on emoji.
- Skeletons (3 rows) replace the bare "Loading…" string in the inbox.
- ReportDialog uses `animate-in fade-in slide-in-from-bottom-4` for a single decisive entrance — no scattered micro-interactions elsewhere.
- The follower/following pills are minimal text + a thin separator, not a third stats grid — keeps the existing 3-stat scientific grid (Observations / RG / Kingdoms) as the dominant content stat row.
- Block confirm uses `confirm()` for v1; a native dialog upgrade is fine for v1.1 once we have a base modal primitive.

## Out of scope (v1.1 follow-ups)

- Reaction count overlay on ExploreRecent / MyObs cards — needs an RPC to avoid N+1 across the feed.
- "Block this user" / "Report comment" buttons on observation cards and comment threads — reuses the same dialog and `blockUser()` once the surfaces want them.
- Real-time push for inbox (M28).

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 454 passing
- [x] `npm run build` — 104 pages, clean
- [ ] Manual smoke (post-merge): two-account follow → inbox notification → mark-read → click row navigates to profile; react on `/share/obs/?id=…` → count increments; click ⋮ → Block → user disappears from feeds; click ⋮ → Report → submit → "Thanks" toast → operator email arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)