### PR TITLE
fix(console): PR #77 review — unban consistency + double-ban guard + per-command policies + locked sentinel

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3473,10 +3473,15 @@ CREATE POLICY user_bans_mod_read ON public.user_bans
   );
 
 -- No client-side writes — service role only via Edge Function.
+-- Three separate per-command policies replace the previous FOR ALL form for
+-- clarity; Postgres processes them independently per statement type.
 DROP POLICY IF EXISTS user_bans_no_client_write ON public.user_bans;
-CREATE POLICY user_bans_no_client_write ON public.user_bans
-  FOR ALL TO authenticated
-  USING (false) WITH CHECK (false);
+DROP POLICY IF EXISTS user_bans_no_client_insert ON public.user_bans;
+DROP POLICY IF EXISTS user_bans_no_client_update ON public.user_bans;
+DROP POLICY IF EXISTS user_bans_no_client_delete ON public.user_bans;
+CREATE POLICY user_bans_no_client_insert ON public.user_bans FOR INSERT TO authenticated WITH CHECK (false);
+CREATE POLICY user_bans_no_client_update ON public.user_bans FOR UPDATE TO authenticated USING (false);
+CREATE POLICY user_bans_no_client_delete ON public.user_bans FOR DELETE TO authenticated USING (false);
 
 GRANT SELECT ON public.user_bans TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.user_bans TO service_role;

--- a/scripts/db-sentinel.sql
+++ b/scripts/db-sentinel.sql
@@ -51,6 +51,16 @@ BEGIN
   -- Console PR5 — moderator surface
   IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'user_bans')              THEN missing := array_append(missing, 'public.user_bans'); END IF;
 
+  -- Module 26 — observation_comments.locked column added in PR #77
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'observation_comments'
+      AND column_name = 'locked'
+  ) THEN
+    missing := array_append(missing, 'public.observation_comments.locked');
+  END IF;
+
   -- Functions used by RLS predicates and Edge Functions
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'has_role')             THEN missing := array_append(missing, 'public.has_role()'); END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'recompute_consensus')  THEN missing := array_append(missing, 'public.recompute_consensus()'); END IF;

--- a/supabase/functions/admin/handlers/user-ban.ts
+++ b/supabase/functions/admin/handlers/user-ban.ts
@@ -16,6 +16,26 @@ export const userBanHandler: ActionHandler<Payload> = {
       ? new Date(Date.now() + payload.duration_hours * 3_600_000).toISOString()
       : null;
 
+    // Idempotent re-ban: if already actively banned, return the existing row
+    // instead of creating a duplicate. The audit row is still written so the
+    // attempt is logged. Future v1.x might extend the existing ban's expires_at
+    // if the new request has a longer duration; for v1 we just no-op.
+    const { data: existing } = await admin
+      .from('user_bans')
+      .select('id, expires_at, reason')
+      .eq('user_id', payload.target_user_id)
+      .is('revoked_at', null)
+      .or('expires_at.is.null,expires_at.gt.' + new Date().toISOString())
+      .maybeSingle();
+
+    if (existing) {
+      return {
+        before: existing,
+        after: existing,
+        target: { type: 'user', id: payload.target_user_id },
+      };
+    }
+
     const { error } = await admin.from('user_bans').insert({
       user_id: payload.target_user_id,
       banned_by: actor.id,

--- a/supabase/functions/admin/handlers/user-unban.ts
+++ b/supabase/functions/admin/handlers/user-unban.ts
@@ -12,15 +12,28 @@ export const userUnbanHandler: ActionHandler<Payload> = {
   requiredRole: 'moderator',
   payloadSchema: Payload,
   async execute(admin, payload, actor, reason) {
-    const { data: before } = await admin.from('user_bans').select('*').eq('id', payload.ban_id).single();
-    if (!before) throw new Error('user.unban: ban not found');
+    const { data: before } = await admin
+      .from('user_bans')
+      .select('*')
+      .eq('id', payload.ban_id)
+      .eq('user_id', payload.target_user_id)
+      .single();
+    // Fail fast if the ban doesn't belong to the stated target — prevents
+    // a mismatched (ban_id, target_user_id) pair from corrupting the audit chain.
+    if (!before) throw new Error('unban: ban_id does not belong to target_user_id');
 
-    const { error } = await admin.from('user_bans').update({
-      revoked_at: new Date().toISOString(),
-      revoked_by: actor.id,
-      revoke_reason: reason,
-    }).eq('id', payload.ban_id);
+    const { data: updated, error } = await admin
+      .from('user_bans')
+      .update({
+        revoked_at: new Date().toISOString(),
+        revoked_by: actor.id,
+        revoke_reason: reason,
+      })
+      .eq('id', payload.ban_id)
+      .eq('user_id', payload.target_user_id)
+      .select();
     if (error) throw new Error(`user.unban: ${error.message}`);
+    if (!updated || updated.length === 0) throw new Error('unban: ban_id does not belong to target_user_id');
 
     const { data: after } = await admin.from('user_bans').select('*').eq('id', payload.ban_id).single();
     return { before, after, target: { type: 'user', id: payload.target_user_id } };


### PR DESCRIPTION
## Summary

Four review-comment fixes from Pamela-ruiz9 (Nyx, APPROVED) + ArtemioPadilla (APPROVED) on PR #77 (Moderator console, already merged).

### 1. `user-unban.ts` — consistency check (Nyx, **real correctness bug**)

The handler updated by `ban_id` only. A moderator could pass mismatched `ban_id` + `target_user_id`, the UPDATE would still succeed, and the audit row's `target.id` would point at the wrong user — the audit chain would lie.

Both the BEFORE fetch and the UPDATE now carry `.eq('id', payload.ban_id).eq('user_id', payload.target_user_id)`. If either fails to match, the handler throws `'unban: ban_id does not belong to target_user_id'` and no audit row gets written. Audit chain integrity preserved.

### 2. `user-ban.ts` — idempotent re-ban (yours)

Double-click on the ban button (or two moderators acting simultaneously) inserted two active rows for the same user. `is_user_banned()` still functioned, but the bans tab showed duplicates and the audit log had two creation events for the same effective state.

Now checks for an active ban (not revoked, not expired) before inserting. If one exists, returns it as `before` + `after` and short-circuits — no duplicate row. The audit row is still written for both attempts so monitoring sees the activity. Future v1.x might extend `expires_at` if the new request has a longer duration; for v1 we no-op.

### 3. `user_bans_no_client_write` — split per-command (yours, clarity)

The single `FOR ALL USING(false) WITH CHECK(false)` was functionally correct (writes from `authenticated` blocked, SELECT delegated to `user_bans_mod_read` via the OR semantics) but the name applied to a `FOR ALL` policy was misleading.

Replaced with three explicit per-command policies: `user_bans_no_client_insert`, `user_bans_no_client_update`, `user_bans_no_client_delete`. The legacy name is DROP'd first for replay-safety against the already-deployed prod DB.

### 4. Sentinel — `observation_comments.locked` column check (yours, defensive)

`ALTER TABLE … ADD COLUMN IF NOT EXISTS locked` is safe in Postgres so risk is low, but a partial migration could land the table without the column and leave the moderator UI silently degraded. Sentinel now does an `information_schema.columns` lookup using the established `array_append(missing, …)` pattern.

## Deferred (correctly per reviewer notes)

- pgTAP RLS policy assertions — already on PR8 list (CORS + rate limit + pgTAP)
- `locked` enforcement on insert (block new comments on locked threads) — v1.1 follow-up

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 459/459 passed
- [x] `npm run build` — 122 pages, zero errors
- [x] `npm run test:e2e -- console-smoke.spec.ts` — 28/28 passed
- [ ] **Post-merge db-apply** — sentinel will verify `locked` column is present on prod (it should be, since PR #77's ALTER TABLE landed; this is a regression guard going forward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)