### PR TITLE
docs(modules): flip 00-index status for M26 + M27 to shipped

### DIFF
--- a/docs/specs/modules/00-index.md
+++ b/docs/specs/modules/00-index.md
@@ -82,8 +82,8 @@ narrative source.
 | # | Module | Target | Status | Spec |
 |---|---|---|---|---|
 | 25 | Profile Privacy & Public Profile (per-facet matrix + `/u/<username>/`) | v1.2 | shipped (v1.2.0 + v1.2.1 merged 2026-04-28; v1.2.2 cleanup deferred) | [`25-profile-privacy.md`](25-profile-privacy.md) |
-| 26 | Social graph + reactions (follows, reactions, blocks, reports, notifications) | v1.3 | planned (spec v1.0) | [`26-social-graph.md`](26-social-graph.md) |
-| 27 | AI Sponsorships (share Anthropic credentials with beneficiaries) | v1.3 | in implementation (PR feat/ai-sponsorships) | [`27-ai-sponsorships.md`](27-ai-sponsorships.md) |
+| 26 | Social graph + reactions (follows, reactions, blocks, reports, notifications) | v1.2 | shipped 2026-04-28 (PR #43 schema + Edge Functions; PRs #63 + #64 UI integration; PR #101 v1.1 follow-ups) | [`26-social-graph.md`](26-social-graph.md) |
+| 27 | AI Sponsorships (share Anthropic credentials with beneficiaries) | v1.3 | shipped 2026-04-28 (PRs #78 core + #84 UX polish + #94 cobertura completa) | [`27-ai-sponsorships.md`](27-ai-sponsorships.md) |
 | 28 | Community discovery (observers page, leaderboards, nearby, experts, country filter) | v1.2 | shipped 2026-04-29 (PR1 #92 + PR2 #96 + PR4 #102 + PR5+PR6 atomic landing; PR3 manual cron fire = operator action) | [`28-community-discovery.md`](28-community-discovery.md) |
 
 ## v1.5 — Territory layer — planned


### PR DESCRIPTION
## Summary

Two-line cleanup. Both M26 (social graph + reactions) and M27 (AI Sponsorships) shipped on 2026-04-28 per \`progress.json\` + \`tasks.md\`, but the module index at \`docs/specs/modules/00-index.md\` still listed them as \`planned\` / \`in implementation\`. Same kind of staleness as the M28 fix in PR #129 — index labels lag the source-of-truth roadmap.

## Changes

- **M26**: \`planned (spec v1.0)\` → \`shipped 2026-04-28 (PR #43 schema + EFs; PRs #63 + #64 UI; PR #101 v1.1 follow-ups)\`
- **M27**: \`in implementation (PR feat/ai-sponsorships)\` → \`shipped 2026-04-28 (PRs #78 core + #84 UX polish + #94 cobertura completa)\`

The M26 phase column also moves \`v1.3 → v1.2\` to match where the social-graph items actually live in \`progress.json\`. M27 keeps \`v1.3\`.

## Test plan

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)