### PR TITLE
docs(roadmap): backfill M29/M30/M31/M32 across roadmap, tasks, module index

### DIFF
--- a/docs/progress.json
+++ b/docs/progress.json
@@ -939,6 +939,42 @@
           "label_es": "Rediseño de la página de detalle de observación — layout dos columnas en desktop / apilado en móvil para /share/obs/?id=...; MapPicker.astro reutilizable extraído de ObservationForm; PhotoGallery.astro con lightbox nativo (teclado ←/→/Esc + swipe + compartir por foto); ObsManagePanel.astro con tabs Detalles/Ubicación/Fotos (edición de fecha/hora + hábitat/clima/establecimiento + editor de coordenadas + agregar/quitar fotos); semántica de edición material-vs-menor con badge 'editado tras IDs' por trigger en observations.last_material_edit_at (ubicación > 1 km, observed_at > 24 h, cambio de primary_taxon_id); soft-delete de fotos via media_files.deleted_at (GC de R2 huérfanos = v1.1); borrado de la foto que generó la cascade es atómico via Edge Function delete-photo + RPC delete_photo_atomic SECURITY DEFINER (limpia validated_by/validated_at + is_research_grade + bumpea last_material_edit_at en una transacción)",
           "done": true,
           "done_at": "2026-04-29"
+        },
+        {
+          "id": "projects-anp-m29",
+          "label": "Projects (Module 29) — ANP polygon protocols + auto-tagging trigger. Researchers define a polygon (typically an ANP, reserve, or sampling grid) at /{en,es}/projects/<slug>/ and observations whose location falls inside are auto-tagged via a BEFORE INSERT/UPDATE trigger on observations. Schema: projects table + project_members + auto-assignment trigger; visibility (public/private) with RLS; SECURITY DEFINER upsert_project() because supabase-js can't write geography directly; views with security_invoker = true. Prerequisite for M30 (CLI batch import) and M31 (camera stations).",
+          "label_es": "Proyectos (Módulo 29) — protocolos de polígono ANP + trigger de auto-tagging. Los investigadores definen un polígono (típicamente ANP, reserva o malla de muestreo) en /{en,es}/projects/<slug>/ y las observaciones cuya ubicación cae dentro se auto-etiquetan vía trigger BEFORE INSERT/UPDATE en observations. Schema: tabla projects + project_members + trigger de asignación automática; visibilidad (público/privado) con RLS; upsert_project() SECURITY DEFINER porque supabase-js no puede escribir geography directamente; vistas con security_invoker = true. Prerrequisito para M30 (CLI batch import) y M31 (camera stations).",
+          "done": true,
+          "done_at": "2026-04-29",
+          "status": "shipped — PR #132 (schema + RLS + upsert_project SECURITY DEFINER + auto-tagging trigger + UI). v1.1 follow-up: surface Projects link from chrome (Header MegaMenu Biodiversity column or new top-level slot)",
+          "status_es": "lanzado — PR #132 (schema + RLS + upsert_project SECURITY DEFINER + trigger de auto-tagging + UI). Seguimiento v1.1: exponer el link de Projects desde el chrome (columna Biodiversidad del Explore MegaMenu o slot top-level nuevo)"
+        },
+        {
+          "id": "cli-batch-import-m30",
+          "label": "CLI batch import for camera-trap memory cards (Module 30) — Node 20+ TypeScript CLI (rastrum-import) that walks a directory of camera-trap photos, reads EXIF GPS + timestamp, uploads each photo to R2 via the new POST /api/upload-url Edge Function, and creates an observation through the rst_* API token endpoint. Built for the CONANP-Oaxaca / DRFSIPS / PROREST 2026 workflow (500–2000 images per camera deployment). Auto-tags into the M29 project polygon when --project-slug is set. Resumable via a state file so re-runs skip already-uploaded photos.",
+          "label_es": "CLI de importación masiva para tarjetas de cámaras trampa (Módulo 30) — CLI Node 20+ TypeScript (rastrum-import) que recorre un directorio de fotos de cámara trampa, lee GPS + fecha del EXIF, sube cada foto a R2 vía la nueva Edge Function POST /api/upload-url, y crea una observación a través del endpoint con token rst_*. Construido para el flujo CONANP-Oaxaca / DRFSIPS / PROREST 2026 (500–2000 imágenes por deployment). Auto-etiqueta en el polígono del proyecto M29 cuando --project-slug está definido. Reanudable vía un archivo de estado para que las re-ejecuciones omitan fotos ya subidas.",
+          "done": true,
+          "done_at": "2026-04-29",
+          "status": "shipped — PR #134 (cli/ TypeScript package + /api/upload-url Edge Function endpoint + EXIF walker; depends on M29)",
+          "status_es": "lanzado — PR #134 (paquete TypeScript cli/ + endpoint /api/upload-url + walker de EXIF; depende de M29)"
+        },
+        {
+          "id": "camera-stations-m31",
+          "label": "Camera stations + sampling-effort tracking (Module 31) — schema only for v1; UI is a v1.1 follow-up. A camera station is a fixed deployment with one or more active periods (start/end dates). Standardised wildlife indices like Relative Abundance Index (RAI), detection rate per 100 trap-nights, and species richness all depend on knowing how long the camera was sampling, not just what it captured. Schema: camera_stations (project_id FK + station_key + coords + camera_model) + camera_station_active_periods (start/end). Depends on M29.",
+          "label_es": "Estaciones de cámara + seguimiento de esfuerzo de muestreo (Módulo 31) — sólo schema en v1; la UI es seguimiento v1.1. Una camera station es un deployment fijo con uno o más periodos activos (fechas inicio/fin). Índices estandarizados de fauna como el Índice de Abundancia Relativa (RAI), tasa de detección por 100 noches-trampa, y riqueza de especies dependen de saber cuánto tiempo estuvo muestreando la cámara, no sólo qué capturó. Schema: camera_stations (FK project_id + station_key + coords + camera_model) + camera_station_active_periods (inicio/fin). Depende de M29.",
+          "done": true,
+          "done_at": "2026-04-29",
+          "status": "shipped — PR #141 (schema only; UI = v1.1 follow-up). Standardised wildlife indices (RAI, detection rate per 100 trap-nights, species richness) become computable once UI captures active periods",
+          "status_es": "lanzado — PR #141 (sólo schema; UI = seguimiento v1.1). Los índices estandarizados de fauna (RAI, tasa de detección por 100 noches-trampa, riqueza de especies) se vuelven computables una vez que la UI capture los periodos activos"
+        },
+        {
+          "id": "multi-provider-vision-m32",
+          "label": "Multi-provider vision + per-sponsor model + platform pool (Module 32) — bundles three closely-coupled M27 extensions that share the same provider abstraction. (a) AWS Bedrock provider + per-sponsor preferred_model (Haiku/Sonnet/Opus or their Bedrock equivalents). (b) OpenAI / Azure OpenAI / Google Gemini / Vertex AI providers. (c) Platform-wide call pool (sponsor_pools table + consume_pool_slot RPC) so heavy beneficiaries can fall through to a shared pool. supabase/functions/_shared/vision-provider.ts exports a VisionProvider interface implemented by 6 concrete providers; buildProvider(credential) is the single dispatcher.",
+          "label_es": "Visión multi-proveedor + modelo por patrocinador + pool de plataforma (Módulo 32) — agrupa tres extensiones M27 estrechamente acopladas que comparten la misma abstracción de proveedor. (a) Proveedor AWS Bedrock + preferred_model por patrocinador (Haiku/Sonnet/Opus o sus equivalentes Bedrock). (b) Proveedores OpenAI / Azure OpenAI / Google Gemini / Vertex AI. (c) Pool de llamadas a nivel plataforma (tabla sponsor_pools + RPC consume_pool_slot) para que los beneficiarios pesados puedan caer al pool compartido. supabase/functions/_shared/vision-provider.ts exporta una interfaz VisionProvider implementada por 6 proveedores concretos; buildProvider(credential) es el dispatcher único.",
+          "done": true,
+          "done_at": "2026-04-29",
+          "status": "shipped — PR #143 (closes #115/#116/#118)",
+          "status_es": "lanzado — PR #143 (cierra #115/#116/#118)"
         }
       ]
     },

--- a/docs/specs/modules/00-index.md
+++ b/docs/specs/modules/00-index.md
@@ -86,9 +86,9 @@ narrative source.
 | 27 | AI Sponsorships (share Anthropic credentials with beneficiaries) | v1.3 | shipped 2026-04-28 (PRs #78 core + #84 UX polish + #94 cobertura completa) | [`27-ai-sponsorships.md`](27-ai-sponsorships.md) |
 | 28 | Community discovery (observers page, leaderboards, nearby, experts, country filter) | v1.2 | shipped 2026-04-29 (PR1 #92 + PR2 #96 + PR4 #102 + PR5+PR6 atomic landing; PR3 manual cron fire = operator action) | [`28-community-discovery.md`](28-community-discovery.md) |
 | 29 | Projects (ANP polygon protocols + auto-tagging) | v1.3 | shipped 2026-04-29 (PR #132 — schema + RLS + `upsert_project` SECURITY DEFINER + auto-tagging trigger + UI) | [`29-projects-anp.md`](29-projects-anp.md) |
-| 30 | CLI batch import for camera-trap memory cards | v1.3 | in implementation (PR feat/cli-batch-import-110) | [`30-cli-batch-import.md`](30-cli-batch-import.md) |
-| 31 | Camera stations + sampling-effort tracking | v1.3 | in implementation (PR feat/camera-stations-112 — schema only; UI v1.1) | [`31-camera-stations.md`](31-camera-stations.md) |
-| 32 | Multi-provider vision + per-sponsor model + platform pool | v1.3 | in implementation (PR feat/multi-provider-vision-116 — closes #115/#116/#118) | [`32-multi-provider-vision.md`](32-multi-provider-vision.md) |
+| 30 | CLI batch import for camera-trap memory cards | v1.3 | shipped 2026-04-29 (PR #134 — `rastrum-import` Node CLI + `/api/upload-url` Edge Function endpoint + EXIF GPS/timestamp walker; depends on M29) | [`30-cli-batch-import.md`](30-cli-batch-import.md) |
+| 31 | Camera stations + sampling-effort tracking | v1.3 | shipped 2026-04-29 (PR #141 — schema only; UI is v1.1 follow-up; depends on M29) | [`31-camera-stations.md`](31-camera-stations.md) |
+| 32 | Multi-provider vision + per-sponsor model + platform pool | v1.3 | shipped 2026-04-29 (PR #143 — closes #115/#116/#118; bundles AWS Bedrock + OpenAI/Azure/Gemini providers + platform-wide `sponsor_pools` call pool atop `_shared/vision-provider.ts`) | [`32-multi-provider-vision.md`](32-multi-provider-vision.md) |
 
 ## v1.5 — Territory layer — planned
 

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -4295,6 +4295,54 @@
         { "label_en": "PR6 — Photos tab + delete-photo Edge Function (atomic transaction via delete_photo_atomic SECURITY DEFINER RPC: media_files.deleted_at + identifications demote clearing validated_by/validated_at/is_research_grade + observations.last_material_edit_at). Photo add via R2 upload flow. Cascade-photo confirm dialog driven by willDemote() helper (covered by vitest)", "label_es": "PR6 — Tab Fotos + Edge Function delete-photo (transacción atómica via RPC delete_photo_atomic SECURITY DEFINER: media_files.deleted_at + degradar identifications limpiando validated_by/validated_at/is_research_grade + observations.last_material_edit_at). Subir fotos via R2 + diálogo confirm cascade-photo dirigido por helper willDemote() (cubierto por vitest)", "status": "done", "pr": 125 },
         { "label_en": "v1.1 follow-ups: gc-orphan-media cron (R2 GC of soft-deleted blobs); native vs PhotoSwipe lightbox decision (was native ≤150 lines per spec)", "label_es": "Seguimientos v1.1: cron gc-orphan-media (GC R2 de blobs soft-deleted); decisión nativo vs PhotoSwipe del lightbox", "status": "planned" }
       ]
+    },
+    "projects-anp-m29": {
+      "phase": "v1.2",
+      "title_en": "Projects (Module 29) — ANP polygon protocols",
+      "title_es": "Proyectos (Módulo 29) — protocolos de polígono ANP",
+      "modules": ["29-projects-anp.md"],
+      "subtasks": [
+        { "label_en": "Schema: projects (slug UNIQUE, polygon geography(MultiPolygon, 4326), visibility public/private) + project_members + RLS + GIST index", "label_es": "Schema: projects (slug UNIQUE, polygon geography(MultiPolygon, 4326), visibility público/privado) + project_members + RLS + índice GIST", "status": "done", "pr": 132 },
+        { "label_en": "BEFORE INSERT/UPDATE OF location trigger on observations: ST_Covers(polygon, NEW.location) → auto-tag NEW.project_id (manual override respected, ORDER BY created_at ASC tiebreaker)", "label_es": "Trigger BEFORE INSERT/UPDATE OF location: ST_Covers(polygon, NEW.location) → auto-etiqueta NEW.project_id (respeta override manual, desempate ORDER BY created_at ASC)", "status": "done", "pr": 132 },
+        { "label_en": "upsert_project SECURITY DEFINER RPC + projects_with_geojson view WITH (security_invoker = true) + UI (List/New/Detail) at /{en,es}/{projects,proyectos}/", "label_es": "RPC upsert_project SECURITY DEFINER + vista projects_with_geojson WITH (security_invoker = true) + UI (List/New/Detail) en /{en,es}/{projects,proyectos}/", "status": "done", "pr": 132 },
+        { "label_en": "v1.1 follow-up: surface Projects link from chrome (Header MegaMenu Biodiversity column) — currently only reachable via direct URL", "label_es": "Seguimiento v1.1: exponer link de Projects desde el chrome (columna Biodiversidad del Explore MegaMenu) — actualmente sólo accesible via URL directa", "status": "planned" }
+      ]
+    },
+    "cli-batch-import-m30": {
+      "phase": "v1.2",
+      "title_en": "CLI batch import for camera-trap memory cards (Module 30)",
+      "title_es": "CLI de importación masiva para tarjetas de cámaras trampa (Módulo 30)",
+      "modules": ["30-cli-batch-import.md"],
+      "subtasks": [
+        { "label_en": "cli/ Node 20+ TypeScript package (rastrum-import) — walker + EXIF reader + orchestrator", "label_es": "Paquete cli/ Node 20+ TypeScript (rastrum-import) — walker + lector EXIF + orquestador", "status": "done", "pr": 134 },
+        { "label_en": "POST /api/upload-url Edge Function endpoint — issues presigned R2 PUT URLs scoped by rst_* token", "label_es": "Endpoint Edge Function POST /api/upload-url — emite URLs presignadas R2 PUT con scope por token rst_*", "status": "done", "pr": 134 },
+        { "label_en": "--project-slug flag auto-tags every observation into the M29 polygon. State file makes the import resumable across SD recoveries", "label_es": "Flag --project-slug auto-etiqueta cada observación en el polígono M29. El archivo de estado vuelve la importación reanudable entre recuperaciones de SD", "status": "done", "pr": 134 },
+        { "label_en": "Built for the CONANP-Oaxaca / DRFSIPS / PROREST 2026 workflow (500–2000 images per camera deployment)", "label_es": "Construido para el flujo CONANP-Oaxaca / DRFSIPS / PROREST 2026 (500–2000 imágenes por deployment)", "status": "done", "pr": 134 }
+      ]
+    },
+    "camera-stations-m31": {
+      "phase": "v1.2",
+      "title_en": "Camera stations + sampling-effort tracking (Module 31)",
+      "title_es": "Estaciones de cámara + seguimiento de esfuerzo de muestreo (Módulo 31)",
+      "modules": ["31-camera-stations.md"],
+      "subtasks": [
+        { "label_en": "Schema: camera_stations (project_id FK + station_key + coords + camera_model)", "label_es": "Schema: camera_stations (FK project_id + station_key + coords + camera_model)", "status": "done", "pr": 141 },
+        { "label_en": "Schema: camera_station_active_periods (start/end) — multiple per station for redeployments across a year", "label_es": "Schema: camera_station_active_periods (inicio/fin) — múltiples por estación para redespliegues a lo largo del año", "status": "done", "pr": 141 },
+        { "label_en": "Foundation for downstream wildlife indices: Relative Abundance Index (RAI), detection rate per 100 trap-nights, species richness — all blocked on knowing how long the camera was sampling", "label_es": "Base para índices de fauna futuros: Índice de Abundancia Relativa (RAI), tasa de detección por 100 noches-trampa, riqueza de especies — todos dependen de saber cuánto tiempo estuvo muestreando la cámara", "status": "done", "pr": 141 },
+        { "label_en": "v1.1 follow-up: UI to capture active periods (CRUD form + station picker on observations + station map layer)", "label_es": "Seguimiento v1.1: UI para capturar periodos activos (formulario CRUD + selector de estación en observaciones + capa de mapa de estaciones)", "status": "planned" }
+      ]
+    },
+    "multi-provider-vision-m32": {
+      "phase": "v1.2",
+      "title_en": "Multi-provider vision + per-sponsor model + platform pool (Module 32)",
+      "title_es": "Visión multi-proveedor + modelo por patrocinador + pool de plataforma (Módulo 32)",
+      "modules": ["32-multi-provider-vision.md"],
+      "subtasks": [
+        { "label_en": "_shared/vision-provider.ts — VisionProvider interface implemented by 6 providers (Anthropic api_key + oauth_token, Bedrock with AWS Sig V4, OpenAI, Azure OpenAI, Gemini)", "label_es": "_shared/vision-provider.ts — interfaz VisionProvider implementada por 6 proveedores (Anthropic api_key + oauth_token, Bedrock con AWS Sig V4, OpenAI, Azure OpenAI, Gemini)", "status": "done", "pr": 143 },
+        { "label_en": "Per-sponsor preferred_model column on ai_credentials — beneficiaries can request Haiku/Sonnet/Opus or Bedrock equivalents (closes #116)", "label_es": "Columna preferred_model por patrocinador en ai_credentials — beneficiarios pueden pedir Haiku/Sonnet/Opus o equivalentes Bedrock (cierra #116)", "status": "done", "pr": 143 },
+        { "label_en": "OpenAI / Azure OpenAI / Google Gemini / Vertex AI providers (closes #118)", "label_es": "Proveedores OpenAI / Azure OpenAI / Google Gemini / Vertex AI (cierra #118)", "status": "done", "pr": 143 },
+        { "label_en": "Platform-wide call pool: sponsor_pools table + consume_pool_slot RPC (closes #115)", "label_es": "Pool de llamadas a nivel plataforma: tabla sponsor_pools + RPC consume_pool_slot (cierra #115)", "status": "done", "pr": 143 }
+      ]
     }
   }
 }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -177,3 +177,44 @@ specs at `docs/superpowers/specs/2026-04-29-*-design.md`.
   last_material_edit_at bump in one transaction via `delete_photo_atomic`
   SECURITY DEFINER RPC). Soft-delete only for v1; R2 orphan GC (`gc-orphan-media`
   cron) is a v1.1 follow-up. _(✓ shipped — see `docs/runbooks/obs-detail-redesign.md`)_
+
+### v1.2 shipped 2026-04-29 — research-workflow modules (M29 / M30 / M31 / M32)
+
+A second wave landed the same day, focused on the CONANP-Oaxaca / DRFSIPS / PROREST 2026 research workflows.
+
+- `projects-anp-m29` — **Module 29 (Projects).** Researchers define a polygon
+  (ANP, reserve, sampling grid) at `/{en,es}/projects/<slug>/`, and observations
+  whose location falls inside are **auto-tagged via a BEFORE INSERT/UPDATE
+  trigger** on `observations`. Schema: `projects` (slug UNIQUE +
+  `polygon geography(MultiPolygon, 4326)` + public/private visibility) +
+  `project_members` + RLS + GIST index. `upsert_project` is `SECURITY DEFINER`
+  (PostgREST can't write geography); the `projects_with_geojson` view ships
+  `WITH (security_invoker = true)`. Prerequisite for M30 and M31. PR #132.
+  _(✓ shipped — runbook [`docs/runbooks/projects-anp.md`](runbooks/projects-anp.md);
+  v1.1 follow-up: surface the link from chrome — currently only reachable via direct URL.)_
+
+- `cli-batch-import-m30` — **Module 30 (CLI batch import).** Node 20+
+  TypeScript CLI (`rastrum-import`): walks a directory of camera-trap photos,
+  reads EXIF GPS + timestamp, uploads to R2 via the new `POST /api/upload-url`
+  Edge Function, and creates an observation through the `rst_*` API token.
+  Built for the **CONANP-Oaxaca / DRFSIPS / PROREST 2026** workflow (500–2000
+  images per deployment). `--project-slug` auto-tags into the M29 polygon.
+  Resumable via state file. PR #134. _(✓ shipped)_
+
+- `camera-stations-m31` — **Module 31 (Camera stations + sampling effort).**
+  Schema only for v1; UI is a v1.1 follow-up. A camera station is a fixed
+  deployment with one or more **active periods** (start/end). Standardised
+  wildlife indices (RAI, detection rate per 100 trap-nights, species richness)
+  all depend on knowing how long the camera was sampling — this module
+  captures that ground truth. Schema: `camera_stations` +
+  `camera_station_active_periods`. Depends on M29. PR #141. _(✓ shipped — UI = v1.1 follow-up)_
+
+- `multi-provider-vision-m32` — **Module 32 (Multi-provider vision + per-sponsor
+  model + platform pool).** Bundles three closely-coupled M27 extensions that
+  share the same provider abstraction: (a) AWS Bedrock provider +
+  per-sponsor `preferred_model`; (b) OpenAI / Azure OpenAI / Google Gemini /
+  Vertex AI providers; (c) platform-wide call pool (`sponsor_pools` +
+  `consume_pool_slot` RPC). `_shared/vision-provider.ts` exports a
+  `VisionProvider` interface implemented by 6 concrete providers;
+  `buildProvider(credential)` is the single dispatcher. Closes #115/#116/#118.
+  PR #143. _(✓ shipped)_


### PR DESCRIPTION
## Summary

Four modules just landed (M29 ANP polygons #132, M30 CLI batch import #134, M31 camera stations #141, M32 multi-provider vision #143) and the doc surfaces lagged. The \`/docs/roadmap/\` and \`/docs/tasks/\` pages would not have shown any of them until this PR; the module index still listed three as \"in implementation\" when they're actually shipped. **In other words: the website didn't show what we shipped today.** This closes that gap.

## Changes

- **\`docs/specs/modules/00-index.md\`** — flip M30 (PR #134), M31 (PR #141), M32 (PR #143) status rows from \`in implementation\` to \`shipped 2026-04-29\`. M29 was already flipped in PR #140.
- **\`docs/progress.json\`** — append four new entries to the v1.2 phase. Each with bilingual labels, \`done: true\`, \`done_at: 2026-04-29\`, and a status string referencing the canonical PR + scope. \`/docs/roadmap/\` now renders all four.
- **\`docs/tasks.json\`** — full subtask breakdown for each of the four modules with PR-number tags. M29 + M31 each include one \`planned\` v1.1 follow-up (Projects link from chrome; camera-stations UI). \`/docs/tasks/\` now renders all four.
- **\`docs/tasks.md\`** — new \`v1.2 shipped 2026-04-29 — research-workflow modules\` subsection with prose for each. Notes the CONANP-Oaxaca / DRFSIPS / PROREST 2026 workflow context.

## Carry-forward

Surfaced one real navigation gap: **the chrome (Header / MegaMenu / MobileDrawer) does not link to \`/projects/\` anywhere.** M29 ships with EN+ES locale-paired pages but is only reachable via direct URL today. Filed as the M29 v1.1 follow-up under \`tasks.json\` → \`projects-anp-m29\`. Could ship as a 2-line MegaMenu addition.

## Test plan

- [x] \`json.load(...)\` on progress.json + tasks.json: both parse.
- [x] \`npm run build\`: clean (148 pages).
- [ ] After merge, verify \`/en/docs/roadmap/\` lists M29/M30/M31/M32 under v1.2.
- [ ] Verify \`/en/docs/tasks/\` lists M29/M30/M31/M32 with subtasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)