### PR TITLE
fix(console): PR #86 review — karma_events admin RLS + karma-config module + rarity-multiplier correction

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2197,6 +2197,17 @@ CREATE POLICY "expert_apps_read_admin" ON public.expert_applications
   FOR SELECT TO authenticated
   USING (public.has_role(auth.uid(), 'admin'));
 
+-- 8c. karma_events admin-read (PR #86 review)
+-- Originally only had self_read RLS, so the admin karma view's
+-- "last 50 events" panel filtered down to the admin's own events.
+-- This policy lets admins see platform-wide karma activity.
+-- Lives in this block (post-has_role()) to avoid the forward reference
+-- bug that would happen if defined alongside the table at line ~1592.
+DROP POLICY IF EXISTS "karma_events_admin_read" ON public.karma_events;
+CREATE POLICY "karma_events_admin_read" ON public.karma_events
+  FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(), 'admin'));
+
 -- 9. Grants
 GRANT SELECT                          ON public.user_roles  TO authenticated;
 GRANT SELECT                          ON public.admin_audit TO authenticated;

--- a/scripts/db-sentinel.sql
+++ b/scripts/db-sentinel.sql
@@ -43,6 +43,7 @@ BEGIN
 
   -- Expert track (module 22 + 23)
   IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'expert_applications')    THEN missing := array_append(missing, 'public.expert_applications'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'karma_events')          THEN missing := array_append(missing, 'public.karma_events'); END IF;
 
   -- Console (module 24 — admin/moderator/expert)
   IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'user_roles')             THEN missing := array_append(missing, 'public.user_roles'); END IF;

--- a/src/components/ConsoleKarmaView.astro
+++ b/src/components/ConsoleKarmaView.astro
@@ -1,5 +1,6 @@
 ---
 import { t } from '../i18n/utils';
+import { KARMA_REASONS, RARITY_MULTIPLIERS } from '../lib/karma-config';
 
 interface Props { lang: 'en' | 'es' }
 const { lang } = Astro.props;
@@ -29,36 +30,22 @@ const tr = t(lang);
           <span>{tr.console.karma_col_base_delta}</span>
           <span>{tr.console.karma_col_notes}</span>
         </div>
-        <div class="grid grid-cols-3 gap-4 px-4 py-2.5 text-sm">
-          <span class="font-mono text-zinc-700 dark:text-zinc-300">observation_synced</span>
-          <span class="font-semibold text-emerald-700 dark:text-emerald-400">+1</span>
-          <span class="text-zinc-500 text-xs">{tr.console.karma_note_obs_synced}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-4 px-4 py-2.5 text-sm">
-          <span class="font-mono text-zinc-700 dark:text-zinc-300">consensus_win</span>
-          <span class="font-semibold text-emerald-700 dark:text-emerald-400">+5</span>
-          <span class="text-zinc-500 text-xs">{tr.console.karma_note_consensus_win}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-4 px-4 py-2.5 text-sm">
-          <span class="font-mono text-zinc-700 dark:text-zinc-300">consensus_loss</span>
-          <span class="font-semibold text-red-600 dark:text-red-400">-2</span>
-          <span class="text-zinc-500 text-xs">{tr.console.karma_note_consensus_loss}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-4 px-4 py-2.5 text-sm">
-          <span class="font-mono text-zinc-700 dark:text-zinc-300">first_in_rastrum</span>
-          <span class="font-semibold text-emerald-700 dark:text-emerald-400">+10</span>
-          <span class="text-zinc-500 text-xs">{tr.console.karma_note_first_in_rastrum}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-4 px-4 py-2.5 text-sm">
-          <span class="font-mono text-zinc-700 dark:text-zinc-300">comment_reaction</span>
-          <span class="font-semibold text-emerald-700 dark:text-emerald-400">+0.5</span>
-          <span class="text-zinc-500 text-xs">{tr.console.karma_note_comment_reaction}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-4 px-4 py-2.5 text-sm">
-          <span class="font-mono text-zinc-700 dark:text-zinc-300">manual_adjust</span>
-          <span class="text-zinc-500">±</span>
-          <span class="text-zinc-500 text-xs">{tr.console.karma_note_manual_adjust}</span>
-        </div>
+        {KARMA_REASONS.map(reason => {
+          const deltaLabel = reason.delta === null ? '±' : (reason.delta >= 0 ? `+${reason.delta}` : `${reason.delta}`);
+          const deltaClass = reason.delta === null
+            ? 'text-zinc-500'
+            : reason.delta >= 0
+              ? 'font-semibold text-emerald-700 dark:text-emerald-400'
+              : 'font-semibold text-red-600 dark:text-red-400';
+          const description = lang === 'es' ? reason.description_es : reason.description_en;
+          return (
+            <div class="grid grid-cols-3 gap-4 px-4 py-2.5 text-sm">
+              <span class="font-mono text-zinc-700 dark:text-zinc-300">{reason.id}</span>
+              <span class={deltaClass}>{deltaLabel}</span>
+              <span class="text-zinc-500 text-xs">{description}</span>
+            </div>
+          );
+        })}
       </div>
     </div>
 
@@ -66,12 +53,16 @@ const tr = t(lang);
     <div class="rounded-lg border border-zinc-200 dark:border-zinc-800 p-4 text-sm">
       <h3 class="font-semibold text-zinc-800 dark:text-zinc-200 mb-2">{tr.console.karma_rarity_heading}</h3>
       <div class="grid grid-cols-5 gap-2">
-        {[1, 2, 3, 4, 5].map(bucket => (
-          <div class="rounded border border-zinc-200 dark:border-zinc-700 p-2 text-center">
-            <div class="text-xs text-zinc-500 mb-1">{tr.console.karma_bucket} {bucket}</div>
-            <div class="font-semibold text-zinc-800 dark:text-zinc-200">{bucket === 1 ? '1.0×' : bucket === 2 ? '1.2×' : bucket === 3 ? '1.5×' : bucket === 4 ? '2.0×' : '3.0×'}</div>
-          </div>
-        ))}
+        {RARITY_MULTIPLIERS.map(rm => {
+          const label = lang === 'es' ? rm.label_es : rm.label_en;
+          return (
+            <div class="rounded border border-zinc-200 dark:border-zinc-700 p-2 text-center">
+              <div class="text-xs text-zinc-500 mb-1">{tr.console.karma_bucket} {rm.bucket}</div>
+              <div class="font-semibold text-zinc-800 dark:text-zinc-200">{rm.multiplier}×</div>
+              <div class="text-xs text-zinc-400 mt-0.5 leading-tight">{label}</div>
+            </div>
+          );
+        })}
       </div>
       <p class="mt-2 text-xs text-zinc-500">{tr.console.karma_rarity_note}</p>
     </div>

--- a/src/lib/karma-config.ts
+++ b/src/lib/karma-config.ts
@@ -1,0 +1,125 @@
+/**
+ * Karma config (Module 23 phase 1) — central source of truth for the
+ * deltas applied per karma_event reason. Currently hardcoded; PR8+ may
+ * promote this to a DB-backed `karma_config` table for runtime tuning.
+ *
+ * Mirrors the deltas in the award_karma() SQL function. Changes here
+ * are display-only — the function in the DB owns the actual write
+ * behavior. Keep both in sync.
+ */
+export interface KarmaReason {
+  id: string;
+  label_en: string;
+  label_es: string;
+  delta: number | null;
+  description_en: string;
+  description_es: string;
+}
+
+export const KARMA_REASONS: KarmaReason[] = [
+  {
+    id: 'observation_synced',
+    label_en: 'Observation synced',
+    label_es: 'Observación sincronizada',
+    delta: 1,
+    description_en: 'Awarded when a user syncs a new observation to the platform.',
+    description_es: 'Otorgado cuando el usuario sincroniza una observación nueva.',
+  },
+  {
+    id: 'consensus_win',
+    label_en: 'Consensus win',
+    label_es: 'Consenso ganador',
+    // SQL: v_delta := 5 * rarity_mult * streak_mult * expertise_mult * conf_factor
+    delta: 5,
+    description_en: 'Base delta before rarity/streak/expertise/confidence multipliers. Awarded when the user\'s identification becomes the consensus pick.',
+    description_es: 'Delta base antes de multiplicadores. Otorgado cuando la identificación del usuario llega al consenso.',
+  },
+  {
+    id: 'consensus_loss',
+    label_en: 'Consensus loss',
+    label_es: 'Consenso perdido',
+    // SQL: v_delta := -2 * LEAST(rarity_mult, 2.0) * conf_factor
+    delta: -2,
+    description_en: 'Base penalty before rarity/confidence multipliers (capped at 2×). Subtracted when another identification overrides the user\'s.',
+    description_es: 'Penalización base antes de multiplicadores (máx 2×). Restado cuando otra identificación sobreescribe la del usuario.',
+  },
+  {
+    id: 'first_in_rastrum',
+    label_en: 'First in Rastrum',
+    label_es: 'Primero en Rastrum',
+    delta: 10,
+    description_en: 'Awarded for the first observation of a taxon ever recorded on the platform.',
+    description_es: 'Otorgado por la primera observación de un taxón registrada en la plataforma.',
+  },
+  {
+    id: 'comment_reaction',
+    label_en: 'Comment reaction',
+    label_es: 'Reacción en comentario',
+    delta: 0.5,
+    description_en: 'Awarded when another user reacts positively to a comment.',
+    description_es: 'Otorgado cuando otro usuario reacciona positivamente a un comentario.',
+  },
+  {
+    id: 'manual_adjust',
+    label_en: 'Manual adjustment',
+    label_es: 'Ajuste manual',
+    // Variable by design — admin sets the delta directly via add_karma_simple()
+    delta: null,
+    description_en: 'Admin-issued karma adjustment. Delta varies per case.',
+    description_es: 'Ajuste de karma emitido por un administrador. El delta varía por caso.',
+  },
+];
+
+export interface RarityMultiplier {
+  bucket: 1 | 2 | 3 | 4 | 5;
+  label_en: string;
+  label_es: string;
+  multiplier: number;
+  description_en: string;
+  description_es: string;
+}
+
+// Multipliers sourced from refresh_taxon_rarity() in supabase-schema.sql.
+// Bucket 1 = top 10% most common; Bucket 5 = obs_count < 5 (ultra-rare).
+export const RARITY_MULTIPLIERS: RarityMultiplier[] = [
+  {
+    bucket: 1,
+    label_en: 'Very common (top 10%)',
+    label_es: 'Muy común (top 10%)',
+    multiplier: 1.0,
+    description_en: 'Taxon in the top 10% most observed on the platform.',
+    description_es: 'Taxón en el top 10% más observado en la plataforma.',
+  },
+  {
+    bucket: 2,
+    label_en: 'Common (50–90th pctile)',
+    label_es: 'Común (percentil 50–90)',
+    multiplier: 1.5,
+    description_en: 'Taxon between the 50th and 90th percentile of observation frequency.',
+    description_es: 'Taxón entre el percentil 50 y 90 de frecuencia de observación.',
+  },
+  {
+    bucket: 3,
+    label_en: 'Uncommon (10–50th pctile)',
+    label_es: 'Poco común (percentil 10–50)',
+    multiplier: 2.5,
+    description_en: 'Taxon between the 10th and 50th percentile of observation frequency.',
+    description_es: 'Taxón entre el percentil 10 y 50 de frecuencia de observación.',
+  },
+  {
+    bucket: 4,
+    label_en: 'Rare (bottom 10%)',
+    label_es: 'Raro (10% inferior)',
+    multiplier: 4.0,
+    description_en: 'Taxon in the bottom 10% — rarely observed on the platform.',
+    description_es: 'Taxón en el 10% inferior — raramente observado en la plataforma.',
+  },
+  {
+    bucket: 5,
+    label_en: 'Very rare (<5 obs)',
+    label_es: 'Muy raro (<5 obs)',
+    multiplier: 5.0,
+    description_en: 'Taxon with fewer than 5 total observations on the platform.',
+    description_es: 'Taxón con menos de 5 observaciones totales en la plataforma.',
+  },
+];


### PR DESCRIPTION
## Summary

Two review comments on PR #86 (5 last admin stubs, already merged), bundled into one fix PR. Plus a real bonus discovery: the previous ConsoleKarmaView's rarity multipliers didn't match the actual `refresh_taxon_rarity()` SQL.

### 1. `karma_events_admin_read` RLS policy (Pamela, real correctness bug)

`ConsoleKarmaView` queries `select * from karma_events` to render "last 50 platform events". But `karma_events` only had `karma_events_self_read` (`auth.uid() = user_id`), so RLS was filtering down to only the admin's own events. The panel claimed to show platform-wide activity but actually showed admin-only.

Added `karma_events_admin_read` policy in the admin-foundation block (post-`has_role()` definition at line 2066) to avoid the forward-reference bug we hit on PR #83. Standard `DROP POLICY IF EXISTS` + `CREATE POLICY` pattern for replay-safety. Also added `karma_events` to `scripts/db-sentinel.sql` (it was referenced by a comment but not actually asserted).

### 2. `src/lib/karma-config.ts` module (yours, consistency with feature-flags pattern)

Hardcoded deltas in HTML moved to a typed module — same pattern as `feature-flags.ts`. New `KARMA_REASONS` and `RARITY_MULTIPLIERS` arrays. ConsoleKarmaView imports them in the frontmatter and loops to render. EN/ES labels live in the module (config-as-code, consistent with feature-flags).

### 3. Rarity multiplier correction (bonus discovery)

While cross-checking the deltas against the SQL, found that `ConsoleKarmaView` was showing `1.0× / 1.2× / 1.5× / 2.0× / 3.0×` for the rarity buckets. The actual `refresh_taxon_rarity()` SQL function uses `1.0× / 1.5× / 2.5× / 4.0× / 5.0×`. The new `RARITY_MULTIPLIERS` array uses the correct SQL values — the admin view now reflects what's actually computed in the DB.

The `award_karma()` SQL function uses `+5 * multipliers` for `consensus_win` and `-2 * LEAST(rarity_mult, 2.0) * conf_factor` for `consensus_loss` — the new `KARMA_REASONS` deltas (`+5`, `-2`) match the SQL base values. Edge Function-driven simple-add events (`observation_synced`, `first_in_rastrum`, etc.) have no hardcoded delta in the SQL itself; their TS values match the original spec.

The TS module's JSDoc explicitly notes: "Mirrors the deltas in the award_karma() SQL function. Changes here are display-only — the function in the DB owns the actual write behavior. Keep both in sync."

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 465/465 passed
- [x] `npm run build` — 144 pages, zero errors
- [x] `npm run test:e2e -- console-smoke.spec.ts` — 42/42 passed
- [ ] **Post-merge as admin**: visit `/console/karma/` — last-50 panel should now show events from any user (not just yours), rarity multipliers should match the SQL values

🤖 Generated with [Claude Code](https://claude.com/claude-code)