### PR TITLE
fix(social): three M26 prod bugs (validation 400, follow 400, dex 404)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2718,10 +2718,17 @@ ALTER TABLE public.users
   ADD COLUMN IF NOT EXISTS follower_count   integer NOT NULL DEFAULT 0,
   ADD COLUMN IF NOT EXISTS following_count  integer NOT NULL DEFAULT 0;
 
--- 3) Counter trigger
+-- 3) Counter trigger.
+-- SECURITY DEFINER is REQUIRED because the function UPDATEs
+-- public.users.{follower_count, following_count}, which the column-level
+-- REVOKE/GRANT pattern (`grants_locked_columns` block above) does NOT
+-- expose to invoker roles. Without this, the trigger fails with
+-- "permission denied for table users" and the parent INSERT into
+-- follows is rolled back — surfaces as a 400 from the follow Edge
+-- Function.
 CREATE OR REPLACE FUNCTION public.tg_follows_counter()
 RETURNS trigger
-LANGUAGE plpgsql AS $$
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
 BEGIN
   IF (TG_OP = 'INSERT') THEN
     IF NEW.status = 'accepted' THEN

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -508,7 +508,7 @@ const pm = pmTree.privacy;
       const { count: idCount } = await supabase
         .from('identifications')
         .select('id', { count: 'exact', head: true })
-        .eq('user_id', profile.id);
+        .eq('validated_by', profile.id);
       show(root.querySelector('[data-pp-validation-section]'));
       const body = root.querySelector<HTMLElement>('[data-pp-validation-body]');
       if (body) {
@@ -533,10 +533,13 @@ const pm = pmTree.privacy;
       }
     }
 
-    // Pokédex link
-    if (showPokedex) {
+    // Pokédex link.
+    // The visitor-side route (/u/<handle>/dex/) is parked under v1.2.2;
+    // until it ships, surface the link only for the owner (who can use
+    // /profile/dex/) and hide it on visitor profiles to avoid 404s.
+    if (showPokedex && isOwner) {
       const link = root.querySelector<HTMLAnchorElement>('[data-pp-pokedex-link]');
-      if (link) link.href = `/${lang}/u/${profile.username}/dex/`;
+      if (link) link.href = `/${lang}/${lang === 'es' ? 'perfil/dex' : 'profile/dex'}/`;
       show(root.querySelector('[data-pp-pokedex-section]'));
       if (isOwner && facets.pokedex === false) {
         const badge = root.querySelector<HTMLElement>('[data-pp-pokedex-owner-only]');


### PR DESCRIPTION
## Summary

Three bugs surfaced from the browser console on `https://rastrum.org/en/u/?username=…`. All three shipped in earlier M26 PRs and were not caught by the smoke tests because they only fire on a real signed-in profile visit.

### Bug 1 — `identifications.user_id` 400

`PublicProfileViewV2.astro` validation-reputation count was filtering on `user_id`, but `identifications.user_id` doesn't exist — the column is `validated_by`. PostgREST returned 400 *"column does not exist"* on every visit to any public profile. Fixed.

### Bug 2 — follow Edge Function 400 (the real one)

`tg_follows_counter` UPDATEs `users.follower_count` and `users.following_count`, but the column-level REVOKE/GRANT pattern on `users` (introduced as a security improvement to block self-escalation of `is_expert` / `karma_total`) does not include those counters in the writable set. Without `SECURITY DEFINER` the trigger ran as the JWT invoker, hit *"permission denied for table users"* on the UPDATE, and rolled back the parent INSERT into `follows` — surfaced to the client as a 400 from the `follow` Edge Function.

Adding `SECURITY DEFINER SET search_path = public` lets the trigger update those columns under the function-owner role (postgres), bypassing the RLS-adjacent column GRANT. The two fan-out triggers (`tg_follow_notify`, `tg_obsreact_notify`) were already `SECURITY DEFINER` for the same reason — this just brings `tg_follows_counter` into line.

### Bug 3 — Pokédex link 404

The link generated `/u/<handle>/dex/` which doesn't exist — the visitor-side pokedex route was already in the v1.2.2 deferred list. Until that route ships, hide the Pokédex link on non-owner profiles; for the owner, route to `/profile/dex/` (or `/perfil/dex/`) which already exists.

## Operator action (automatic)

The SQL change to `tg_follows_counter` is in `docs/specs/infra/supabase-schema.sql`, so `db-apply.yml` will fire automatically on merge and re-apply the schema. No manual step.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 454 passing
- [x] `npm run build` — clean
- [ ] Post-merge manual: visit any `/u/?username=…` profile in browser console — no 400s. Click Follow on a non-self profile → should land in `following` state (or `requested` for private profiles), no 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)