### PR TITLE
feat(community): PR2 — recompute-user-stats Edge Function + nightly cron (M28)

### DIFF
--- a/docs/specs/infra/cron-schedules.sql
+++ b/docs/specs/infra/cron-schedules.sql
@@ -20,6 +20,7 @@
 --   v3 (2026-04-27): added 'plantnet-quota-daily' (23:55 UTC) and
 --                    'streak-push-nightly' (01:55 UTC ≈ 19:55 America/Mexico_City).
 --   v4 (2026-04-27): added 'refresh-taxon-rarity-nightly' (03:00 UTC).
+--   v5 (2026-04-29): added 'recompute-user-stats-nightly' (08:00 UTC) for M28.
 -- ════════════════════════════════════════════════════════════════════════
 
 CREATE EXTENSION IF NOT EXISTS pg_cron;
@@ -85,13 +86,31 @@ BEGIN
     $$ SELECT public.refresh_taxon_rarity(); $$
   );
 
+  -- 6. recompute-user-stats-nightly — 08:00 UTC (M28)
+  --    Recomputes denormalized counters (species_count, obs_count_7d,
+  --    obs_count_30d), centroid_geog, and backfills country_code from
+  --    region_primary via normalize_country_code(). Scheduled at 08:00
+  --    UTC — after the 07:00/07:30 streaks/badges cluster so the per-user
+  --    fields they read aren't being rewritten mid-run.
+  PERFORM cron.unschedule('recompute-user-stats-nightly')
+    FROM cron.job WHERE jobname = 'recompute-user-stats-nightly';
+  PERFORM cron.schedule('recompute-user-stats-nightly', '0 8 * * *', format($body$
+    SELECT net.http_post(
+      url     := %L,
+      headers := '{"Content-Type":"application/json"}'::jsonb,
+      body    := '{}'::jsonb
+    );
+  $body$, v_base || '/recompute-user-stats'));
+
   RAISE NOTICE '✓ Cron schedules applied';
 END
 $migration$;
 
 SELECT jobid, jobname, schedule, active
 FROM cron.job
-WHERE jobname IN ('streaks-nightly', 'badges-nightly', 'plantnet-quota-daily', 'streak-push-nightly', 'refresh-taxon-rarity-nightly')
+WHERE jobname IN ('streaks-nightly', 'badges-nightly', 'plantnet-quota-daily',
+                  'streak-push-nightly', 'refresh-taxon-rarity-nightly',
+                  'recompute-user-stats-nightly')
 ORDER BY jobname;
 
 -- m26: prune read notifications older than 90 days, daily at 04:30 UTC.

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4102,3 +4102,49 @@ WHERE profile_public = true
 
 GRANT SELECT ON public.community_observers_with_centroid TO authenticated;
 -- Explicitly NO grant to anon. Lack of grant is the security gate.
+
+-- 8) recompute_user_stats() — called by the nightly Edge Function.
+-- supabase-js cannot execute multi-statement CTE+UPDATE, so the aggregate
+-- lives in a SECURITY DEFINER function. Restricted to service_role to keep
+-- it off the public surface; the cron-only Edge Function uses the
+-- auto-injected SUPABASE_SERVICE_ROLE_KEY to invoke it via db.rpc(...).
+CREATE OR REPLACE FUNCTION public.recompute_user_stats()
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  WITH stats AS (
+    SELECT
+      o.observer_id AS uid,
+      COUNT(*)::int                                                            AS obs_total,
+      COUNT(DISTINCT i.taxon_id)::int                                          AS species_total,
+      COUNT(*) FILTER (WHERE o.observed_at >= now() - interval '7 days')::int  AS obs_7d,
+      COUNT(*) FILTER (WHERE o.observed_at >= now() - interval '30 days')::int AS obs_30d,
+      ST_Centroid(ST_Collect(o.location::geometry))::geography                 AS centroid
+    FROM public.observations o
+    LEFT JOIN public.identifications i
+      ON i.observation_id = o.id AND i.is_primary = true
+    WHERE o.sync_status = 'synced'
+      AND o.location IS NOT NULL
+    GROUP BY o.observer_id
+  )
+  UPDATE public.users u
+  SET
+    observation_count = COALESCE(s.obs_total, 0),
+    species_count     = COALESCE(s.species_total, 0),
+    obs_count_7d      = COALESCE(s.obs_7d, 0),
+    obs_count_30d     = COALESCE(s.obs_30d, 0),
+    centroid_geog     = s.centroid,
+    country_code      = COALESCE(u.country_code, public.normalize_country_code(u.region_primary))
+  FROM stats s
+  WHERE u.id = s.uid;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.recompute_user_stats() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.recompute_user_stats() TO service_role;

--- a/supabase/functions/recompute-user-stats/index.ts
+++ b/supabase/functions/recompute-user-stats/index.ts
@@ -1,0 +1,44 @@
+/**
+ * /functions/v1/recompute-user-stats — nightly cron job (M28).
+ *
+ * Calls public.recompute_user_stats() — a SECURITY DEFINER function that
+ * runs a single CTE+UPDATE recomputing denormalized counters
+ * (species_count, obs_count_7d, obs_count_30d), the user's centroid_geog,
+ * and backfills country_code from region_primary via
+ * normalize_country_code() for users where country_code is currently NULL.
+ *
+ * The aggregate lives in SQL because supabase-js can't run multi-statement
+ * CTE+UPDATE; the wrapper is GRANTed to service_role only, and this
+ * function authenticates with the auto-injected SUPABASE_SERVICE_ROLE_KEY.
+ *
+ * Schedule via pg_cron — see docs/specs/infra/cron-schedules.sql.
+ * Cron-only; deployed --no-verify-jwt like recompute-streaks/award-badges.
+ */
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+serve(async () => {
+  const url = Deno.env.get('SUPABASE_URL');
+  const role = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!url || !role) return new Response('Function not configured', { status: 500 });
+
+  const db = createClient(url, role, { auth: { persistSession: false } });
+
+  const started = Date.now();
+  const { data, error } = await db.rpc('recompute_user_stats');
+
+  if (error) {
+    return new Response(JSON.stringify({ ok: false, error: error.message }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({
+    ok: true,
+    elapsed_ms: Date.now() - started,
+    rows_updated: typeof data === 'number' ? data : 0,
+  }), {
+    headers: { 'content-type': 'application/json' },
+  });
+});


### PR DESCRIPTION
## Summary

PR2 of the **Community Discovery** feature (M28). Adds the nightly aggregate that backs the new `community_observers` views shipped in #92.

- **`public.recompute_user_stats()`** — `SECURITY DEFINER` Postgres function in `supabase-schema.sql`. Single CTE+UPDATE that refreshes denormalized counters (`observation_count`, `species_count`, `obs_count_7d`, `obs_count_30d`), `centroid_geog`, and backfills `country_code` from `region_primary` via `normalize_country_code()` — but only where `country_code IS NULL`, so user-set values are never overwritten. `GRANT EXECUTE` to `service_role` only.
- **`supabase/functions/recompute-user-stats/index.ts`** — Deno Edge Function. Mirrors the `recompute-streaks` / `award-badges` pattern: cron-only, deployed `--no-verify-jwt`, internal access via the auto-injected `SUPABASE_SERVICE_ROLE_KEY`, calls `db.rpc('recompute_user_stats')`, returns `{ ok, elapsed_ms, rows_updated }`.
- **`recompute-user-stats-nightly`** cron entry in `cron-schedules.sql` at `0 8 * * *` (08:00 UTC) — slotted after the existing 07:00/07:30 streaks/badges cluster so the per-user counters they read aren't being rewritten mid-run.

### Why a SECURITY DEFINER wrapper?

`supabase-js` can't execute an arbitrary multi-statement CTE+UPDATE against the REST API. The aggregate therefore lives in SQL and the EF dispatches via `db.rpc()`. The function is GRANTed to `service_role` only, so this surface is unreachable from anon / authenticated roles.

### Deferred (out of scope)

- **PR3** — operator action: manual fire (`make db-cron-test`) once this lands and the EF deploys.
- **PR4** — Profile → Edit country picker + opt-out toggle UI (the `country_code` column itself is on `main`).
- **PR5+** — `/community` route, page body, i18n.

### References

- Spec: `docs/superpowers/specs/2026-04-29-community-discovery-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-community-discovery-plan.md`
- Prerequisite: #92 (schema deltas + dual views)

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — vitest, 465/465 green
- [x] `npm run build` — zero errors, 144 pages
- [ ] `db-validate.yml` CI passes (idempotency + sentinel-table check enforces the SQL)
- [ ] After merge: `deploy-functions.yml` auto-detects `supabase/functions/recompute-user-stats/**` and deploys only that function
- [ ] Operator: run `make db-cron-schedule` to register the cron in production
- [ ] Operator: smoke-fire via `curl https://reppvlqejgoqvitturxp.supabase.co/functions/v1/recompute-user-stats` (200, JSON body)
- [ ] Operator: `psql "$SUPABASE_DB_URL" -c "SELECT public.recompute_user_stats();"` returns an integer (rows updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)