### PR TITLE
docs(roadmap): track 2 v1.1 backlog items — deploy resilience + visitor pokedex

### DIFF
--- a/docs/progress.json
+++ b/docs/progress.json
@@ -805,6 +805,18 @@
           "label": "M26 v1.1 follow-ups — ReactionStrip count overlay on feed cards (RPC), Block/Report affordances on observation cards + comments, 'Block from list' on profile lists, focus-trap polish (delivered) + future ARIA refinements",
           "label_es": "Seguimientos v1.1 de M26 — superposición de conteos ReactionStrip en tarjetas del feed (RPC), Bloquear/Reportar en tarjetas de observación + comentarios, 'Bloquear desde lista' en listas de perfiles, refinamientos ARIA futuros",
           "done": false
+        },
+        {
+          "id": "deploy-functions-resilience",
+          "label": "Deploy-functions resilience — pin esm.sh imports to versioned URLs (e.g. @supabase/supabase-js@2.39.7) so a transient esm.sh 522 doesn't leave the auto-deploy in a permanently failed state. Surfaced when PR #66's auto-deploy 522'd on a Cloudflare hiccup; the admin function changes only landed after a manual workflow_dispatch backfill",
+          "label_es": "Resiliencia de deploy-functions — fijar imports de esm.sh a URLs versionadas (p.ej. @supabase/supabase-js@2.39.7) para que un 522 transitorio en esm.sh no deje el auto-deploy en estado fallido permanente hasta intervención manual. Surgió cuando el auto-deploy de PR #66 falló con 522 por un hipo de Cloudflare; los cambios de la función admin solo aterrizaron tras un workflow_dispatch manual",
+          "done": false
+        },
+        {
+          "id": "visitor-pokedex-route",
+          "label": "Visitor /u/<handle>/dex/ route — public pokedex page so the link on PublicProfileViewV2 doesn't have to be hidden for non-owners (PR #68 currently hides it). Was previously buried in tasks.md as v1.2.2 cleanup deferred; promoting to a real backlog entry",
+          "label_es": "Ruta de Pokédex visitante /u/<handle>/dex/ — página de pokédex pública para que el enlace en PublicProfileViewV2 no tenga que esconderse a no-dueños (PR #68 lo esconde por ahora). Estaba enterrada en tasks.md como cleanup de v1.2.2 diferido; ahora promovida a backlog explícito",
+          "done": false
         }
       ]
     },

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -119,3 +119,5 @@ Remaining:
 Remaining:
 
 - `social-graph-m26-v11` — Follow-ups: ReactionStrip count overlay on feed cards (needs an aggregate RPC to avoid N+1), Block/Report on observation cards + comments, "Block this user" affordance on profile cards in lists, additional ARIA refinements. _(· planned)_
+- `deploy-functions-resilience` — Pin esm.sh imports to versioned URLs across `supabase/functions/*/index.ts` so a transient esm.sh 522 doesn't permanently park the auto-deploy. Surfaced when PR #66's auto-deploy 522'd on a Cloudflare hiccup. _(· planned)_
+- `visitor-pokedex-route` — Public `/u/<handle>/dex/` page so the Pokédex link on PublicProfileViewV2 doesn't have to be hidden for non-owners (PR #68 currently hides it as a workaround). _(· planned)_


### PR DESCRIPTION
Promotes two items from prose-only mentions to first-class progress.json entries so they show up on the public /docs/roadmap/ page.

1. `deploy-functions-resilience` — pin esm.sh imports to versioned URLs across function files so a transient esm.sh 522 doesn't park the auto-deploy permanently (surfaced from PR #66's failed auto-deploy that needed manual backfill)
2. `visitor-pokedex-route` — `/u/<handle>/dex/` public route so the Pokédex link on PublicProfileViewV2 doesn't have to be hidden for non-owners (PR #68 hid it as a workaround)

Pure docs PR — both items go into v1.2 phase. Verified rendered HTML at `/{en,es}/docs/roadmap/` now lists them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)