### PR TITLE
fix(sync): false 'sign in to sync' for already-signed-in users

### DIFF
--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -153,8 +153,18 @@ export async function saveObservationToOutbox(draft: ObservationDraft): Promise<
  * The optional timeout exists purely to bound step 1 in pathological cases;
  * step 2 is sync. We never network-fetch the user here.
  */
-export async function resolveObserverRef(timeoutMs: number = 2_000): Promise<ObserverRef> {
+export async function resolveObserverRef(timeoutMs: number = 8_000): Promise<ObserverRef> {
   const guest: ObserverRef = { kind: 'guest', localId: 'local-' + crypto.randomUUID() };
+
+  // Fast path: read the persisted session straight out of localStorage
+  // BEFORE awaiting `auth.getSession()`. supabase-js's auth lock can
+  // serialize getSession() calls on slow Android Chrome and the 2 s
+  // timeout fired prematurely (issue #127, Eugenio Oaxaca) — a cached
+  // signed-in user looked like a guest and the success message read
+  // "Sign in to sync" despite an active session. The fast path closes
+  // that race without a network or auth-lock dependency.
+  const cachedId = readCachedUserIdFromLocalStorage();
+  if (cachedId) return { kind: 'user', id: cachedId };
 
   try {
     const sessionPromise = getSupabase().auth.getSession();
@@ -164,11 +174,9 @@ export async function resolveObserverRef(timeoutMs: number = 2_000): Promise<Obs
     const { data: { session } } = await Promise.race([sessionPromise, timeout]);
     if (session?.user?.id) return { kind: 'user', id: session.user.id };
   } catch {
-    // fall through to localStorage probe
+    // session lookup failed — only fall through to guest if localStorage
+    // also had no cached user above.
   }
-
-  const cachedId = readCachedUserIdFromLocalStorage();
-  if (cachedId) return { kind: 'user', id: cachedId };
 
   return guest;
 }


### PR DESCRIPTION
## Summary

`resolveObserverRef()` had a 2 s timeout on supabase-js `auth.getSession()`. On slow Android Chrome (Eugenio's CFE TEIT, Oaxaca), the auth lock occasionally serialised calls past 2 s and the timeout fired before the cached session resolved — the function fell through to `kind: 'guest'`, and the post-save message read \"Saved on this device. Sign in to sync.\" despite an active session.

Closes #127.

## Two changes

1. **Read the persisted session from localStorage *before* awaiting `getSession()`.** supabase-js writes `sb-<project-ref>-auth-token` synchronously on signin and clears it on signout, so a cached uid is a strong signal of an active session. This is the same fallback we already had — just promoted to the fast path so it doesn't depend on the async lock.
2. **Bump the `getSession()` timeout from 2 s → 8 s.** With the fast path absorbing the common case, the timeout only matters when localStorage is unavailable (private mode, custom Chromium forks). 8 s is generous for the rare slow-startup case.

## Invariant preserved

The downgrade-resistance rule (\"no network failure may demote a signed-in user to guest\") still holds: we only return `guest` when *both* localStorage and `getSession()` fail.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test -- --run` — 572/572 pass
- [ ] Field retest: Eugenio creates an observation on Android Chrome / cel; success message should read \"Saved and synced\" or \"Saved on this device. Will sync when you're online.\" — never \"Sign in to sync.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)