### PR TITLE
feat(ui): ConfirmDialog component — replace native confirm() in Block + delete-photo flows

### DIFF
--- a/src/components/ConfirmDialog.astro
+++ b/src/components/ConfirmDialog.astro
@@ -1,0 +1,128 @@
+---
+/**
+ * ConfirmDialog — shared promise-based replacement for `window.confirm()`.
+ * Mounted once in `BaseLayout.astro`; opened by callers via
+ * `openConfirmDialog({...})` from `src/lib/confirm-dialog.ts`.
+ *
+ * Mirrors the `ReportDialog` pattern: focus trap, Esc + backdrop close,
+ * restores prior focus on close. Promise resolves true on confirm,
+ * false on cancel / Esc / backdrop.
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+
+const { lang } = Astro.props;
+const tr = t(lang);
+const cdTr = tr.confirm_dialog;
+---
+
+<div
+  id="rastrum-confirm-dialog"
+  class="hidden fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/60 backdrop-blur-sm px-4"
+  data-lang={lang}
+  data-default-confirm={cdTr.default_confirm}
+  data-default-cancel={cdTr.default_cancel}
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="rastrum-confirm-title"
+  aria-label={cdTr.aria_dialog_label}
+>
+  <div class="w-full max-w-md rounded-2xl bg-white dark:bg-zinc-900 ring-1 ring-zinc-200 dark:ring-zinc-800 shadow-2xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200">
+    <header class="px-5 py-4 border-b border-zinc-100 dark:border-zinc-800">
+      <h2 id="rastrum-confirm-title" data-cd-title class="text-base font-semibold text-zinc-900 dark:text-zinc-100"></h2>
+    </header>
+
+    <div class="px-5 py-4">
+      <p data-cd-message class="text-sm text-zinc-700 dark:text-zinc-300 whitespace-pre-line"></p>
+    </div>
+
+    <footer class="flex items-center justify-end gap-2 px-5 py-3 border-t border-zinc-100 dark:border-zinc-800">
+      <button
+        type="button"
+        data-cd-cancel
+        class="px-4 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-400"
+      >
+        {cdTr.default_cancel}
+      </button>
+      <button
+        type="button"
+        data-cd-confirm
+        class="inline-flex min-h-[40px] items-center justify-center rounded-lg bg-emerald-700 hover:bg-emerald-800 px-5 py-2 text-sm font-semibold text-white transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {cdTr.default_confirm}
+      </button>
+    </footer>
+  </div>
+</div>
+
+<script>
+  import { CONFIRM_DIALOG_ID, CONFIRM_DIALOG_EVENT } from '../lib/confirm-dialog';
+
+  const dialog = document.getElementById(CONFIRM_DIALOG_ID);
+  if (dialog) {
+    const confirmBtn = dialog.querySelector<HTMLButtonElement>('[data-cd-confirm]');
+    const cancelBtn = dialog.querySelector<HTMLButtonElement>('[data-cd-cancel]');
+
+    let lastFocused: HTMLElement | null = null;
+
+    const FOCUSABLE_SEL = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    function focusableEls(): HTMLElement[] {
+      return Array.from(dialog!.querySelectorAll<HTMLElement>(FOCUSABLE_SEL))
+        .filter((el) => el.offsetParent !== null || el === document.activeElement);
+    }
+
+    function resolve(result: boolean) {
+      if (dialog!.classList.contains('hidden')) return;
+      dialog!.classList.add('hidden');
+      dialog!.dispatchEvent(new CustomEvent(CONFIRM_DIALOG_EVENT, { detail: { result } }));
+      lastFocused?.focus();
+      lastFocused = null;
+    }
+
+    function onOpen() {
+      lastFocused = (document.activeElement as HTMLElement | null) ?? null;
+      const first = (cancelBtn as HTMLElement | null) ?? focusableEls()[0];
+      first?.focus();
+    }
+
+    confirmBtn?.addEventListener('click', () => resolve(true));
+    cancelBtn?.addEventListener('click', () => resolve(false));
+
+    dialog.addEventListener('click', (e) => {
+      if (e.target === dialog) resolve(false);
+    });
+
+    document.addEventListener('keydown', (e) => {
+      const ev = e as KeyboardEvent;
+      if (dialog.classList.contains('hidden')) return;
+      if (ev.key === 'Escape') {
+        ev.preventDefault();
+        resolve(false);
+        return;
+      }
+      if (ev.key === 'Tab') {
+        const els = focusableEls();
+        if (els.length === 0) return;
+        const first = els[0];
+        const last = els[els.length - 1];
+        const active = document.activeElement as HTMLElement | null;
+        if (ev.shiftKey && active === first) {
+          ev.preventDefault();
+          last.focus();
+        } else if (!ev.shiftKey && active === last) {
+          ev.preventDefault();
+          first.focus();
+        }
+      }
+    });
+
+    const observer = new MutationObserver(() => {
+      if (!dialog.classList.contains('hidden')) onOpen();
+    });
+    observer.observe(dialog, { attributes: true, attributeFilter: ['class'] });
+  }
+</script>

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -225,6 +225,7 @@ const sponsoringI18n = {
 
 <script>
   import { getSupabase } from '../lib/supabase';
+  import { openConfirmDialog } from '../lib/confirm-dialog';
 
   type Lang = 'en' | 'es';
 
@@ -516,10 +517,13 @@ const sponsoringI18n = {
 
       blockBtn?.addEventListener('click', async () => {
         closeMenu();
-        const confirmCopy = lang === 'es'
-          ? `¿Bloquear a @${handleStr}?\n\nNo verán tus reacciones ni tú las suyas. Puedes deshacerlo en Ajustes → Privacidad.`
-          : `Block @${handleStr}?\n\nThey won't see your reactions and you won't see theirs. You can undo this in Settings → Privacy.`;
-        if (!confirm(confirmCopy)) return;
+        const title = lang === 'es' ? `¿Bloquear a @${handleStr}?` : `Block @${handleStr}?`;
+        const message = lang === 'es'
+          ? 'No verán tus reacciones ni tú las suyas. Puedes deshacerlo en Ajustes → Privacidad.'
+          : "They won't see your reactions and you won't see theirs. You can undo this in Settings → Privacy.";
+        const confirmLabel = lang === 'es' ? 'Bloquear' : 'Block';
+        const ok = await openConfirmDialog({ title, message, confirmLabel, variant: 'danger' });
+        if (!ok) return;
         blockBtn.disabled = true;
         try {
           const { blockUser } = await import('../lib/social');

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2507,5 +2507,10 @@
     "error_invalid_polygon": "GeoJSON must be a Polygon or MultiPolygon with valid coordinates.",
     "error_slug_taken": "That slug is already taken.",
     "error_save_failed": "Could not save the project."
+  },
+  "confirm_dialog": {
+    "default_confirm": "Confirm",
+    "default_cancel": "Cancel",
+    "aria_dialog_label": "Confirmation dialog"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2507,5 +2507,10 @@
     "error_invalid_polygon": "El GeoJSON debe ser un Polygon o MultiPolygon con coordenadas válidas.",
     "error_slug_taken": "Ese slug ya está en uso.",
     "error_save_failed": "No se pudo guardar el proyecto."
+  },
+  "confirm_dialog": {
+    "default_confirm": "Confirmar",
+    "default_cancel": "Cancelar",
+    "aria_dialog_label": "Diálogo de confirmación"
   }
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,6 +10,7 @@ import GlobalShareFab from '../components/GlobalShareFab.astro';
 import SwUpdateToast from '../components/SwUpdateToast.astro';
 import OfflineBanner from '../components/OfflineBanner.astro';
 import ReportDialog from '../components/ReportDialog.astro';
+import ConfirmDialog from '../components/ConfirmDialog.astro';
 import PhotoCropModal from '../components/PhotoCropModal.astro';
 import BanBanner from '../components/BanBanner.astro';
 import { getAlternateUrl } from '../i18n/utils';
@@ -168,6 +169,7 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <OnboardingTour lang={installLang} />
     <SwUpdateToast lang={lang} />
     <ReportDialog lang={installLang} />
+    <ConfirmDialog lang={installLang} />
     <PhotoCropModal lang={installLang} />
   </body>
 </html>

--- a/src/lib/confirm-dialog.test.ts
+++ b/src/lib/confirm-dialog.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  openConfirmDialog,
+  CONFIRM_DIALOG_ID,
+  CONFIRM_DIALOG_EVENT,
+} from './confirm-dialog';
+
+function mountDialogShell(lang: 'en' | 'es' = 'en') {
+  document.body.innerHTML = `
+    <div id="${CONFIRM_DIALOG_ID}" class="hidden" data-lang="${lang}"
+         data-default-confirm="${lang === 'es' ? 'Confirmar' : 'Confirm'}"
+         data-default-cancel="${lang === 'es' ? 'Cancelar' : 'Cancel'}">
+      <h2 data-cd-title></h2>
+      <p data-cd-message></p>
+      <button type="button" data-cd-cancel></button>
+      <button type="button" data-cd-confirm></button>
+    </div>
+  `;
+  return document.getElementById(CONFIRM_DIALOG_ID)!;
+}
+
+describe('confirm-dialog helper', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns false when the dialog is not mounted', async () => {
+    const result = await openConfirmDialog({ title: 't', message: 'm' });
+    expect(result).toBe(false);
+  });
+
+  it('renders title + message + default labels and reveals the dialog', async () => {
+    const dialog = mountDialogShell('en');
+    void openConfirmDialog({ title: 'Block @bob?', message: 'Are you sure?' });
+    expect(dialog.classList.contains('hidden')).toBe(false);
+    expect(dialog.querySelector<HTMLElement>('[data-cd-title]')!.textContent).toBe('Block @bob?');
+    expect(dialog.querySelector<HTMLElement>('[data-cd-message]')!.textContent).toBe('Are you sure?');
+    expect(dialog.querySelector<HTMLButtonElement>('[data-cd-confirm]')!.textContent).toBe('Confirm');
+    expect(dialog.querySelector<HTMLButtonElement>('[data-cd-cancel]')!.textContent).toBe('Cancel');
+  });
+
+  it('overrides labels when caller passes them', async () => {
+    const dialog = mountDialogShell('en');
+    void openConfirmDialog({
+      title: 't',
+      message: 'm',
+      confirmLabel: 'Block',
+      cancelLabel: 'Keep',
+    });
+    expect(dialog.querySelector<HTMLButtonElement>('[data-cd-confirm]')!.textContent).toBe('Block');
+    expect(dialog.querySelector<HTMLButtonElement>('[data-cd-cancel]')!.textContent).toBe('Keep');
+  });
+
+  it('uses ES defaults when data-lang="es"', async () => {
+    const dialog = mountDialogShell('es');
+    void openConfirmDialog({ title: 't', message: 'm' });
+    expect(dialog.querySelector<HTMLButtonElement>('[data-cd-confirm]')!.textContent).toBe('Confirmar');
+    expect(dialog.querySelector<HTMLButtonElement>('[data-cd-cancel]')!.textContent).toBe('Cancelar');
+  });
+
+  it('paints the confirm button red for the danger variant', async () => {
+    const dialog = mountDialogShell('en');
+    void openConfirmDialog({ title: 't', message: 'm', variant: 'danger' });
+    const btn = dialog.querySelector<HTMLButtonElement>('[data-cd-confirm]')!;
+    expect(btn.classList.contains('bg-rose-600')).toBe(true);
+    expect(btn.classList.contains('bg-emerald-700')).toBe(false);
+  });
+
+  it('paints the confirm button emerald for the default variant', async () => {
+    const dialog = mountDialogShell('en');
+    void openConfirmDialog({ title: 't', message: 'm' });
+    const btn = dialog.querySelector<HTMLButtonElement>('[data-cd-confirm]')!;
+    expect(btn.classList.contains('bg-emerald-700')).toBe(true);
+    expect(btn.classList.contains('bg-rose-600')).toBe(false);
+  });
+
+  it('resolves true when a CONFIRM_DIALOG_EVENT with result:true is dispatched', async () => {
+    const dialog = mountDialogShell('en');
+    const promise = openConfirmDialog({ title: 't', message: 'm' });
+    dialog.dispatchEvent(new CustomEvent(CONFIRM_DIALOG_EVENT, { detail: { result: true } }));
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it('resolves false when a CONFIRM_DIALOG_EVENT with result:false is dispatched', async () => {
+    const dialog = mountDialogShell('en');
+    const promise = openConfirmDialog({ title: 't', message: 'm' });
+    dialog.dispatchEvent(new CustomEvent(CONFIRM_DIALOG_EVENT, { detail: { result: false } }));
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('only resolves once per open() call (listener is cleaned up)', async () => {
+    const dialog = mountDialogShell('en');
+    const first = openConfirmDialog({ title: 't', message: 'm' });
+    dialog.dispatchEvent(new CustomEvent(CONFIRM_DIALOG_EVENT, { detail: { result: true } }));
+    await expect(first).resolves.toBe(true);
+
+    const second = openConfirmDialog({ title: 't2', message: 'm2' });
+    dialog.dispatchEvent(new CustomEvent(CONFIRM_DIALOG_EVENT, { detail: { result: false } }));
+    await expect(second).resolves.toBe(false);
+  });
+});

--- a/src/lib/confirm-dialog.ts
+++ b/src/lib/confirm-dialog.ts
@@ -1,0 +1,63 @@
+/**
+ * Promise-based replacement for `window.confirm()` that drives the
+ * global `<ConfirmDialog>` mounted in `BaseLayout.astro`. Mirrors the
+ * `ReportDialog` open-via-dataset pattern so all global modals share
+ * one mental model.
+ *
+ * Resolves `true` on confirm, `false` on cancel / Esc / backdrop click.
+ * Safe to call before the dialog is mounted (returns `false`).
+ */
+
+export interface ConfirmDialogOptions {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'default' | 'danger';
+}
+
+export const CONFIRM_DIALOG_ID = 'rastrum-confirm-dialog';
+export const CONFIRM_DIALOG_EVENT = 'rastrum:confirm-dialog-resolve';
+
+export interface ConfirmDialogResolveDetail {
+  result: boolean;
+}
+
+export function openConfirmDialog(opts: ConfirmDialogOptions): Promise<boolean> {
+  if (typeof document === 'undefined') return Promise.resolve(false);
+  const dialog = document.getElementById(CONFIRM_DIALOG_ID);
+  if (!dialog) return Promise.resolve(false);
+
+  const titleEl = dialog.querySelector<HTMLElement>('[data-cd-title]');
+  const messageEl = dialog.querySelector<HTMLElement>('[data-cd-message]');
+  const confirmBtn = dialog.querySelector<HTMLButtonElement>('[data-cd-confirm]');
+  const cancelBtn = dialog.querySelector<HTMLButtonElement>('[data-cd-cancel]');
+
+  if (titleEl) titleEl.textContent = opts.title;
+  if (messageEl) messageEl.textContent = opts.message;
+
+  const lang = (dialog.dataset.lang === 'es' ? 'es' : 'en') as 'en' | 'es';
+  const defaultConfirm = dialog.dataset.defaultConfirm ?? (lang === 'es' ? 'Confirmar' : 'Confirm');
+  const defaultCancel = dialog.dataset.defaultCancel ?? (lang === 'es' ? 'Cancelar' : 'Cancel');
+
+  if (confirmBtn) confirmBtn.textContent = opts.confirmLabel ?? defaultConfirm;
+  if (cancelBtn) cancelBtn.textContent = opts.cancelLabel ?? defaultCancel;
+
+  const variant = opts.variant ?? 'default';
+  if (confirmBtn) {
+    const dangerCls = ['bg-rose-600', 'hover:bg-rose-700', 'focus:ring-rose-500'];
+    const defaultCls = ['bg-emerald-700', 'hover:bg-emerald-800', 'focus:ring-emerald-500'];
+    confirmBtn.classList.remove(...dangerCls, ...defaultCls);
+    confirmBtn.classList.add(...(variant === 'danger' ? dangerCls : defaultCls));
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const onResolve = (e: Event) => {
+      const detail = (e as CustomEvent<ConfirmDialogResolveDetail>).detail;
+      dialog.removeEventListener(CONFIRM_DIALOG_EVENT, onResolve as EventListener);
+      resolve(Boolean(detail?.result));
+    };
+    dialog.addEventListener(CONFIRM_DIALOG_EVENT, onResolve as EventListener);
+    dialog.classList.remove('hidden');
+  });
+}

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -14,6 +14,7 @@ import { willDemote, type PhotoForDeletion } from './photo-deletion';
 import { resizeImage, uploadMedia } from './upload';
 import { escapeHtml as escAttr } from './escape';
 import { t } from '../i18n/utils';
+import { openConfirmDialog } from './confirm-dialog';
 
 type Ident = { scientific_name?: string; is_primary?: boolean } | undefined;
 
@@ -219,6 +220,8 @@ type PhotoRow = PhotoForDeletion & {
 type PhotosCopy = {
   delete_confirm_demote: string;
   delete_confirm_simple: string;
+  delete_confirm_title: string;
+  delete_confirm_label: string;
   upload_failed: string;
   uploading: string;
   delete_photo_aria: string;
@@ -261,6 +264,8 @@ export async function wireManagePanelPhotos(obsId: string): Promise<void> {
     ? {
         delete_confirm_demote: 'Esta foto fue la base de la identificación actual. Eliminarla marcará la observación como pendiente de revisión. ¿Continuar?',
         delete_confirm_simple: '¿Eliminar esta foto?',
+        delete_confirm_title:  'Eliminar foto',
+        delete_confirm_label:  'Eliminar',
         upload_failed:         'Subida de foto fallida. Intenta de nuevo.',
         uploading:             'Subiendo…',
         delete_photo_aria:     'Eliminar foto',
@@ -268,6 +273,8 @@ export async function wireManagePanelPhotos(obsId: string): Promise<void> {
     : {
         delete_confirm_demote: 'This photo was the basis for the current identification. Deleting it will mark the observation as needing review. Continue?',
         delete_confirm_simple: 'Delete this photo?',
+        delete_confirm_title:  'Delete photo',
+        delete_confirm_label:  'Delete',
         upload_failed:         'Photo upload failed. Please try again.',
         uploading:             'Uploading…',
         delete_photo_aria:     'Delete photo',
@@ -347,7 +354,13 @@ export async function wireManagePanelPhotos(obsId: string): Promise<void> {
     setError(null);
     const demote = willDemote(allPhotos, mediaId);
     const msg = demote ? copy.delete_confirm_demote : copy.delete_confirm_simple;
-    if (!window.confirm(msg)) return;
+    const ok = await openConfirmDialog({
+      title: copy.delete_confirm_title,
+      message: msg,
+      confirmLabel: copy.delete_confirm_label,
+      variant: 'danger',
+    });
+    if (!ok) return;
 
     const { data, error } = await supabase.functions.invoke<{ ok: boolean; error?: string }>(
       'delete-photo',

--- a/tests/e2e/confirm-dialog.spec.ts
+++ b/tests/e2e/confirm-dialog.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+
+// E2E for the global ConfirmDialog component mounted in BaseLayout.
+// The component lives at #rastrum-confirm-dialog and is hidden by
+// default. The page-level helper `openConfirmDialog()` drives it via
+// dataset + class toggle; the component's own script handles focus
+// trap + Esc + backdrop close, which is what we exercise here.
+//
+// Strategy: rather than depend on a real consumer (Block flow needs
+// auth, delete-photo needs an owner session), we open the dialog by
+// directly applying the same DOM mutations the helper would, then
+// listen for the resolve event the same way the helper does.
+
+const ROUTE = '/en/';
+const DIALOG_ID = 'rastrum-confirm-dialog';
+const RESOLVE_EVENT = 'rastrum:confirm-dialog-resolve';
+
+async function openDialog(
+  page: import('@playwright/test').Page,
+  opts: { title: string; message: string; confirmLabel?: string; cancelLabel?: string },
+) {
+  await page.evaluate(
+    ({ id, evt, opts }) => {
+      const dialog = document.getElementById(id);
+      if (!dialog) throw new Error('confirm dialog not mounted');
+      const titleEl = dialog.querySelector<HTMLElement>('[data-cd-title]');
+      const msgEl = dialog.querySelector<HTMLElement>('[data-cd-message]');
+      const cBtn = dialog.querySelector<HTMLButtonElement>('[data-cd-confirm]');
+      const xBtn = dialog.querySelector<HTMLButtonElement>('[data-cd-cancel]');
+      if (titleEl) titleEl.textContent = opts.title;
+      if (msgEl) msgEl.textContent = opts.message;
+      if (cBtn && opts.confirmLabel) cBtn.textContent = opts.confirmLabel;
+      if (xBtn && opts.cancelLabel) xBtn.textContent = opts.cancelLabel;
+
+      (window as unknown as { __cdResult?: boolean | null }).__cdResult = null;
+      const onResolve = (e: Event) => {
+        const detail = (e as CustomEvent<{ result: boolean }>).detail;
+        (window as unknown as { __cdResult?: boolean | null }).__cdResult = Boolean(detail?.result);
+        dialog.removeEventListener(evt, onResolve);
+      };
+      dialog.addEventListener(evt, onResolve);
+      dialog.classList.remove('hidden');
+    },
+    { id: DIALOG_ID, evt: RESOLVE_EVENT, opts },
+  );
+}
+
+async function readResult(page: import('@playwright/test').Page): Promise<boolean | null> {
+  return page.evaluate(() => (window as unknown as { __cdResult?: boolean | null }).__cdResult ?? null);
+}
+
+test.describe('ConfirmDialog (global)', () => {
+  test('renders title + message and traps focus inside the dialog', async ({ page }) => {
+    await page.goto(ROUTE);
+    await openDialog(page, { title: 'Block @bob?', message: 'Cannot be undone.' });
+
+    const dialog = page.locator(`#${DIALOG_ID}`);
+    await expect(dialog).toBeVisible();
+    await expect(dialog.locator('[data-cd-title]')).toHaveText('Block @bob?');
+    await expect(dialog.locator('[data-cd-message]')).toHaveText('Cannot be undone.');
+
+    const cancelBtn = dialog.locator('[data-cd-cancel]');
+    const confirmBtn = dialog.locator('[data-cd-confirm]');
+
+    // Focus lands inside the dialog on open.
+    await expect(cancelBtn).toBeFocused();
+
+    // Tab from last → first wraps to the cancel button (focus trap).
+    await confirmBtn.focus();
+    await page.keyboard.press('Tab');
+    await expect(cancelBtn).toBeFocused();
+
+    // Shift+Tab from first → last wraps to confirm.
+    await page.keyboard.press('Shift+Tab');
+    await expect(confirmBtn).toBeFocused();
+  });
+
+  test('Esc key closes with false', async ({ page }) => {
+    await page.goto(ROUTE);
+    await openDialog(page, { title: 'Discard?', message: 'You will lose changes.' });
+
+    const dialog = page.locator(`#${DIALOG_ID}`);
+    await expect(dialog).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+    expect(await readResult(page)).toBe(false);
+  });
+
+  test('backdrop click closes with false', async ({ page }) => {
+    await page.goto(ROUTE);
+    await openDialog(page, { title: 'Discard?', message: 'You will lose changes.' });
+
+    const dialog = page.locator(`#${DIALOG_ID}`);
+    await expect(dialog).toBeVisible();
+    // Click the backdrop (top-left corner is outside the inner card).
+    await dialog.click({ position: { x: 4, y: 4 } });
+    await expect(dialog).toBeHidden();
+    expect(await readResult(page)).toBe(false);
+  });
+
+  test('confirm button click resolves true', async ({ page }) => {
+    await page.goto(ROUTE);
+    await openDialog(page, { title: 'Block?', message: 'Confirm block.' });
+
+    const dialog = page.locator(`#${DIALOG_ID}`);
+    await expect(dialog).toBeVisible();
+    await dialog.locator('[data-cd-confirm]').click();
+    await expect(dialog).toBeHidden();
+    expect(await readResult(page)).toBe(true);
+  });
+
+  test('cancel button click resolves false', async ({ page }) => {
+    await page.goto(ROUTE);
+    await openDialog(page, { title: 'Block?', message: 'Confirm block.' });
+
+    const dialog = page.locator(`#${DIALOG_ID}`);
+    await expect(dialog).toBeVisible();
+    await dialog.locator('[data-cd-cancel]').click();
+    await expect(dialog).toBeHidden();
+    expect(await readResult(page)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable global `ConfirmDialog` modal that replaces synchronous `window.confirm()` in the two consumer flows reviewers have flagged repeatedly. Pattern mirrors `ReportDialog.astro` exactly so the team has one mental model for global modals.

- New `<ConfirmDialog>` mounted once in `BaseLayout.astro`. Focus trap, Esc + backdrop close, prior-focus restore — same as `ReportDialog`.
- New `openConfirmDialog({ title, message, confirmLabel?, cancelLabel?, variant? }): Promise<boolean>` helper in `src/lib/confirm-dialog.ts`. Resolves `true` on confirm, `false` on cancel / Esc / backdrop. `variant: 'danger'` paints the confirm button red.
- New `confirm_dialog.*` i18n namespace (EN + ES) with `default_confirm`, `default_cancel`, `aria_dialog_label`.

## Consumer migrations

1. **Block flow** — `src/components/PublicProfileViewV2.astro` — `if (!confirm(...)) return` replaced with `await openConfirmDialog({ title, message, confirmLabel: 'Block', variant: 'danger' })`. Flagged in [PR #101](https://github.com/ArtemioPadilla/rastrum/pull/101) review.
2. **Delete-photo flow** — `src/lib/manage-panel.ts` `wireManagePanelPhotos` `handleDelete` — `if (!window.confirm(msg)) return` replaced with the async equivalent (with separate title + message + Delete confirm label, danger variant). Flagged in [PR #125](https://github.com/ArtemioPadilla/rastrum/pull/125) review.

Tracked as item #4 of `m26-v1-1-review-followups` in `docs/tasks.json`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 628/628 pass (9 new vitest cases for the helper)
- [x] `npm run build` — 168 pages, no errors
- [ ] e2e (`tests/e2e/confirm-dialog.spec.ts`) — focus trap + Esc + backdrop + confirm/cancel resolution; runs in the next CI cycle
- [ ] Manual: open a public profile while signed in, click ⋮ → Block; verify the new dialog appears and the await flow works
- [ ] Manual: open an obs detail you own, manage panel → Photos → delete; verify dialog + danger paint

🤖 Generated with [Claude Code](https://claude.com/claude-code)