### PR TITLE
fix(console): localize buttons in Proposals + Webhooks (PR #136 review)

### DIFF
--- a/src/components/ConsoleProposalsView.astro
+++ b/src/components/ConsoleProposalsView.astro
@@ -36,6 +36,8 @@ const pSelfApproval = (pNs?.selfApprovalForbidden as string) ?? 'You cannot appr
   data-label-self-approval={pSelfApproval}
   data-label-approve-title={pSlide.approveTitle ?? 'Approve proposal'}
   data-label-reject-title={pSlide.rejectTitle ?? 'Reject proposal'}
+  data-label-approve={pActions.approve ?? 'Approve'}
+  data-label-reject={pActions.reject ?? 'Reject'}
 >
   <h1 class="text-xl font-semibold mb-1">{pTitle}</h1>
   <p class="mb-4 text-sm text-zinc-500 dark:text-zinc-400">{pDesc}</p>
@@ -133,6 +135,10 @@ const pSelfApproval = (pNs?.selfApprovalForbidden as string) ?? 'You cannot appr
     executed: sectionEl?.dataset.labelStatusExecuted ?? 'Executed',
   };
   const SELF_APPROVAL_MSG = sectionEl?.dataset.labelSelfApproval ?? 'You cannot approve your own proposal.';
+  const labelApprove = sectionEl?.dataset.labelApprove ?? 'Approve';
+  const labelReject = sectionEl?.dataset.labelReject ?? 'Reject';
+  const labelApproveTitle = sectionEl?.dataset.labelApproveTitle ?? 'Approve proposal';
+  const labelRejectTitle = sectionEl?.dataset.labelRejectTitle ?? 'Reject proposal';
 
   let allRows: ProposalRow[] = [];
   let actors: Record<string, ActorMeta> = {};
@@ -198,8 +204,8 @@ const pSelfApproval = (pNs?.selfApprovalForbidden as string) ?? 'You cannot appr
           <td class="px-3 py-2 text-xs text-zinc-500">${esc(fmtDate(r.expires_at))}</td>
           <td class="px-3 py-2 text-right">
             ${canAct
-              ? `<button data-approve-id="${esc(r.id)}" class="px-2 py-1 rounded border border-emerald-600 text-xs text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 mr-1">Approve</button>
-                 <button data-reject-id="${esc(r.id)}" class="px-2 py-1 rounded border border-red-500 text-xs text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">Reject</button>`
+              ? `<button data-approve-id="${esc(r.id)}" class="px-2 py-1 rounded border border-emerald-600 text-xs text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 mr-1">${esc(labelApprove)}</button>
+                 <button data-reject-id="${esc(r.id)}" class="px-2 py-1 rounded border border-red-500 text-xs text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">${esc(labelReject)}</button>`
               : (r.status === 'pending' && isOwn
                 ? `<span class="text-[11px] text-zinc-500 italic">${esc(SELF_APPROVAL_MSG)}</span>`
                 : '')}
@@ -220,7 +226,7 @@ const pSelfApproval = (pNs?.selfApprovalForbidden as string) ?? 'You cannot appr
     const row = allRows.find(r => r.id === proposalId);
     if (!row) return;
     const id = kind === 'approve' ? 'console-slideover-proposal-approve' : 'console-slideover-proposal-reject';
-    const title = `${kind === 'approve' ? 'Approve' : 'Reject'} ${row.op}`;
+    const title = `${kind === 'approve' ? labelApprove : labelReject} ${row.op}`;
     const action = kind === 'approve' ? 'proposal.approve' : 'proposal.reject';
     if (kind === 'approve') {
       const notesEl = document.getElementById('proposal-approve-notes') as HTMLTextAreaElement | null;

--- a/src/components/ConsoleWebhooksView.astro
+++ b/src/components/ConsoleWebhooksView.astro
@@ -28,7 +28,13 @@ const eventKeys: Array<keyof typeof wEvents> = [
 ];
 ---
 
-<section class="max-w-6xl space-y-6">
+<section
+  class="max-w-6xl space-y-6"
+  data-label-action-test={wActions.test ?? 'Test'}
+  data-label-action-enable={wActions.enable ?? 'Enable'}
+  data-label-action-disable={wActions.disable ?? 'Disable'}
+  data-label-action-delete={wActions.delete ?? 'Delete'}
+>
   <header>
     <h1 class="text-xl font-semibold mb-1">{wTitle}</h1>
     <p class="text-sm text-zinc-500 dark:text-zinc-400">{wDesc}</p>
@@ -164,6 +170,12 @@ const eventKeys: Array<keyof typeof wEvents> = [
     attempted_at: string;
   };
 
+  const sectionEl = document.querySelector<HTMLElement>('section[data-label-action-test]');
+  const labelTest = sectionEl?.dataset.labelActionTest ?? 'Test';
+  const labelEnable = sectionEl?.dataset.labelActionEnable ?? 'Enable';
+  const labelDisable = sectionEl?.dataset.labelActionDisable ?? 'Disable';
+  const labelDelete = sectionEl?.dataset.labelActionDelete ?? 'Delete';
+
   let allWebhooks: WebhookRow[] = [];
   let allDeliveries: DeliveryRow[] = [];
   let jwt: string | null = null;
@@ -213,9 +225,9 @@ const eventKeys: Array<keyof typeof wEvents> = [
           <td class="px-3 py-2 text-xs text-zinc-500">${esc(fmtDate(w.last_delivery_at))}</td>
           <td class="px-3 py-2 text-right tabular-nums text-zinc-700 dark:text-zinc-300">${w.consecutive_failures}</td>
           <td class="px-3 py-2 text-right whitespace-nowrap">
-            <button data-test-id="${esc(w.id)}" class="px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700 text-xs hover:bg-zinc-50 dark:hover:bg-zinc-800 mr-1">Test</button>
-            <button data-toggle-id="${esc(w.id)}" data-toggle-to="${w.enabled ? 'false' : 'true'}" class="px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700 text-xs hover:bg-zinc-50 dark:hover:bg-zinc-800 mr-1">${w.enabled ? 'Disable' : 'Enable'}</button>
-            <button data-delete-id="${esc(w.id)}" class="px-2 py-1 rounded border border-red-500 text-xs text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">Delete</button>
+            <button data-test-id="${esc(w.id)}" class="px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700 text-xs hover:bg-zinc-50 dark:hover:bg-zinc-800 mr-1">${esc(labelTest)}</button>
+            <button data-toggle-id="${esc(w.id)}" data-toggle-to="${w.enabled ? 'false' : 'true'}" class="px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700 text-xs hover:bg-zinc-50 dark:hover:bg-zinc-800 mr-1">${esc(w.enabled ? labelDisable : labelEnable)}</button>
+            <button data-delete-id="${esc(w.id)}" class="px-2 py-1 rounded border border-red-500 text-xs text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">${esc(labelDelete)}</button>
           </td>
         </tr>
       `;


### PR DESCRIPTION
## Summary

PR #136 auto-review flagged the same hardcoded-button-text pattern that PR #133 fixed for the Anomalies tab — this time in two of PR13's new views:

- **`ConsoleProposalsView.astro`** — `Approve` and `Reject` buttons + slide-over title prefix were hardcoded English. ES would have shown "Approve role.revoke" instead of "Aprobar role.revoke".
- **`ConsoleWebhooksView.astro`** — `Test`, `Enable`/`Disable` (toggle), and `Delete` buttons were hardcoded English.

All i18n keys already existed under `console.proposalsView.actions.*` and `console.webhooksView.actions.*` — just unused. Wired through the existing `data-label-*` attribute pattern.

## Other PR136 review observations

The auto-review also flagged:

1. **`pg_net.http_post` async → `status_code` may stay NULL in `admin_webhook_deliveries`** — this is documented in the runbook as expected behavior. The `webhook.test` handler does a synchronous fetch and writes `status_code` directly. Triggered deliveries from `dispatch_admin_webhooks()` rely on receivers' eventual response; v1 displays NULL for in-flight deliveries. Not a bug.

2. **`admin_action_proposals.op` enum mismatch concern** — investigated: the proposal-create handler maps the dotted action key (`'role.revoke'`) to the underscore enum value (`'role_revoke'`) via `AUDIT_OP_BY_ACTION` before INSERT. Code is correct; the mapping just isn't documented inline. Not a bug.

3. **No webhook rate limit per-INSERT** — design observation, not a bug. Documented as v1.1 follow-up.

This PR addresses only the i18n bug, which is the only actionable item.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 589 passed
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)