### PR TITLE
fix(postgrest): disambiguate users embed on observations (2 surfaces)

### DIFF
--- a/src/components/ConsoleObservationsView.astro
+++ b/src/components/ConsoleObservationsView.astro
@@ -216,7 +216,7 @@ const tr = t(lang);
 
     let query = supabase
       .from('observations')
-      .select('id, observer_id, observed_at, primary_taxon_id, obscure_level, location_obscured, observer_license, hidden, hidden_reason, hidden_at, hidden_by, sync_status, created_at, taxa(scientific_name), users(username, display_name)')
+      .select('id, observer_id, observed_at, primary_taxon_id, obscure_level, location_obscured, observer_license, hidden, hidden_reason, hidden_at, hidden_by, sync_status, created_at, taxa(scientific_name), users:observer_id(username, display_name)')
       .order('created_at', { ascending: false })
       .limit(50);
 

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -240,7 +240,7 @@ const rgTitle = validation.research_grade_title  ?? rgLabel;
           id, observed_at, state_province, observer_id,
           identifications(scientific_name, is_primary, is_research_grade, confidence, taxa(common_name_es, common_name_en)),
           media_files(url, is_primary),
-          users(id, username, display_name, profile_public, profile_privacy)
+          users:observer_id(id, username, display_name, profile_public, profile_privacy)
         `)
         .eq('sync_status', 'synced')
         .order('observed_at', { ascending: false })


### PR DESCRIPTION
User-reported error in prod:
```
Could not embed because more than one relationship was found for 'observations' and 'users'
```

**Root cause:** `observations` has two FKs to `users` — the original `observer_id` (NOT NULL, the observer) and `hidden_by` (added by the admin console moderation work for hide audit). PostgREST can't auto-pick when an embed says bare `users(...)`.

**Fix:** alias-style hint `users:observer_id(...)` in:
- `ConsoleObservationsView.astro:219` (admin moderation list)
- `ExploreRecentView.astro:243` (public recent feed)

The alias both names the relationship explicitly and keeps the embed key as `users` so consumer code that reads `row.users` doesn't need any refactoring.

Audited every other `from('observations')` site — none of them embed `users`, so these two were the only affected surfaces.

Verifications: typecheck 0, 454 tests, build clean.