### PR TITLE
feat(observe): byte-size cap on client-side photo compression

### DIFF
--- a/src/lib/photo-compress.test.ts
+++ b/src/lib/photo-compress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeScale, isImageFile, compressIfLarge, DEFAULT_MAX_MP } from './photo-compress';
+import { computeScale, isImageFile, compressIfLarge, DEFAULT_MAX_MP, DEFAULT_MAX_BYTES, MIN_QUALITY } from './photo-compress';
 
 describe('computeScale', () => {
   it('returns 1 when pixels exactly equal the maxMP budget (no resize)', () => {
@@ -64,5 +64,14 @@ describe('compressIfLarge', () => {
     const out = await compressIfLarge(f);
     expect(out.file).toBe(f);
     expect(out.resized).toBe(false);
+  });
+});
+
+describe('byte-cap defaults', () => {
+  it('exposes DEFAULT_MAX_BYTES at 4 MB', () => {
+    expect(DEFAULT_MAX_BYTES).toBe(4 * 1024 * 1024);
+  });
+  it('exposes MIN_QUALITY floor at 0.6 to preserve AI-id detail', () => {
+    expect(MIN_QUALITY).toBe(0.6);
   });
 });

--- a/src/lib/photo-compress.ts
+++ b/src/lib/photo-compress.ts
@@ -18,6 +18,10 @@
  */
 export const DEFAULT_MAX_MP = 4;
 export const DEFAULT_QUALITY = 0.9;
+/** Hard byte cap after compression. R2 storage cost + mobile upload speed. */
+export const DEFAULT_MAX_BYTES = 4 * 1024 * 1024;
+/** Floor on JPEG quality when iteratively reducing to fit byte cap. */
+export const MIN_QUALITY = 0.6;
 
 export interface CompressResult {
   /** May be the same File reference if no resize was needed. */
@@ -59,6 +63,7 @@ export async function compressIfLarge(
   file: File,
   maxMP: number = DEFAULT_MAX_MP,
   quality: number = DEFAULT_QUALITY,
+  maxBytes: number = DEFAULT_MAX_BYTES,
 ): Promise<CompressResult> {
   if (!(file instanceof File)) {
     throw new TypeError('compressIfLarge: expected a File');
@@ -79,13 +84,28 @@ export async function compressIfLarge(
   const w = bitmap.width;
   const h = bitmap.height;
   const scale = computeScale(w, h, maxMP);
-  if (scale >= 1) {
+  const needsResize = scale < 1;
+  const overByteCap = file.size > maxBytes;
+
+  if (!needsResize && !overByteCap) {
     bitmap.close?.();
     return { file, resized: false, originalDims: { w, h } };
   }
-  const targetW = Math.max(1, Math.round(w * scale));
-  const targetH = Math.max(1, Math.round(h * scale));
-  const blob = await drawAndEncode(bitmap, targetW, targetH, quality);
+
+  const targetW = needsResize ? Math.max(1, Math.round(w * scale)) : w;
+  const targetH = needsResize ? Math.max(1, Math.round(h * scale)) : h;
+
+  // Iteratively drop quality until we're under the byte cap, but never
+  // below MIN_QUALITY (preserves visible detail for AI identification).
+  let q = quality;
+  let blob: Blob | null = null;
+  for (let i = 0; i < 5; i++) {
+    blob = await drawAndEncode(bitmap, targetW, targetH, q);
+    if (!blob) break;
+    if (blob.size <= maxBytes) break;
+    if (q <= MIN_QUALITY) break;
+    q = Math.max(MIN_QUALITY, q - 0.1);
+  }
   bitmap.close?.();
   if (!blob) return { file, resized: false, originalDims: { w, h } };
 


### PR DESCRIPTION
## Summary

- New defaults: `DEFAULT_MAX_BYTES = 4 MB` and `MIN_QUALITY = 0.6` (floor on iterative quality reduction).
- `compressIfLarge` accepts a `maxBytes` parameter and iteratively drops JPEG quality in 0.1 steps until the result fits the cap, with a 5-iteration ceiling.
- Now re-encodes when the file fits the MP cap but exceeds the byte cap (the 12 MP camera JPEG already-under-4-MP-but-5-MB-on-disk case).

Closes #106 (the MP cap and the wiring into `addPhotos()` shipped earlier; this PR is the missing byte cap).

## Why a quality floor

PlantNet/Claude both downscale to ≤1024 px anyway, but artifacts below q≈0.6 hurt the human review-grade decision and the sensitive-species verification flow. The floor keeps the worst-case output usable for those paths.

## What's not in this PR

- Propagating `compressIfLarge` to the `PhotoGallery.astro` add-photo flow (PR #103 just merged; the new add-photo handler in the obs detail redesign should call this helper too). Tracked separately.
- Per-photo "resized" badge in the UI — silent operation per the issue spec.

## Test plan

- [x] `npm run typecheck` clean
- [x] New tests for `DEFAULT_MAX_BYTES` and `MIN_QUALITY` defaults (13/13 in `photo-compress.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)