### PR TITLE
docs: sync M26 across all surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Bilingual EN/ES from day one.
 |---|---|
 | [`docs/progress.json`](docs/progress.json)              | Source of truth for the roadmap. Bilingual labels (`_es` suffix). |
 | [`docs/tasks.json`](docs/tasks.json) + [`docs/tasks.md`](docs/tasks.md) | Per-roadmap-item subtask breakdown. Check current status before starting work. |
-| [`docs/specs/modules/00-index.md`](docs/specs/modules/00-index.md) | Catalog of 20 module specs (numbers `01`–`19`, with two `15-` files). Each module has its own design doc. |
+| [`docs/specs/modules/00-index.md`](docs/specs/modules/00-index.md) | Catalog of ~29 module specs. Each module has its own design doc. |
 | [`docs/architecture.md`](docs/architecture.md)            | High-level architecture diagram + critical-path flows. |
 | [`docs/specs/infra/supabase-schema.sql`](docs/specs/infra/supabase-schema.sql) | Idempotent SQL — apply with `make db-apply`. |
 | `Makefile`                                                | Run `make help` to see every dev workflow. |
@@ -41,7 +41,7 @@ make help                     # list every target with descriptions
 make install                  # npm ci
 make dev                      # astro dev — http://localhost:4321
 make build                    # static build into dist/
-make test                     # vitest run (225 tests today)
+make test                     # vitest run (~454 tests today)
 make typecheck                # tsc --noEmit
 make db-apply                 # apply supabase-schema.sql (idempotent)
 make db-verify                # show tables, RLS, triggers, extensions
@@ -51,12 +51,20 @@ make db-cron-test             # fire both cron jobs once + show responses
 make db-psql                  # interactive psql shell
 ```
 
-Edge Function deploys go through CI because the local `supabase` CLI
-(2.90.0) is broken on this project's config:
+Edge Function deploys go through CI (the local `supabase` CLI 2.90.0
+is broken on this project's config). **As of PR #62 this is automatic**
+on push to `main` when any file under `supabase/functions/**` changes —
+the workflow detects the changed function set via `git diff` and only
+redeploys those (mirrors the `db-apply.yml` symmetry). The workflow's
+"all functions" list is derived from `ls supabase/functions/` at
+runtime so it can't drift from disk.
+
+Manual dispatch is still available for surgical rollback / redeploy /
+secrets resync:
 
 ```bash
 gh workflow run deploy-functions.yml --ref main \
-  -f function=identify   # or all / get-upload-url / etc.
+  -f function=identify       # or all / follow / react / report / etc.
 gh run watch <run-id>
 ```
 
@@ -220,6 +228,49 @@ colour requires extending that safelist or the classes will be purged in
 production builds.
 
 Full design rationale: `docs/superpowers/specs/2026-04-26-ux-revamp-design.md`.
+
+### Social surfaces (M26)
+
+The header bell (`BellIcon.astro`) is the entry to the social inbox at
+`/{en,es}/{inbox,bandeja}/`. It polls `notifications` every 60s while
+visible, uses `getSession()` (no server round-trip) to decide whether
+to render itself, and shows a numeric badge capped at "9+". The legacy
+m08 watchlist activity remains accessible from the profile page; a
+unified inbox is a v1.1 follow-up.
+
+Reports use `ReportDialog.astro` — a single global modal mounted in
+`BaseLayout.astro`. Other surfaces open it by setting
+`#rastrum-report-dialog` dataset (`target` / `targetId` /
+`targetLabel`) and removing `.hidden`. Submit calls `reportTarget()`
+from `src/lib/social.ts`. The dialog has a focus trap, restores
+previous focus on close, and closes on Esc / backdrop click.
+
+Public profile (`PublicProfileViewV2.astro`) renders follower/following
+pills under the bio and an overflow ⋮ menu (Block + Report) for non-self
+signed-in viewers. Block uses `confirm()` for v1; Report opens
+`ReportDialog`. The follower/following pages live at
+`/{en,es}/{profile,perfil}/u/{followers,following | seguidores,siguiendo}/`.
+
+`FollowButton.astro` calls the `follow` Edge Function via
+`followUser()` / `unfollowUser()` from `src/lib/social.ts` so
+rate-limits and profile-privacy gating fire server-side. It paints
+4 states: `signin` / `follow` / `following` / `requested` (amber
+pill for follows in `pending` against private profiles).
+
+`ReactionStrip.astro` is self-hydrating: it queries the relevant
+`<target>_reactions` table on mount and listens for the
+`rastrum:reactions-ready` event so dynamic surfaces (e.g.
+`/share/obs/`) can set `data-reaction-target-id` after the
+observation loads. Wired interactive on `/share/obs/`; feed-card
+overlays are a v1.1 follow-up gated on an aggregate RPC to avoid
+N+1 fetches.
+
+i18n: m26 strings live under the `socialgraph.*` namespace —
+`social.*` was already taken by the m08 flat namespace consumed by
+six shipping components, so we added a parallel namespace rather than
+rewriting consumers.
+
+Full design rationale: `docs/superpowers/specs/2026-04-28-social-features-design.md`.
 
 ### Console / privileged surfaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,6 +338,75 @@ browser-tab visits, not just inside the standalone session.
 
 ---
 
+## Social graph (Module 26)
+
+Asymmetric-follow social layer added in v1.2. Composes against the
+existing privacy mechanics — no parallel `visibility` enum on
+observations.
+
+**Tables (all RLS-enabled):**
+- `follows(follower_id, followee_id, tier ∈ {follower,collaborator}, status ∈ {pending,accepted}, requested_at, accepted_at)`
+- `observation_reactions(user_id, observation_id, kind, …)` — kinds
+  `fave`/`agree_id`/`needs_id`/`confirm_id`/`helpful`
+- `photo_reactions(user_id, media_file_id, kind, …)` — kinds `fave`/`helpful`
+- `identification_reactions(user_id, identification_id, kind, …)` —
+  kinds `agree_id`/`disagree_id`/`helpful`
+- `blocks(blocker_id, blocked_id)` — read-symmetric: hide rows in
+  both directions
+- `reports(reporter_id, target_type, target_id, reason, note, status)`
+- `notifications(user_id, kind, payload jsonb, read_at, created_at)` —
+  pruned daily by `pg_cron` at 04:30 UTC for `read_at < now() - 90 days`
+
+**Counter columns** (denormalised, trigger-maintained):
+`users.follower_count` / `users.following_count`. Updated by
+`tg_follows_counter` only when `status='accepted'` is gained or lost.
+
+**Privacy helpers** (STABLE SQL, inlined into RLS predicates):
+- `social_visible_to(viewer, owner)` — owner-or-accepted-follower
+- `is_collaborator_of(viewer, owner)` — accepted collaborator-tier
+  follower; gives the same coord-precision unlock on obscured obs that
+  `is_credentialed_researcher` does
+
+**Edge Functions** (deployed via auto-deploy on push to `main`):
+- `follow` — request/accept/reject + collaborator-tier upgrades; rate
+  limits 30 follows/hr, 5 collab requests/day
+- `react` — idempotent (target, kind) toggle on the per-target tables;
+  rate limit 200/hr
+- `report` — inserts into `reports`, best-effort operator email via
+  Resend; rate limit 10/day
+
+**Fan-out triggers** (skip blocked recipients before insert):
+- `tg_follow_notify` on `follows` insert/update → `notifications`
+  (kinds `follow` / `follow_accepted`)
+- `tg_obsreact_notify` on `observation_reactions` insert →
+  `notifications` (kind `reaction`)
+
+**RLS pattern for reactions** (illustrative):
+
+```
+reaction is readable
+  iff observation is readable
+       AND not block-symmetric to viewer.
+
+observation is readable
+  iff o.observer_id = auth.uid()
+       OR (o.obscure_level <> 'full'
+           AND can_see_facet(o.observer_id, 'observations', auth.uid()))
+       OR is_collaborator_of(auth.uid(), o.observer_id)
+```
+
+**UI surfaces (chrome integration in v1.2):**
+- Header bell → `/inbox` ↔ `/bandeja` with unread badge
+- Public profile: follower / following pills + overflow ⋮ menu (Block /
+  Report)
+- `/share/obs/` observation viewer: interactive `ReactionStrip` + Report
+  button next to Follow / Share
+- Settings → Privacy: blocked users list
+
+Full spec + plan: [`docs/superpowers/specs/2026-04-28-social-features-design.md`](superpowers/specs/2026-04-28-social-features-design.md), [`docs/superpowers/plans/2026-04-28-m26-social-graph.md`](superpowers/plans/2026-04-28-m26-social-graph.md).
+
+---
+
 ## Further reading
 
 - [`AGENTS.md`](../AGENTS.md) — conventions, pitfalls, pre-PR checklist.

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -785,6 +785,26 @@
           "label_es": "Grafo social + reacciones (Módulo 26) — seguimiento asimétrico + nivel colaborador opcional, reacciones por objetivo (observación/foto/identificación), bloqueos, reportes, bandeja en la app, poda 90 días",
           "done": true,
           "done_at": "2026-04-28"
+        },
+        {
+          "id": "social-graph-m26-ui",
+          "label": "M26 UI integration — bell→inbox + unread badge, rich notification cards, profile follower/following pills + Block/Report overflow, shared ReportDialog with focus trap, ReactionStrip on /share/obs/, FollowButton on the new follow Edge Function (Requested state for private profiles)",
+          "label_es": "Integración UI de M26 — campana→bandeja + badge no leídos, tarjetas ricas, pills de seguidores/siguiendo + menú ⋮ Bloquear/Reportar, ReportDialog compartido con focus trap, ReactionStrip en /share/obs/, FollowButton sobre la nueva Edge Function (estado Solicitado en perfiles privados)",
+          "done": true,
+          "done_at": "2026-04-29"
+        },
+        {
+          "id": "ci-cd-edge-auto-deploy",
+          "label": "CI/CD — auto-deploy Edge Functions on path-filtered push (mirrors db-apply.yml). Filesystem-derived function list eliminates drift; manual workflow_dispatch preserved for surgical rollback",
+          "label_es": "CI/CD — auto-deploy de Edge Functions en push con filtro de ruta (refleja db-apply.yml). Lista derivada del filesystem elimina drift; workflow_dispatch manual preservado para rollback quirúrgico",
+          "done": true,
+          "done_at": "2026-04-29"
+        },
+        {
+          "id": "social-graph-m26-v11",
+          "label": "M26 v1.1 follow-ups — ReactionStrip count overlay on feed cards (RPC), Block/Report affordances on observation cards + comments, 'Block from list' on profile lists, focus-trap polish (delivered) + future ARIA refinements",
+          "label_es": "Seguimientos v1.1 de M26 — superposición de conteos ReactionStrip en tarjetas del feed (RPC), Bloquear/Reportar en tarjetas de observación + comentarios, 'Bloquear desde lista' en listas de perfiles, refinamientos ARIA futuros",
+          "done": false
         }
       ]
     },

--- a/docs/runbooks/social-features.md
+++ b/docs/runbooks/social-features.md
@@ -1,0 +1,134 @@
+# Social features — operator runbook
+
+> Module 26 (asymmetric follow + reactions + reports + inbox).
+> Last updated 2026-04-29.
+
+This runbook covers the operator-side of the social layer: env vars,
+email setup, monitoring, and when each surface fails what to look at
+first.
+
+---
+
+## Required env vars
+
+| Secret (GitHub Actions) | Used by | Notes |
+|---|---|---|
+| `SUPABASE_DB_URL` | `db-apply.yml` | Already required pre-M26 — applies the schema + cron. |
+| `SUPABASE_ACCESS_TOKEN` | `deploy-functions.yml` | Already required pre-M26. |
+| `RESEND_API_KEY` | `report` Edge Function | NEW. Without it the function still inserts the row and returns 200 — only the operator email is best-effort suppressed. Free tier: 100 emails/day. |
+| `OPERATOR_EMAIL` | `report` Edge Function | NEW. Defaults to `artemiopadilla@gmail.com` if unset; override per environment. |
+
+The deploy-functions workflow auto-syncs all of the above into
+Supabase Edge Function secrets when `sync_secrets=true` (the
+`workflow_dispatch` default). Push-triggered auto-deploys never
+sync secrets — that path is reserved for explicit dispatch.
+
+---
+
+## Email deliverability (`reports@rastrum.org`)
+
+The `report` Edge Function sends the operator email via Resend with
+`from: "reports@rastrum.org"`. For deliverability:
+
+1. **Verify the `rastrum.org` domain in Resend dashboard.** Add the
+   DKIM CNAME records they provide to your DNS (Cloudflare).
+2. **Add SPF for `rastrum.org`:**
+   ```
+   v=spf1 include:_spf.resend.com ~all
+   ```
+3. **Optional — DMARC** at `_dmarc.rastrum.org`:
+   ```
+   v=DMARC1; p=none; rua=mailto:dmarc@rastrum.org
+   ```
+
+Without DKIM/SPF, Resend may drop messages or Gmail / iCloud may
+silently spam-filter them. The function never fails the user request
+on email error — check the Resend dashboard if a report didn't land.
+
+---
+
+## Schema apply
+
+The m26 schema is part of `docs/specs/infra/supabase-schema.sql` and
+auto-applies on push to `main` via `db-apply.yml` when the SQL file
+changes. To force a re-apply (for example, after editing a single
+trigger):
+
+```bash
+gh workflow run db-apply.yml --ref main
+gh run watch
+```
+
+The 90-day notification prune cron is in
+`docs/specs/infra/cron-schedules.sql`; `make db-cron-schedule` (or
+the workflow on push) re-registers it idempotently.
+
+To smoke-test the schema after apply:
+
+```bash
+psql "$SUPABASE_DB_URL" -f tests/sql/social-rls.sql
+# expects: NOTICE:  social-rls regression OK
+```
+
+---
+
+## When something breaks — first look
+
+| Symptom | First check |
+|---|---|
+| Bell shows no badge for a user with unread notifications | `select count(*) from public.notifications where user_id = '<uid>' and read_at is null` — if 0, the issue is upstream (trigger fan-out or the source action). If > 0, investigate the BellIcon poll (browser console, network tab). |
+| Follow button never moves off "Follow" after clicking | Edge Function logs in Supabase dashboard → `follow`. Common cause: rate-limit (429 `rate_limited`) — the user hit 30 follows/hr or 5 collab requests/day. |
+| Reactions disappear after toggling | Most likely RLS — a reaction row exists in the table but the viewer's RLS predicate filters it (e.g., the observation became `obscure_level = 'full'`, or one of the parties blocked the other). |
+| Report submitted but no email arrives | `reports` table has the row? If yes, check Resend dashboard for delivery / bounce. If no, check the `report` Edge Function logs for an error other than email. |
+| Unread badge stays at "9+" forever | The 90-day prune cron only deletes **read** notifications. A user with 100+ unread will see "9+" until they mark-all-read. The "mark all read" button at the top of `/inbox/` does this in one update. |
+| `db-apply` workflow fails after a schema change | Run it manually via `gh run view <id> --log-failed`. The most common cause is a SQL incompatibility (e.g., the `min(uuid)` bug fixed in PR #62 — Postgres lacks `min()` for the uuid type; cast through text). |
+
+---
+
+## Operations / monitoring
+
+There is no dedicated `social_metrics` view yet — `progress.json`
+tracks it as a follow-up. For now:
+
+- **Daily volume:**
+  ```sql
+  select date_trunc('day', created_at) as d, count(*)
+    from public.notifications group by 1 order by 1 desc limit 30;
+  ```
+- **Most-followed users:**
+  ```sql
+  select u.username, u.follower_count
+    from public.users u
+   order by u.follower_count desc nulls last limit 20;
+  ```
+- **Open reports queue:**
+  ```sql
+  select * from public.reports where status = 'open' order by created_at desc;
+  ```
+
+Reports → moderate by hand for now (set `status` to `triaged` /
+`resolved` / `dismissed`); a moderator UI is on the M28+ roadmap.
+
+---
+
+## Useful URLs
+
+| What | URL |
+|---|---|
+| Resend dashboard | https://resend.com/emails |
+| Supabase Edge Function logs | https://supabase.com/dashboard/project/reppvlqejgoqvitturxp/functions |
+| Supabase auth users | https://supabase.com/dashboard/project/reppvlqejgoqvitturxp/auth/users |
+| GitHub Actions — `deploy-functions.yml` | https://github.com/ArtemioPadilla/rastrum/actions/workflows/deploy-functions.yml |
+| GitHub Actions — `db-apply.yml` | https://github.com/ArtemioPadilla/rastrum/actions/workflows/db-apply.yml |
+
+---
+
+## Related runbooks
+
+- [`docs/runbooks/admin-bootstrap.md`](admin-bootstrap.md) — granting
+  the first admin role.
+- [`docs/runbooks/admin-audit.md`](admin-audit.md) — reading the audit
+  log.
+- [`docs/runbooks/onboarding-events.md`](onboarding-events.md) —
+  onboarding tour signal handling (referenced from the inbox icon
+  semantically).

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -3854,8 +3854,12 @@
       ]
     },
     "social-graph-m26": {
-      "label_en": "Social graph + reactions (Module 26)",
-      "label_es": "Grafo social + reacciones (Módulo 26)",
+      "phase": "v1.2",
+      "title_en": "Social graph + reactions (Module 26)",
+      "title_es": "Grafo social + reacciones (Módulo 26)",
+      "modules": [
+        "26-social-graph.md"
+      ],
       "subtasks": [
         {
           "label_en": "follows table + counters trigger + privacy helpers (social_visible_to, is_collaborator_of) + collaborator coord-precision unlock",
@@ -3903,9 +3907,24 @@
           "status": "done"
         },
         {
-          "label_en": "deferred to operator: make db-apply (schema + cron) + gh workflow run deploy-functions.yml -f function={follow,react,report}",
-          "label_es": "diferido al operador: make db-apply (esquema + cron) + gh workflow run deploy-functions.yml -f function={follow,react,report}",
-          "status": "todo"
+          "label_en": "schema applied to prod (auto-fired by db-apply.yml on merge of #43); MIN(uuid) view bug fixed in #62",
+          "label_es": "esquema aplicado en producción (auto-disparado por db-apply.yml al mergear #43); bug MIN(uuid) corregido en #62",
+          "status": "done"
+        },
+        {
+          "label_en": "Edge Functions deployed (follow/react/report) — auto-deployed by deploy-functions.yml after CI/CD revamp in #62",
+          "label_es": "Edge Functions desplegadas (follow/react/report) — auto-desplegadas por deploy-functions.yml tras la revamp CI/CD en #62",
+          "status": "done"
+        },
+        {
+          "label_en": "UI integration (#63 + #64): BellIcon→/inbox + unread badge, rich notification cards (avatars + thumbnails + type-coded icons + skeletons + empty state), profile follower/following pills, profile overflow ⋮ menu (Block + Report), shared ReportDialog modal in BaseLayout (focus trap + Esc + backdrop close), FollowButton swapped to follow Edge Function with Requested state, ReactionStrip wired interactive on /share/obs/",
+          "label_es": "Integración UI (#63 + #64): BellIcon→/inbox + badge no leídos, tarjetas ricas (avatares + thumbs + iconos por tipo + skeletons + vacío), pills de seguidores/siguiendo en perfil, menú ⋮ en perfil (Bloquear + Reportar), ReportDialog compartido en BaseLayout (focus trap + Esc + click fuera), FollowButton usa Edge Function con estado Solicitado, ReactionStrip activo en /share/obs/",
+          "status": "done"
+        },
+        {
+          "label_en": "v1.1 follow-ups: ReactionStrip count overlay on feed cards (needs RPC), Block/Report on observation cards + comments, real-time push for inbox (M28), 'Block this user' affordance on profile cards in lists",
+          "label_es": "Seguimientos v1.1: superposición de conteos ReactionStrip en tarjetas del feed (requiere RPC), Bloquear/Reportar en tarjetas de observación + comentarios, push en tiempo real para bandeja (M28), 'Bloquear usuario' en tarjetas de listas",
+          "status": "planned"
         }
       ]
     }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -107,3 +107,15 @@ Remaining:
 - `profile-widgets-richer` — Calendar heatmap, taxonomic donut, streak ring, top species grid, observation mini-map, badges grid, activity timeline, Pokédex page, intro banner; reused on `/profile/` (owner). _(✓ done)_
 
 **v1.2.2 cleanup deferred:** visitor `/u/<username>/dex/` route, `Person` JSON-LD on PublicProfileViewV2, wire widgets into visitor `/u/<username>/`, migrate `share/obs/index.astro` off `profile_public`, drop legacy `profile_public` boolean (one-release safety net runs out at v1.3).
+
+## v1.2 — Module 26: Social graph + reactions — shipped 2026-04-28/29
+
+**3 items done, 1 follow-up todo.** Shipped via PRs #43 (foundation), #62 (CI/CD revamp + MIN(uuid) fix), #63 + #64 (UI integration + polish).
+
+- `social-graph-m26` — Asymmetric follow + opt-in close-collaborator tier; per-target reaction tables (`observation_reactions`, `photo_reactions`, `identification_reactions`); blocks (read-symmetric); reports queue; in-app inbox with 90-day prune cron; `social_visible_to()` + `is_collaborator_of()` STABLE SQL helpers; fan-out triggers (follow → notification, observation_reactions → notification, with block-aware skip); three Edge Functions (`follow`, `react`, `report`) with inline windowed `count(*)` rate-limits. _(✓ done)_
+- `ci-cd-edge-auto-deploy` — Path-filtered auto-deploy of Edge Functions on push to `main` (mirrors `db-apply.yml`). Filesystem-derived "all functions" list eliminates drift between the UI dropdown enum and the deploy loop. Manual `workflow_dispatch` preserved for surgical rollback. Same PR fixed a `MIN(uuid)` schema bug in `profile_top_species` that was blocking subsequent `db-apply` reruns. _(✓ done)_
+- `social-graph-m26-ui` — UI integration so the M26 surfaces are discoverable from the chrome: BellIcon repointed to `/inbox` with unread badge from `notifications`; rich notification cards (avatars + thumbnails + type-coded icons + skeletons + wildlife empty state); profile follower/following pills + ⋮ overflow menu (Block + Report); shared `ReportDialog` modal mounted globally in `BaseLayout` (focus trap, Esc, backdrop close, reason radio + optional note); `FollowButton` swapped to call the m26 `follow` Edge Function with a 4th "Requested" state for private profiles; `ReactionStrip` rewritten to self-hydrate and wired interactive on `/share/obs/`. _(✓ done)_
+
+Remaining:
+
+- `social-graph-m26-v11` — Follow-ups: ReactionStrip count overlay on feed cards (needs an aggregate RPC to avoid N+1), Block/Report on observation cards + comments, "Block this user" affordance on profile cards in lists, additional ARIA refinements. _(· planned)_

--- a/src/components/TasksView.astro
+++ b/src/components/TasksView.astro
@@ -39,7 +39,7 @@ type TaskItem = {
 
 // Group items by phase. Precompute every localised string here so the JSX
 // stays free of `Record<…>` casts (which Astro's parser misreads as tags).
-const phaseOrder = ['v0.1','v0.3','v0.5','v1.0','v1.5','v2.0','v2.5'];
+const phaseOrder = ['v0.1','v0.3','v0.5','v1.0','v1.1','v1.2','v1.5','v2.0','v2.5'];
 const items = tasksData.items as Record<string, TaskItem>;
 
 interface DisplaySubtask {


### PR DESCRIPTION
## Summary

Documentation drifted across three M26-related merges (PRs #43, #62, #63). This PR brings all the doc surfaces back in line and **also fixes a latent renderer bug** that was silently dropping every v1.1/v1.2 task entry from `/docs/tasks/`.

### What was stale → what's fixed

| Surface | Was | Now |
|---|---|---|
| `CLAUDE.md` "20 module specs" | wrong | "~29" |
| `CLAUDE.md` "225 tests" | wrong | "~454" |
| `CLAUDE.md` Edge Function deploy paragraph | said only manual `workflow_dispatch` | documents auto-deploy (PR #62) + keeps manual for rollback |
| `CLAUDE.md` Chrome / IA conventions | no M26 mention | new "Social surfaces (M26)" subsection: BellIcon→/inbox via `getSession()`, ReportDialog as global modal pattern, profile pills + ⋮, FollowButton's 4-state UI, ReactionStrip self-hydration, `socialgraph.*` namespace |
| `docs/architecture.md` | no social tables | new "Social graph (Module 26)" subsection: tables, helpers, Edge Functions, trigger fan-out, RLS pattern, UI-surface map |
| `docs/progress.json` | only `social-graph-m26` | adds `social-graph-m26-ui` (#63 UI), `ci-cd-edge-auto-deploy` (#62), `social-graph-m26-v11` (planned) |
| `docs/tasks.json` | M26 entry used wrong schema (`label_en` instead of `title_en`, missing `phase`/`modules`) — silently dropped by renderer | fixed schema; "deferred to operator" subtask flipped to done; new subtasks for the deploy + UI integration; "todo" → "planned" |
| `src/components/TasksView.astro` | `phaseOrder` lacked `v1.1` and `v1.2` — both M26 and the existing admin-console-foundation entry were dropped | added both phases |
| `docs/tasks.md` | no v1.2 narrative | new section with 3 done + 1 planned |
| `docs/runbooks/social-features.md` | did not exist | new operator runbook: env vars (`RESEND_API_KEY`, `OPERATOR_EMAIL`), SPF/DKIM setup for `reports@rastrum.org`, schema apply + smoke-test, first-look breakage table, monitoring queries |

### Latent renderer bug

The biggest find: every task in v1.1 (`admin-console-foundation`) and v1.2 (`social-graph-m26`) was silently dropped from `/docs/tasks/` because `TasksView.astro`'s hardcoded `phaseOrder` didn't list those phases. Adding them brings four months of work back into the rendered task list.

### Verifications

- [x] `progress.json` + `tasks.json` valid
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 454 passing
- [x] `npm run build` — clean
- [x] Rendered HTMLs (`dist/{en,es}/docs/{roadmap,tasks}/index.html`) now contain "Module 26" / "Grafo social" / "Social graph" entries that were missing before

🤖 Generated with [Claude Code](https://claude.com/claude-code)