### PR TITLE
fix(profile): 'View public profile' link 404 — wrong URL shape

### DIFF
--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -249,8 +249,11 @@ const k = (tr as unknown as { karma: Record<string, string> }).karma;
 
     if (profile.username && viewPublicLink) {
       const lang = document.documentElement.lang || 'en';
-      const base = lang === 'es' ? `/${lang}/perfil/u/${profile.username}/` : `/${lang}/profile/u/${profile.username}/`;
-      viewPublicLink.href = base;
+      // Canonical visitor route is /{lang}/u/?username=<handle>; the
+      // path-segment form /{lang}/profile/u/<handle>/ is NOT a route
+      // (only the legacy /profile/u/ index exists, and it 301-redirects
+      // to /u/). Linking by path-segment 404s.
+      viewPublicLink.href = `/${lang}/u/?username=${encodeURIComponent(profile.username)}`;
       viewPublicLink.classList.remove('hidden');
     }
 


### PR DESCRIPTION
## Summary

User-reported bug:

> *"I changed my profile name to artemio, it saved but https://rastrum.org/en/profile/u/artemio/ shows 404"*

`ProfileView.astro:252` was building the "View public profile" link as a path-segment URL `/${lang}/profile/u/${username}/` — but that path doesn't exist. Only the legacy `/{lang}/profile/u/` index exists, and it 301-redirects to `/u/`. Adding a `<handle>` segment 404s.

## Fix

The canonical visitor route is `/{lang}/u/?username=<handle>` (query-string form). Switched the link to that, added a 4-line comment naming the trap so the next person editing the file doesn't re-introduce the path-segment form.

```diff
- const base = lang === 'es' ? `/${lang}/perfil/u/${profile.username}/` : `/${lang}/profile/u/${profile.username}/`;
- viewPublicLink.href = base;
+ // Canonical visitor route is /{lang}/u/?username=<handle>; the
+ // path-segment form /{lang}/profile/u/<handle>/ is NOT a route...
+ viewPublicLink.href = `/${lang}/u/?username=${encodeURIComponent(profile.username)}`;
```

## Note on the 403 in the same console log

The user also pasted a `PATCH /rest/v1/users → 403` line. That was the same bug fixed in PR #71 (client-set `updated_at`). The PATCH succeeded on the next attempt because #71 had landed; the user's report explicitly says "it saved." No action needed here.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 454 passing
- [x] `npm run build` — clean
- [ ] Post-merge: edit profile → click "View public profile" → should land on `/en/u/?username=artemio` (no 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)