### PR TITLE
docs(modules): flip M29 row to shipped (carry-over from #132 conflict resolution)

### DIFF
--- a/docs/specs/modules/00-index.md
+++ b/docs/specs/modules/00-index.md
@@ -85,7 +85,7 @@ narrative source.
 | 26 | Social graph + reactions (follows, reactions, blocks, reports, notifications) | v1.2 | shipped 2026-04-28 (PR #43 schema + Edge Functions; PRs #63 + #64 UI integration; PR #101 v1.1 follow-ups) | [`26-social-graph.md`](26-social-graph.md) |
 | 27 | AI Sponsorships (share Anthropic credentials with beneficiaries) | v1.3 | shipped 2026-04-28 (PRs #78 core + #84 UX polish + #94 cobertura completa) | [`27-ai-sponsorships.md`](27-ai-sponsorships.md) |
 | 28 | Community discovery (observers page, leaderboards, nearby, experts, country filter) | v1.2 | shipped 2026-04-29 (PR1 #92 + PR2 #96 + PR4 #102 + PR5+PR6 atomic landing; PR3 manual cron fire = operator action) | [`28-community-discovery.md`](28-community-discovery.md) |
-| 29 | Projects (ANP polygon protocols + auto-tagging) | v1.3 | in implementation (PR feat/projects-anp-111) | [`29-projects-anp.md`](29-projects-anp.md) |
+| 29 | Projects (ANP polygon protocols + auto-tagging) | v1.3 | shipped 2026-04-29 (PR #132 — schema + RLS + `upsert_project` SECURITY DEFINER + auto-tagging trigger + UI) | [`29-projects-anp.md`](29-projects-anp.md) |
 
 ## v1.5 — Territory layer — planned
 


### PR DESCRIPTION
Single-line follow-up to PR #132. During the merge-conflict resolution on `docs/specs/modules/00-index.md`, M29's row was kept verbatim from HEAD — which still said "in implementation (PR feat/projects-anp-111)". The PR merged minutes later (#132), so the row needed flipping. Same class of staleness PR #131 fixed for M26 + M27.

Closes the only doc-surface follow-up I introduced during this session's merges.