### PR TITLE
fix(profile): show 'profile not found' instead of 'private' for non-existent usernames

### DIFF
--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -30,6 +30,8 @@ const pmTree = tr as unknown as {
   privacy: {
     private_profile_empty_title: string;
     private_profile_empty_body: string;
+    not_found_title: string;
+    not_found_body: string;
     signed_in_required_title: string;
     signed_in_required_body: string;
     owner_only_badge: string;
@@ -63,6 +65,14 @@ const pm = pmTree.privacy;
   <div data-pp-private class="hidden py-12 text-center">
     <p class="text-base font-semibold text-zinc-900 dark:text-zinc-100">{pm.private_profile_empty_title}</p>
     <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{pm.private_profile_empty_body}</p>
+  </div>
+
+  <div data-pp-not-found class="hidden py-12 text-center">
+    <p class="text-base font-semibold text-zinc-900 dark:text-zinc-100">{pm.not_found_title}</p>
+    <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{pm.not_found_body}</p>
+    <a href={`/${lang}/${lang === 'es' ? 'explorar/recientes' : 'explore/recent'}/`} class="mt-3 inline-block text-emerald-700 dark:text-emerald-400 hover:underline">
+      {lang === 'es' ? 'Explorar observaciones recientes →' : 'Browse recent observations →'}
+    </a>
   </div>
 
   <div data-pp-signed-in class="hidden py-12 text-center">
@@ -241,14 +251,14 @@ const pm = pmTree.privacy;
 
     if (!username || !/^[a-zA-Z0-9_]{3,30}$/.test(username)) {
       hide(root.querySelector('[data-pp-loading]'));
-      show(root.querySelector('[data-pp-private]'));
+      show(root.querySelector('[data-pp-not-found]'));
       return;
     }
 
     let supabase;
     try { supabase = getSupabase(); } catch {
       hide(root.querySelector('[data-pp-loading]'));
-      show(root.querySelector('[data-pp-private]'));
+      show(root.querySelector('[data-pp-not-found]'));
       return;
     }
 
@@ -262,7 +272,7 @@ const pm = pmTree.privacy;
 
     if (!profile) {
       hide(root.querySelector('[data-pp-loading]'));
-      show(root.querySelector('[data-pp-private]'));
+      show(root.querySelector('[data-pp-not-found]'));
       return;
     }
 

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -32,6 +32,7 @@ const pmTree = tr as unknown as {
     private_profile_empty_body: string;
     not_found_title: string;
     not_found_body: string;
+    not_found_cta: string;
     signed_in_required_title: string;
     signed_in_required_body: string;
     owner_only_badge: string;
@@ -71,7 +72,7 @@ const pm = pmTree.privacy;
     <p class="text-base font-semibold text-zinc-900 dark:text-zinc-100">{pm.not_found_title}</p>
     <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{pm.not_found_body}</p>
     <a href={`/${lang}/${lang === 'es' ? 'explorar/recientes' : 'explore/recent'}/`} class="mt-3 inline-block text-emerald-700 dark:text-emerald-400 hover:underline">
-      {lang === 'es' ? 'Explorar observaciones recientes →' : 'Browse recent observations →'}
+      {pm.not_found_cta}
     </a>
   </div>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1428,6 +1428,7 @@
     "private_profile_empty_body": "The owner has not made any public information available. Try a different observer, or browse public observations.",
     "not_found_title": "Profile not found",
     "not_found_body": "We couldn't find an observer with that username. Check the spelling, or browse public observations to discover others.",
+    "not_found_cta": "Browse recent observations →",
     "signed_in_required_title": "Sign in to view this profile",
     "signed_in_required_body": "The observer has limited their profile to signed-in viewers. Sign in with any account to continue.",
     "saved_toast": "Privacy saved",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1426,6 +1426,8 @@
     "nuclear_confirm_cancel": "Cancel",
     "private_profile_empty_title": "This profile is private",
     "private_profile_empty_body": "The owner has not made any public information available. Try a different observer, or browse public observations.",
+    "not_found_title": "Profile not found",
+    "not_found_body": "We couldn't find an observer with that username. Check the spelling, or browse public observations to discover others.",
     "signed_in_required_title": "Sign in to view this profile",
     "signed_in_required_body": "The observer has limited their profile to signed-in viewers. Sign in with any account to continue.",
     "saved_toast": "Privacy saved",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1428,6 +1428,7 @@
     "private_profile_empty_body": "El propietario no ha publicado información. Prueba con otro observador o explora observaciones públicas.",
     "not_found_title": "Perfil no encontrado",
     "not_found_body": "No encontramos un observador con ese nombre de usuario. Revisa la ortografía o explora observaciones públicas para descubrir a otros.",
+    "not_found_cta": "Explorar observaciones recientes →",
     "signed_in_required_title": "Inicia sesión para ver este perfil",
     "signed_in_required_body": "El observador limitó su perfil a usuarios con sesión. Inicia sesión con cualquier cuenta para continuar.",
     "saved_toast": "Privacidad guardada",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1426,6 +1426,8 @@
     "nuclear_confirm_cancel": "Cancelar",
     "private_profile_empty_title": "Este perfil es privado",
     "private_profile_empty_body": "El propietario no ha publicado información. Prueba con otro observador o explora observaciones públicas.",
+    "not_found_title": "Perfil no encontrado",
+    "not_found_body": "No encontramos un observador con ese nombre de usuario. Revisa la ortografía o explora observaciones públicas para descubrir a otros.",
     "signed_in_required_title": "Inicia sesión para ver este perfil",
     "signed_in_required_body": "El observador limitó su perfil a usuarios con sesión. Inicia sesión con cualquier cuenta para continuar.",
     "saved_toast": "Privacidad guardada",


### PR DESCRIPTION
User-reported UX bug: hitting `/u/?username=<nonexistent>` renders **'This profile is private'** with the owner-has-hidden-everything copy. The profile literally doesn't exist — that copy implies the user opted out, which is wrong and confusing.

`PublicProfileViewV2` had three failure modes — bad/missing username, supabase env not configured, profile not found — all collapsing into the same `[data-pp-private]` empty state.

**Fix:** split into two empty states.

| State | Used for | Copy |
|---|---|---|
| `[data-pp-private]` (kept) | The privacy-matrix gate hiding everything | "This profile is private — owner has not made info available" |
| `[data-pp-not-found]` (new) | Bad username, supabase env missing, no row found | "Profile not found — we couldn't find an observer with that username. Check the spelling, or browse public observations to discover others." + CTA to /explore/recent/ |

i18n strings added in EN + ES (`privacy.not_found_title`, `privacy.not_found_body`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)