### PR TITLE
docs(m27): final sync — tasks.md + status + outcomes

### DIFF
--- a/docs/specs/modules/27-ai-sponsorships.md
+++ b/docs/specs/modules/27-ai-sponsorships.md
@@ -1,6 +1,6 @@
 # Module 27 — AI Sponsorships
 
-**Status:** in implementation (PR feat/ai-sponsorships)
+**Status:** shipped (v1.3 — PRs #78, #84, #94)
 **Related modules:** 04 (auth), 13 (identifier registry), 14 (BYO keys), karma module.
 **Design doc:** `docs/superpowers/specs/2026-04-28-ai-sponsorships-design.md`
 

--- a/docs/superpowers/plans/2026-04-28-m20-ai-sponsorships.md
+++ b/docs/superpowers/plans/2026-04-28-m20-ai-sponsorships.md
@@ -3668,3 +3668,23 @@ Plan complete and saved to `docs/superpowers/plans/2026-04-28-m20-ai-sponsorship
 **2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints. Faster end-to-end if you want me to drive everything but uses more context per turn.
 
 Which approach?
+
+---
+
+## Execution outcome
+
+This plan executed via subagent-driven development with the following deviations from the original 42-task structure:
+
+- **Tasks bundled** for parallel dispatch where files didn't conflict. The original plan had 42 individual tasks; actual execution used 6 waves of 1-6 parallel subagents each.
+- **Module renumber 20 → 27** — collision with existing `20-chat.md`. Schema + spec + plan adapted.
+- **Three follow-up PRs** beyond the original plan:
+  - PR #84 closed 9 UX gaps not covered by the initial implementation.
+  - PR #94 closed 8 items the user requested as "complete coverage" (stubs activated, out-of-spec features added: request flow, real Resend, docs page, onboarding tour, time selector, reciprocal badge, report button).
+- **Final state shipped on:** see `docs/tasks.md` for the user-facing summary.
+
+### Lessons (for future plans)
+
+- Schema-conflict-prone files (e.g. `supabase-schema.sql`, large i18n JSONs) need to be in their own atomic-task — parallel subagents committing to the same file in a worktree race on git index.
+- `:'var'` psql substitution does NOT work inside `$$ ... $$` dollar-quoted blocks — use a SQL helper function with regular bind variables instead.
+- Supabase managed Postgres restricts `ALTER DATABASE … SET` to superuser — Vault is the right place for runtime secrets that pg_cron needs to reach.
+- GitGuardian flags `sk-ant-` prefix as "Generic High Entropy Secret" even when the actual string is a fixture — use string concatenation + `.gitguardian.yml` to handle.

--- a/docs/superpowers/specs/2026-04-28-ai-sponsorships-design.md
+++ b/docs/superpowers/specs/2026-04-28-ai-sponsorships-design.md
@@ -795,3 +795,31 @@ const estimateCost = (tokensIn: number, tokensOut: number) =>
 ```
 
 For `oauth_token` credentials, the UI displays "Covered by your Claude subscription" instead of a USD figure. No server-side persistence of cost data — pricing changes only require a frontend release.
+
+---
+
+## Implementation outcome (post-ship)
+
+The feature shipped via 3 PRs over ~24 hours:
+
+- **PR #78** — module 27 core (schema + RLS + Vault + Edge Functions + base UI + cron jobs).
+- **PR #84** — UX polish (9 gaps closed: analytics section implemented, beneficiary username resolution, self-sponsorship badge, friendly paused_reason mapping, credential picker dropdown, live preview of secret kind, confirm modals).
+- **PR #94** — complete coverage of the 8 items reported as "not exposed", "stubbed", or "out of spec":
+  - Reciprocal "Sponsored by @X" badge on beneficiary's public profile
+  - Report abuse button on beneficiary cards (uses existing `reports` table + `ReportDialog`)
+  - Public docs page at `/{en,es}/docs/sponsorships`
+  - Onboarding tour (first-visit + replay)
+  - Time range selector for analytics (7/30/90 days)
+  - Real Resend SMTP integration (threshold 80%/100% + auto-pause emails)
+  - Sponsorship request flow (`sponsorship_requests` table + 5 endpoints + UI both sides) — beneficiary can ask, sponsor approves/rejects/credential-picks; requester can withdraw
+
+### Decisions made during implementation (not in original design)
+
+1. **Module number changed from 20 to 27** to avoid collision with the existing `20-chat.md`. Plan doc filename retains the old number for git history reasons.
+2. **`app.cron_token` GUC abandoned in favor of Vault** — Supabase managed Postgres restricts `ALTER DATABASE … SET` to superuser. Cron token is now upserted to `vault.secrets` named `sponsorships_cron_token`; the heartbeat cron reads via `SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = '…' LIMIT 1`.
+3. **Self-sponsoring permitted** — the `CHECK (sponsor_id <> beneficiary_id)` was removed so the same UI manages personal usage. Karma triggers guard against rewarding self-flow.
+4. **GitGuardian false positives** — test fixtures use `'sk-ant-api03-' + 'TEST_FIXTURE_NOT_A_REAL_SECRET'` concat trick + `.gitguardian.yml` ignore list to prevent the secret-detector from flagging deliberately-fake test strings.
+
+### Email integration — now active
+
+`maybeNotifyThreshold` and `autoPauseSponsorship` use Resend SMTP via `_shared/email.ts`. Idempotency is enforced via `notifications_sent (sponsorship_id, threshold, year_month)`. Graceful degradation if `RESEND_API_KEY` is unset (logs to `console.warn`, doesn't throw).

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -3646,6 +3646,41 @@
         {
           "label_en": "Rollout + remove server-side ANTHROPIC_API_KEY (operator action)",
           "label_es": "Rollout + remover ANTHROPIC_API_KEY del servidor (acción del operador)",
+          "status": "done"
+        },
+        {
+          "label_en": "M27 polish — 9 UX gaps (PR #84)",
+          "label_es": "Pulido M27 — 9 gaps UX (PR #84)",
+          "status": "done"
+        },
+        {
+          "label_en": "M27 complete coverage (PR #94)",
+          "label_es": "Cobertura completa M27 (PR #94)",
+          "status": "done"
+        },
+        {
+          "label_en": "Resend SMTP integration (active)",
+          "label_es": "Integración Resend SMTP (activa)",
+          "status": "done"
+        },
+        {
+          "label_en": "Sponsorship request flow",
+          "label_es": "Flujo de solicitudes de patrocinio",
+          "status": "done"
+        },
+        {
+          "label_en": "Public docs page /docs/sponsorships",
+          "label_es": "Página pública /docs/sponsorships",
+          "status": "done"
+        },
+        {
+          "label_en": "Onboarding tour + replay",
+          "label_es": "Tour de bienvenida + replay",
+          "status": "done"
+        },
+        {
+          "label_en": "Optional: delete ANTHROPIC_API_KEY env",
+          "label_es": "Opcional: borrar env ANTHROPIC_API_KEY",
           "status": "planned"
         }
       ]

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -19,6 +19,7 @@
 | v1.0.x | Post-launch polish | in_progress | 8 / 24 |
 | v1.1 | UX polish (post-launch brainstorm) | shipped (mostly) | 19 / 21 |
 | v1.2 | Profile privacy & public profile | shipped 2026-04-28 | 3 / 3 |
+| v1.3 | Module 27: AI Sponsorships | shipped 2026-04-28 | 1 / 1 |
 | **v0.1 → v1.0** | **Public launch** | **shipped 2026-04-26** | **54 / 59** |
 
 Phases v1.5, v2.0, v2.5 are tracked in [`progress.json`](progress.json) but have no shipped code yet — they are planned scope only.
@@ -125,3 +126,12 @@ Remaining:
 ### Bundled review follow-ups still planned
 
 - `m26-v1-1-review-followups` — Six small polish items flagged by ArtemIO/Nyx on PR #100 + #101 reviews: `?u=` alias documentation, `document.title` → i18n key, runVisitor error-vs-not-found split, `ConfirmDialog` component to replace `confirm()`/`alert()` in the Block flow (matches `ReportDialog` pattern), extract overflow-menu logic into `lib/overflow-menu.ts` (currently duplicated 3× across `PublicProfileViewV2`, `ExploreRecentView`, `Comments`), and `fave_count` data-attr naming standardization across feed views. All non-blocking; deferred for a deliberate v1.2 polish sweep. _(· planned)_
+- `social-graph-m26-v11` — Follow-ups: ReactionStrip count overlay on feed cards (needs an aggregate RPC to avoid N+1), Block/Report on observation cards + comments, "Block this user" affordance on profile cards in lists, additional ARIA refinements. _(· planned)_
+- `deploy-functions-resilience` — Pin esm.sh imports to versioned URLs across `supabase/functions/*/index.ts` so a transient esm.sh 522 doesn't permanently park the auto-deploy. Surfaced when PR #66's auto-deploy 522'd on a Cloudflare hiccup. _(· planned)_
+- `visitor-pokedex-route` — Public `/u/<handle>/dex/` page so the Pokédex link on PublicProfileViewV2 doesn't have to be hidden for non-owners (PR #68 currently hides it as a workaround). _(· planned)_
+
+## v1.3 — Module 27: AI Sponsorships — shipped 2026-04-28
+
+**1 item done.** Shipped via PRs #78 (core), #84 (UX polish — 9 gaps), #94 (cobertura completa — stubs activados, request flow, docs page).
+
+- `ai-sponsorships` — Permite a cualquier user compartir su credencial Anthropic (API key u OAuth long-lived token) con beneficiaries específicos. Cuota mensual por llamadas, auto-pause por rate-limit, karma híbrido, y removal del operator-key fallback en `identify`. Entregado: schema (5 tablas + RLS + Vault) + cron jobs + audit log; Edge Functions `sponsorships` (CRUD + heartbeat) e `identify` modificado; UI en `/profile/sponsoring/`, `/profile/sponsored-by/`, banner en `/identify`, discovery card, header dropdown, mobile drawer entries, badge de sponsor + recíproco en perfil público; Resend SMTP para threshold (80%/100%) + auto-pause emails; request-to-be-sponsored flow (5 endpoints + dialogs ambos lados); onboarding tour first-visit + replay; página `/docs/sponsorships` (EN+ES); time range selector 7/30/90 en analytics; report abuse button por beneficiary; CI guards (smoke + secret-leak). **Operator action única:** `gh secret set SPONSORSHIPS_CRON_TOKEN` (hecho). **Operator action opcional:** `gh secret delete ANTHROPIC_API_KEY` (no urgente; identify ya no la lee). _(✓ done)_


### PR DESCRIPTION
## Summary

Sync de los 4 surfaces de documentación que reflejaban estado mid-implementation post-merge de PRs #78, #84, #94.

## Cambios

1. **`docs/tasks.md`** — agregada sección `## v1.3 — Module 27: AI Sponsorships — shipped` + fila en "At a glance" table.
2. **`docs/specs/modules/27-ai-sponsorships.md`** — status flipped de \`in implementation\` → \`shipped (v1.3 — PRs #78, #84, #94)\`.
3. **`docs/tasks.json`** — 7 → 14 subtasks. Los 7 originales todos \`done\`. 7 nuevos cubren PRs #84 y #94 + el opcional de borrar \`ANTHROPIC_API_KEY\` (\`planned\`).
4. **Spec doc + plan doc** en \`docs/superpowers/\` — appended "Implementation outcome (post-ship)" / "Execution outcome" sections con decisiones tomadas durante implementación (renumbering 20→27, Vault para cron token, self-sponsoring permitido, GitGuardian fix) y lecciones para planes futuros.

## Test plan
- [x] Both JSONs parse
- [x] Module 27 spec status === "shipped"
- [x] tasks.json has ≥ 14 subtasks
- [x] tasks.md has sponsorship section

🤖 Generated with [Claude Code](https://claude.com/claude-code)