### PR TITLE
chore(community): automate M28 backfill via workflow_dispatch + v1.2 status flips

### DIFF
--- a/.github/workflows/community-backfill.yml
+++ b/.github/workflows/community-backfill.yml
@@ -1,0 +1,77 @@
+name: Community discovery — manual backfill
+
+# One-time / on-demand fire of the deployed `recompute-user-stats` Edge
+# Function. Computes counters (species_count, obs_count_7d, obs_count_30d),
+# centroid_geog, and country_code (where currently NULL) for every user.
+#
+# Why this exists: the nightly cron (08:00 UTC) only sees users who are
+# active. Until each user posts a new observation, their counters stay at
+# zero and they don't appear on /{en,es}/community/observers/. Firing this
+# once after Module 28 ships gives the page useful data on day 1.
+#
+# This replaces the previous "operator runs curl" instruction in
+# docs/runbooks/community-discovery.md (PR3 — backfill).
+#
+# Safe to run repeatedly: the EF is idempotent (UPDATE … FROM stats CTE
+# rewrites the same fields each call). At v1 scale runs in under 2 seconds.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'If true, only checks the EF responds; does not record output as a backfill run.'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    name: Fire recompute-user-stats once
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_REF: reppvlqejgoqvitturxp
+    steps:
+      - name: Invoke recompute-user-stats Edge Function
+        run: |
+          set -euo pipefail
+          url="https://${PROJECT_REF}.supabase.co/functions/v1/recompute-user-stats"
+          echo "POST $url"
+          # The EF is deployed --no-verify-jwt (cron-only contract); no Auth
+          # header needed. Internal access control happens inside via the
+          # auto-injected SUPABASE_SERVICE_ROLE_KEY.
+          response=$(curl -sS -X POST \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            -w '\n%{http_code}' \
+            "$url")
+          body="${response%$'\n'*}"
+          status="${response##*$'\n'}"
+
+          echo "::group::Response"
+          echo "HTTP $status"
+          echo "$body"
+          echo "::endgroup::"
+
+          if [ "$status" != "200" ]; then
+            echo "::error::Edge Function returned HTTP $status"
+            exit 1
+          fi
+
+          # Surface the rows_updated count so the operator can sanity-check
+          # in the Actions UI. The EF returns { ok, elapsed_ms, rows_updated }.
+          rows=$(echo "$body" | grep -oE '"rows_updated"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' || echo '?')
+          elapsed=$(echo "$body" | grep -oE '"elapsed_ms"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' || echo '?')
+          echo "::notice::Backfilled $rows users in ${elapsed}ms"
+
+      - name: Annotate run
+        if: ${{ inputs.dry_run != 'true' }}
+        run: |
+          echo "## Community discovery — backfill complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Fired \`recompute-user-stats\` against project \`${PROJECT_REF}\`. The nightly cron at 08:00 UTC will continue to refresh counters going forward." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/community-backfill.yml
+++ b/.github/workflows/community-backfill.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'If true, only checks the EF responds; does not record output as a backfill run.'
+        description: 'If true, only HEADs the EF endpoint to verify it resolves; does NOT recompute.'
         required: false
         default: 'false'
         type: choice
@@ -37,7 +37,28 @@ jobs:
     env:
       PROJECT_REF: reppvlqejgoqvitturxp
     steps:
+      - name: Dry-run — probe endpoint only
+        if: ${{ inputs.dry_run == 'true' }}
+        run: |
+          set -euo pipefail
+          url="https://${PROJECT_REF}.supabase.co/functions/v1/recompute-user-stats"
+          echo "Probing $url (HEAD; no recompute)"
+          # HEAD verifies the function is deployed and routable. We accept
+          # any 2xx/4xx — Edge Functions sometimes 405 HEAD, which still
+          # confirms reachability.
+          status=$(curl -sS -o /dev/null -w '%{http_code}' -X HEAD "$url")
+          echo "HTTP $status"
+          if [ -z "$status" ] || [ "$status" -ge 500 ] 2>/dev/null; then
+            echo "::error::Endpoint unreachable (HTTP ${status:-no-response})"
+            exit 1
+          fi
+          echo "::notice::Dry-run OK — endpoint reachable (HTTP $status). No backfill performed."
+          echo "## Community discovery — dry-run OK" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Endpoint \`recompute-user-stats\` reachable (HTTP $status). No recompute performed. Re-run with \`dry_run=false\` to fire the actual backfill." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Invoke recompute-user-stats Edge Function
+        if: ${{ inputs.dry_run != 'true' }}
         run: |
           set -euo pipefail
           url="https://${PROJECT_REF}.supabase.co/functions/v1/recompute-user-stats"
@@ -69,9 +90,6 @@ jobs:
           elapsed=$(echo "$body" | grep -oE '"elapsed_ms"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' || echo '?')
           echo "::notice::Backfilled $rows users in ${elapsed}ms"
 
-      - name: Annotate run
-        if: ${{ inputs.dry_run != 'true' }}
-        run: |
           echo "## Community discovery — backfill complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Fired \`recompute-user-stats\` against project \`${PROJECT_REF}\`. The nightly cron at 08:00 UTC will continue to refresh counters going forward." >> "$GITHUB_STEP_SUMMARY"
+          echo "Fired \`recompute-user-stats\` against project \`${PROJECT_REF}\`. \`$rows\` users updated in \`${elapsed}ms\`. The nightly cron at 08:00 UTC will continue to refresh counters going forward." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -407,7 +407,7 @@ Full spec + plan: [`docs/superpowers/specs/2026-04-28-social-features-design.md`
 
 ---
 
-## Community discovery (Module 28, v1.2 in-flight)
+## Community discovery (Module 28, v1.2 shipped 2026-04-29)
 
 Adds a Community surface to the Explore MegaMenu — Observers / Top / Nearby /
 Experts by taxon / By country — backed by denormalized counters refreshed
@@ -434,7 +434,7 @@ Operator runbook: [`docs/runbooks/community-discovery.md`](runbooks/community-di
 
 ---
 
-## Observation detail page redesign (M03 viewer + owner edit, v1.2 in-flight)
+## Observation detail page redesign (M03 viewer + owner edit, v1.2 shipped 2026-04-29)
 
 `/share/obs/?id=<uuid>` rebuilt as a two-column desktop / stacked mobile
 layout. Three reusable components extracted: `MapPicker.astro` (mode='view'|'edit',

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -894,8 +894,8 @@
           "label_es": "Descubrimiento comunitario (Módulo 28) — MegaMenu de Explorar dividido en columnas Biodiversidad / Comunidad; página /community/observers/ con chips de filtros componibles (orden, país, taxón, sólo expertos, cercanos); contadores denormalizados (species_count, obs_count_7d/30d, centroid_geog, country_code) refrescados cada noche por la Edge Function recompute-user-stats; tabla de referencia ISO-3166 + normalize_country_code(); vistas duales (anon-safe + authenticated-only con centroide); toggle de opt-out + selector de país en Perfil → Editar; reescribe los strings 'no leaderboards' que estaban en producción",
           "done": true,
           "done_at": "2026-04-29",
-          "status": "shipped — PR1 (#92) + PR2 (#96) + PR4 (#102) on main; PR5+PR6 lands page + MegaMenu split + atomic i18n rewrite of the two production 'no leaderboards' strings; operator manual cron fire (PR3) is the only remaining backfill task",
-          "status_es": "lanzado — PR1 (#92) + PR2 (#96) + PR4 (#102) en main; PR5+PR6 aterriza la página + split del MegaMenu + reescritura atómica i18n de los dos strings 'no leaderboards' en producción; el disparo manual del cron (PR3) por el operador es la única tarea de backfill restante"
+          "status": "shipped — PR1 (#92) + PR2 (#96) + PR4 (#102) + PR5+PR6 (#122) on main. Backfill (formerly PR3 operator action) is now automated via the .github/workflows/community-backfill.yml workflow_dispatch button — fire once after deploy",
+          "status_es": "lanzado — PR1 (#92) + PR2 (#96) + PR4 (#102) + PR5+PR6 (#122) en main. El backfill (antes acción manual del operador PR3) está automatizado vía el workflow_dispatch en .github/workflows/community-backfill.yml — disparar una vez tras el deploy"
         },
         {
           "id": "obs-detail-redesign",

--- a/docs/runbooks/community-discovery.md
+++ b/docs/runbooks/community-discovery.md
@@ -35,32 +35,30 @@
 `docs/specs/infra/cron-schedules.sql`. The 30-minute gap after badges-nightly is
 adequate for typical scale; the recompute job is read-mostly with one bulk UPDATE.
 
-## Manual cron fire (PR3 backfill — operator action)
+## One-time backfill (formerly PR3 operator action — now CI/CD)
 
-After PR2 merges and the Edge Function auto-deploys, the cron will start
-populating counters and centroids for users who post new observations. To
-backfill **all existing users** (including those who haven't posted recently) so
-the page shows useful data on day 1:
+After all six PRs ship, the cron will start populating counters and centroids
+for users who post new observations. To backfill **all existing users**
+(including those who haven't posted recently) so the page shows useful data
+on day 1, fire the CI workflow once:
 
-```bash
-# Local — uses SUPABASE_SERVICE_ROLE_KEY from .env.local
-make db-cron-test
-# That fires recompute-streaks + award-badges + recompute-user-stats.
-
-# Or hit the Edge Function directly (CI / remote operator):
-curl -X POST \
-  -H "Content-Type: application/json" \
-  -d '{}' \
-  "https://reppvlqejgoqvitturxp.supabase.co/functions/v1/recompute-user-stats"
+```
+GitHub Actions → Community discovery — manual backfill → Run workflow
 ```
 
-The function returns `{ ok, elapsed_ms, rows_updated }`. At the v1 scale this is
-under 2 seconds; expect a few minutes once the table grows past 100k users.
+The workflow is at `.github/workflows/community-backfill.yml`. It posts to the
+deployed `recompute-user-stats` Edge Function (no shell needed) and surfaces
+`{ rows_updated, elapsed_ms }` in the Actions UI as a notice annotation. At
+v1 scale the run completes in under 2 seconds.
 
-**Sequencing:** Run this **before** the Profile → Edit country picker is
-exposed (PR4) so users see the inferred country *and* the "inferred from your
-region" badge from the start, instead of a NULL field that gets backfilled days
-later.
+The workflow is idempotent — fire it again any time you want a fresh recompute
+without waiting for the nightly 08:00 UTC tick.
+
+**For local debugging** (developer machine, not the production backfill):
+
+```bash
+make db-cron-test   # fires streaks + badges + recompute-user-stats locally
+```
 
 ## Privacy invariants — do NOT break
 
@@ -96,7 +94,7 @@ Profile → Edit toggle.
 |---|---|---|
 | #92 | merged 2026-04-29 | PR1 — schema deltas + dual views + iso_countries seed + `normalize_country_code` |
 | #96 | merged 2026-04-29 | PR2 — `recompute-user-stats` Edge Function + cron + `SECURITY DEFINER` wrapper |
-| (operator) | pending | PR3 — manual cron fire to backfill (see "Manual cron fire" above) |
+| `community-backfill.yml` | shipped 2026-04-29 | PR3 — one-time backfill, automated as a GitHub Actions workflow_dispatch (formerly an operator curl) |
 | #102 | merged 2026-04-29 | PR4 — Profile → Edit country picker + `hide_from_leaderboards` toggle + `country_code_source` |
 | PR5+PR6 | merged 2026-04-29 | Atomic landing — `/community/observers/` page (CSR) + composable filter chips + URL-state serializer + `community_observers_nearby` SQL RPC + MegaMenu split (Biodiversity / Community columns) + MobileDrawer subheading + atomic i18n rewrite of the two production "no leaderboards" strings + OG card + Vitest + Playwright e2e + module status flip to "shipped" |
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -136,9 +136,9 @@ Remaining:
 
 - `ai-sponsorships` — Permite a cualquier user compartir su credencial Anthropic (API key u OAuth long-lived token) con beneficiaries específicos. Cuota mensual por llamadas, auto-pause por rate-limit, karma híbrido, y removal del operator-key fallback en `identify`. Entregado: schema (5 tablas + RLS + Vault) + cron jobs + audit log; Edge Functions `sponsorships` (CRUD + heartbeat) e `identify` modificado; UI en `/profile/sponsoring/`, `/profile/sponsored-by/`, banner en `/identify`, discovery card, header dropdown, mobile drawer entries, badge de sponsor + recíproco en perfil público; Resend SMTP para threshold (80%/100%) + auto-pause emails; request-to-be-sponsored flow (5 endpoints + dialogs ambos lados); onboarding tour first-visit + replay; página `/docs/sponsorships` (EN+ES); time range selector 7/30/90 en analytics; report abuse button por beneficiary; CI guards (smoke + secret-leak). **Operator action única:** `gh secret set SPONSORSHIPS_CRON_TOKEN` (hecho). **Operator action opcional:** `gh secret delete ANTHROPIC_API_KEY` (no urgente; identify ya no la lee). _(✓ done)_
 
-### v1.2 in-flight (2026-04-29) — Module 28 + observation-detail redesign
+### v1.2 shipped 2026-04-29 — Module 28 + observation-detail redesign
 
-Both features are landing as 6-PR sequences. Plans at
+Both features landed as 6-PR sequences each. Plans at
 `docs/superpowers/plans/2026-04-29-{community-discovery,obs-detail-redesign}-plan.md`,
 specs at `docs/superpowers/specs/2026-04-29-*-design.md`.
 
@@ -150,24 +150,24 @@ specs at `docs/superpowers/specs/2026-04-29-*-design.md`.
   centroid) and `community_observers_with_centroid` (authenticated only) plus the
   authenticated-only `community_observers_nearby(...)` SQL RPC for the Nearby
   filter. Country picker + `hide_from_leaderboards` opt-out + `country_code_source`
-  'auto'/'user' badge on Profile → Edit. PR1 (#92) + PR2 (#96) + PR4 (#102) merged.
-  PR5+PR6 (this PR) atomically lands the page + MegaMenu split + i18n rewrite of
-  the two shipped "no leaderboards" strings + OG card + roadmap flip. PR3 manual
-  cron fire is the only remaining backfill task (operator action). _(✓ done)_
+  'auto'/'user' badge on Profile → Edit. PRs #92 (PR1 schema), #96 (PR2 EF + cron),
+  #102 (PR4 Profile → Edit), #122 (PR5+PR6 atomic — page + MegaMenu split + i18n
+  rewrite + OG card + roadmap flip). The one-time backfill (formerly PR3 operator
+  action) is now automated via the `community-backfill.yml` workflow_dispatch
+  button. _(✓ shipped — see `docs/runbooks/community-discovery.md`)_
 
 - `obs-detail-redesign` — Rebuilt `/share/obs/?id=...` as two-column desktop /
-  stacked mobile layout. PR1 (#91) extracted reusable `MapPicker.astro` from
-  `ObservationForm.astro`. PR2 (#98) added schema deltas
-  (`last_material_edit_at` + `media_files.deleted_at` +
-  `observations_material_edit_check_trg` material-edit trigger),
-  `observation-enums.ts`, and `obs_detail.*` i18n. PR3 (#103) shipped
-  `PhotoGallery.astro` (native lightbox + keyboard + swipe + share) plus the new
-  two-column layout. PR4 (#120) wired the Details tab (date/time + habitat +
-  weather + establishment + scientific-name override + notes + obscure-level).
-  PR6 wired the Photos tab + the atomic `delete-photo` Edge Function (soft-delete
-  + ID demote clearing validated_by/validated_at/is_research_grade +
+  stacked mobile layout. PRs #91 (PR1 — extract reusable `MapPicker.astro` from
+  `ObservationForm.astro`), #98 (PR2 — schema deltas: `last_material_edit_at` +
+  `media_files.deleted_at` + `observations_material_edit_check_trg` material-edit
+  trigger + `observation-enums.ts` + `obs_detail.*` i18n), #103 (PR3 —
+  `PhotoGallery.astro` native lightbox + new two-column layout + `ShareObsView`
+  i18n migration), #120 (PR4 — `ObsManagePanel.Details` tab: date/time + habitat
+  + weather + establishment + sci-name override + notes + obscure-level), #124
+  (PR5 — Location tab with coordinate-edit modal via `MapPicker mode='edit'`,
+  `pickerId='obs-detail-edit'`, `wireManagePanelLocation` + `pointGeographyLiteral`
+  helper), #125 (PR6 — Photos tab + atomic `delete-photo` Edge Function:
+  soft-delete + ID demote clearing validated_by/validated_at/is_research_grade +
   last_material_edit_at bump in one transaction via `delete_photo_atomic`
-  SECURITY DEFINER RPC). PR5 (Location tab — coordinate edit modal) is the only
-  remaining slice and is tracked as a v1.1 follow-up under the spec. Soft-delete
-  only for v1; R2 orphan GC is a v1.1 follow-up. _(✓ shipped — see
-  `docs/runbooks/obs-detail-redesign.md`)_
+  SECURITY DEFINER RPC). Soft-delete only for v1; R2 orphan GC (`gc-orphan-media`
+  cron) is a v1.1 follow-up. _(✓ shipped — see `docs/runbooks/obs-detail-redesign.md`)_


### PR DESCRIPTION
## Summary

The M28 PR3 'one-time backfill of `recompute-user-stats`' was the only remaining operator-action across the M28 + obs-detail-redesign launch. Per the project's rule that operator actions go through CI/CD, wired it as a GitHub Actions \`workflow_dispatch\` button. Plus a small batch of status flips for spots that were stale post-merge.

## What this PR ships

### 1. \`.github/workflows/community-backfill.yml\` (new)

Single-step workflow that POSTs to the deployed \`recompute-user-stats\` Edge Function and surfaces \`{ rows_updated, elapsed_ms }\` as an Actions notice annotation. The EF is \`--no-verify-jwt\` (cron-only contract); internal access control happens inside via the auto-injected \`SUPABASE_SERVICE_ROLE_KEY\`. Idempotent — fire any time for a fresh recompute without waiting for the 08:00 UTC nightly cron.

Operators run it from **GitHub Actions → Community discovery — manual backfill → Run workflow**. No shell needed.

### 2. Status flips for the two v1.2 features (both merged 2026-04-29)

- **\`docs/progress.json\`** — \`community-discovery-m28\` status string updated to acknowledge PR5+PR6 (#122) merged + reference the new CI backfill workflow instead of the operator curl.
- **\`docs/architecture.md\`** — both section headers (\`v1.2 in-flight\` → \`v1.2 shipped 2026-04-29\`).
- **\`docs/tasks.md\`** — section header + obs-detail bullet rewritten past-tense, with full PR # map (#91 + #98 + #103 + #120 + #124 + #125), correct PR5/PR6 attribution.
- **\`docs/runbooks/community-discovery.md\`** — 'Manual cron fire' section rewritten to point operators at the Actions UI button instead of a curl command. Per-PR map row updated for the new workflow file.

## What's already correct (no change)

- \`progress.json\` \`done: true\` / \`done_at: 2026-04-29\` (set on merge by the PR5+PR6 and PR6 agents).
- \`docs/specs/modules/00-index.md\` M28 row (already \"shipped\" post-merge).
- \`docs/specs/modules/28-community-discovery.md\` Status header (already \"shipped 2026-04-29\").

## After this lands

Every v1.2 follow-up is either pure code (\`gc-orphan-media\` cron, \`ConfirmDialog\`, residual \`ShareObsView\` ternary mop-up, M28 v1.1 heatmap/time-windows/rollup) or already in CI/CD. **No operator actions remain.**

## Test plan

- [x] \`python3 -c 'json.load(open(\".../progress.json\"))'\` + \`tasks.json\` — both parse.
- [x] \`npm run build\` — clean (148 pages).
- [ ] Manual workflow_dispatch run after merge to actually fire the backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)