### PR TITLE
fix(observe): surface EXIF parse failures + handle alternate GPS keys

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -1916,21 +1916,40 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
   });
 
   async function fillFromExif(file: File) {
+    let exif: Record<string, unknown> | undefined;
     try {
-      const exif = await parseExif(file, { gps: true, tiff: true, exif: true });
-      if (exif?.latitude != null && exif?.longitude != null) {
-        // EXIF GPS always wins over live GPS — the photo was taken at that
-        // specific location. Live GPS is only a fallback for photos without EXIF.
-        location = {
-          lat: exif.latitude,
-          lng: exif.longitude,
-          accuracyM: 15,               // EXIF GPS is phone-derived; assume ~15m
-          altitudeM: exif.GPSAltitude ?? null,
-          capturedFrom: 'exif',
-        };
-        paintLocation();
-      }
-    } catch { /* non-fatal */ }
+      exif = await parseExif(file, { gps: true, tiff: true, exif: true }) as Record<string, unknown> | undefined;
+    } catch (err) {
+      console.warn('[rastrum] EXIF parse failed', { name: file.name, type: file.type, err });
+      return;
+    }
+    if (!exif) {
+      console.warn('[rastrum] EXIF empty', { name: file.name, type: file.type });
+      return;
+    }
+    const lat = pickNumber(exif.latitude, exif.Latitude, exif.GPSLatitude);
+    const lng = pickNumber(exif.longitude, exif.Longitude, exif.GPSLongitude);
+    if (lat == null || lng == null) {
+      console.warn('[rastrum] EXIF has no GPS', { name: file.name, keys: Object.keys(exif).slice(0, 20) });
+      return;
+    }
+    // EXIF GPS always wins over live GPS — the photo was taken at that
+    // specific location. Live GPS is only a fallback for photos without EXIF.
+    location = {
+      lat,
+      lng,
+      accuracyM: 15,
+      altitudeM: pickNumber(exif.GPSAltitude),
+      capturedFrom: 'exif',
+    };
+    paintLocation();
+  }
+
+  function pickNumber(...candidates: unknown[]): number | null {
+    for (const c of candidates) {
+      if (typeof c === 'number' && Number.isFinite(c) && c !== 0) return c;
+    }
+    return null;
   }
 
   function showGpsError(code: number) {
@@ -2126,13 +2145,16 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
   // -------------------------------------------------------------------------
   cameraInput?.addEventListener('change', async () => {
     if (!cameraInput.files?.length) return;
-    await addPhotos(cameraInput.files);
+    // Read EXIF from the original File before any compression / canvas
+    // re-encode (which strips EXIF). compressIfLarge doesn't mutate the
+    // input, but reading metadata first matches intent and is cheaper.
     await fillFromExif(cameraInput.files[0]);
+    await addPhotos(cameraInput.files);
   });
   galleryInput?.addEventListener('change', async () => {
     if (!galleryInput.files?.length) return;
-    await addPhotos(galleryInput.files);
     await fillFromExif(galleryInput.files[0]);
+    await addPhotos(galleryInput.files);
   });
 
   gpsManualBtn?.addEventListener('click', () => {

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -1933,13 +1933,20 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       console.warn('[rastrum] EXIF has no GPS', { name: file.name, keys: Object.keys(exif).slice(0, 20) });
       return;
     }
+    // Reject (0,0) only as a *pair* — null island is the well-known
+    // EXIF default-when-stripped. lat=0 alone is the equator (legit
+    // for observers in Ecuador, Colombia, Brasil, Kenya, etc.).
+    if (lat === 0 && lng === 0) {
+      console.warn('[rastrum] EXIF GPS is null island (0,0); ignoring', { name: file.name });
+      return;
+    }
     // EXIF GPS always wins over live GPS — the photo was taken at that
     // specific location. Live GPS is only a fallback for photos without EXIF.
     location = {
       lat,
       lng,
       accuracyM: 15,
-      altitudeM: pickNumber(exif.GPSAltitude),
+      altitudeM: pickNumber(exif.GPSAltitude, exif.altitude, exif.Altitude),
       capturedFrom: 'exif',
     };
     paintLocation();
@@ -1947,7 +1954,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
 
   function pickNumber(...candidates: unknown[]): number | null {
     for (const c of candidates) {
-      if (typeof c === 'number' && Number.isFinite(c) && c !== 0) return c;
+      if (typeof c === 'number' && Number.isFinite(c)) return c;
     }
     return null;
   }


### PR DESCRIPTION
## Summary

- `fillFromExif()` no longer swallows errors silently — logs to `console.warn` with the file name, MIME type, and underlying error so the next field-test failure is debuggable
- Tries `latitude` / `Latitude` / `GPSLatitude` (and longitude variants), via a `pickNumber()` helper that also rejects NaN/Infinity and 0,0 (null island)
- Reads EXIF *before* `addPhotos()` in both camera and gallery handlers (defensive ordering — `compressIfLarge` doesn't mutate the input File but reading metadata first matches intent)

Closes #90.

## Background

Reported by Eugenio (field tester, Oaxaca, 2026-04-29): photos with EXIF GPS were not auto-populating the location field. The previous `fillFromExif` silently caught every error, so we had zero visibility into whether exifr was failing, whether the photo had no GPS at all, or whether we were looking at the wrong property name. This PR adds the missing telemetry plus broadens the property lookup.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test -- --run` — 496/496 pass
- [ ] Field retest: Eugenio opens DevTools console, adds a photo on `/es/observar`. Any EXIF failure now surfaces a `[rastrum] EXIF …` warn with the concrete cause (HEIC unsupported / no GPS in metadata / alternate property layout / null-island).

🤖 Generated with [Claude Code](https://claude.com/claude-code)