### PR TITLE
fix(profile): 403 on profile/settings — drop client-set updated_at + server-side touch trigger

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3125,6 +3125,27 @@ CREATE TRIGGER obsreact_notify_trigger
   AFTER INSERT ON public.observation_reactions
   FOR EACH ROW EXECUTE FUNCTION public.tg_obsreact_notify();
 
+-- 15) Audit columns. The column-level GRANT on `public.users`
+-- intentionally does NOT include `updated_at` (it's an audit column
+-- — clients shouldn't dictate it). Without this BEFORE UPDATE trigger
+-- the column would silently rot. The trigger sets NEW.updated_at on
+-- every row update so the DB owns the timestamp.
+--
+-- See docs/specs/infra/users-column-grants.md for the column inventory.
+CREATE OR REPLACE FUNCTION public.tg_users_touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS users_touch_updated_at ON public.users;
+CREATE TRIGGER users_touch_updated_at
+  BEFORE UPDATE ON public.users
+  FOR EACH ROW EXECUTE FUNCTION public.tg_users_touch_updated_at();
+
 -- ═════════════════════════════════════════════════════════════════════
 -- Module 27 — Expertise Legends (regional rankings)
 -- Issue #47 — "Top identificador de Fabaceae en Oaxaca"

--- a/docs/specs/infra/users-column-grants.md
+++ b/docs/specs/infra/users-column-grants.md
@@ -50,7 +50,8 @@ from `authenticated` is denied.
 | Column | Writer | Why locked |
 |---|---|---|
 | `id` | `auth.users` FK | Primary key, immutable |
-| `created_at` / `updated_at` / `joined_at` | trigger / default | Audit columns |
+| `created_at` / `joined_at` | column DEFAULT now() on INSERT | Audit columns; immutable after creation |
+| `updated_at` | `tg_users_touch_updated_at` BEFORE UPDATE trigger | Audit column; trigger sets `NEW.updated_at = now()` so clients shouldn't touch it (and the GRANT prevents it). Bug surfaced when ProfileEditForm was setting it from the client → 403. |
 | `is_expert` | `expert_applications` admin flow + `is_expert_in()` SQL | Self-elevation would let anyone weight their votes |
 | `credentialed_researcher` / `credentialed_at` / `credentialed_by` | admin grant | Unlocks precise coords on sensitive species |
 | `karma_total` / `karma_updated_at` / `vote_count` | karma engine triggers (SECURITY DEFINER) | Self-bump would game leaderboards + vote weighting |

--- a/src/components/AdminExpertsView.astro
+++ b/src/components/AdminExpertsView.astro
@@ -275,7 +275,7 @@ const profilePath = getLocalizedPath(lang, routes.profile[lang] + '/');
 
     const { error: userErr } = await supabase
       .from('users')
-      .update({ is_expert: true, expert_taxa: merged, updated_at: new Date().toISOString() })
+      .update({ is_expert: true, expert_taxa: merged })
       .eq('id', userId);
     if (userErr) {
       btn.disabled = false; btn.textContent = labels.approve;

--- a/src/components/PrivacyMatrix.astro
+++ b/src/components/PrivacyMatrix.astro
@@ -226,7 +226,7 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
         .update({
           profile_privacy: next,
           profile_public: next.profile === 'public',
-          updated_at: new Date().toISOString(),
+          // updated_at handled by users_touch_updated_at trigger.
         })
         .eq('id', user.id);
       if (error) throw error;
@@ -394,7 +394,7 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
       const body = JSON.stringify({
         profile_privacy: matrix,
         profile_public: matrix.profile === 'public',
-        updated_at: new Date().toISOString(),
+        // updated_at handled by users_touch_updated_at trigger.
       });
       // navigator.sendBeacon cannot set Authorization, so we PATCH with
       // keepalive: true. This survives `beforeunload` and we drop the

--- a/src/components/PrivacyMatrix.astro
+++ b/src/components/PrivacyMatrix.astro
@@ -226,7 +226,7 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
         .update({
           profile_privacy: next,
           profile_public: next.profile === 'public',
-          // updated_at handled by users_touch_updated_at trigger.
+          // updated_at is bumped server-side by the users_touch_updated_at trigger; clients can't write to it (column-level GRANT).
         })
         .eq('id', user.id);
       if (error) throw error;
@@ -394,7 +394,7 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
       const body = JSON.stringify({
         profile_privacy: matrix,
         profile_public: matrix.profile === 'public',
-        // updated_at handled by users_touch_updated_at trigger.
+        // updated_at is bumped server-side by the users_touch_updated_at trigger; clients can't write to it (column-level GRANT).
       });
       // navigator.sendBeacon cannot set Authorization, so we PATCH with
       // keepalive: true. This survives `beforeunload` and we drop the

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -474,7 +474,8 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
       observer_license:     (data.get('observer_license') ?? 'CC BY 4.0').toString(),
       gamification_opt_in:  data.get('gamification_opt_in') === 'on',
       streak_digest_opt_in: data.get('streak_digest_opt_in') === 'on',
-      updated_at:           new Date().toISOString(),
+      // updated_at is bumped server-side by the users_touch_updated_at
+      // trigger; clients can't write to it (column-level GRANT).
     };
 
     const supabase = getSupabase();


### PR DESCRIPTION
## Summary

User-reported prod bug:
```
PATCH /rest/v1/users?id=eq.<self> → 403 Forbidden
```
when saving any change in `/profile/settings/profile/`.

## Root cause

The PATCH payload included `updated_at: new Date().toISOString()`. The column-level GRANT on `public.users` (the same one inventoried in PR #69) intentionally excludes `updated_at` because it's an audit column — clients shouldn't dictate it. PostgREST rejects the **entire** UPDATE when any patched column is outside the GRANT, so even valid edits (`username`, `bio`, `display_name`, etc.) silently couldn't be saved.

Same latent bug existed in two more places that hadn't been hit yet:
- `PrivacyMatrix.astro` — both the `supabase-js update` AND the `keepalive` PATCH that fires on `beforeunload` would have 403'd the next time someone toggled a privacy setting
- `AdminExpertsView.astro` — would fail once it migrates from the service-role admin function to direct PostgREST

## Two-part fix

**1) DB owns the timestamp.** New `tg_users_touch_updated_at` BEFORE UPDATE trigger sets `NEW.updated_at = now()` on every row update. Without this, dropping the client write would silently rot the column.

```sql
CREATE OR REPLACE FUNCTION public.tg_users_touch_updated_at()
RETURNS trigger LANGUAGE plpgsql AS $$
BEGIN NEW.updated_at := now(); RETURN NEW; END;
$$;
DROP TRIGGER IF EXISTS users_touch_updated_at ON public.users;
CREATE TRIGGER users_touch_updated_at
  BEFORE UPDATE ON public.users
  FOR EACH ROW EXECUTE FUNCTION public.tg_users_touch_updated_at();
```

**2) Client stops sending it.** Removed from `ProfileEditForm.astro`, both call sites in `PrivacyMatrix.astro`, and `AdminExpertsView.astro`. Audit columns shouldn't come from the client anyway — defense in depth.

**3) Doc updated.** `docs/specs/infra/users-column-grants.md` now explicitly calls out `tg_users_touch_updated_at` as the writer for `updated_at`, with a one-line "this exact bug surfaced when ProfileEditForm was setting it from the client → 403" so the next person editing the GRANT sees the trap.

## Operator action

Automatic. The SQL change is in `supabase-schema.sql` so `db-apply.yml` fires on the merge push. `CREATE OR REPLACE` + `DROP TRIGGER IF EXISTS … ; CREATE TRIGGER …` are idempotent.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 454 passing
- [x] `npm run build` — clean
- [ ] Post-merge manual: edit username/bio/display_name in `/profile/settings/profile/` → save → should succeed; row's `updated_at` should advance to now (verifiable via Supabase dashboard or `select updated_at from users where id = …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)