### PR TITLE
fix(console): PR #70 review — dead i18n vars + ETA + cron try/catch + schema comment + sentinel + GRANT tightening

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3310,11 +3310,28 @@ AS $$
 $$;
 
 REVOKE ALL ON FUNCTION public.list_admin_cron_runs(int) FROM public;
-GRANT EXECUTE ON FUNCTION public.list_admin_cron_runs(int) TO authenticated;
+-- Intentionally NOT granted to authenticated — only the _guarded wrapper below
+-- should be callable by end users. Granting authenticated on the inner function
+-- would let any logged-in user bypass the has_role check entirely.
+GRANT EXECUTE ON FUNCTION public.list_admin_cron_runs(int) TO service_role;
 
--- Caller-side admin guard: runs as the schema owner so cron schema is
--- reachable; verifies the calling user holds the admin role before
--- returning any data.
+-- Why STABLE on list_admin_cron_runs_guarded:
+--   auth.uid() reads a session GUC (request.jwt.claims) that is set once
+--   per PostgREST request and does not change within a single query
+--   execution. STABLE is therefore correct — the function returns the same
+--   result for the same p_limit within one statement.
+--
+--   VOLATILE would be wrong: it suppresses inlining and forces a
+--   materialisation barrier, degrading query optimization for no benefit.
+--
+--   The has_role check runs once per call (not per row) because it lives in
+--   the BEGIN block before the RETURN QUERY — any admin check failure raises
+--   immediately, before any rows from the inner function are fetched.
+--
+--   The inner list_admin_cron_runs (unguarded) is SECURITY DEFINER so it
+--   can read the cron schema; it must NOT be granted to authenticated
+--   directly — only service_role. All authenticated callers must go through
+--   this _guarded wrapper.
 CREATE OR REPLACE FUNCTION public.list_admin_cron_runs_guarded(p_limit int DEFAULT 50)
 RETURNS TABLE (
   jobname          text,

--- a/scripts/db-sentinel.sql
+++ b/scripts/db-sentinel.sql
@@ -52,6 +52,8 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'has_role')             THEN missing := array_append(missing, 'public.has_role()'); END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'recompute_consensus')  THEN missing := array_append(missing, 'public.recompute_consensus()'); END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'handle_new_user')      THEN missing := array_append(missing, 'public.handle_new_user()'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'list_admin_cron_runs')         THEN missing := array_append(missing, 'public.list_admin_cron_runs()'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'list_admin_cron_runs_guarded') THEN missing := array_append(missing, 'public.list_admin_cron_runs_guarded()'); END IF;
 
   IF array_length(missing, 1) IS NOT NULL THEN
     RAISE EXCEPTION 'Sentinel verify failed — missing objects: %', missing;

--- a/src/components/ConsoleApiQuotasView.astro
+++ b/src/components/ConsoleApiQuotasView.astro
@@ -5,7 +5,7 @@ const { lang } = Astro.props;
 const tr = t(lang);
 ---
 
-<section class="max-w-5xl">
+<section class="max-w-5xl" data-eta-none-label={tr.console.api_eta_none}>
   <h1 class="text-xl font-semibold mb-1">{tr.console.api_heading}</h1>
   <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">{tr.console.api_intro}</p>
 
@@ -80,17 +80,19 @@ const tr = t(lang);
     return `M${pts.join(' L')}`;
   }
 
+  const etaNoneLabel = document.querySelector<HTMLElement>('section[data-eta-none-label]')?.dataset.etaNoneLabel ?? 'Not at current rate';
+
   function computeEta(todayUsed: number, quota: number): string {
-    if (todayUsed <= 0) return 'Not at current rate';
+    if (todayUsed <= 0) return etaNoneLabel;
     const nowUtc = new Date();
     const secondsSinceMidnight = nowUtc.getUTCHours() * 3600 + nowUtc.getUTCMinutes() * 60 + nowUtc.getUTCSeconds();
-    if (secondsSinceMidnight === 0) return 'Not at current rate';
+    if (secondsSinceMidnight === 0) return etaNoneLabel;
     const ratePerSecond = todayUsed / secondsSinceMidnight;
     const remaining = quota - todayUsed;
     if (remaining <= 0) return 'Exhausted';
     const secsUntilExhaustion = remaining / ratePerSecond;
     const exhaustAt = new Date(nowUtc.getTime() + secsUntilExhaustion * 1000);
-    if (exhaustAt.getUTCDate() !== nowUtc.getUTCDate()) return 'Not at current rate';
+    if (exhaustAt.getUTCDate() !== nowUtc.getUTCDate()) return etaNoneLabel;
     return `Will exhaust at ${String(exhaustAt.getUTCHours()).padStart(2,'0')}:${String(exhaustAt.getUTCMinutes()).padStart(2,'0')} UTC at current rate`;
   }
 

--- a/src/components/ConsoleCronRunsView.astro
+++ b/src/components/ConsoleCronRunsView.astro
@@ -5,7 +5,7 @@ const { lang } = Astro.props;
 const tr = t(lang);
 ---
 
-<section class="max-w-5xl">
+<section class="max-w-5xl" data-load-failed-label={tr.console.cron_load_failed}>
   <h1 class="text-xl font-semibold mb-1">{tr.console.cron_heading}</h1>
   <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">{tr.console.cron_intro}</p>
 
@@ -84,6 +84,7 @@ const tr = t(lang);
   }
 
   const supabase = getSupabase();
+  const loadFailedLabel = document.querySelector<HTMLElement>('section[data-load-failed-label]')?.dataset.loadFailedLabel ?? 'Could not load cron runs.';
 
   async function init() {
     const { data: { session } } = await supabase.auth.getSession();
@@ -120,9 +121,10 @@ const tr = t(lang);
 
       renderTable(rows);
     } catch (err) {
+      console.warn('cron loadRows threw:', err);
       hide('cron-loading');
       const e = document.getElementById('cron-error')!;
-      e.textContent = (err as Error).message;
+      e.textContent = loadFailedLabel;
       show('cron-error');
     }
   }

--- a/src/components/ConsoleSyncFailuresView.astro
+++ b/src/components/ConsoleSyncFailuresView.astro
@@ -5,7 +5,12 @@ const { lang } = Astro.props;
 const tr = t(lang);
 ---
 
-<section class="max-w-5xl">
+<section
+  class="max-w-5xl"
+  data-view-user-label={tr.console.sync_view_user}
+  data-retry-label={tr.console.sync_retry_pr4}
+  data-summary-template={tr.console.sync_summary}
+>
   <h1 class="text-xl font-semibold mb-1">{tr.console.sync_heading}</h1>
   <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">{tr.console.sync_intro}</p>
 
@@ -69,9 +74,10 @@ const tr = t(lang);
     return s.replace(/[<>&'"]/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;',"'":'&#39;','"':'&quot;'}[c]!));
   }
 
-  const notAuthEl = document.getElementById('sync-not-auth')!;
-  const viewUserLabel = notAuthEl.closest('section')?.querySelector<HTMLElement>('[data-view-user-label]')?.dataset.viewUserLabel ?? 'View user';
-  const retryLabel = notAuthEl.closest('section')?.querySelector<HTMLElement>('[data-retry-label]')?.dataset.retryLabel ?? 'Retry — coming in PR4';
+  const sectionEl = document.querySelector<HTMLElement>('section[data-view-user-label]')!;
+  const viewUserLabel = sectionEl.dataset.viewUserLabel ?? 'View user';
+  const retryLabel = sectionEl.dataset.retryLabel ?? 'Retry';
+  const summaryTemplate = sectionEl.dataset.summaryTemplate ?? '{n} failures across {m} unique error groups';
 
   const supabase = getSupabase();
   let allRows: SyncFailureRow[] = [];
@@ -134,8 +140,8 @@ const tr = t(lang);
 
     const banner = document.getElementById('sync-summary-banner')!;
     banner.textContent = filtered.length === 0
-      ? 'No failures in the selected window.'
-      : `${totalHits} failure${totalHits !== 1 ? 's' : ''} across ${uniqueGroups} unique error group${uniqueGroups !== 1 ? 's' : ''} in the last ${(document.getElementById('sync-days-filter') as HTMLSelectElement).value} days`;
+      ? ''
+      : summaryTemplate.replace('{n}', String(totalHits)).replace('{m}', String(uniqueGroups));
 
     if (filtered.length === 0) {
       show('sync-empty');
@@ -159,13 +165,13 @@ const tr = t(lang);
           <td class="px-3 py-2 text-xs text-zinc-500">${escHtml(r.app_version ?? '—')}</td>
           <td class="px-3 py-2 text-xs">
             ${r.user_id
-              ? `<a href="/console/users/?focus=${escHtml(r.user_id)}" class="text-emerald-700 dark:text-emerald-400 underline text-xs">View user</a>`
+              ? `<a href="/console/users/?focus=${escHtml(r.user_id)}" class="text-emerald-700 dark:text-emerald-400 underline text-xs">${escHtml(viewUserLabel)}</a>`
               : '<span class="text-zinc-400">—</span>'}
           </td>
           <td class="px-3 py-2 text-xs text-zinc-400">${r.blob_count ?? 0}</td>
           <td class="px-3 py-2 text-xs text-zinc-500 font-mono">${r.last_seen_at ? escHtml(new Date(r.last_seen_at).toISOString().replace('T', ' ').slice(0, 19)) : '—'}</td>
           <td class="px-3 py-2">
-            <button disabled title="Retry — coming in PR4" class="rounded px-2 py-0.5 text-xs border border-zinc-300 dark:border-zinc-700 text-zinc-400 cursor-not-allowed">Retry</button>
+            <button disabled title="${escHtml(retryLabel)}" class="rounded px-2 py-0.5 text-xs border border-zinc-300 dark:border-zinc-700 text-zinc-400 cursor-not-allowed">${escHtml(retryLabel)}</button>
           </td>
         </tr>
       `).join('');

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1606,6 +1606,7 @@
     "cron_status_failed": "failed",
     "cron_status_running": "running",
     "cron_status_unknown": "unknown",
-    "cron_force_run_pr4": "Force run — coming in PR4"
+    "cron_force_run_pr4": "Force run — coming in PR4",
+    "cron_load_failed": "Could not load cron runs."
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1606,6 +1606,7 @@
     "cron_status_failed": "fallido",
     "cron_status_running": "corriendo",
     "cron_status_unknown": "desconocido",
-    "cron_force_run_pr4": "Forzar corrida — próximamente PR4"
+    "cron_force_run_pr4": "Forzar corrida — próximamente PR4",
+    "cron_load_failed": "No se pudieron cargar las corridas de cron."
   }
 }


### PR DESCRIPTION
## Summary

Five fixes addressing review comments from ArtemioPadilla + Pamela-ruiz9 (Nyx) on PR #70 (already merged).

### 1. ConsoleSyncFailuresView — dead i18n vars resurrected
`viewUserLabel`, `retryLabel`, and the `sync_summary` template literal were defined in i18n but `renderRows()` had English hardcoded. Spanish locale never rendered correctly. Now reads from data attributes and substitutes `{n}`/`{m}` placeholders into the summary banner.

### 2. ConsoleApiQuotasView — hardcoded ETA fallback
`computeEta()` returned `'Not at current rate'` literally in three branches. Now uses `tr.console.api_eta_none` via a `data-eta-none-label` attribute.

### 3. ConsoleCronRunsView — fallback message on RPC throw
Adds new i18n key `cron_load_failed` (EN + ES), wired through a data attribute and rendered into `#cron-error` if the `supabase.rpc()` call throws.

### 4. Schema — GRANT tightening + STABLE comment
**Real security fix:** the unguarded `list_admin_cron_runs` was previously `GRANT EXECUTE TO authenticated` — meaning any authenticated user could call it directly and bypass the `has_role(admin)` check. Changed to `GRANT EXECUTE TO service_role` only. The guarded `_guarded` wrapper remains the only authenticated entry point. Plus a 10-line comment block above the wrapper explaining why STABLE + auth.uid() is safe (session GUC), why VOLATILE would be wrong (suppresses inlining), and the GRANT invariant.

### 5. scripts/db-sentinel.sql — register both new functions
Adds `list_admin_cron_runs` and `list_admin_cron_runs_guarded` to the sentinel set so a regression in either is caught by both `db-validate` (per-PR) and `db-apply` (post-prod-apply).

## Reviewer false positives (no action)

- `console.loading` key — already present at line 1518 of both en.json/es.json (added in PR #42)
- RLS on `sync_failures` and `api_usage` — already gated by `has_role(auth.uid(), 'admin')` since PR #61's policy refactor

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 454/454 passed
- [x] `npm run build` — 114 pages, zero errors
- [x] `npm run test:e2e -- console-smoke.spec.ts` — 20/20 passed
- [ ] Post-merge: switch to ES locale on `/consola/sync/`, verify "View user" shows "Ver usuario" and the summary banner shows "{n} fallos en {m} grupos…" not English
- [ ] Post-merge: db-apply on main runs the updated sentinel; expect green with both new functions verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)