### PR TITLE
fix(schema): DROP resolve_sponsorship before re-CREATE (M27.1 hotfix)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3801,6 +3801,12 @@ CREATE POLICY notifications_sent_no_client_delete ON public.notifications_sent
   AS RESTRICTIVE FOR DELETE TO authenticated, anon USING (false);
 
 -- 9. resolve_sponsorship — devuelve la mejor credencial activa con cuota.
+-- M27.1 (#116, PR #143) added two columns to the OUT-table
+-- (preferred_model, endpoint). `CREATE OR REPLACE FUNCTION` can't
+-- change a function's return type, so on environments where the
+-- pre-M27.1 signature already exists (production) we must DROP first.
+-- Idempotent — a no-op on first install.
+DROP FUNCTION IF EXISTS public.resolve_sponsorship(uuid, public.ai_provider);
 CREATE OR REPLACE FUNCTION public.resolve_sponsorship(
   p_beneficiary uuid, p_provider public.ai_provider
 ) RETURNS TABLE (


### PR DESCRIPTION
## Summary

Hotfix for the M27.1 schema apply that failed in production after PR #143 merged.

`resolve_sponsorship` gained two new OUT columns (`preferred_model`, `endpoint`) for multi-provider support. `CREATE OR REPLACE FUNCTION` can't change the return type — production rejected with:

```
ERROR:  cannot change return type of existing function
HINT:  Use DROP FUNCTION resolve_sponsorship(uuid,ai_provider) first.
```

Add `DROP FUNCTION IF EXISTS public.resolve_sponsorship(uuid, public.ai_provider)` immediately before the re-CREATE. Idempotent — no-op on fresh installs.

## Why this matters

Without the fix, the production `identify` Edge Function deployed with PR #143's code reads `preferred_model` / `endpoint` fields the old RPC doesn't return — sponsorship-driven identifications would fail at runtime.

## Test plan

- [x] db-validate ephemeral Postgres CI gate (no-op on fresh install)
- [ ] db-apply against production reruns and succeeds
- [ ] `identify` EF redeploys cleanly and serves a sponsorship-backed call

🤖 Generated with [Claude Code](https://claude.com/claude-code)