### PR TITLE
feat(chrome): expose Projects (M29) link in Explore MegaMenu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -44,6 +44,7 @@ const exploreRecentPath = getLocalizedPath(lang, routes.exploreRecent[locale] + 
 const exploreWatchlistPath = getLocalizedPath(lang, routes.exploreWatchlist[locale] + '/');
 const exploreSpeciesPath = getLocalizedPath(lang, routes.exploreSpecies[locale] + '/');
 const exploreValidatePath = getLocalizedPath(lang, routes.exploreValidate[locale] + '/');
+const projectsPath = getLocalizedPath(lang, routes.projects[locale] + '/');
 
 // Community discovery (M28) — preset-filtered links into /community/observers/.
 const communityObserversBase = getLocalizedPath(lang, routes.communityObservers[locale] + '/');
@@ -63,6 +64,7 @@ interface ExploreMegaMenu {
   community_nearby: string;
   community_experts: string;
   community_country: string;
+  projects?: string;
 }
 const em = (tr as unknown as { nav: { explore_megamenu: ExploreMegaMenu } }).nav.explore_megamenu;
 
@@ -75,6 +77,7 @@ const exploreColumns = [
       { key: 'exploreWatchlist', label: tr.nav.explore_dropdown.watchlist, href: exploreWatchlistPath },
       { key: 'exploreSpecies',   label: tr.nav.explore_dropdown.species,   href: exploreSpeciesPath },
       { key: 'exploreValidate',  label: validateLabel,                     href: exploreValidatePath },
+      { key: 'projects',         label: em.projects ?? (lang === 'es' ? 'Proyectos' : 'Projects'), href: projectsPath },
     ],
   },
   {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -27,7 +27,8 @@
       "community_nearby": "Nearby",
       "community_experts": "Experts by taxon",
       "community_country": "By country",
-      "nearby_signin_tooltip": "Sign in to find observers near you"
+      "nearby_signin_tooltip": "Sign in to find observers near you",
+      "projects": "Projects (ANP polygons)"
     },
     "docs_groups": {
       "product": "Product",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -27,7 +27,8 @@
       "community_nearby": "Cerca",
       "community_experts": "Expertos por taxón",
       "community_country": "Por país",
-      "nearby_signin_tooltip": "Inicia sesión para encontrar observadores cerca"
+      "nearby_signin_tooltip": "Inicia sesión para encontrar observadores cerca",
+      "projects": "Proyectos (polígonos ANP)"
     },
     "docs_groups": {
       "product": "Producto",


### PR DESCRIPTION
Single-link addition. The M29 ANP polygon Projects route shipped in PR #132 with locale-paired pages at `/{en,es}/{projects,proyectos}/`, but the chrome navigation never gained a link to it — reachable only via direct URL until this PR.

Adds **Projects (ANP polygons)** / **Proyectos (polígonos ANP)** as the 6th item in the Explore MegaMenu's **Biodiversity column**, sibling to Map / Recent / Watchlist / Species / Validate. Same conceptual umbrella ('explore the biodiversity inside this polygon') so it slots cleanly without needing a new top-level nav slot.

Closes the v1.1 follow-up filed in `tasks.json` under `projects-anp-m29`.

## Test plan

- [x] `npm run typecheck`: zero errors.
- [x] `npm run build`: clean.
- [ ] After merge, verify Projects link visible in EN + ES Explore MegaMenu Biodiversity column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)