### PR TITLE
feat(community): PR4 — Profile Edit country picker + leaderboards opt-out (M28)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2361,11 +2361,12 @@ GRANT UPDATE (
   streak_digest_opt_in,
   profile_privacy,
   dismissed_privacy_intro_at,
-  expert_taxa,
-  country_code,
-  country_code_source,
-  hide_from_leaderboards
+  expert_taxa
 ) ON public.users TO authenticated;
+-- M28 columns (country_code, country_code_source, hide_from_leaderboards)
+-- are GRANTed separately in the M28 block far below, after their ALTER
+-- TABLE … ADD COLUMN runs. Don't list them here — would forward-reference
+-- columns that don't exist yet on a fresh apply.
 
 -- Observation pins for the public observation_map facet. Honours
 -- obscure_level + location_obscured: sensitive species → coarsened to
@@ -3977,6 +3978,15 @@ ALTER TABLE public.users
 ALTER TABLE public.users
   ADD COLUMN IF NOT EXISTS country_code_source text NOT NULL DEFAULT 'auto'
     CHECK (country_code_source IN ('auto','user'));
+
+-- 1c) Column-level UPDATE grants for the three M28-writable columns. Lives
+-- here (rather than in the consolidated REVOKE/GRANT block above) because
+-- those columns are added by the ALTER TABLE statements above; granting
+-- on them at file head would forward-reference a non-existent column on a
+-- fresh apply. Column-level GRANTs are additive in Postgres, so this
+-- composes cleanly with the earlier GRANT UPDATE (...) block.
+GRANT UPDATE (country_code, country_code_source, hide_from_leaderboards)
+  ON public.users TO authenticated;
 
 -- 2) Partial indexes — every list query operates on an already-filtered
 -- set, so opted-out / private users add zero cost to anyone's query plan.

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2361,7 +2361,10 @@ GRANT UPDATE (
   streak_digest_opt_in,
   profile_privacy,
   dismissed_privacy_intro_at,
-  expert_taxa
+  expert_taxa,
+  country_code,
+  country_code_source,
+  hide_from_leaderboards
 ) ON public.users TO authenticated;
 
 -- Observation pins for the public observation_map facet. Honours
@@ -3964,6 +3967,16 @@ ALTER TABLE public.users
   ADD COLUMN IF NOT EXISTS centroid_geog          geography(POINT, 4326),
   ADD COLUMN IF NOT EXISTS country_code           text    CHECK (country_code ~ '^[A-Z]{2}$'),
   ADD COLUMN IF NOT EXISTS hide_from_leaderboards boolean NOT NULL DEFAULT false;
+
+-- 1b) Track whether country_code was set by the user or inferred by the
+-- nightly recompute_user_stats() job. PR4 carry-forward from PR #92 review:
+-- the Profile → Edit "inferred from your region" badge only renders when
+-- source = 'auto'. recompute_user_stats() does NOT touch this column —
+-- the DEFAULT 'auto' applies to existing rows and to any auto-fill via
+-- normalize_country_code(). Profile → Edit save flips it to 'user'.
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS country_code_source text NOT NULL DEFAULT 'auto'
+    CHECK (country_code_source IN ('auto','user'));
 
 -- 2) Partial indexes — every list query operates on an already-filtered
 -- set, so opted-out / private users add zero cost to anyone's query plan.

--- a/docs/specs/infra/users-column-grants.md
+++ b/docs/specs/infra/users-column-grants.md
@@ -40,6 +40,9 @@ PATCH their own row through PostgREST, gated by RLS on row.
 | `profile_privacy` | jsonb | PrivacyMatrix component (m25) |
 | `dismissed_privacy_intro_at` | timestamptz | "Got it" button on the privacy intro banner |
 | `expert_taxa` | text[] | Self-declared expertise (read-only metadata; expert status itself is gated separately) |
+| `country_code` | text (ISO-3166 alpha-2) | Profile edit (m28 community discovery) |
+| `country_code_source` | text ('auto' / 'user') | Profile edit (m28); flipped to 'user' on every save so the "inferred from your region" badge disappears |
+| `hide_from_leaderboards` | boolean | Profile edit (m28); inverted UI ("Show me in community discovery and leaderboards") |
 
 ## Locked (UPDATE blocked at column level)
 

--- a/docs/specs/modules/28-community-discovery.md
+++ b/docs/specs/modules/28-community-discovery.md
@@ -1,6 +1,6 @@
 # Module 28 — Community discovery
 
-**Status:** v1.0 — implementation in progress (PR1 — schema deltas)
+**Status:** v1.0 — implementation in progress (PR4 — Profile → Edit picker + opt-out)
 **Spec source:** `docs/superpowers/specs/2026-04-29-community-discovery-design.md`
 **Plan:** `docs/superpowers/plans/2026-04-29-community-discovery-plan.md`
 **Sequenced after:** Module 26 (social graph — provides `follows` table and `FollowButton`).
@@ -13,7 +13,7 @@
 ## Scope
 
 - Discovery page at `/{en,es}/community/observers/` with composable filters: sort, country, taxon, experts-only, nearby.
-- Schema deltas on `public.users`: `species_count`, `obs_count_7d`, `obs_count_30d`, `centroid_geog`, `country_code`, `hide_from_leaderboards`.
+- Schema deltas on `public.users`: `species_count`, `obs_count_7d`, `obs_count_30d`, `centroid_geog`, `country_code`, `country_code_source`, `hide_from_leaderboards`.
 - Two views: `community_observers` (anon-safe) and `community_observers_with_centroid` (authenticated only, gates the Nearby feature at the SQL layer).
 - New Edge Function `recompute-user-stats`, scheduled nightly (deferred to PR2).
 - ISO-3166 reference table `iso_countries`, seeded with the Latin American countries plus common observer locales (US, CA, ES, PT, FR, GB, DE, IT). The seed is idempotent — additional codes can be appended later.
@@ -33,6 +33,7 @@
 - Centroid is exposed only via the authenticated view; anon callers cannot read it via any path. The lack of a `GRANT SELECT … TO anon` on `community_observers_with_centroid` is the security gate.
 - The Nearby feature is sign-in gated in the UI; the SQL gate is enforced regardless.
 - `country_code` setter never overwrites a user-set value (the cron only writes when `country_code IS NULL`).
+- `country_code_source` distinguishes auto-inferred from user-set values: defaults to `'auto'`; Profile → Edit save flips it to `'user'`. Used by the "inferred from your region" badge so the user can see when the country wasn't their choice and override it.
 
 ## PR sequence
 

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -44,7 +44,8 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
       <select id="country_code" name="country_code" class="block w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm">
         <option value="">{tr.profile.country_any}</option>
       </select>
-      <p class="mt-1 text-xs text-zinc-500">{tr.profile.country_hint}</p>
+      <p class="mt-1 text-xs text-zinc-500" data-country-hint>{tr.profile.country_hint}</p>
+      <p class="mt-1 hidden text-xs text-amber-700 dark:text-amber-400" data-country-load-error>{tr.profile.country_load_error}</p>
     </div>
     <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">{tr.profile.avatar_url}</label>
@@ -462,13 +463,22 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
   async function populateCountryOptions(supabase: ReturnType<typeof getSupabase>, selectedCode: string | null) {
     const select = form?.elements.namedItem('country_code') as HTMLSelectElement | null;
     if (!select) return;
+    const errEl  = document.querySelector<HTMLElement>('[data-country-load-error]');
+    const hintEl = document.querySelector<HTMLElement>('[data-country-hint]');
     const isEs = document.documentElement.lang === 'es';
     const nameCol: 'name_es' | 'name_en' = isEs ? 'name_es' : 'name_en';
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from('iso_countries')
       .select('code, name_en, name_es')
       .order(nameCol, { ascending: true });
-    const rows = (data ?? []) as IsoCountry[];
+    if (error || !data || data.length === 0) {
+      // Network/RLS failure or empty seed — surface a load-error hint so the
+      // user doesn't see an empty select and assume there are no options.
+      errEl?.classList.remove('hidden');
+      hintEl?.classList.add('hidden');
+      return;
+    }
+    const rows = data as IsoCountry[];
     const frag = document.createDocumentFragment();
     for (const row of rows) {
       const opt = document.createElement('option');
@@ -514,6 +524,17 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
       inferredBadge.classList.toggle('hidden', !shouldShowInferredCountryBadge(profile));
     }
 
+    // The inferred-country badge is meaningful only when a country is set.
+    // If the user clears the picker, hide the badge optimistically — saving
+    // will flip country_code_source to 'user' regardless, but this gives
+    // immediate UI feedback so they don't see "inferred" pinned to an empty
+    // field while editing.
+    const countrySelect = form.elements.namedItem('country_code') as HTMLSelectElement | null;
+    countrySelect?.addEventListener('change', () => {
+      if (!inferredBadge) return;
+      if (!countrySelect.value) inferredBadge.classList.add('hidden');
+    });
+
     syncCommunityVisibleEnabled(Boolean(profile.profile_public));
   }
 
@@ -543,6 +564,8 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
       streak_digest_opt_in: data.get('streak_digest_opt_in') === 'on',
       ...buildCommunityDiscoveryPayload({
         country_code:       ((data.get('country_code') as string) ?? '').trim(),
+        // UI-true ("Show me…") inverts to DB-false (hide_from_leaderboards).
+        // Inversion happens inside buildCommunityDiscoveryPayload.
         community_visible:  data.get('community_visible') === 'on',
       }),
       // updated_at is bumped server-side by the users_touch_updated_at

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -33,6 +33,20 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
       <input name="region_primary" type="text" placeholder={tr.profile.region_placeholder} class="block w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm" />
     </div>
     <div>
+      <div class="flex items-center justify-between mb-1">
+        <label for="country_code" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">{tr.profile.country}</label>
+        <span
+          id="country-inferred-badge"
+          class="hidden text-[11px] font-medium text-amber-700 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 rounded-full"
+          title={tr.profile.country_inferred_title}
+        >{tr.profile.country_inferred_badge}</span>
+      </div>
+      <select id="country_code" name="country_code" class="block w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm">
+        <option value="">{tr.profile.country_any}</option>
+      </select>
+      <p class="mt-1 text-xs text-zinc-500">{tr.profile.country_hint}</p>
+    </div>
+    <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">{tr.profile.avatar_url}</label>
       <input name="avatar_url" type="url" class="block w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm" />
     </div>
@@ -80,6 +94,14 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
         <div>
           <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">{tr.profile.streak_digest}</p>
           <p class="text-xs text-zinc-500">{tr.profile.streak_digest_hint}</p>
+        </div>
+      </label>
+      <label class="flex items-start gap-3 cursor-pointer" id="community-visible-row">
+        <input type="checkbox" name="community_visible" class="mt-1" />
+        <div>
+          <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">{tr.profile.community_visible}</p>
+          <p class="text-xs text-zinc-500" data-helper-on>{tr.profile.community_visible_hint}</p>
+          <p class="text-xs text-amber-700 dark:text-amber-400 hidden" data-helper-off>{tr.profile.community_visible_disabled}</p>
         </div>
       </label>
     </fieldset>
@@ -407,6 +429,7 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
 
 <script>
   import { getSupabase } from '../lib/supabase';
+  import { shouldShowInferredCountryBadge, buildCommunityDiscoveryPayload } from '../lib/profile-edit';
   import type { UserProfile } from '../lib/types';
 
   const form = document.getElementById('edit-form') as HTMLFormElement | null;
@@ -420,8 +443,42 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
 
   type EditableKey =
     | 'username' | 'display_name' | 'bio' | 'region_primary' | 'avatar_url'
-    | 'preferred_lang' | 'observer_license'
+    | 'preferred_lang' | 'observer_license' | 'country_code'
     | 'gamification_opt_in' | 'streak_digest_opt_in';
+
+  type IsoCountry = { code: string; name_en: string; name_es: string };
+
+  function syncCommunityVisibleEnabled(isPublic: boolean) {
+    const visibleEl = form?.elements.namedItem('community_visible') as HTMLInputElement | null;
+    const helperOn = form?.querySelector('[data-helper-on]') as HTMLElement | null;
+    const helperOff = form?.querySelector('[data-helper-off]') as HTMLElement | null;
+    if (!visibleEl || !helperOn || !helperOff) return;
+    visibleEl.disabled = !isPublic;
+    helperOn.classList.toggle('hidden', !isPublic);
+    helperOff.classList.toggle('hidden', isPublic);
+    if (!isPublic) visibleEl.checked = false;
+  }
+
+  async function populateCountryOptions(supabase: ReturnType<typeof getSupabase>, selectedCode: string | null) {
+    const select = form?.elements.namedItem('country_code') as HTMLSelectElement | null;
+    if (!select) return;
+    const isEs = document.documentElement.lang === 'es';
+    const nameCol: 'name_es' | 'name_en' = isEs ? 'name_es' : 'name_en';
+    const { data } = await supabase
+      .from('iso_countries')
+      .select('code, name_en, name_es')
+      .order(nameCol, { ascending: true });
+    const rows = (data ?? []) as IsoCountry[];
+    const frag = document.createDocumentFragment();
+    for (const row of rows) {
+      const opt = document.createElement('option');
+      opt.value = row.code;
+      opt.textContent = row[nameCol];
+      frag.appendChild(opt);
+    }
+    select.appendChild(frag);
+    select.value = selectedCode ?? '';
+  }
 
   async function load() {
     if (!form) return;
@@ -448,6 +505,16 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
     (form.elements.namedItem('observer_license') as HTMLSelectElement).value = profile.observer_license ?? 'CC BY 4.0';
     (form.elements.namedItem('gamification_opt_in') as HTMLInputElement).checked = profile.gamification_opt_in;
     (form.elements.namedItem('streak_digest_opt_in') as HTMLInputElement).checked = profile.streak_digest_opt_in;
+    (form.elements.namedItem('community_visible') as HTMLInputElement).checked = !profile.hide_from_leaderboards;
+
+    await populateCountryOptions(supabase, profile.country_code ?? null);
+
+    const inferredBadge = document.getElementById('country-inferred-badge');
+    if (inferredBadge) {
+      inferredBadge.classList.toggle('hidden', !shouldShowInferredCountryBadge(profile));
+    }
+
+    syncCommunityVisibleEnabled(Boolean(profile.profile_public));
   }
 
   form?.addEventListener('submit', async (e) => {
@@ -474,6 +541,10 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
       observer_license:     (data.get('observer_license') ?? 'CC BY 4.0').toString(),
       gamification_opt_in:  data.get('gamification_opt_in') === 'on',
       streak_digest_opt_in: data.get('streak_digest_opt_in') === 'on',
+      ...buildCommunityDiscoveryPayload({
+        country_code:       ((data.get('country_code') as string) ?? '').trim(),
+        community_visible:  data.get('community_visible') === 'on',
+      }),
       // updated_at is bumped server-side by the users_touch_updated_at
       // trigger; clients can't write to it (column-level GRANT).
     };
@@ -506,6 +577,9 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
     }
     status?.classList.remove('hidden');
     setTimeout(() => status?.classList.add('hidden'), 3000);
+
+    // Save flips country_code_source to 'user'; hide the inferred badge.
+    document.getElementById('country-inferred-badge')?.classList.add('hidden');
 
     // Re-render the user's OG card so /perfil/u/<username>/ embeds the
     // latest display name + stats. Best-effort: a render or upload

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -404,6 +404,7 @@
     "view_public": "View public",
     "country": "Country",
     "country_hint": "Used to label your card on the Community page. You can change or clear this any time.",
+    "country_load_error": "Couldn't load the country list. Check your connection and reload.",
     "country_any": "—",
     "country_inferred_badge": "inferred from your region",
     "country_inferred_title": "We guessed this from your region. Pick a country to override.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -401,7 +401,15 @@
     "public_profile_no_observations": "No public observations yet.",
     "public_profile_member_since": "Member since",
     "settings_link": "Settings",
-    "view_public": "View public"
+    "view_public": "View public",
+    "country": "Country",
+    "country_hint": "Used to label your card on the Community page. You can change or clear this any time.",
+    "country_any": "—",
+    "country_inferred_badge": "inferred from your region",
+    "country_inferred_title": "We guessed this from your region. Pick a country to override.",
+    "community_visible": "Show me in community discovery and leaderboards",
+    "community_visible_hint": "When on, your public profile can appear on the Community page and in leaderboards. Turn off any time.",
+    "community_visible_disabled": "Make your profile public to enable community discovery."
   },
   "observe": {
     "title": "New observation",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -401,7 +401,15 @@
     "public_profile_no_observations": "Aún no hay observaciones públicas.",
     "public_profile_member_since": "Miembro desde",
     "settings_link": "Ajustes",
-    "view_public": "Ver perfil público"
+    "view_public": "Ver perfil público",
+    "country": "País",
+    "country_hint": "Se usa para etiquetar tu tarjeta en la página de Comunidad. Puedes cambiarlo o borrarlo cuando quieras.",
+    "country_any": "—",
+    "country_inferred_badge": "inferido por tu región",
+    "country_inferred_title": "Lo dedujimos de tu región. Elige un país para reemplazarlo.",
+    "community_visible": "Mostrarme en descubrimiento y clasificaciones de la comunidad",
+    "community_visible_hint": "Cuando está activo, tu perfil público puede aparecer en la página de Comunidad y en las clasificaciones. Puedes desactivarlo cuando quieras.",
+    "community_visible_disabled": "Haz tu perfil público para habilitar el descubrimiento en la comunidad."
   },
   "observe": {
     "title": "Nueva observación",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -404,6 +404,7 @@
     "view_public": "Ver perfil público",
     "country": "País",
     "country_hint": "Se usa para etiquetar tu tarjeta en la página de Comunidad. Puedes cambiarlo o borrarlo cuando quieras.",
+    "country_load_error": "No se pudo cargar la lista de países. Revisa tu conexión y recarga.",
     "country_any": "—",
     "country_inferred_badge": "inferido por tu región",
     "country_inferred_title": "Lo dedujimos de tu región. Elige un país para reemplazarlo.",

--- a/src/lib/profile-edit.ts
+++ b/src/lib/profile-edit.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers for ProfileEditForm.astro — extracted so the
+ * inversion + carry-forward invariants are unit-testable without
+ * mounting the form in a browser.
+ *
+ * The form itself wires these into the load/save handlers; the
+ * inverted-checkbox + country_code_source='user'-on-save invariants
+ * are the load-bearing rules from PR4 of M28 (community discovery).
+ */
+
+/**
+ * Whether the inferred-from-region badge should render. True only
+ * when the cron auto-filled country_code AND it's still set.
+ *
+ * After the user saves Profile → Edit, country_code_source flips to
+ * 'user' (regardless of whether the country actually changed), so
+ * this returns false.
+ */
+export function shouldShowInferredCountryBadge(profile: {
+  country_code?: string | null;
+  country_code_source?: 'auto' | 'user';
+}): boolean {
+  return profile.country_code != null && profile.country_code_source === 'auto';
+}
+
+/**
+ * Subset of the Profile → Edit payload that PR4 of M28 introduces
+ * (country_code, country_code_source, hide_from_leaderboards).
+ *
+ * - `country_code` is nullable (empty string = "Don't declare").
+ * - `country_code_source` is ALWAYS `'user'` on save — re-saving a
+ *   `'user'` row stays `'user'`, so this is idempotent.
+ * - `hide_from_leaderboards` is the *inverted* form of the
+ *   `community_visible` UI checkbox (UI-true → column-false).
+ */
+export interface CommunityDiscoveryPayload {
+  country_code: string | null;
+  country_code_source: 'user';
+  hide_from_leaderboards: boolean;
+}
+
+export function buildCommunityDiscoveryPayload(form: {
+  country_code: string;
+  community_visible: boolean;
+}): CommunityDiscoveryPayload {
+  return {
+    country_code: form.country_code === '' ? null : form.country_code,
+    country_code_source: 'user',
+    hide_from_leaderboards: !form.community_visible,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -126,6 +126,12 @@ export interface UserProfile {
   gamification_opt_in: boolean;
   streak_digest_opt_in: boolean;
   region_primary: string | null;
+  /** Module 28 community discovery: ISO-3166 alpha-2. NULL if undeclared. */
+  country_code?: string | null;
+  /** Module 28: 'auto' if last set by recompute_user_stats; 'user' once edited via Profile → Edit. */
+  country_code_source?: 'auto' | 'user';
+  /** Module 28: opt-out of leaderboards + community page. Defaults false. */
+  hide_from_leaderboards?: boolean;
   joined_at: string;
   last_observation_at: string | null;
   stats_cached_at: string | null;

--- a/tests/unit/profile-edit.test.ts
+++ b/tests/unit/profile-edit.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shouldShowInferredCountryBadge,
+  buildCommunityDiscoveryPayload,
+} from '../../src/lib/profile-edit';
+
+describe('shouldShowInferredCountryBadge', () => {
+  it('shows when country_code is set AND source is auto', () => {
+    expect(shouldShowInferredCountryBadge({ country_code: 'MX', country_code_source: 'auto' })).toBe(true);
+  });
+
+  it('hides when source is user, regardless of country', () => {
+    expect(shouldShowInferredCountryBadge({ country_code: 'MX', country_code_source: 'user' })).toBe(false);
+  });
+
+  it('hides when country_code is null even if source is auto', () => {
+    expect(shouldShowInferredCountryBadge({ country_code: null, country_code_source: 'auto' })).toBe(false);
+  });
+
+  it('hides when country_code is undefined', () => {
+    expect(shouldShowInferredCountryBadge({})).toBe(false);
+  });
+
+  it('hides when source is undefined (defaults are not user-set)', () => {
+    expect(shouldShowInferredCountryBadge({ country_code: 'MX' })).toBe(false);
+  });
+});
+
+describe('buildCommunityDiscoveryPayload', () => {
+  it('always sets country_code_source to "user" on save (idempotent)', () => {
+    const a = buildCommunityDiscoveryPayload({ country_code: 'MX', community_visible: true });
+    expect(a.country_code_source).toBe('user');
+    const b = buildCommunityDiscoveryPayload({ country_code: '', community_visible: false });
+    expect(b.country_code_source).toBe('user');
+  });
+
+  it('inverts community_visible (UI-true) into hide_from_leaderboards (column-false)', () => {
+    expect(buildCommunityDiscoveryPayload({ country_code: 'MX', community_visible: true }).hide_from_leaderboards).toBe(false);
+    expect(buildCommunityDiscoveryPayload({ country_code: 'MX', community_visible: false }).hide_from_leaderboards).toBe(true);
+  });
+
+  it('coerces empty country_code to null (the "Don\'t declare" option)', () => {
+    expect(buildCommunityDiscoveryPayload({ country_code: '', community_visible: true }).country_code).toBeNull();
+  });
+
+  it('preserves a non-empty country_code as-is', () => {
+    expect(buildCommunityDiscoveryPayload({ country_code: 'AR', community_visible: true }).country_code).toBe('AR');
+  });
+});


### PR DESCRIPTION
## Summary

PR4 of the community-discovery feature (M28). Two new fields on Profile → Edit:

- **Country picker** (`<select>` populated from `iso_countries`, alphabetical by `name_en` for EN / `name_es` for ES). Empty option = "Don't declare" / "No declarar".
- **Community visibility toggle** ("Show me in community discovery and leaderboards") — UI-true maps to `hide_from_leaderboards = false` (inverted). Disabled when `profile_public = false` with helper text "Make your profile public to enable community discovery."

Plus the carry-forward from PR #92 review: an "inferred from your region" pill renders next to the country picker when the cron auto-filled the country code, so the user can override.

## Schema delta (idempotent)

- New `users.country_code_source` column (text, default `'auto'`, CHECK in (`'auto'`,`'user'`)). Profile → Edit save always sets it to `'user'`; `recompute_user_stats()` does not touch it (DEFAULT applies). The badge renders only when `country_code IS NOT NULL AND country_code_source = 'auto'`.
- Extends the column-level UPDATE GRANT on `public.users` to include `country_code`, `country_code_source`, `hide_from_leaderboards`. The existing `users_self_update` / `users_update_self_privacy` policies are column-agnostic, so RLS Just Works once the GRANT lands.

## Files

- `src/i18n/{en,es}.json` — 8 new keys per locale under `profile.*` (parity verified: 85/85).
- `src/components/ProfileEditForm.astro` — country `<select>` after `region_primary`, community-visible toggle in the existing fieldset, load/save wiring, disable-when-private behavior, inferred-badge logic.
- `src/lib/profile-edit.ts` (new) — pure helpers `shouldShowInferredCountryBadge()` + `buildCommunityDiscoveryPayload()`. The form imports these, so the inversion + always-`'user'`-source invariants are unit-testable.
- `tests/unit/profile-edit.test.ts` (new) — 9 cases covering badge visibility matrix + payload-shape invariants.
- `src/lib/types.ts` — `UserProfile` gets the three new optional columns.
- `docs/specs/infra/supabase-schema.sql` — `country_code_source` ALTER TABLE + extended GRANT block.
- `docs/specs/infra/users-column-grants.md` — three new rows in the writable inventory.
- `docs/specs/modules/28-community-discovery.md` — status bumped to PR4; schema-deltas list extended.

## Deferred (PR5+PR6, atomic merge)

- Community page at `/{en,es}/community/observers/`.
- MegaMenu wiring (Explore promoted to two-column layout).
- Mobile drawer additions.
- Atomic i18n rewrite of the two shipped "no leaderboards" strings (`profile.gamification_hint` line 349, plus the about-page mirror at line 959). Keeping these alive until the page that surfaces leaderboards goes live ensures no copy is wrong-at-rest.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 492 / 492 passing (was 483; +9 new in profile-edit.test)
- [x] `npm run build` — 144 pages, clean
- [x] EN/ES i18n parity — 85 / 85 keys under `profile.*`
- [ ] Manual: sign in → `/en/profile/edit/` → pick a country, toggle visibility off, save, reload, both persist
- [ ] Manual (post-cron-fire): existing user with `region_primary='Oaxaca, MX'` and no country gets `country_code='MX', country_code_source='auto'` after the next nightly run; Profile → Edit shows the amber pill until the user saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)