### PR TITLE
docs: sync M26 v1.1 + visitor pokedex + deploy resilience across roadmap/tasks/CLAUDE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ make help                     # list every target with descriptions
 make install                  # npm ci
 make dev                      # astro dev — http://localhost:4321
 make build                    # static build into dist/
-make test                     # vitest run (~454 tests today)
+make test                     # vitest run (~465 tests today)
 make typecheck                # tsc --noEmit
 make db-apply                 # apply supabase-schema.sql (idempotent)
 make db-verify                # show tables, RLS, triggers, extensions
@@ -444,7 +444,7 @@ The validate gate is the fix.
 
 ```bash
 npm run typecheck   # tsc --noEmit, zero errors
-npm run test        # vitest run — 225 tests today, all green
+npm run test        # vitest run — ~465 tests today, all green
 npm run build       # zero errors, 57 pages today, EN/ES paired
 git status -s       # nothing untracked except .claude/ or .env.local
 ```

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -863,6 +863,28 @@
           "label_es": "Gate CI — db-validate.yml falla si cualquier tabla public.* no tiene ENABLE ROW LEVEL SECURITY. Cierra el ciclo del lint rls_disabled_in_public de Supabase atrapando RLS faltante en PR review en lugar de via el email de alerta de seguridad post-merge",
           "done": true,
           "done_at": "2026-04-29"
+        },
+        {
+          "id": "m26-v1-1-review-followups",
+          "label": "M26 v1.1 review follow-ups — bundled polish flagged by ArtemIO/Nyx on PR #100 + #101 reviews. 6 small items: ?u= alias documentation, document.title → i18n key, runVisitor error vs not-found split, ConfirmDialog component (replaces confirm()/alert() in Block flow), extract overflow-menu to lib/, fave_count data-attr naming standardization. All non-blocking, deferred for a v1.2 polish sweep",
+          "label_es": "Seguimientos de review de M26 v1.1 — pulido agrupado de los notes de ArtemIO/Nyx en reviews de PR #100 + #101. 6 ítems pequeños: documentación del alias ?u=, document.title → key i18n, split de runVisitor error vs not-found, componente ConfirmDialog (reemplaza confirm()/alert() en flujo Block), extraer overflow-menu a lib/, estandarización de naming de data-attrs fave_count. Todos no-bloqueantes, diferidos para un sweep de pulido v1.2",
+          "done": false
+        },
+        {
+          "id": "community-discovery-m28",
+          "label": "Community discovery (Module 28) — Explore MegaMenu split into Biodiversity / Community columns; /community/observers/ page with composable filter chips (sort, country, taxon, experts-only, nearby); denormalized counters (species_count, obs_count_7d/30d, centroid_geog, country_code) refreshed nightly by recompute-user-stats Edge Function; ISO-3166 reference table + normalize_country_code(); dual views (anon-safe + authenticated-only with centroid); opt-out toggle + country picker on Profile → Edit; rewrites the shipped 'no leaderboards' i18n strings",
+          "label_es": "Descubrimiento comunitario (Módulo 28) — MegaMenu de Explorar dividido en columnas Biodiversidad / Comunidad; página /community/observers/ con chips de filtros componibles (orden, país, taxón, sólo expertos, cercanos); contadores denormalizados (species_count, obs_count_7d/30d, centroid_geog, country_code) refrescados cada noche por la Edge Function recompute-user-stats; tabla de referencia ISO-3166 + normalize_country_code(); vistas duales (anon-safe + authenticated-only con centroide); toggle de opt-out + selector de país en Perfil → Editar; reescribe los strings 'no leaderboards' que estaban en producción",
+          "done": false,
+          "status": "in implementation (PR1+PR2+PR4 merged on main; PR5+PR6 = page + MegaMenu + atomic i18n rewrite remaining)",
+          "status_es": "en implementación (PR1+PR2+PR4 mergeados en main; PR5+PR6 = página + MegaMenu + reescritura atómica de i18n pendientes)"
+        },
+        {
+          "id": "obs-detail-redesign",
+          "label": "Observation detail page redesign — two-column desktop / stacked mobile layout for /share/obs/?id=...; reusable MapPicker.astro extracted from ObservationForm; PhotoGallery.astro with native lightbox (keyboard ←/→/Esc + swipe + per-photo share); ObsManagePanel.astro with Details/Location/Photos tabs (date/time + habitat/weather/establishment edit + coordinate editor + photo add/remove); material-vs-minor edit semantics with 'edited after IDs' badge driven by observations.last_material_edit_at trigger (location > 1 km, observed_at > 24 h, primary_taxon_id change); soft-delete photos via media_files.deleted_at (orphan R2 GC = v1.1 follow-up); cascade-driving photo deletion atomic via delete-photo Edge Function (clears validated_by/validated_at + is_research_grade)",
+          "label_es": "Rediseño de la página de detalle de observación — layout dos columnas en desktop / apilado en móvil para /share/obs/?id=...; MapPicker.astro reutilizable extraído de ObservationForm; PhotoGallery.astro con lightbox nativo (teclado ←/→/Esc + swipe + compartir por foto); ObsManagePanel.astro con tabs Detalles/Ubicación/Fotos (edición de fecha/hora + hábitat/clima/establecimiento + editor de coordenadas + agregar/quitar fotos); semántica de edición material-vs-menor con badge 'editado tras IDs' por trigger en observations.last_material_edit_at (ubicación > 1 km, observed_at > 24 h, cambio de primary_taxon_id); soft-delete de fotos via media_files.deleted_at (GC de R2 huérfanos = v1.1); borrado de la foto que generó la cascade es atómico via Edge Function delete-photo (limpia validated_by/validated_at + is_research_grade)",
+          "done": false,
+          "status": "in implementation (PR1 MapPicker extraction + PR2 schema/enums/i18n merged on main; PR3 PhotoGallery + viewer layout in review; PR4 Details tab, PR5 Location tab, PR6 Photos tab + delete-photo EF remaining)",
+          "status_es": "en implementación (PR1 extracción de MapPicker + PR2 schema/enums/i18n mergeados en main; PR3 PhotoGallery + layout viewer en revisión; PR4 tab Detalles, PR5 tab Ubicación, PR6 tab Fotos + EF delete-photo pendientes)"
         }
       ]
     },

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -4034,10 +4034,64 @@
           "status": "done"
         },
         {
-          "label_en": "v1.1 follow-ups: ReactionStrip count overlay on feed cards (needs RPC), Block/Report on observation cards + comments, real-time push for inbox (M28), 'Block this user' affordance on profile cards in lists",
-          "label_es": "Seguimientos v1.1: superposición de conteos ReactionStrip en tarjetas del feed (requiere RPC), Bloquear/Reportar en tarjetas de observación + comentarios, push en tiempo real para bandeja (M28), 'Bloquear usuario' en tarjetas de listas",
-          "status": "planned"
+          "label_en": "v1.1 follow-ups (DELIVERED in PR #97 + #100 + #101): see social-graph-m26-v11, visitor-pokedex-route, deploy-functions-resilience entries below",
+          "label_es": "Seguimientos v1.1 (ENTREGADOS en PR #97 + #100 + #101): ver social-graph-m26-v11, visitor-pokedex-route, deploy-functions-resilience abajo",
+          "status": "done"
         }
+      ]
+    },
+    "social-graph-m26-v11": {
+      "phase": "v1.2",
+      "title_en": "M26 v1.1 polish — reactions on feed + Block/Report on cards/comments + ARIA",
+      "title_es": "Pulido M26 v1.1 — reacciones en feed + Bloquear/Reportar en tarjetas/comentarios + ARIA",
+      "modules": ["26-social-graph.md"],
+      "subtasks": [
+        { "label_en": "observation_reaction_summary view (security_invoker = true) for batched reaction counts without N+1", "label_es": "Vista observation_reaction_summary (security_invoker = true) para conteos por batch sin N+1", "status": "done" },
+        { "label_en": "❤ N reaction count chip on ExploreRecentView + MyObservationsView feed cards", "label_es": "Chip de conteo ❤ N en tarjetas ExploreRecentView + MyObservationsView", "status": "done" },
+        { "label_en": "Overflow ⋮ menu on observation cards (Block + Report) — same pattern as PublicProfileViewV2; hidden on owner cards", "label_es": "Menú ⋮ en tarjetas de observación (Bloquear + Reportar) — mismo patrón que PublicProfileViewV2; oculto en tarjetas propias", "status": "done" },
+        { "label_en": "Block/Report per-comment in Comments.astro (lazy import of blockUser, ReportDialog with target='comment')", "label_es": "Bloquear/Reportar por comentario en Comments.astro (lazy import de blockUser, ReportDialog con target='comment')", "status": "done" },
+        { "label_en": "ARIA: aria-live region on ReactionStrip toggle, role=menu/menuitem on overflows, aria-label per InboxView row", "label_es": "ARIA: región aria-live en toggle de ReactionStrip, role=menu/menuitem en overflows, aria-label por fila en InboxView", "status": "done" },
+        { "label_en": "i18n EN/ES under socialgraph.cards.* + socialgraph.reactions.* (12 new keys)", "label_es": "i18n EN/ES bajo socialgraph.cards.* + socialgraph.reactions.* (12 keys nuevas)", "status": "done" }
+      ]
+    },
+    "visitor-pokedex-route": {
+      "phase": "v1.2",
+      "title_en": "Public visitor Pokédex route /u/dex/?username=",
+      "title_es": "Ruta pública de Pokédex visitante /u/dex/?username=",
+      "modules": ["25-profile-privacy.md"],
+      "subtasks": [
+        { "label_en": "Parametrize PokedexView.astro with visitor mode prop (owner self-view fallback when prop absent)", "label_es": "Parametrizar PokedexView.astro con prop visitor (fallback a vista del dueño cuando ausente)", "status": "done" },
+        { "label_en": "Privacy gate via can_see_facet(target, 'pokedex', viewer) RPC; private fallback when false", "label_es": "Gate de privacidad vía RPC can_see_facet(target, 'pokedex', viewer); fallback privado cuando false", "status": "done" },
+        { "label_en": "EN + ES paired pages at /u/dex/ with noindex,nofollow", "label_es": "Páginas EN + ES emparejadas en /u/dex/ con noindex,nofollow", "status": "done" },
+        { "label_en": "PublicProfileViewV2.astro — un-hide Pokédex link for visitors (owner → /profile/dex/, visitor → /u/dex/?username=)", "label_es": "PublicProfileViewV2.astro — re-mostrar link Pokédex para visitantes (dueño → /profile/dex/, visitante → /u/dex/?username=)", "status": "done" },
+        { "label_en": "OG card: profile-dex-visitor slug in generate-og.ts + ogSlugForPath() in BaseLayout (EN + ES)", "label_es": "OG card: slug profile-dex-visitor en generate-og.ts + ogSlugForPath() en BaseLayout (EN + ES)", "status": "done" },
+        { "label_en": "i18n: pokedex.visitor_* keys (title, subtitle, empty, private, not_found, not_found_cta, back_to_profile)", "label_es": "i18n: keys pokedex.visitor_* (title, subtitle, empty, private, not_found, not_found_cta, back_to_profile)", "status": "done" }
+      ]
+    },
+    "deploy-functions-resilience": {
+      "phase": "v1.2",
+      "title_en": "Pin esm.sh imports across Edge Functions for deploy resilience",
+      "title_es": "Fijar imports esm.sh en Edge Functions para resiliencia de deploy",
+      "modules": ["13-identifier-registry.md"],
+      "subtasks": [
+        { "label_en": "Pin @supabase/supabase-js@2 → @2.39.7 across 24 Edge Function files", "label_es": "Fijar @supabase/supabase-js@2 → @2.39.7 en 24 archivos Edge Function", "status": "done" },
+        { "label_en": "Verify all other esm.sh imports already pinned (aws-sdk@3.658.1, jszip@3.10.1, zod@3.23.8)", "label_es": "Verificar que otros imports esm.sh ya estaban fijados (aws-sdk@3.658.1, jszip@3.10.1, zod@3.23.8)", "status": "done" },
+        { "label_en": "Inline pin during merge cascade for new file recompute-user-stats/index.ts that landed mid-PR", "label_es": "Pin inline durante cascada de merge para recompute-user-stats/index.ts que llegó a mid-PR", "status": "done" },
+        { "label_en": "Follow-up: pin imports in PR #99's 5 new admin handlers once #99 merges (~5 LOC patch)", "label_es": "Seguimiento: fijar imports en los 5 nuevos handlers admin de PR #99 cuando #99 mergee (~5 LOC patch)", "status": "planned" }
+      ]
+    },
+    "m26-v1-1-review-followups": {
+      "phase": "v1.2",
+      "title_en": "M26 v1.1 review follow-ups — minor polish from PR #100/#101 reviewer notes",
+      "title_es": "Seguimientos de review M26 v1.1 — pulido menor de los notes en PR #100/#101",
+      "modules": ["26-social-graph.md"],
+      "subtasks": [
+        { "label_en": "?u= alias on readUsername() — document or remove (PR #100 review)", "label_es": "Alias ?u= en readUsername() — documentar o eliminar (review de PR #100)", "status": "planned" },
+        { "label_en": "document.title in JS → use i18n key for consistency (PR #100 review)", "label_es": "document.title en JS → usar key i18n por consistencia (review de PR #100)", "status": "planned" },
+        { "label_en": "runVisitor catch-all → distinguish error vs not-found state (PR #100 review)", "label_es": "runVisitor catch-all → distinguir estado error vs not-found (review de PR #100)", "status": "planned" },
+        { "label_en": "ConfirmDialog component — replace confirm()/alert() in Block flow (matches ReportDialog pattern, PR #101 review)", "label_es": "Componente ConfirmDialog — reemplazar confirm()/alert() en flujo Block (patrón ReportDialog, review de PR #101)", "status": "planned" },
+        { "label_en": "Extract overflow-menu logic into lib/overflow-menu.ts (currently duplicated 3× across PublicProfileViewV2, ExploreRecentView, Comments)", "label_es": "Extraer lógica de overflow-menu a lib/overflow-menu.ts (duplicada 3× en PublicProfileViewV2, ExploreRecentView, Comments)", "status": "planned" },
+        { "label_en": "Standardize fave_count_one vs fave_aria_one data-attr naming across ExploreRecentView + MyObservationsView", "label_es": "Estandarizar naming de data-attrs fave_count_one vs fave_aria_one en ExploreRecentView + MyObservationsView", "status": "planned" }
       ]
     }
   }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -118,6 +118,10 @@ Remaining:
 
 Remaining:
 
-- `social-graph-m26-v11` — Follow-ups: ReactionStrip count overlay on feed cards (needs an aggregate RPC to avoid N+1), Block/Report on observation cards + comments, "Block this user" affordance on profile cards in lists, additional ARIA refinements. _(· planned)_
-- `deploy-functions-resilience` — Pin esm.sh imports to versioned URLs across `supabase/functions/*/index.ts` so a transient esm.sh 522 doesn't permanently park the auto-deploy. Surfaced when PR #66's auto-deploy 522'd on a Cloudflare hiccup. _(· planned)_
-- `visitor-pokedex-route` — Public `/u/<handle>/dex/` page so the Pokédex link on PublicProfileViewV2 doesn't have to be hidden for non-owners (PR #68 currently hides it as a workaround). _(· planned)_
+- `social-graph-m26-v11` — Reaction count chip on feed cards (`observation_reaction_summary` view with `security_invoker = true`, batched fetch with no N+1), overflow ⋮ menu (Block + Report) on observation cards via the existing `PublicProfileViewV2` pattern, per-comment Block/Report in `Comments.astro` (lazy import of `blockUser`), ARIA refinements (live region on ReactionStrip toggle, role=menu/menuitem on overflows, aria-label per InboxView row), 12 new i18n keys under `socialgraph.cards.*` + `socialgraph.reactions.*`. _(✓ done — PR #101)_
+- `deploy-functions-resilience` — Pinned `@supabase/supabase-js@2` → `@2.39.7` across 24 Edge Function files so a transient esm.sh 522 (which broke PR #66's auto-deploy until manual workflow_dispatch backfill) can't park the auto-deploy in a failed state again. _(✓ done — PR #97; one follow-up sub-item still planned: pin imports in PR #99's 5 new admin handlers once #99 merges)_
+- `visitor-pokedex-route` — Public `/{en,es}/u/dex/?username=<handle>` route. Parametrized `PokedexView.astro` with a visitor mode prop, gated by `can_see_facet(target, 'pokedex', viewer)` RPC, EN+ES paired pages with `noindex,nofollow`, OG card via `profile-dex-visitor` slug, un-hid the Pokédex link in `PublicProfileViewV2` (was workaround-hidden in PR #68), 7 new `pokedex.visitor_*` i18n keys. _(✓ done — PR #100)_
+
+### Bundled review follow-ups still planned
+
+- `m26-v1-1-review-followups` — Six small polish items flagged by ArtemIO/Nyx on PR #100 + #101 reviews: `?u=` alias documentation, `document.title` → i18n key, runVisitor error-vs-not-found split, `ConfirmDialog` component to replace `confirm()`/`alert()` in the Block flow (matches `ReportDialog` pattern), extract overflow-menu logic into `lib/overflow-menu.ts` (currently duplicated 3× across `PublicProfileViewV2`, `ExploreRecentView`, `Comments`), and `fave_count` data-attr naming standardization across feed views. All non-blocking; deferred for a deliberate v1.2 polish sweep. _(· planned)_


### PR DESCRIPTION
After PRs #97 / #100 / #101 shipped, the 3 progress.json done flags were flipped by their respective subagents but the per-item subtask breakdowns and narrative paragraphs weren't filed. Closing the loop on documentation.

## What's tracked now (was missing)

- **`tasks.json`** — added 4 new task blocks (`social-graph-m26-v11`, `visitor-pokedex-route`, `deploy-functions-resilience`, `m26-v1-1-review-followups`) with full per-PR subtask breakdowns, EN+ES paired
- **`tasks.md`** — flipped the 3 v1.2 items from `_(· planned)_` to `_(✓ done — PR #N)_` with one-paragraph narratives each; new "Bundled review follow-ups still planned" subsection
- **`progress.json`** — added `m26-v1-1-review-followups` rolled-up backlog entry for the 6 small polish items flagged by ArtemIO + Nyx on PR #100 / #101 reviews (`?u=` alias, document.title → i18n, runVisitor catch-all split, ConfirmDialog component, overflow-menu refactor, fave_count data-attr standardization). All non-blocking
- **`CLAUDE.md`** — bumped test counts from stale `~454` and `225` to current `~465`

## Verifications

- [x] `progress.json` + `tasks.json` valid JSON
- [x] `npm run build` — clean
- [x] Rendered `dist/{en,es}/docs/tasks/index.html` now contains the 4 new entries (EN + ES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)