### PR TITLE
docs(specs): community discovery + obs detail page redesign brainstorms

### DIFF
--- a/docs/superpowers/specs/2026-04-29-community-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-29-community-discovery-design.md
@@ -1,0 +1,378 @@
+# Community discovery in Explore (observers, leaderboards, nearby)
+
+**Date:** 2026-04-29
+**Status:** Design — pending user review
+**Owner:** Artemio Padilla
+**Related modules:** 04 (auth/users), 08 (profile / activity / gamification), 25 (profile privacy + public profiles), `2026-04-26-ux-revamp-design.md` (chrome / IA), `2026-04-28-social-features-design.md` (M26 follow + privacy ladder).
+
+---
+
+## Goals
+
+1. Add a **community discovery surface** to Rastrum so signed-in users can find other observers — by activity, taxon expertise, country, or proximity — and follow them.
+2. **Walk back** the shipped "no leaderboards" stance with explicit, granular consent. Discovery is opt-out at the user level, opt-out at the profile-visibility level, and never surfaces precise location.
+3. Stay **zero-cost** on infrastructure — no new paid services, no new compute beyond the existing Supabase free tier, no new external dependencies. All ranking is precomputed nightly into denormalized columns; queries hit partial indexes.
+4. Reuse the existing `MegaMenu.astro`, the existing pmtiles map stack, and the existing follow / privacy primitives shipped in M26.
+
+## Non-goals
+
+- Real-time / streaming leaderboards. Nightly refresh is enough for community discovery; "top this week" doesn't need minute-level freshness.
+- An observer **heatmap** or community map view. Tempting, but punted to v1.1 ("Community Map") so this spec stays scoped.
+- Cross-platform discovery (importing iNaturalist follow graphs etc.). Rastrum-local only.
+- Mod-curated featured-observer lists. v1.0 is purely algorithmic + opt-out; editorial picks are v1.1.
+- New gamification mechanics — no new badges, points, or competitive UX. This is *discovery* infrastructure, not a game.
+- Time-window slicing beyond `7d` and `30d` denorm counters. "All time" remains the default; arbitrary windows are out of scope.
+
+---
+
+## Decisions captured (brainstorming outcome)
+
+| Axis | Decision | Rationale |
+|---|---|---|
+| Principle | **Walk back "no leaderboards"** with explicit consent | User wants full discovery surface incl. ranked lists; principle preserved as opt-out |
+| IA | **Promote `Explore ▾` to MegaMenu**, two columns: Biodiversity / Community | Reuses existing `MegaMenu.astro`; clean conceptual divider; scales to future Community surfaces |
+| Surface | **One page, composable filter chips**, not separate pages per lens | Filters compose ("top in Mexico filtering Aves"); single ranking algorithm; one route to maintain |
+| Time windows | **Include 7-day and 30-day** as denorm counters; no arbitrary windows | "Top this week" is a real UX win; cheap on denorm columns; broader windows are v1.1 |
+| Ranking architecture | **Denorm columns + nightly cron** (not live aggregates, not materialized rollup) | Cheapest at zero-cost target; scales fine through 100k obs; staleness of 24 h acceptable for discovery |
+| Privacy gate | **Single `hide_from_leaderboards` opt-out**, AND requires `profile_public` | Honors existing visibility setting; new toggle separates "ranked" consent from "visible" consent |
+| Nearby gate | **Sign-in required** | Sidesteps anonymous geolocation cost + privacy ick; "log an observation to see nearby observers" is a healthy CTA |
+| Country source | **`country_code` column on `users`**, backfilled from `region_primary` once via in-Postgres ISO-3166 normalizer; user-editable on Profile → Edit | Avoids per-request geocoding; single source of truth; fixable by user when normalizer guesses wrong |
+
+---
+
+## Information architecture
+
+### MegaMenu shape (`src/components/Header.astro` + `MegaMenu.astro`)
+
+```
+Explore ▾
+┌─────────────────────────────────┬─────────────────────────────────┐
+│ BIODIVERSITY                    │ COMMUNITY                       │
+│   • Map                         │   • Observers (all)             │
+│   • Recent                      │   • Top observers               │
+│   • Watchlist                   │   • Nearby     (sign-in gated)  │
+│   • Species                     │   • Experts by taxon            │
+│   • Validate                    │   • By country                  │
+└─────────────────────────────────┴─────────────────────────────────┘
+```
+
+- The Biodiversity column is the existing flat dropdown's contents — no behavior change.
+- The Community column items all link into a single page with different default filters (see "Filter presets" below).
+- The Nearby item is **disabled with a tooltip** for signed-out viewers ("Sign in to find observers near you").
+
+### Mobile drawer (`src/components/MobileDrawer.astro`)
+
+Single grouped section with two sub-headings (`Biodiversity`, `Community`) and a thin divider between them. Same items as desktop, no Nearby gating in the drawer (taps fall through to the page's own empty state).
+
+### Routes
+
+| EN | ES |
+|---|---|
+| `/en/community/observers/` | `/es/comunidad/observadores/` |
+| `/en/community/observers/?sort=obs_count_7d` | `/es/comunidad/observadores/?sort=obs_count_7d` |
+| `/en/community/observers/?nearby=true` | `/es/comunidad/observadores/?nearby=true` |
+| `/en/community/observers/?taxon=Aves` | `/es/comunidad/observadores/?taxon=Aves` |
+| `/en/community/observers/?country=MX` | `/es/comunidad/observadores/?country=MX` |
+
+Add to `src/i18n/utils.ts`:
+
+```ts
+community: { en: '/community', es: '/comunidad' },
+communityObservers: {
+  en: '/community/observers',
+  es: '/comunidad/observadores',
+},
+```
+
+### Filter presets per MegaMenu link
+
+| MegaMenu link | URL params |
+|---|---|
+| Observers (all) | `?sort=observation_count` |
+| Top observers | `?sort=obs_count_30d` |
+| Nearby | `?nearby=true&sort=distance` |
+| Experts by taxon | `?expert=true` (opens taxon-facet picker if no taxon param) |
+| By country | `?country=` (opens country-facet picker if blank) |
+
+---
+
+## Page design — `/community/observers/`
+
+### Layout
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ H1: Community observers      [ Profile → Edit ↗ opt-out link ]   │
+│ Sub: Find observers by activity, expertise, location, or country │
+├──────────────────────────────────────────────────────────────────┤
+│ Filter chips (sticky):                                           │
+│ [ Sort: Most species ▾ ] [ Country: Any ▾ ]                      │
+│ [ Taxon: Any ▾ ] [ Experts only ☐ ] [ Nearby ☐ ]                 │
+├──────────────────────────────────────────────────────────────────┤
+│ Result list (paginated, 20 per page):                            │
+│ ┌──────────────────────────────────────────────────────────────┐ │
+│ │ [avatar] @username · Display Name                  Follow ▸  │ │
+│ │ 🇲🇽 Mexico · Birds, Plants                                    │ │
+│ │ 1,247 obs · 312 species · last seen 2d ago                   │ │
+│ └──────────────────────────────────────────────────────────────┘ │
+│ ...                                                              │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Sort options
+
+| Value | Label (EN) | Underlying column | Index |
+|---|---|---|---|
+| `observation_count` | Most observations (all-time) | `observation_count` | `idx_users_lb_obs_count` |
+| `species_count` | Most species | `species_count` | `idx_users_lb_species` |
+| `obs_count_7d` | Most active this week | `obs_count_7d` | `idx_users_lb_obs_7d` |
+| `obs_count_30d` | Most active this month | `obs_count_30d` | `idx_users_lb_obs_30d` |
+| `last_observation_at` | Recently active | `last_observation_at` | (existing) |
+| `joined_at` | Newest | `joined_at` | (existing) |
+| `distance` | Nearest to me | `centroid_geog` `<->` viewer | `idx_users_lb_centroid` (GIST) |
+
+### Composable filters
+
+- `country=MX` — single ISO-3166-alpha-2 code; partial index on `country_code` makes this fast.
+- `taxon=Aves` — matches against `expert_taxa text[]` (GIN index). Multiple taxa supported via `taxon=Aves,Plantae`.
+- `expert=true` — restricts to `is_expert = true`.
+- `nearby=true` — adds `ST_DWithin(centroid_geog, viewer_centroid, 200000)` (200 km) clause; requires viewer's centroid (sign-in + at least one obs). Also forces `sort=distance` if no other sort given.
+
+All filters compose via `WHERE` AND across the partial-indexed view `community_observers` (defined below).
+
+### Empty states
+
+- No results match filters: *"No observers match these filters. Try removing one."*
+- Nearby with no viewer centroid: *"Log an observation to find observers near you."* + CTA → `/{en,es}/observe/`.
+- Anonymous viewer hits Nearby URL directly: *"Sign in to find observers near you."* + CTA → `/{en,es}/sign-in/`.
+
+---
+
+## Schema — additive, idempotent
+
+```sql
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS species_count          int  NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS obs_count_7d           int  NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS obs_count_30d          int  NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS centroid_geog          geography(POINT, 4326),
+  ADD COLUMN IF NOT EXISTS country_code           text CHECK (country_code ~ '^[A-Z]{2}$'),
+  ADD COLUMN IF NOT EXISTS hide_from_leaderboards boolean NOT NULL DEFAULT false;
+
+-- Partial indexes — every list query operates on an already-filtered set,
+-- so opted-out / private users add zero cost to anyone's query plan.
+CREATE INDEX IF NOT EXISTS idx_users_lb_obs_count ON public.users (observation_count DESC)
+  WHERE NOT hide_from_leaderboards AND profile_public;
+
+CREATE INDEX IF NOT EXISTS idx_users_lb_species   ON public.users (species_count     DESC)
+  WHERE NOT hide_from_leaderboards AND profile_public;
+
+CREATE INDEX IF NOT EXISTS idx_users_lb_obs_7d    ON public.users (obs_count_7d      DESC)
+  WHERE NOT hide_from_leaderboards AND profile_public;
+
+CREATE INDEX IF NOT EXISTS idx_users_lb_obs_30d   ON public.users (obs_count_30d     DESC)
+  WHERE NOT hide_from_leaderboards AND profile_public;
+
+CREATE INDEX IF NOT EXISTS idx_users_lb_country   ON public.users (country_code)
+  WHERE country_code IS NOT NULL AND NOT hide_from_leaderboards AND profile_public;
+
+CREATE INDEX IF NOT EXISTS idx_users_lb_centroid  ON public.users USING GIST (centroid_geog)
+  WHERE centroid_geog IS NOT NULL AND NOT hide_from_leaderboards AND profile_public;
+
+CREATE INDEX IF NOT EXISTS idx_users_lb_expert_taxa ON public.users USING GIN (expert_taxa)
+  WHERE NOT hide_from_leaderboards AND profile_public;
+
+-- Single view consumed by the community page. Centralizing the eligibility
+-- predicate (`profile_public AND NOT hide_from_leaderboards`) means the
+-- predicate appears in exactly one place in application code and exactly
+-- one place in the SQL.
+CREATE OR REPLACE VIEW public.community_observers AS
+SELECT
+  id, username, display_name, avatar_url, country_code,
+  expert_taxa, is_expert,
+  observation_count, species_count, obs_count_7d, obs_count_30d,
+  centroid_geog, last_observation_at, joined_at
+FROM public.users
+WHERE profile_public = true
+  AND hide_from_leaderboards = false;
+
+GRANT SELECT ON public.community_observers TO anon, authenticated;
+
+-- ISO-3166 reference table seeded once; used by the country-code normalizer
+-- in recompute-user-stats and by the Profile → Edit country picker.
+CREATE TABLE IF NOT EXISTS public.iso_countries (
+  code text PRIMARY KEY CHECK (code ~ '^[A-Z]{2}$'),
+  name_en text NOT NULL,
+  name_es text NOT NULL
+);
+
+GRANT SELECT ON public.iso_countries TO anon, authenticated;
+```
+
+### Why a view, not direct queries against `users`?
+
+1. The eligibility predicate has two parts (`profile_public` + `NOT hide_from_leaderboards`); centralizing it in a view prevents drift if either rule evolves.
+2. RLS on `users` already exposes only-self for many columns; the view exposes only the discovery-safe columns (no email, no streak counters, no admin flags).
+3. The community page can `select('*')` against the view and trust the predicate.
+
+### RLS
+
+- View `community_observers` inherits the `users` table's RLS but the predicate filters at the view level. No new policies needed.
+- `iso_countries`: enable RLS, single `SELECT TO PUBLIC` policy, no writes from the application.
+
+---
+
+## Cron — `recompute-user-stats`
+
+New Edge Function `supabase/functions/recompute-user-stats/index.ts`. Deno, deployed via the existing `deploy-functions.yml` workflow (auto-deploys on push to main). Scheduled via pg_cron in `docs/specs/infra/supabase-schema.sql` alongside `recompute-streaks` and `award-badges`.
+
+### Schedule
+
+Nightly at 03:30 UTC (after `recompute-streaks` at 03:00 to avoid contention with the streak cron's `users` writes).
+
+```sql
+SELECT cron.unschedule('recompute-user-stats');
+SELECT cron.schedule(
+  'recompute-user-stats',
+  '30 3 * * *',
+  $$
+    SELECT net.http_post(
+      url := current_setting('app.settings.functions_base_url') || '/recompute-user-stats',
+      headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.settings.cron_token')),
+      timeout_milliseconds := 90000
+    );
+  $$
+);
+```
+
+### Function logic
+
+Single SQL block executed by the function:
+
+```sql
+WITH stats AS (
+  SELECT
+    o.observer_id AS uid,
+    COUNT(*)::int                                          AS obs_total,
+    COUNT(DISTINCT i.taxon_id)::int                        AS species_total,
+    COUNT(*) FILTER (WHERE o.observed_at >= now() - interval '7 days')::int  AS obs_7d,
+    COUNT(*) FILTER (WHERE o.observed_at >= now() - interval '30 days')::int AS obs_30d,
+    ST_Centroid(ST_Collect(o.location::geometry))::geography AS centroid
+  FROM public.observations o
+  LEFT JOIN public.identifications i
+    ON i.observation_id = o.id AND i.is_primary = true
+  WHERE o.sync_status = 'synced'
+    AND o.location IS NOT NULL
+  GROUP BY o.observer_id
+)
+UPDATE public.users u
+SET
+  observation_count = COALESCE(s.obs_total, 0),
+  species_count     = COALESCE(s.species_total, 0),
+  obs_count_7d      = COALESCE(s.obs_7d, 0),
+  obs_count_30d     = COALESCE(s.obs_30d, 0),
+  centroid_geog     = s.centroid,
+  country_code      = COALESCE(u.country_code, public.normalize_country_code(u.region_primary))
+FROM stats s
+WHERE u.id = s.uid;
+```
+
+`public.normalize_country_code(text)` is a stable function that does a case-insensitive lookup against `iso_countries.name_en` / `name_es` first, then a fuzzy match (`pg_trgm` similarity > 0.6). Returns NULL on miss; only sets `country_code` when currently NULL (so user-set values are never overwritten).
+
+### Performance
+
+Estimated cost at 10k users / 100k obs:
+- Aggregate scan: ~200 ms (already indexed on `observer_id`).
+- Centroid: ~500 ms.
+- UPDATE: ~300 ms.
+- **Total: under 2 seconds.** Well within the free-tier compute budget.
+
+At 100k users / 1M obs the cron is still under a minute; rollup-table refactor (option C from brainstorming) becomes attractive only well beyond v1 scale.
+
+---
+
+## Profile → Edit changes
+
+Add two controls to `ProfileEditForm.astro`:
+
+1. **Country** — select bound to `iso_countries`, options labeled per locale. Sets `users.country_code`. Empty option allowed (for users who don't want to declare).
+2. **"Show me in community discovery and leaderboards"** — toggle bound to `users.hide_from_leaderboards` (inverted: on = visible). Helper text: *"When on, your public profile can appear on the Community page and in leaderboards. Turn off any time."*
+
+Toggle is only enabled when `profile_public = true`. When `profile_public = false`, the toggle is rendered disabled with helper text *"Make your profile public to enable community discovery."*
+
+---
+
+## i18n updates
+
+The two shipped strings explicitly stating "no leaderboards" must be rewritten before this surface ships. They contradict the new product direction.
+
+`src/i18n/en.json` line 349 (`gamification_hint`):
+
+```diff
+- "Enable badges, streaks, and activity feed. Quality-gated. No leaderboards."
++ "Enable badges, streaks, and activity feed. Quality-gated. Community leaderboards are opt-in."
+```
+
+`src/i18n/en.json` line 959 (`streak_enable_body`):
+
+```diff
+- "Track your daily observation streak. Quality-gated, opt-in, no leaderboards."
++ "Track your daily observation streak. Quality-gated and opt-in. Community leaderboards are a separate opt-in."
+```
+
+Mirror in `src/i18n/es.json`.
+
+New i18n namespace `community.*` in both locales:
+
+```jsonc
+"community": {
+  "page_title": "Community observers",
+  "page_subtitle": "Find observers by activity, expertise, location, or country.",
+  "sort": { "obs": "Most observations", "species": "Most species", "active_7d": "Most active this week", "active_30d": "Most active this month", "recent": "Recently active", "newest": "Newest", "distance": "Nearest to me" },
+  "filter": { "country": "Country", "taxon": "Taxon", "nearby": "Nearby", "experts_only": "Experts only", "any": "Any" },
+  "card": { "obs": "{n} obs", "species": "{n} species", "last_seen": "last seen {when}", "follow": "Follow", "following": "Following" },
+  "empty": { "no_match": "No observers match these filters. Try removing one.", "nearby_no_centroid": "Log an observation to find observers near you.", "nearby_anon": "Sign in to find observers near you." },
+  "leaderboards_optout_link": "Hide me from community leaderboards"
+}
+```
+
+---
+
+## Tests
+
+### Vitest
+
+- `tests/community/url-state.test.ts` — round-trip the filter state object → URLSearchParams → object. Covers all sort/filter combinations including unknown values (should drop, not crash).
+- `tests/community/normalize-country.test.ts` — input/output table for `normalize_country_code` Postgres function via in-memory pglite (or a seeded test DB if pglite proves slow); covers: ISO codes pass through, `"Mexico"` → `MX`, `"México"` → `MX`, `"México DF"` → `MX`, gibberish → `NULL`.
+
+### Playwright
+
+- `tests/e2e/community.spec.ts` — visit `/en/community/observers/?sort=species`, assert the list is non-empty (seeded fixtures), click the first card, assert nav to `/en/u/<username>/`. Mobile project covers the drawer "Community" subheading appears.
+- Smoke test for `?nearby=true` while signed out: expect the empty-state CTA, no list.
+
+### Manual verification
+
+- Confirm `make db-apply` is replay-safe with the new schema.
+- Confirm `make db-cron-test` fires `recompute-user-stats` and the `users` table updates as expected.
+- Confirm the `hide_from_leaderboards` toggle on Profile → Edit immediately removes the user from the page on next load (no caching issues).
+
+---
+
+## Rollout
+
+1. Schema deltas + view + indexes via `make db-apply`. Pre-merge `db-validate.yml` enforces idempotency.
+2. Deploy `recompute-user-stats` Edge Function via `deploy-functions.yml` (auto on push to main).
+3. Manually trigger the cron once via `make db-cron-test` to backfill all users' stats before the page goes live.
+4. Ship Profile → Edit changes (country picker + opt-out toggle) **before** the Community page link is exposed in the MegaMenu — gives users a chance to opt out before they appear in any list.
+5. Ship the Community page itself + MegaMenu changes.
+6. Update the two "no leaderboards" i18n strings as part of the same PR as step 5 (atomic with surfacing the feature).
+
+---
+
+## Open questions for the implementation plan
+
+(These are deliberately **not** decided here — they're for the planning step.)
+
+- Does the Community page support server-side rendering (SSR) for SEO, or stay client-rendered like other PWA shells? The latter is simpler, the former marginally better for discoverability.
+- Should the Community card show the user's most recent observation thumbnail? Adds visual richness; costs an extra column on the view + nightly thumbnail materialization. Decide in planning.
+- Backfill of `country_code` for existing users — the normalizer will catch most. Stragglers can be left NULL and prompted on next visit. Decide in planning whether to send a one-shot prompt email.

--- a/docs/superpowers/specs/2026-04-29-community-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-29-community-discovery-design.md
@@ -186,7 +186,27 @@ CREATE INDEX IF NOT EXISTS idx_users_lb_expert_taxa ON public.users USING GIN (e
 -- predicate (`profile_public AND NOT hide_from_leaderboards`) means the
 -- predicate appears in exactly one place in application code and exactly
 -- one place in the SQL.
+-- Two views: an anon-safe one without geographic data, and an authenticated-
+-- only one that adds the centroid for the Nearby feature. This addresses the
+-- privacy concern that even a coarse 200 km centroid could narrow location
+-- for low-obs-count users when exposed without authentication.
 CREATE OR REPLACE VIEW public.community_observers AS
+SELECT
+  id, username, display_name, avatar_url, country_code,
+  expert_taxa, is_expert,
+  observation_count, species_count, obs_count_7d, obs_count_30d,
+  last_observation_at, joined_at
+FROM public.users
+WHERE profile_public = true
+  AND hide_from_leaderboards = false;
+
+GRANT SELECT ON public.community_observers TO anon, authenticated;
+
+-- Same eligibility predicate, plus centroid_geog. Authenticated only.
+-- The Nearby feature is sign-in-gated in the UI, and this view enforces
+-- the gate at the SQL layer too — anon callers cannot read centroid even
+-- if they bypass the UI.
+CREATE OR REPLACE VIEW public.community_observers_with_centroid AS
 SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
@@ -196,7 +216,7 @@ FROM public.users
 WHERE profile_public = true
   AND hide_from_leaderboards = false;
 
-GRANT SELECT ON public.community_observers TO anon, authenticated;
+GRANT SELECT ON public.community_observers_with_centroid TO authenticated;
 
 -- ISO-3166 reference table seeded once; used by the country-code normalizer
 -- in recompute-user-stats and by the Profile → Edit country picker.
@@ -214,6 +234,14 @@ GRANT SELECT ON public.iso_countries TO anon, authenticated;
 1. The eligibility predicate has two parts (`profile_public` + `NOT hide_from_leaderboards`); centralizing it in a view prevents drift if either rule evolves.
 2. RLS on `users` already exposes only-self for many columns; the view exposes only the discovery-safe columns (no email, no streak counters, no admin flags).
 3. The community page can `select('*')` against the view and trust the predicate.
+
+### Why two views?
+
+`community_observers` (anon + authenticated) supports the public list, sort, country filter, taxon filter, and experts filter — none of which need the centroid. `community_observers_with_centroid` (authenticated only) is consumed exclusively by the Nearby feature, which already requires sign-in for product reasons (a viewer needs at least one observation to compute their own centroid). Splitting the views means anon callers cannot read `centroid_geog` even via direct PostgREST traffic. The cost is one extra view definition; the benefit is the privacy gate is enforced at the SQL layer, not just in the UI.
+
+### Behavior when a user toggles `profile_public = false`
+
+Because both views read `profile_public` live (no caching, no nightly cron involvement on this column), a user who flips their profile from public to private drops out of `community_observers` and `community_observers_with_centroid` on their next request — no propagation delay. This matters for the rollout plan (step 4 below) and for the user mental model: privacy changes are immediate, not eventually-consistent.
 
 ### RLS
 

--- a/docs/superpowers/specs/2026-04-29-obs-detail-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-29-obs-detail-redesign-design.md
@@ -165,6 +165,11 @@ CREATE INDEX IF NOT EXISTS idx_media_files_active
 ### Material edit detection (trigger)
 
 ```sql
+-- Composes with sync_primary_id_trigger (also BEFORE UPDATE on observations).
+-- The sync trigger *writes* primary_taxon_id from the identifications table;
+-- this trigger *reads* (compares NEW.primary_taxon_id vs OLD) to decide
+-- whether to flag the row as materially edited. Different responsibilities,
+-- no column-write contention, alphabetical trigger ordering is irrelevant.
 CREATE OR REPLACE FUNCTION public.observations_material_edit_check()
 RETURNS trigger AS $$
 DECLARE
@@ -284,7 +289,9 @@ UPDATE public.observations
 
 The community-IDs section then renders a "needs review" pill on the primary ID. Owner can clear it by re-affirming manually (selecting a new primary identification, or making a new manual ID).
 
-The choice to do this client-side vs. server-side: an Edge Function `delete-photo` is preferred for atomicity (the soft-delete + ID demote + edit-flag should be one logical commit). Implementation-plan decision; spec says "the operation is atomic" without nailing the implementation.
+**Decision: server-side via a new `delete-photo` Edge Function.** The soft-delete + ID demote + `last_material_edit_at` bump must commit atomically. A client-side two-call implementation has a real failure mode: if the soft-delete succeeds and the user closes the tab before the demote call lands, the observation is left with no primary photo but an active primary ID — the exact "stale state" the spec is trying to prevent. Edge Functions wrap the operations in a single SQL transaction (`BEGIN ... COMMIT`) and return only after all three writes succeed.
+
+The function lives at `supabase/functions/delete-photo/index.ts` and is deployed via the existing `deploy-functions.yml` workflow. RLS on `media_files` and `identifications` already gates writes to the owner; the function re-verifies `auth.uid() = observer_id` before issuing the transaction.
 
 ---
 
@@ -357,6 +364,5 @@ Each step is independently shippable and independently revertible. The order is 
 (These are deliberately **not** decided here — they're for the planning step.)
 
 - Photo replacement workflow when the cascade-driving photo is deleted **and** the user immediately uploads a replacement: does the new photo become eligible to be "the" cascade photo (which would then need a fresh AI run), or does the obs stay in "needs review" until manually re-affirmed? Recommend: stay in needs-review; the cascade does not auto-re-fire on edit. Confirm during planning.
-- Is the photo-delete + ID-demote done client-side (two RLS-gated calls) or server-side (one `delete-photo` Edge Function)? Edge Function preferred for atomicity. Confirm during planning.
-- Lightbox library: bring in `photoswipe` (mature, ~30 kB gzipped) or write a minimal native one? PWA bundle is performance-sensitive per CLAUDE.md; default to native unless the savings are too small. Decide during planning.
+- Lightbox implementation: write a minimal native one if it lands at ≤150 lines (keyboard nav + swipe + Esc + share button per photo); fall back to `photoswipe` (~30 kB gzipped) only if the native version pushes past that line budget. PWA bundle is performance-sensitive per CLAUDE.md; native is the default. Final call after a prototype during planning.
 - Whether to add an "Edited at" line to the public-facing metadata grid (showing `updated_at` to viewers) — minor transparency win vs. extra clutter. Defer to planning.

--- a/docs/superpowers/specs/2026-04-29-obs-detail-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-29-obs-detail-redesign-design.md
@@ -1,0 +1,362 @@
+# Observation detail page redesign — viewer + owner edit
+
+**Date:** 2026-04-29
+**Status:** Design — pending user review
+**Owner:** Artemio Padilla
+**Related modules:** 03 (observations / media files), 06 (sensitive species + obscure_level), 13 (identifier registry / cascade), 22 (community validation), 25 (privacy ladder), 26 (social — reactions / follow on detail page).
+
+---
+
+## Goals
+
+1. Turn `src/pages/share/obs/index.astro` from a single-column data dump into a **richer viewer** with map + photo gallery + a layout that respects the photo+map as the primary content.
+2. Replace the 3-field "manage" form with a real **owner edit experience** — coordinate editor (the page's central pain point: today owners cannot fix wrong coordinates at all), date/time, full metadata (habitat / weather / establishment), photo add/remove.
+3. Stay **zero-cost** on infrastructure. All map UX reuses the existing pmtiles + MapLibre stack already wired into `ObservationForm.astro` (lines 568–600 today). No new external services.
+4. Ship clean **edit-after-IDs semantics** — owner edits never silently invalidate community-given IDs, but material edits (photo, location, date, primary name) are flagged so reviewers can re-affirm. Cascade-driving photo removal prompts the owner before demoting the primary ID.
+5. Reuse the new map-picker component for the future v1.1 community heatmap, the existing observe form, and any other surface that needs map view/edit.
+
+## Non-goals
+
+- A full edit "republish" workflow (drafts, version history, edit notifications to followers). Edits are immediate and atomic; no draft state.
+- Mod-curated observation showcases / featured-obs UX. Out of scope.
+- Bulk edit (edit many observations at once). Single-obs only.
+- A new identifier cascade run on photo replacement. The cascade fires only on the original create path; replacing photos does not re-trigger AI ID generation.
+- Real R2 blob deletion. Soft-delete only for v1; an `gc-orphan-media` cron is a v1.1 follow-up.
+- Restructuring the URL or making it locale-prefixed. The page stays at `/share/obs/?id=…` (locale-neutral, per the existing CLAUDE.md regression note).
+
+---
+
+## Decisions captured (brainstorming outcome)
+
+| Axis | Decision | Rationale |
+|---|---|---|
+| Scope | **All 7 items in** (① map view, ② coord editor, ③ photo gallery, ④ date edit, ⑤ habitat/weather/establishment edit, ⑥ photo add/remove, ⑦ layout overhaul) | User confirmed full redesign over phased "minimum" |
+| Layout | **Two-column desktop, stacked mobile.** Sticky photo + map on left, scrolling metadata + IDs + manage + comments on right | Matches iNaturalist / eBird / Observation.org idiom; preserves single-scroll mobile experience |
+| Edit invalidation | **Minor / material split.** Material edits flag `last_material_edit_at` and surface an "edited after IDs" badge | Audit trail without silent ID invalidation; weight-down logic is a module 13 follow-up |
+| Photo deletion | **Soft-delete only (v1).** R2 blobs left as orphans; `gc-orphan-media` cron is v1.1 | Cheapest and safest; matches current v1 policy in `share/obs/index.astro` comments |
+| Cascade-driving photo removal | **Confirm dialog + demote primary ID to needs-review.** Identification record persists | Audit trail intact; UX is explicit and reversible (re-adding a photo doesn't auto-restore primary, owner re-affirms manually) |
+| Map component | **Extract a reusable `MapPicker.astro`** from `ObservationForm.astro` lines 568–600 | The view/edit modes share 90% of code; extracting prevents drift and unlocks v1.1 community heatmap |
+| Manage panel structure | **Tabs inside the manage panel** — `Details` / `Location` / `Photos` | Five+ editable surfaces become unwieldy in a single form; tabs keep each task focused |
+| Date editing | **`<input type="datetime-local">`** | Native, free, accessible; matches the create form's pattern |
+| Privacy of edits | **Edits inherit the existing `obscure_level` rules** | No new RLS policies; existing trigger handles re-coarsening on coord change |
+
+---
+
+## Layout
+
+### Desktop (`md:` and up)
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ STICKY LEFT (md:w-1/2 lg:w-7/12, max 720px)                              │
+│   Hero photo (16:10, max-h-[60vh], lazy-loaded)                          │
+│   ▣ ▣ ▣ ▣ thumb strip (only if >1 photo)                                 │
+│   ─────                                                                  │
+│   Mini-map (h-[240px])                                                   │
+│     📍 pin (precise / coarsened per obscure_level)                       │
+│     "Coords: 19.500°N, 101.600°W (precise)" — owner only                 │
+│     "Coords: ~19.5°N, ~101.6°W (10 km)" — public, sensitive species      │
+│     [ Edit location ↗ ] — owner only, opens MapPicker(mode='edit')       │
+├──────────────────────────────────────────────────────────────────────────┤
+│ SCROLL RIGHT                                                             │
+│   H1 species (italic) + meta line (date · observer link)                 │
+│   FollowButton + ShareButton + Report button                             │
+│   ReactionStrip (existing)                                               │
+│   Sensitive species notice (existing, hidden by default)                 │
+│   Metadata grid: Date · Region · Habitat · Weather · Establishment       │
+│   Community IDs section (existing, with "edited after IDs" badge if      │
+│       last_material_edit_at IS NOT NULL)                                 │
+│   ───── (owner-only divider)                                             │
+│   ObsManagePanel — owner-only, with internal tabs                        │
+│     [ Details ] [ Location ] [ Photos ]                                  │
+│   Comments (existing)                                                    │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Mobile (`< md:`)
+
+Single column, stacked in this order:
+
+```
+1. Hero photo + thumb strip
+2. Mini-map (h-[180px], coords below)
+3. H1 + meta line
+4. Action row: Follow · Share · Report
+5. ReactionStrip
+6. Sensitive notice
+7. Metadata grid (2-col)
+8. Community IDs
+9. ObsManagePanel (owner only) — tabs work the same as desktop
+10. Comments
+```
+
+The mobile and desktop layouts share 100% of the same components — the difference is purely Tailwind responsive classes on the outer grid container.
+
+---
+
+## New shared components
+
+### `src/components/MapPicker.astro` (new)
+
+Extracted from `ObservationForm.astro` lines 568–600. Accepts:
+
+| Prop | Type | Notes |
+|---|---|---|
+| `mode` | `'view' \| 'edit'` | View = pin only, no drag, no save. Edit = draggable pin + lat/lng inputs + Save / Cancel buttons. |
+| `initialCoords` | `{ lat: number; lng: number } \| null` | Initial pin position. `null` is valid in edit mode (drops pin at viewer's location or a default region). |
+| `obscureLevel` | `'none' \| '5km' \| '0.1deg' \| '0.2deg' \| 'full'` | Drives both pin precision (in view mode) and the coarsening preview (in edit mode). |
+| `lang` | `'en' \| 'es'` | i18n. |
+| `onSelect` | `(coords) => void` | Edit-mode only; called when user clicks Save. |
+
+Internally uses MapLibre + the existing `PUBLIC_PMTILES_MX_URL` pmtiles source. The `ObservationForm.astro` create flow migrates to consume this component (no behavior change there; this is pure refactor).
+
+### `src/components/PhotoGallery.astro` (new)
+
+| Prop | Type | Notes |
+|---|---|---|
+| `photos` | `Array<{ id; url; thumbnail_url; caption?; width?; height? }>` | Filtered already to `deleted_at IS NULL` rows. |
+| `lang` | `'en' \| 'es'` | i18n. |
+| `mode` | `'viewer' \| 'owner'` | Owner mode shows a delete button on each photo in the lightbox. |
+
+Renders a hero photo + below-the-hero thumbnail strip (only when `photos.length > 1`). Click any thumbnail or the hero opens a full-screen lightbox with keyboard nav (← / →), swipe-on-mobile, Esc-to-close, and per-photo share button. Below-fold thumbnails get `loading="lazy"` per the existing CLAUDE.md convention.
+
+### `src/components/ObsManagePanel.astro` (new)
+
+Replaces the inline `<section id="manage-panel">` block in `share/obs/index.astro` (lines 105–135 today). Three internal tabs:
+
+#### Details tab
+
+- Scientific-name override (existing input).
+- Date / time: `<input type="datetime-local">` bound to `observed_at` in the user's local timezone.
+- Habitat: `<select>` reusing options from new `src/lib/observation-enums.ts`.
+- Weather: `<select>` from same module.
+- Establishment means: `<select>` from same module.
+- Notes textarea (existing).
+- Location-privacy `<select>` (existing).
+- Save button.
+
+#### Location tab
+
+- Static map preview at the obs's current pin (read-only `MapPicker mode='view'`).
+- "Edit location" button → opens `MapPicker mode='edit'` in a modal. Save persists new lat/lng to `observations`.
+- Helper text: *"Drag the pin or type coordinates. If the species is sensitive, the public map will still show only a coarsened area."*
+
+#### Photos tab
+
+- Grid of current photos with delete button each.
+- "Add photo" button at the bottom — opens the existing photo picker / camera flow from `ObservationForm.astro` and uploads via `lib/upload.ts` (R2 → `media_files` insert).
+- Delete confirmation logic per Q3 below.
+
+---
+
+## Schema deltas
+
+```sql
+ALTER TABLE public.observations
+  ADD COLUMN IF NOT EXISTS last_material_edit_at timestamptz;
+
+ALTER TABLE public.media_files
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_media_files_active
+  ON public.media_files (observation_id) WHERE deleted_at IS NULL;
+```
+
+### Material edit detection (trigger)
+
+```sql
+CREATE OR REPLACE FUNCTION public.observations_material_edit_check()
+RETURNS trigger AS $$
+DECLARE
+  is_material boolean := false;
+BEGIN
+  -- location moved more than 1 km
+  IF NEW.location IS DISTINCT FROM OLD.location AND OLD.location IS NOT NULL THEN
+    IF ST_Distance(NEW.location, OLD.location) > 1000 THEN
+      is_material := true;
+    END IF;
+  END IF;
+
+  -- observed_at moved more than 24 hours
+  IF NEW.observed_at IS DISTINCT FROM OLD.observed_at AND OLD.observed_at IS NOT NULL THEN
+    IF abs(extract(epoch FROM (NEW.observed_at - OLD.observed_at))) > 86400 THEN
+      is_material := true;
+    END IF;
+  END IF;
+
+  -- primary taxon changed (denormalized from identifications by the existing
+  -- sync_primary_id_trigger; covers the "scientific name override" case
+  -- because changing the primary identification flows through that trigger)
+  IF NEW.primary_taxon_id IS DISTINCT FROM OLD.primary_taxon_id THEN
+    is_material := true;
+  END IF;
+
+  IF is_material THEN
+    NEW.last_material_edit_at := now();
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS observations_material_edit_check_trg ON public.observations;
+CREATE TRIGGER observations_material_edit_check_trg
+  BEFORE UPDATE ON public.observations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.observations_material_edit_check();
+```
+
+The trigger fires `BEFORE UPDATE` and only mutates `last_material_edit_at` on `NEW`. It composes safely with the existing `sync_primary_id_trigger` (which propagates primary-identification changes into `observations.primary_taxon_id`): when an owner changes the primary ID, the sync trigger updates `primary_taxon_id`, this trigger then fires on the same UPDATE row and sees `NEW.primary_taxon_id IS DISTINCT FROM OLD.primary_taxon_id`. Trigger ordering is alphabetical by name in Postgres; `observations_material_edit_check_trg` sorts after any `sync_primary_…` name, but trigger ordering only matters when both triggers mutate the same column — they don't here, so the apparent ordering is irrelevant.
+
+Photo material-edits — adding/removing photos — are detected in application code at the `media_files` insert/soft-delete site, which then issues `UPDATE observations SET last_material_edit_at = now() WHERE id = $1`. This UPDATE will pass through the trigger above; none of the watched columns (`location`, `observed_at`, `primary_taxon_id`) change, so the trigger is a no-op for that pass.
+
+### RLS
+
+No new RLS policies needed.
+
+- `observations` UPDATE: existing policy already gates on `auth.uid() = observer_id`.
+- `media_files` UPDATE (for soft-delete): existing policy gates on owner via the FK to `observations`.
+- `media_files` INSERT (for add-photo): existing policy.
+
+---
+
+## Edit semantics — minor vs. material
+
+| Edit | Class | Behavior |
+|---|---|---|
+| Notes change | Minor | `updated_at` bumps, no badge |
+| Habitat / weather / establishment_means change | Minor | `updated_at` bumps, no badge |
+| Location-privacy (`obscure_level`) change | Minor | `updated_at` bumps, sensitivity recomputed by existing trigger, no badge |
+| Location move ≤ 1 km | Minor | `updated_at` bumps, no badge (small fixes don't invalidate IDs) |
+| Location move > 1 km | **Material** | Trigger sets `last_material_edit_at` |
+| Date moves ≤ 24 h | Minor | No badge |
+| Date moves > 24 h | **Material** | Trigger sets `last_material_edit_at` |
+| Primary taxon changes (via name override or accepted ID switch) | **Material** | `sync_primary_id_trigger` updates `primary_taxon_id`, this trigger flags it |
+| Photo added | Minor | No badge (additive) |
+| Photo removed | **Material** | Application sets `last_material_edit_at` |
+
+The "edited after IDs" badge in the IDs section reads: *"Edited after IDs were given. Suggesters may want to re-affirm."* (EN) / *"Editado después de las identificaciones. Los sugerentes pueden querer reafirmar."* (ES).
+
+The badge is suppressed when there are no community IDs yet (no one to alert). The badge persists indefinitely once set; there is no "clear edit history" UX in v1.
+
+Module 13 (consensus weighting) will read `last_material_edit_at` in a follow-up; this spec only persists the column and surfaces the badge. Wire-up of consensus weight is a v1.1 follow-up captured in the implementation plan's open questions.
+
+---
+
+## Photo deletion semantics
+
+### Soft-delete only
+
+Clicking "Delete photo" in the Photos tab issues:
+
+```sql
+UPDATE public.media_files
+   SET deleted_at = now()
+ WHERE id = $1
+   AND observation_id IN (SELECT id FROM observations WHERE observer_id = auth.uid());
+```
+
+The R2 blob is **not** deleted. Future GC cron `gc-orphan-media` (v1.1) walks R2 and removes blobs not referenced by any non-deleted `media_files` row. Documented as a known v1.0 limitation.
+
+### Confirm-before-demote logic (Q3)
+
+Before issuing the soft-delete, the client checks:
+
+```ts
+const willLeaveZeroPhotos = photos.filter(p => p.id !== id && !p.deleted_at).length === 0;
+const isCascadePhoto = primaryIdentification?.source_photo_id === id;
+const willDemote = willLeaveZeroPhotos || isCascadePhoto;
+```
+
+If `willDemote`, render confirm: *"This photo was the basis for the current identification. Deleting it will mark the observation as needing review. Continue?"*
+
+On confirm, after the soft-delete UPDATE succeeds, the client (or — preferably — a `delete-photo` Edge Function for atomicity):
+
+```sql
+UPDATE public.identifications
+   SET verified = false
+ WHERE observation_id = $obs_id AND is_primary = true;
+
+UPDATE public.observations
+   SET last_material_edit_at = now()
+ WHERE id = $obs_id;
+```
+
+The community-IDs section then renders a "needs review" pill on the primary ID. Owner can clear it by re-affirming manually (selecting a new primary identification, or making a new manual ID).
+
+The choice to do this client-side vs. server-side: an Edge Function `delete-photo` is preferred for atomicity (the soft-delete + ID demote + edit-flag should be one logical commit). Implementation-plan decision; spec says "the operation is atomic" without nailing the implementation.
+
+---
+
+## i18n
+
+Add to `src/i18n/{en,es}.json`:
+
+```jsonc
+"obs_detail": {
+  "tabs": { "details": "Details", "location": "Location", "photos": "Photos" },
+  "edit_location": "Edit location",
+  "coords_precise_label": "Precise (only you can see this)",
+  "coords_obscured_label": "Coarsened to ~{km} km (public)",
+  "edited_badge": "Edited after IDs were given. Suggesters may want to re-affirm.",
+  "needs_review": "Needs review",
+  "delete_photo_confirm": "This photo was the basis for the current identification. Deleting it will mark the observation as needing review. Continue?",
+  "delete_obs_confirm": "Delete this observation? This cannot be undone.",
+  "add_photo": "Add photo",
+  "delete_photo": "Delete photo",
+  "save_changes": "Save changes",
+  "saved": "Saved.",
+  "errors": { "coords_invalid": "Latitude must be between −90 and 90, longitude between −180 and 180.", "save_failed": "Save failed. Please try again.", "upload_failed": "Photo upload failed. Please try again." }
+}
+```
+
+Mirror in ES.
+
+`src/lib/observation-enums.ts` (new) exports the option lists previously inline in `ObservationForm.astro` — `habitats`, `weathers`, `establishmentMeans`, plus their bilingual labels — so the create form and the manage panel share one source of truth.
+
+---
+
+## Tests
+
+### Vitest
+
+- `tests/obs-detail/material-edit-trigger.test.ts` — pglite (or seeded test DB) — table of input deltas → expected `last_material_edit_at` set / not set. Covers all branches of the trigger (coords ≤/> 1 km, date ≤/> 24 h, sci-name change, no-op).
+- `tests/obs-detail/observation-enums.test.ts` — snapshot test of the enum option lists; ensures the create form and manage panel can't drift.
+- `tests/obs-detail/photo-deletion-policy.test.ts` — given a list of photos and a primary ID, assert `willDemote` correctly identifies the cases.
+
+### Playwright
+
+- `tests/e2e/obs-detail-view.spec.ts` — open a seeded multi-photo obs, assert hero photo + thumb strip + map render, click thumb opens lightbox, Esc closes.
+- `tests/e2e/obs-detail-edit.spec.ts` — sign in as owner, open Location tab, drag pin, save, reload, assert pin moved + "edited after IDs" badge if seeded with prior IDs.
+- Mobile-chrome project: same flows, asserting the stacked layout.
+
+### Manual verification
+
+- Confirm `make db-apply` is replay-safe (the trigger drop-and-recreate is idempotent).
+- Confirm photo soft-delete preserves the R2 blob (check bucket; verify `media_files.deleted_at` is set, file still listable in R2).
+- Confirm cascade-photo deletion demotes the primary ID and the "needs review" pill renders.
+
+---
+
+## Rollout
+
+1. Schema deltas (columns + trigger) via `make db-apply`. Pre-merge `db-validate.yml` enforces idempotency.
+2. Extract `MapPicker.astro` and refactor `ObservationForm.astro` to consume it — ship as a no-behavior-change refactor PR first, with full e2e coverage, before any user-visible changes to the obs detail page.
+3. Build `PhotoGallery.astro` and integrate into the obs detail page (Phase A, viewer-only).
+4. Build `ObsManagePanel.astro` with the Details tab first (date/time + habitat/weather/establishment + existing fields). Ship.
+5. Add the Location tab (coordinate edit). Ship.
+6. Add the Photos tab (gallery management with cascade-photo confirm logic). Ship.
+7. Update the in-code `share/obs/index.astro` comment that says "the R2 photo blobs are left as orphans, acceptable for v1" to reference the new `gc-orphan-media` v1.1 follow-up explicitly.
+
+Each step is independently shippable and independently revertible. The order is chosen to surface bugs in the most-reused component (MapPicker) first.
+
+---
+
+## Open questions for the implementation plan
+
+(These are deliberately **not** decided here — they're for the planning step.)
+
+- Photo replacement workflow when the cascade-driving photo is deleted **and** the user immediately uploads a replacement: does the new photo become eligible to be "the" cascade photo (which would then need a fresh AI run), or does the obs stay in "needs review" until manually re-affirmed? Recommend: stay in needs-review; the cascade does not auto-re-fire on edit. Confirm during planning.
+- Is the photo-delete + ID-demote done client-side (two RLS-gated calls) or server-side (one `delete-photo` Edge Function)? Edge Function preferred for atomicity. Confirm during planning.
+- Lightbox library: bring in `photoswipe` (mature, ~30 kB gzipped) or write a minimal native one? PWA bundle is performance-sensitive per CLAUDE.md; default to native unless the savings are too small. Decide during planning.
+- Whether to add an "Edited at" line to the public-facing metadata grid (showing `updated_at` to viewers) — minor transparency win vs. extra clutter. Defer to planning.


### PR DESCRIPTION
## Summary

Two design specs from the 2026-04-29 brainstorming session, ready for review:

- **`2026-04-29-community-discovery-design.md`** — adds a Community surface to the Explore MegaMenu (Observers / Top / Nearby / Experts by taxon / By country) with composable filters. Walks back the shipped *"no leaderboards"* stance via an opt-out toggle. Zero-cost: denormalized counters refreshed nightly by a new \`recompute-user-stats\` Edge Function; partial indexes filter to opted-in public users only.
- **`2026-04-29-obs-detail-redesign-design.md`** — rebuilds \`/share/obs/?id=...\` as a two-column desktop / stacked mobile layout. Adds map view, photo gallery + lightbox, and a full owner edit experience (coordinate editor, date/time, habitat/weather/establishment, photo add+remove). Extracts a reusable \`MapPicker.astro\` from \`ObservationForm\`. Material-vs-minor edit semantics with an *\"edited after IDs\"* badge; cascade-driving photo deletion prompts before demoting the primary ID to needs-review.

Both specs include: goals, non-goals, decisions table, schema deltas (idempotent), RLS notes, i18n updates, test plan, and rollout. Implementation plans + feature PRs follow once these are approved.

## Test plan

This PR is docs-only; no runtime impact. Review focus:

- [ ] Community spec — confirm the privacy gate (\`profile_public AND NOT hide_from_leaderboards\`) is acceptable; review the i18n rewrites to the two existing \"no leaderboards\" strings.
- [ ] Community spec — confirm \`recompute-user-stats\` cron schedule (nightly 03:30 UTC) doesn't conflict with existing crons.
- [ ] Obs detail spec — confirm the material-edit thresholds (coords >1 km, date >24 h, primary_taxon_id change) match your editorial sense.
- [ ] Obs detail spec — confirm the soft-delete-only photo policy (R2 GC parked as v1.1) is acceptable.
- [ ] Obs detail spec — confirm the cascade-photo confirm-then-demote flow.
- [ ] Both — confirm no decisions are buried in \"open questions\" that should have been settled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)