### PR TITLE
fix(console): PR #66 review — loadActivity error handling + tighter e2e

### DIFF
--- a/src/components/ConsoleCredentialsView.astro
+++ b/src/components/ConsoleCredentialsView.astro
@@ -16,6 +16,7 @@ const tr = t(lang);
 <section class="max-w-6xl">
   <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">{tr.console.credentials_intro}</p>
 
+  {/* uses console.not_authorized which is shared across console views */}
   <div id="creds-not-auth" class="hidden rounded border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-900/20 p-3 text-sm text-amber-900 dark:text-amber-100">
     {tr.console.not_authorized}
   </div>
@@ -58,7 +59,7 @@ const tr = t(lang);
 
       <div>
         <h3 class="text-xs font-semibold uppercase tracking-wide text-zinc-500 mb-2">{tr.console.users_activity_heading}</h3>
-        <dl id="creds-detail-activity" class="grid grid-cols-2 gap-2 text-sm text-zinc-700 dark:text-zinc-300"></dl>
+        <dl id="creds-detail-activity" data-failed-msg={tr.console.users_activity_failed} class="grid grid-cols-2 gap-2 text-sm text-zinc-700 dark:text-zinc-300"></dl>
       </div>
     </div>
   </div>
@@ -225,11 +226,19 @@ const tr = t(lang);
   async function loadActivity(userId: string) {
     const dl = document.getElementById('creds-detail-activity')!;
     dl.innerHTML = '<dt class="text-zinc-500 col-span-2 text-xs italic">Loading…</dt>';
-    const { count: obsCount } = await supabase
-      .from('observations')
-      .select('id', { count: 'exact', head: true })
-      .eq('observer_id', userId);
-    dl.innerHTML = `<dt class="text-zinc-500">Observations</dt><dd class="font-medium">${obsCount ?? 0}</dd>`;
+
+    try {
+      const { count: obsCount, error } = await supabase
+        .from('observations')
+        .select('id', { count: 'exact', head: true })
+        .eq('observer_id', userId);
+      if (error) throw error;
+      dl.innerHTML = `<dt class="text-zinc-500">Observations</dt><dd class="font-medium">${obsCount ?? 0}</dd>`;
+    } catch (err) {
+      console.warn('console: loadActivity failed', err);
+      const msg = dl.dataset.failedMsg ?? 'Could not load activity stats.';
+      dl.innerHTML = `<dt class="text-zinc-500 col-span-2 text-sm">${msg}</dt>`;
+    }
   }
 
   document.addEventListener('click', (ev) => {

--- a/src/components/ConsoleUsersView.astro
+++ b/src/components/ConsoleUsersView.astro
@@ -51,7 +51,7 @@ const tr = t(lang);
 
       <div>
         <h3 class="text-xs font-semibold uppercase tracking-wide text-zinc-500 mb-2">{tr.console.users_activity_heading}</h3>
-        <dl id="detail-activity" class="grid grid-cols-2 gap-2 text-sm text-zinc-700 dark:text-zinc-300"></dl>
+        <dl id="detail-activity" data-failed-msg={tr.console.users_activity_failed} class="grid grid-cols-2 gap-2 text-sm text-zinc-700 dark:text-zinc-300"></dl>
       </div>
     </div>
   </div>
@@ -228,18 +228,27 @@ const tr = t(lang);
     const dl = document.getElementById('detail-activity')!;
     dl.innerHTML = '<dt class="text-zinc-500 col-span-2 text-xs italic">Loading…</dt>';
 
-    const [obsResult, rgResult] = await Promise.all([
-      supabase.from('observations').select('id', { count: 'exact', head: true }).eq('observer_id', userId),
-      supabase.from('identifications').select('id', { count: 'exact', head: true }).eq('identifier_id', userId).eq('quality_grade', 'research'),
-    ]);
+    try {
+      const [obsResult, rgResult] = await Promise.all([
+        supabase.from('observations').select('id', { count: 'exact', head: true }).eq('observer_id', userId),
+        supabase.from('identifications').select('id', { count: 'exact', head: true }).eq('identifier_id', userId).eq('quality_grade', 'research'),
+      ]);
 
-    const obsCount = obsResult.count ?? 0;
-    const rgCount = rgResult.count ?? 0;
+      if (obsResult.error) throw obsResult.error;
+      if (rgResult.error) throw rgResult.error;
 
-    dl.innerHTML = `
-      <dt class="text-zinc-500">Observations</dt><dd class="font-medium">${obsCount}</dd>
-      <dt class="text-zinc-500">Research grade</dt><dd class="font-medium">${rgCount}</dd>
-    `;
+      const obsCount = obsResult.count ?? 0;
+      const rgCount = rgResult.count ?? 0;
+
+      dl.innerHTML = `
+        <dt class="text-zinc-500">Observations</dt><dd class="font-medium">${obsCount}</dd>
+        <dt class="text-zinc-500">Research grade</dt><dd class="font-medium">${rgCount}</dd>
+      `;
+    } catch (err) {
+      console.warn('console: loadActivity failed', err);
+      const msg = dl.dataset.failedMsg ?? 'Could not load activity stats.';
+      dl.innerHTML = `<dt class="text-zinc-500 col-span-2 text-sm">${msg}</dt>`;
+    }
   }
 
   document.addEventListener('click', (ev) => {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1560,6 +1560,7 @@
     "users_select_prompt": "Select a user to view their roles and recent activity.",
     "users_roles_heading": "Roles",
     "users_activity_heading": "Recent activity",
+    "users_activity_failed": "Could not load activity stats.",
     "users_grant_title": "Grant role",
     "users_revoke_title": "Revoke role",
     "users_grant_role_label": "Role",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1560,6 +1560,7 @@
     "users_select_prompt": "Selecciona un usuario para ver sus roles y actividad reciente.",
     "users_roles_heading": "Roles",
     "users_activity_heading": "Actividad reciente",
+    "users_activity_failed": "No se pudieron cargar las estadísticas de actividad.",
     "users_grant_title": "Otorgar rol",
     "users_revoke_title": "Revocar rol",
     "users_grant_role_label": "Rol",

--- a/tests/e2e/console-smoke.spec.ts
+++ b/tests/e2e/console-smoke.spec.ts
@@ -35,17 +35,23 @@ test.describe('console — smoke', () => {
     await expect(pill).toHaveClass(/hidden/);
   });
 
-  test('/en/console/users/ renders the gate for an unauth visitor', async ({ page }) => {
-    await page.goto('/en/console/users/');
-    // The gate uses the same #console-gate id as the overview page or shows
-    // "Not authorized" inline. Either is acceptable for a smoke check.
-    const body = await page.locator('body').textContent();
-    expect(body).toBeTruthy();
+  test('/en/console/users/ renders not-auth banner element for an unauth visitor', async ({ page }) => {
+    await page.goto('/en/console/users/', { waitUntil: 'domcontentloaded' });
+    // #users-not-auth is hidden until JS resolves the session check;
+    // assert the element is present in the DOM and contains the right text.
+    const notAuth = page.locator('#users-not-auth');
+    await expect(notAuth).toHaveText(/don't have console access/i);
+    expect(page.url()).not.toContain('500');
+    expect(await page.locator('body').textContent()).not.toContain('Internal Server Error');
   });
 
-  test('/en/console/credentials/ renders for an unauth visitor', async ({ page }) => {
-    await page.goto('/en/console/credentials/');
-    const body = await page.locator('body').textContent();
-    expect(body).toBeTruthy();
+  test('/en/console/credentials/ renders not-auth banner element for an unauth visitor', async ({ page }) => {
+    await page.goto('/en/console/credentials/', { waitUntil: 'domcontentloaded' });
+    // #creds-not-auth is hidden until JS resolves the session check;
+    // assert the element is present in the DOM and contains the right text.
+    const notAuth = page.locator('#creds-not-auth');
+    await expect(notAuth).toHaveText(/don't have console access/i);
+    expect(page.url()).not.toContain('500');
+    expect(await page.locator('body').textContent()).not.toContain('Internal Server Error');
   });
 });


### PR DESCRIPTION
## Summary

Three review comments from Nyx + ArtemioPadilla on PR #66, addressed in one small commit.

### 1. `loadActivity` error handling (ArtemioPadilla, point 1)
Both `ConsoleUsersView` and `ConsoleCredentialsView` had a `loadActivity` function that loaded obs count + RG count for the selected user. If either query failed, the spinner stayed and nothing rendered. Now wrapped in try/catch with `console.warn` log and a localized fallback ("Could not load activity stats." / "No se pudieron cargar las estadísticas de actividad."). New i18n key `console.users_activity_failed` in both en.json and es.json.

### 2. Tighter e2e smoke (ArtemioPadilla, point 2)
The two new tests added in PR #66 used `expect(body).toBeTruthy()` which passes even on a 500 page. Replaced with `toHaveText()` against the actual `#users-not-auth` / `#creds-not-auth` banner elements + a `not.toContain('Internal Server Error')` guard. Tests now assert structural correctness, not just "page rendered something."

### 3. Verify `console.not_authorized` i18n key (ArtemioPadilla, point 3)
False positive from your local diff — the key was added in PR #42 (`console.not_authorized` at line 1517 of both i18n files). No change needed. Added an inline code comment in `ConsoleCredentialsView.astro` near the use site clarifying the key is shared across console views, so future readers don't grep for it under a tab-specific name.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 454/454 passed
- [x] `npm run build` — 108 pages, zero errors
- [x] `npm run test:e2e -- tests/e2e/console-smoke.spec.ts` — 14/14 on chromium + mobile-chrome

## Backlog deferrals (per Nyx review)

Tracked separately, not in scope here:
- ConsoleSlideOver split into per-action variants when ban/hide/license land
- SSR auth guard to remove the "Loading…" flash on `/console/`
- `comments` sentinel addition once PR #63 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)