### PR TITLE
fix(identify): show friendly error for video files instead of infinite spinner

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -1046,6 +1046,22 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
   async function triggerClientIdentify(file: File, excludeSource: string | null = null) {
     lastFile = file;
     hideAllIdStates();
+
+    // Bug #126: video files were entering the photo cascade and the
+    // PlantNet/Claude image POST hung indefinitely (the file is not
+    // image bytes). Fail fast with a friendly note. Frame extraction
+    // for camera-trap videos is tracked as a v1.1 follow-up.
+    const fileType = file.type || '';
+    if (fileType.startsWith('video/')) {
+      idSpinner?.classList.add('hidden');
+      if (idAllFailed) {
+        idAllFailed.textContent = isEs
+          ? 'La identificación de video aún no está soportada. Sube una foto, o usa el botón de cámara para tomar una.'
+          : 'Video identification is not yet supported. Upload a photo, or use the camera button to take one.';
+        idAllFailed.classList.remove('hidden');
+      }
+      return;
+    }
     idSpinner?.classList.remove('hidden');
 
     // Build the runner set based on what's actually available.


### PR DESCRIPTION
## Summary

When the user picks a video via the gallery picker (some browsers allow it despite `accept=\"image/*\"`), the identification cascade POSTed video bytes to PlantNet/Claude as if they were image data. The HTTP request hung waiting for a response that never came — spinner ran indefinitely with no error.

Fix: detect `file.type.startsWith('video/')` at the top of `triggerClientIdentify()` and short-circuit with a localized message via the existing `#id-all-failed` slot. Spinner is hidden in the same step.

Closes #126.

## Out of scope

Frame extraction for camera-trap videos (run AI ID on the first frame) is tracked as a v1.1 follow-up — needs an `<video>`+`canvas` decode step before the cascade.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test -- --run` — 560/560 pass
- [ ] Manual: open `/{en,es}/identify/`, pick a `.mp4`, confirm friendly Spanish/English message instead of spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)