### PR TITLE
docs(specs): correct community + obs-detail specs against schema reality

### DIFF
--- a/docs/superpowers/specs/2026-04-29-community-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-29-community-discovery-design.md
@@ -256,21 +256,21 @@ New Edge Function `supabase/functions/recompute-user-stats/index.ts`. Deno, depl
 
 ### Schedule
 
-Nightly at 03:30 UTC (after `recompute-streaks` at 03:00 to avoid contention with the streak cron's `users` writes).
+Nightly at 08:00 UTC, slotted after the existing `streaks-nightly` (07:00 UTC) and `badges-nightly` (07:30 UTC) cluster in `docs/specs/infra/cron-schedules.sql`. The 30-minute gap after badges-nightly is enough headroom; the recompute job is read-mostly with one bulk UPDATE so contention with badges (which writes user_badges) is minimal even if badges runs long.
+
+The schedule registration goes into `docs/specs/infra/cron-schedules.sql` alongside the existing entries, in the same `DO $$ ... v_base := … $$` block. Match the existing cron pattern verbatim — `recompute-user-stats` is deployed `--no-verify-jwt` (cron-only, not user-facing), so no Authorization header is needed and no Bearer token / vault read is involved.
 
 ```sql
-SELECT cron.unschedule('recompute-user-stats');
-SELECT cron.schedule(
-  'recompute-user-stats',
-  '30 3 * * *',
-  $$
-    SELECT net.http_post(
-      url := current_setting('app.settings.functions_base_url') || '/recompute-user-stats',
-      headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.settings.cron_token')),
-      timeout_milliseconds := 90000
-    );
-  $$
-);
+PERFORM cron.unschedule('recompute-user-stats')
+  FROM cron.job WHERE jobname = 'recompute-user-stats';
+
+PERFORM cron.schedule('recompute-user-stats', '0 8 * * *', format($body$
+  SELECT net.http_post(
+    url     := %L,
+    headers := '{"Content-Type":"application/json"}'::jsonb,
+    body    := '{}'::jsonb
+  );
+$body$, v_base || '/recompute-user-stats'));
 ```
 
 ### Function logic

--- a/docs/superpowers/specs/2026-04-29-obs-detail-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-29-obs-detail-redesign-design.md
@@ -165,11 +165,17 @@ CREATE INDEX IF NOT EXISTS idx_media_files_active
 ### Material edit detection (trigger)
 
 ```sql
--- Composes with sync_primary_id_trigger (also BEFORE UPDATE on observations).
--- The sync trigger *writes* primary_taxon_id from the identifications table;
--- this trigger *reads* (compares NEW.primary_taxon_id vs OLD) to decide
--- whether to flag the row as materially edited. Different responsibilities,
--- no column-write contention, alphabetical trigger ordering is irrelevant.
+-- Composition with sync_primary_id_trigger (the AFTER INSERT/UPDATE trigger
+-- on the *identifications* table that cascades primary-ID changes into
+-- observations.primary_taxon_id):
+--   1. owner switches primary identification on identifications row
+--   2. sync_primary_id_trigger fires AFTER, runs UPDATE on observations
+--      setting primary_taxon_id to the new taxon
+--   3. that UPDATE on observations fires this BEFORE UPDATE trigger
+--   4. NEW.primary_taxon_id IS DISTINCT FROM OLD.primary_taxon_id
+--      → is_material := true → last_material_edit_at := now()
+-- The two triggers operate on different tables, so there is no ordering
+-- ambiguity at all. They compose in the conventional cascading style.
 CREATE OR REPLACE FUNCTION public.observations_material_edit_check()
 RETURNS trigger AS $$
 DECLARE
@@ -211,7 +217,7 @@ CREATE TRIGGER observations_material_edit_check_trg
   EXECUTE FUNCTION public.observations_material_edit_check();
 ```
 
-The trigger fires `BEFORE UPDATE` and only mutates `last_material_edit_at` on `NEW`. It composes safely with the existing `sync_primary_id_trigger` (which propagates primary-identification changes into `observations.primary_taxon_id`): when an owner changes the primary ID, the sync trigger updates `primary_taxon_id`, this trigger then fires on the same UPDATE row and sees `NEW.primary_taxon_id IS DISTINCT FROM OLD.primary_taxon_id`. Trigger ordering is alphabetical by name in Postgres; `observations_material_edit_check_trg` sorts after any `sync_primary_…` name, but trigger ordering only matters when both triggers mutate the same column — they don't here, so the apparent ordering is irrelevant.
+The trigger fires `BEFORE UPDATE` on `observations` and only mutates `last_material_edit_at` on `NEW`. It composes with the existing `sync_primary_id_trigger`, which lives on the *`identifications`* table (not `observations`) and fires `AFTER INSERT OR UPDATE OF is_primary, taxon_id`. The composition is purely cascading: a primary-identification change on `identifications` → `sync_primary_id_trigger` AFTER fires → it issues an UPDATE on `observations` setting `primary_taxon_id` → that UPDATE fires this BEFORE UPDATE trigger on `observations` → it observes `NEW.primary_taxon_id IS DISTINCT FROM OLD.primary_taxon_id` and stamps `last_material_edit_at`. The two triggers run on different tables, so there is no ordering or column-contention concern.
 
 Photo material-edits — adding/removing photos — are detected in application code at the `media_files` insert/soft-delete site, which then issues `UPDATE observations SET last_material_edit_at = now() WHERE id = $1`. This UPDATE will pass through the trigger above; none of the watched columns (`location`, `observed_at`, `primary_taxon_id`) change, so the trigger is a no-op for that pass.
 
@@ -269,7 +275,11 @@ Before issuing the soft-delete, the client checks:
 
 ```ts
 const willLeaveZeroPhotos = photos.filter(p => p.id !== id && !p.deleted_at).length === 0;
-const isCascadePhoto = primaryIdentification?.source_photo_id === id;
+// media_files.is_primary marks the cover/lead photo for the observation;
+// it is the column the AI cascade and the public viewer key off. Removing
+// it without a replacement leaves the obs in a needs-review state.
+const photoToDelete = photos.find(p => p.id === id);
+const isCascadePhoto = photoToDelete?.is_primary === true;
 const willDemote = willLeaveZeroPhotos || isCascadePhoto;
 ```
 
@@ -278,8 +288,15 @@ If `willDemote`, render confirm: *"This photo was the basis for the current iden
 On confirm, after the soft-delete UPDATE succeeds, the client (or — preferably — a `delete-photo` Edge Function for atomicity):
 
 ```sql
+-- The identifications table has no `verified` column; community validation
+-- is tracked by validated_at/validated_by, and research-grade status by
+-- is_research_grade. Demoting clears all three so the consensus view drops
+-- the row from is_research_grade joins and the UI's "needs review" pill
+-- can read either flag.
 UPDATE public.identifications
-   SET verified = false
+   SET validated_by      = NULL,
+       validated_at      = NULL,
+       is_research_grade = false
  WHERE observation_id = $obs_id AND is_primary = true;
 
 UPDATE public.observations


### PR DESCRIPTION
## Summary

While writing the implementation plans for the two 2026-04-29 design specs (parallel agent runs against \`docs/superpowers/specs/2026-04-29-*.md\`), three real schema bugs surfaced in the obs-detail spec and one infra-pattern mismatch in the community spec. Verified each against the live \`supabase-schema.sql\` + \`cron-schedules.sql\` before amending.

The plans themselves landed in \`ab24457\` (PR #85) — this PR is just the spec catch-up so the specs stop misrepresenting the codebase.

### obs-detail-redesign-design.md

- **\`primaryIdentification?.source_photo_id\` → \`media_files.is_primary\`.** No \`source_photo_id\` column exists; the canonical \"this photo is the cover\" flag is \`media_files.is_primary\` (schema line 350).
- **\`SET verified = false\` → \`validated_by = NULL, validated_at = NULL, is_research_grade = false\`.** No \`verified\` column on \`identifications\`; community validation is tracked via \`validated_by\`/\`validated_at\` and research-grade status via \`is_research_grade\`. Comment explains why all three flip together.
- **Trigger composition prose corrected.** Spec said \`sync_primary_id_trigger\` is \"BEFORE UPDATE on observations\" — it actually fires \`AFTER INSERT/UPDATE\` on \`identifications\` and propagates to \`observations.primary_taxon_id\` via cascading UPDATE. The composition still works; the description was just wrong.

### community-discovery-design.md

- **Cron pattern + slot.** Spec proposed \`current_setting('app.settings.functions_base_url')\` + Bearer cron token at 03:30 UTC. Existing \`cron-schedules.sql\` deploys all crons \`--no-verify-jwt\` with a bare \`net.http_post\` (no Authorization header). Switched to match the existing pattern verbatim and slotted at 08:00 UTC, after the existing 07:00 / 07:30 cluster.

## Test plan

Docs-only; no runtime impact. Review focus:

- [ ] Confirm \`media_files.is_primary\` is the right cascade-photo proxy (vs. adding a real \`source_photo_id\` column in v1.1).
- [ ] Confirm the demote triple (\`validated_by\`/\`validated_at\`/\`is_research_grade\`) matches the consensus view's read columns.
- [ ] Confirm 08:00 UTC cron slot doesn't conflict with anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)