### PR TITLE
fix(pwa): suppress install banner when app is already installed

### DIFF
--- a/src/components/InstallDiscoveryHint.astro
+++ b/src/components/InstallDiscoveryHint.astro
@@ -197,13 +197,16 @@ const pwa = (tr as unknown as { pwa: Record<string, string> }).pwa;
       }
     });
 
-    window.addEventListener('beforeinstallprompt', (ev) => {
+    window.addEventListener('beforeinstallprompt', async (ev) => {
       ev.preventDefault();
-      // Don't show if already installed (localStorage flag is the fastest check).
-      // This handles the case where the user opens the site in the browser
-      // after having installed the PWA from the home screen — Chrome still
-      // fires beforeinstallprompt in that context.
+      // Don't show if already installed. The fast path is the localStorage
+      // memo + display-mode standalone + android-app intent referrer; the
+      // slow path re-probes Chrome's getInstalledRelatedApps() to catch the
+      // race where beforeinstallprompt fires before the async probe lands
+      // (browser-tab visit after a prior install on the same device).
       if (isPwaInstalled() || isDismissed()) return;
+      await markInstalledIfRelatedAppsKnown();
+      if (isPwaInstalled()) return;
       savedPrompt = ev as InstallPromptEvent;
       cta?.classList.remove('hidden');
     });

--- a/src/components/InstallPwaButton.astro
+++ b/src/components/InstallPwaButton.astro
@@ -39,7 +39,7 @@ const tr = t(lang);
 </div>
 
 <script>
-  import { isIOS, isStandaloneDisplayMode } from '../lib/local-ai-helpers';
+  import { isIOS, isStandaloneDisplayMode, isFromAndroidIntent } from '../lib/local-ai-helpers';
 
   // The browser's beforeinstallprompt event isn't fully typed in lib.dom yet.
   type InstallPromptEvent = Event & {
@@ -86,7 +86,7 @@ const tr = t(lang);
     // tapped a link inside the installed PWA, which dropped them into a
     // browser tab). Strong signal the app is installed even when
     // display-mode is browser.
-    if (typeof document !== 'undefined' && document.referrer.startsWith('android-app://')) {
+    if (isFromAndroidIntent()) {
       try { localStorage.setItem('rastrum.pwaInstalled', 'true'); } catch { /* ignore */ }
       return true;
     }

--- a/src/components/InstallPwaButton.astro
+++ b/src/components/InstallPwaButton.astro
@@ -82,6 +82,14 @@ const tr = t(lang);
     try { if (localStorage.getItem('rastrum.pwaInstalled') === 'true') return true; } catch { /* ignore */ }
     // Fast path: running in standalone mode = already installed and open from icon.
     if (isStandaloneDisplayMode()) return true;
+    // Fast path: navigated here from an Android app intent (the user
+    // tapped a link inside the installed PWA, which dropped them into a
+    // browser tab). Strong signal the app is installed even when
+    // display-mode is browser.
+    if (typeof document !== 'undefined' && document.referrer.startsWith('android-app://')) {
+      try { localStorage.setItem('rastrum.pwaInstalled', 'true'); } catch { /* ignore */ }
+      return true;
+    }
     // Slow path: ask Chrome directly (async, may be empty on older versions).
     try {
       const nav = window.navigator as Navigator & { getInstalledRelatedApps?: () => Promise<unknown[]> };

--- a/src/lib/local-ai-helpers.test.ts
+++ b/src/lib/local-ai-helpers.test.ts
@@ -8,6 +8,7 @@ import {
   compactFields,
   CHAT_SYSTEM_PROMPT,
   isIOS,
+  isFromAndroidIntent,
 } from './local-ai-helpers';
 
 describe('local-ai-helpers · locale detection', () => {
@@ -107,5 +108,15 @@ describe('local-ai-helpers · iOS detection', () => {
     expect(isIOS('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36')).toBe(false);
     expect(isIOS('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36')).toBe(false);
     expect(isIOS('')).toBe(false);
+  });
+});
+
+describe('local-ai-helpers · Android intent referrer', () => {
+  it('matches android-app:// referrers', () => {
+    expect(isFromAndroidIntent('android-app://org.rastrum.twa/https/rastrum.org')).toBe(true);
+  });
+  it('rejects regular web referrers and empty strings', () => {
+    expect(isFromAndroidIntent('https://google.com/')).toBe(false);
+    expect(isFromAndroidIntent('')).toBe(false);
   });
 });

--- a/src/lib/local-ai-helpers.ts
+++ b/src/lib/local-ai-helpers.ts
@@ -106,6 +106,17 @@ export function isStandaloneDisplayMode(): boolean {
   return navStandalone === true;
 }
 
+/**
+ * True when the navigation came from an Android app intent
+ * (e.g. the user tapped a link inside the installed Rastrum PWA on
+ * Android Chrome and landed back in a browser tab). This is a strong
+ * signal the PWA is installed even when display-mode is 'browser' and
+ * `getInstalledRelatedApps()` hasn't yet populated.
+ */
+export function isFromAndroidIntent(referrer: string = typeof document !== 'undefined' ? document.referrer : ''): boolean {
+  return typeof referrer === 'string' && referrer.startsWith('android-app://');
+}
+
 const PWA_INSTALLED_KEY = 'rastrum.pwaInstalled';
 
 /**
@@ -126,6 +137,10 @@ const PWA_INSTALLED_KEY = 'rastrum.pwaInstalled';
 export function isPwaInstalled(): boolean {
   if (typeof window === 'undefined') return false;
   if (isStandaloneDisplayMode()) return true;
+  if (isFromAndroidIntent()) {
+    markPwaInstalled();
+    return true;
+  }
   try { return localStorage.getItem(PWA_INSTALLED_KEY) === 'true'; }
   catch { return false; }
 }


### PR DESCRIPTION
## Summary

- `InstallDiscoveryHint.astro` — `beforeinstallprompt` listener is now async; re-probes `getInstalledRelatedApps()` before showing the banner to fix the race where the event fired before the async probe landed.
- `local-ai-helpers.ts` — added `isFromAndroidIntent()` (checks `document.referrer.startsWith('android-app://')`) so that a browser-tab visit reached via app intent is recognised as an installed-state signal. `isPwaInstalled()` now consults it and persists the localStorage memo automatically.
- `InstallPwaButton.astro` — same Android intent check in `isAlreadyInstalled()`.

Closes #89.

## Why two signals weren't enough before

`isStandaloneDisplayMode()` is false in browser-tab context. The localStorage memo only gets set when `appinstalled` fires — which doesn't fire on subsequent visits, only at install time. `getInstalledRelatedApps()` is async and can return `[]` on the first call right after install in some Chrome versions. With all three failing, the banner re-appeared every browser-tab visit.

The Android intent referrer is the missing fourth signal: when the user taps a link inside the installed PWA on Android Chrome, they land in a browser tab with `document.referrer === 'android-app://...'`. That's a strong installed-state signal even when the other three checks are inconclusive.

## Test plan

- [x] `npm run typecheck` clean
- [x] New unit tests for `isFromAndroidIntent()` (13/13 in `local-ai-helpers.test.ts`)
- [ ] Field retest: Eugenio opens rastrum.org in Chrome (not from icon) after install. Banner should not appear. If it does, reload — the 2nd load should have the flag persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)