### PR TITLE
fix(security): enable RLS on public.taxon_usage_history

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -201,27 +201,9 @@ CREATE TABLE IF NOT EXISTS public.taxon_usage_history (
   synonym_since       date,
   created_at          timestamptz NOT NULL DEFAULT now()
 );
-
--- RLS — bookkeeping table for taxonomy renames/synonyms. A row is
--- readable iff the linked observation is publicly viewable (matches
--- the gate used by `media_public_read`). Writes are server-side only
--- (populated by future rename triggers / admin operations); no client
--- write policy is defined, so authenticated/anon writes are denied
--- by RLS default-deny.
---
--- Surfaced by Supabase's `rls_disabled_in_public` lint on 2026-04-27;
--- the table predates the table-by-table RLS audit and was missed.
-ALTER TABLE public.taxon_usage_history ENABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS taxon_usage_history_public_read ON public.taxon_usage_history;
-CREATE POLICY taxon_usage_history_public_read ON public.taxon_usage_history FOR SELECT
-  USING (
-    observation_id IN (
-      SELECT id FROM public.observations
-       WHERE sync_status = 'synced'
-         AND obscure_level <> 'full'
-    )
-  );
+-- RLS for `public.taxon_usage_history` is enabled below in the RLS
+-- POLICIES section once `public.observations` exists (its read policy
+-- references that table; defining it here would forward-reference).
 
 -- ============================================================
 -- OBSERVATIONS (plain table; partition later if >1M rows)
@@ -468,6 +450,27 @@ CREATE POLICY "media_public_read" ON public.media_files FOR SELECT
   USING (
     observation_id IN (SELECT id FROM observations WHERE sync_status = 'synced')
     AND metadata_redacted = false
+  );
+
+-- Taxon usage history (taxonomy renames/synonyms bookkeeping). Read
+-- gate matches the obs_public_read pattern via correlated EXISTS:
+-- a row is readable iff its linked observation is publicly viewable.
+-- No write policy → RLS default-deny blocks all client writes; rows
+-- are populated by future server-side rename triggers / admin ops.
+--
+-- Surfaced by Supabase's `rls_disabled_in_public` lint on 2026-04-27;
+-- the table predates the table-by-table RLS audit and was missed.
+ALTER TABLE public.taxon_usage_history ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS taxon_usage_history_public_read ON public.taxon_usage_history;
+CREATE POLICY taxon_usage_history_public_read ON public.taxon_usage_history FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.observations o
+       WHERE o.id = taxon_usage_history.observation_id
+         AND o.sync_status = 'synced'
+         AND o.obscure_level <> 'full'
+    )
   );
 
 -- ============================================================

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -202,6 +202,27 @@ CREATE TABLE IF NOT EXISTS public.taxon_usage_history (
   created_at          timestamptz NOT NULL DEFAULT now()
 );
 
+-- RLS — bookkeeping table for taxonomy renames/synonyms. A row is
+-- readable iff the linked observation is publicly viewable (matches
+-- the gate used by `media_public_read`). Writes are server-side only
+-- (populated by future rename triggers / admin operations); no client
+-- write policy is defined, so authenticated/anon writes are denied
+-- by RLS default-deny.
+--
+-- Surfaced by Supabase's `rls_disabled_in_public` lint on 2026-04-27;
+-- the table predates the table-by-table RLS audit and was missed.
+ALTER TABLE public.taxon_usage_history ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS taxon_usage_history_public_read ON public.taxon_usage_history;
+CREATE POLICY taxon_usage_history_public_read ON public.taxon_usage_history FOR SELECT
+  USING (
+    observation_id IN (
+      SELECT id FROM public.observations
+       WHERE sync_status = 'synced'
+         AND obscure_level <> 'full'
+    )
+  );
+
 -- ============================================================
 -- OBSERVATIONS (plain table; partition later if >1M rows)
 -- ============================================================


### PR DESCRIPTION
Supabase security alert (`rls_disabled_in_public`):
> *Anyone with your project URL can read, edit, and delete all data in this table because Row-Level Security is not enabled.*

**Root cause:** `public.taxon_usage_history` (a taxonomy-rename bookkeeping table — tracks what an observation's taxon used to be called when a synonym is reconciled) predates the table-by-table RLS audit and was missed when `ENABLE ROW LEVEL SECURITY` was added to every other public table. Defensive sweep just now confirms it was the only one.

**Fix:**
- `ALTER TABLE public.taxon_usage_history ENABLE ROW LEVEL SECURITY`
- One SELECT policy gating reads on the linked observation being publicly viewable (`sync_status = 'synced' AND obscure_level <> 'full'`) — matches the `media_public_read` pattern
- No write policy → RLS default-deny blocks all client writes (correct: this is server-side bookkeeping only, populated by rename triggers, never by users)

**Operator action:** automatic. `db-apply.yml` fires on push since SQL changed; `ALTER` + `CREATE POLICY IF NOT EXISTS` patterns are idempotent.

**Backlog idea (for a follow-up, not this PR):** add a CI check to `db-validate.yml` that fails if any `public.*` table lacks an `ENABLE ROW LEVEL SECURITY` line — would have caught this at PR review time instead of via Supabase's after-the-fact lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)