### PR TITLE
docs: M29/M30/M31/M32 runbooks + CLAUDE/architecture deep-dives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 > Briefing for AI coding agents (Claude Code, Copilot, Cursor, Codex, …)
 > working in this repo. Read this before making changes.
 >
-> **Last full doc sync:** 2026-04-26 (v1.0 + chrome revamp).
+> **Last full doc sync:** 2026-04-30 (v1.2 — research workflow M29/M30/M31, multi-provider vision + pool M32).
 
 ---
 
@@ -122,15 +122,26 @@ supabase/
 │   └── mcp                   MCP server for AI agents (rst_* token auth, JSON-RPC over HTTP)
 └── config.toml             Local CLI config (deploy via CI, not local)
 
+cli/                            M30 — batch import CLI for camera-trap memory cards
+├── bin/rastrum-import.js   Node entry point (loads compiled dist/cli.js)
+├── src/cli.ts              Orchestrator + parseArgs (pure helper, unit-tested)
+├── src/walker.ts           Recursive async-generator file walker
+├── src/exif.ts             exifr wrapper, parity with PWA's fillFromExif
+├── src/api-client.ts       /api/upload-url + /api/observe + /api/identify client
+├── src/log.ts              Resumable import-log.json
+└── test/                   Node native test runner (--import tsx --test)
+
 docs/
 ├── progress.json           Roadmap (60+ items, bilingual labels)
 ├── tasks.json              Per-item subtask breakdown (rendered at /docs/tasks/)
 ├── tasks.md                Phase summary (regenerated from tasks.json)
 ├── architecture.md         High-level architecture + critical-path flows
 ├── gbif-ipt.md             Operator notes for GBIF IPT publishing
+├── runbooks/               Operator playbooks per module (M29 projects, M30 CLI,
+│                           M31 camera stations, M32 multi-provider + pools, …)
 └── specs/
     ├── infra/              SQL schema, cron, testing, future migrations, CI yml
-    └── modules/            20 module specs + 00-index.md (see numbering note)
+    └── modules/            32+ module specs + 00-index.md (see numbering note)
 ```
 
 ---
@@ -388,6 +399,109 @@ Client-side two-call has a real race window. R2 blobs are left as
 orphans for v1; `gc-orphan-media` cron is a v1.1 follow-up.
 
 Full notes: [`docs/runbooks/obs-detail-redesign.md`](docs/runbooks/obs-detail-redesign.md).
+
+### Projects (M29)
+
+A *project* is a named polygon (typically an ANP or sampling grid)
+under `/{en,es}/projects/`. Three load-bearing rules:
+
+1. **Polygon is the routing key.** `assign_observation_to_project_trigger`
+   runs `BEFORE INSERT OR UPDATE OF location` on `observations` —
+   if `project_id IS NULL` and a location is set, the trigger picks
+   the first project (by `created_at ASC`) whose polygon `ST_Covers`
+   the point. Manual assignments via direct UPDATE are honoured.
+2. **Geography writes go through `upsert_project()` SECURITY
+   DEFINER**, not direct `INSERT INTO projects`. PostgREST has no
+   WKB encoder for the `geography(MultiPolygon, 4326)` column, so
+   the client posts GeoJSON to the RPC which parses + enforces
+   `owner_user_id = auth.uid()`.
+3. **Reads use `projects_with_geojson` view (SECURITY INVOKER).** RLS
+   on the underlying table gates rows by visibility (`public` →
+   anon; `private` → owner + members). Don't `SELECT polygon`
+   directly from `projects` — base64 WKB is what comes back.
+
+Spec: [`docs/specs/modules/29-projects-anp.md`](docs/specs/modules/29-projects-anp.md).
+Runbook: [`docs/runbooks/projects-anp.md`](docs/runbooks/projects-anp.md).
+
+### CLI batch import (M30)
+
+Lives at [`cli/`](cli/) — a separate Node 20+ TypeScript package
+with its own `package.json` so the PWA bundle never picks up
+Node-only deps (`exifr`, AWS SDK). The CLI authenticates with an
+`rst_*` token (scope: `observe`) against the `/api/upload-url` and
+`/api/observe` endpoints in the existing `api` Edge Function.
+
+Two contracts that must stay aligned:
+
+1. **EXIF parsing parity with the PWA** — `cli/src/exif.ts` mirrors
+   `ObservationForm.fillFromExif()` for property-name fallback
+   (`latitude` / `Latitude` / `GPSLatitude`) and the (0,0)
+   null-island rejection.
+2. **Project auto-tagging happens server-side** via M29's trigger.
+   The CLI doesn't pass `--project-slug`; observations whose EXIF
+   GPS lands in a project polygon are tagged automatically.
+
+Spec: [`docs/specs/modules/30-cli-batch-import.md`](docs/specs/modules/30-cli-batch-import.md).
+Runbook: [`docs/runbooks/cli-batch-import.md`](docs/runbooks/cli-batch-import.md).
+
+### Camera stations (M31)
+
+Schema-only in v1 — a `camera_station` is a fixed deployment with
+one or more `camera_station_periods` (start/end dates). Standardised
+indices like RAI / detection-rate-per-100-trap-nights need to know
+*how long the camera was sampling*, not just *what it captured*.
+
+- Station uniqueness is **per project** (`UNIQUE(project_id,
+  station_key)`), so two projects can both have a `SJ-CAM-01`.
+- Station assignment to observations stays **explicit**
+  (`observations.camera_station_id`); two stations within one
+  polygon need different trap-night counts so the polygon trigger
+  doesn't auto-fill it.
+- Use `station_trap_nights(station_id, p_from, p_to)` for trap-night
+  counts. NULL `end_date` is counted up to `current_date` (or
+  `p_to`).
+
+UI is a v1.1 follow-up; until then, create stations via SQL (see
+runbook).
+
+Spec: [`docs/specs/modules/31-camera-stations.md`](docs/specs/modules/31-camera-stations.md).
+Runbook: [`docs/runbooks/camera-stations.md`](docs/runbooks/camera-stations.md).
+
+### Multi-provider vision + platform pool (M32)
+
+`supabase/functions/_shared/vision-provider.ts` exports a
+`VisionProvider` interface with a `buildProvider(credential)`
+dispatcher. Six concrete providers: Anthropic-direct (api_key /
+oauth_token), AWS Bedrock, OpenAI, Azure OpenAI, Google Gemini,
+Vertex AI.
+
+Three load-bearing rules:
+
+1. **Don't add a new provider class without updating
+   `buildProvider`'s exhaustive switch.** The `never`-typed default
+   case is the compiler hook that catches missing dispatch.
+2. **Bedrock secrets are JSON envelopes**
+   `{ region, accessKeyId, secretAccessKey, sessionToken? }`. The
+   AWS Sig V4 signer is hand-rolled (~70 LOC) instead of bundling
+   `@aws-sdk/client-bedrock-runtime` (~3 MB) into the EF.
+   `bedrockModelId(model)` auto-translates Anthropic shorthand
+   (`claude-haiku-4-5` → `us.anthropic.claude-haiku-4-5-v1:0`).
+3. **Pool resolution is atomic via `consume_pool_slot()` SECURITY
+   DEFINER + FOR UPDATE SKIP LOCKED.** It picks an active pool with
+   capacity, enforces `daily_user_cap` per beneficiary, increments
+   both counters, and marks `exhausted` when the pool fills — all
+   in a single PL/pgSQL transaction. The `identify` EF wraps the
+   call after the personal-sponsorship resolution fails.
+
+Resolution order: BYO key → personal sponsorship → platform pool →
+skip Claude (PlantNet only).
+
+UI for credential creation + pool donation is a v1.1 follow-up;
+until then, register credentials via Supabase Vault + SQL.
+
+Spec: [`docs/specs/modules/32-multi-provider-vision.md`](docs/specs/modules/32-multi-provider-vision.md).
+Runbooks: [`docs/runbooks/multi-provider-vision.md`](docs/runbooks/multi-provider-vision.md),
+[`docs/runbooks/sponsor-pools.md`](docs/runbooks/sponsor-pools.md).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -462,6 +462,117 @@ Operator runbook: [`docs/runbooks/obs-detail-redesign.md`](runbooks/obs-detail-r
 
 ---
 
+## Projects + research workflow (M29 / M30 / M31, v1.2 shipped 2026-04-30)
+
+A polygon-anchored monitoring stack for ANP / DRFSIPS / PROREST 2026 use:
+
+```
+                          ┌──────────────────────────┐
+                          │  projects                │
+                          │   (geography MultiPolygon)│
+                          │   visibility, owner,     │
+                          │   bilingual name + desc  │
+                          └─────────┬────────────────┘
+                                    │ FK + auto-tag trigger
+                  ┌─────────────────┼──────────────────────┐
+                  │                 │                      │
+                  ▼                 ▼                      ▼
+       ┌──────────────────┐  ┌──────────────────┐  ┌────────────────────┐
+       │  observations    │  │  camera_stations │  │  CLI batch import  │
+       │    project_id    │  │    project_id +  │  │   (cli/, M30)      │
+       │    camera_       │  │    station_key   │  │                    │
+       │    station_id    │  │    (UNIQUE per   │  │  walks SD card →   │
+       │                  │  │    project)      │  │  /api/upload-url → │
+       └──────────────────┘  └──────────────────┘  │  /api/observe      │
+                                                   └────────────────────┘
+```
+
+- **Auto-tagging**: `assign_observation_to_project_trigger` runs `BEFORE
+  INSERT OR UPDATE OF location` on `observations`; if `project_id` is null
+  and a location is set, it picks the first project (by `created_at ASC`)
+  whose polygon `ST_Covers` the point.
+- **Geography writes** go through `upsert_project()` SECURITY DEFINER —
+  PostgREST has no WKB encoder for the `geography(MultiPolygon, 4326)`
+  column, so the client posts GeoJSON to the RPC.
+- **Trap-night counts** for camera stations come from
+  `station_trap_nights(station_id, p_from, p_to)` SQL function. NULL
+  `end_date` is counted up to `current_date` (or `p_to`).
+- **CLI** (`cli/`) is a separate Node 20+ TypeScript package with its own
+  `package.json` so the PWA never picks up Node-only deps; it uses
+  `rst_*` API tokens against `POST /api/upload-url` (added in M30) for
+  batch upload of camera-trap photos.
+
+Specs: [`docs/specs/modules/29-projects-anp.md`](specs/modules/29-projects-anp.md),
+[`docs/specs/modules/30-cli-batch-import.md`](specs/modules/30-cli-batch-import.md),
+[`docs/specs/modules/31-camera-stations.md`](specs/modules/31-camera-stations.md).
+Runbooks: [`projects-anp.md`](runbooks/projects-anp.md),
+[`cli-batch-import.md`](runbooks/cli-batch-import.md),
+[`camera-stations.md`](runbooks/camera-stations.md).
+
+---
+
+## Multi-provider vision + platform pool (M32, v1.2 shipped 2026-04-30)
+
+The original cascade in `identify/index.ts` called `api.anthropic.com`
+directly with a hard-coded model. M32 replaces that with a `VisionProvider`
+abstraction so the same call site can route through any of six providers,
+plus adds a platform-wide call pool that sponsors donate to.
+
+```
+                ┌─────────────────────┐
+   image bytes  │  identify/index.ts  │
+   ──────────► │   parallel cascade   │
+                │   ─────────────────  │
+                │   PlantNet runner    │
+                │   Vision runner ────┤
+                │   ONNX (placeholder) │
+                └──────────┬───────────┘
+                           │ resolve credential:
+                           │   1. BYO key (client_keys)
+                           │   2. Personal sponsorship
+                           │   3. consume_pool_slot() ─┐ FOR UPDATE SKIP LOCKED
+                           │   4. skip                  │ atomic per-user cap
+                           ▼                            │
+              ┌─────────────────────────────┐           │
+              │  buildProvider(credential)  │           │
+              ├─────────────────────────────┤           │
+              │ AnthropicProvider           │           │
+              │ BedrockProvider (Sig V4)    │           │
+              │ OpenAIProvider              │           │
+              │ AzureOpenAIProvider         │           │
+              │ GeminiProvider              │           │
+              │ VertexAIProvider            │           │
+              └─────────────────────────────┘           │
+                                                        ▼
+                                              ┌──────────────────┐
+                                              │  sponsor_pools   │
+                                              │  pool_consumption│
+                                              │  (atomic ledger) │
+                                              └──────────────────┘
+```
+
+- **`buildProvider()` exhaustive switch** — adding a new
+  `CredentialKind` without updating the dispatcher fails the
+  TypeScript build via the `never`-typed default case.
+- **Bedrock Sig V4 hand-rolled** (~70 LOC) instead of bundling
+  `@aws-sdk/client-bedrock-runtime` (~3 MB) into the EF.
+- **`bedrockModelId(model)` translation** — the column default
+  `claude-haiku-4-5` (Anthropic shorthand) auto-converts to
+  `us.anthropic.claude-haiku-4-5-v1:0` so a Bedrock credential
+  configured without an explicit Bedrock model still works.
+- **Pool privacy**: `pool_consumption (user_id, day, count)` is
+  service-role-write / self-read. No RPC joins it to `auth.users`;
+  sponsors see only aggregate stats.
+
+UI for credential creation + pool donation lands in v1.1; until
+then, register credentials via Supabase Vault + SQL.
+
+Spec: [`docs/specs/modules/32-multi-provider-vision.md`](specs/modules/32-multi-provider-vision.md).
+Runbooks: [`multi-provider-vision.md`](runbooks/multi-provider-vision.md),
+[`sponsor-pools.md`](runbooks/sponsor-pools.md).
+
+---
+
 ## Further reading
 
 - [`AGENTS.md`](../AGENTS.md) — conventions, pitfalls, pre-PR checklist.

--- a/docs/runbooks/camera-stations.md
+++ b/docs/runbooks/camera-stations.md
@@ -1,0 +1,124 @@
+# Camera stations (M31) — runbook
+
+> **Spec:** [`docs/specs/modules/31-camera-stations.md`](../specs/modules/31-camera-stations.md).
+> **Status:** schema only in v1; UI is a v1.1 follow-up.
+> **Depends on:** M29 (Projects).
+
+## Apply schema
+
+```bash
+make db-apply
+```
+
+Creates `camera_stations`, `camera_station_periods`,
+`observations.camera_station_id` column, GIST + B-tree indexes,
+`station_trap_nights()` SQL function, and RLS policies. Idempotent.
+
+Verify:
+
+```bash
+make db-psql
+\d camera_stations
+\d camera_station_periods
+\df station_trap_nights
+SELECT public.station_trap_nights('00000000-0000-0000-0000-000000000000'::uuid);
+```
+
+## Create a station + active period (no UI in v1)
+
+The UI lands in v1.1. Until then, use SQL via `make db-psql` while
+signed in as the project owner (RLS gates writes by
+`project.owner_user_id = auth.uid()`):
+
+```sql
+-- 1. Create the station, anchored to an existing M29 project
+INSERT INTO public.camera_stations (project_id, station_key, name, name_es, coords, habitat, camera_model)
+SELECT p.id, 'SJ-CAM-01',
+       'Sierra Juárez camera 01',
+       'Cámara Sierra Juárez 01',
+       ST_SetSRID(ST_MakePoint(-96.7123, 17.2856), 4326)::geography,
+       'cloud forest', 'Bushnell Trophy Cam HD'
+  FROM public.projects p
+ WHERE p.slug = 'anp-sierra-juarez';
+
+-- 2. Open an active period (NULL end_date = "still active")
+INSERT INTO public.camera_station_periods (station_id, start_date, end_date, notes)
+SELECT id, '2025-04-01', NULL, 'First deployment, dry season'
+  FROM public.camera_stations
+ WHERE station_key = 'SJ-CAM-01';
+```
+
+To close a period (camera retrieved):
+
+```sql
+UPDATE public.camera_station_periods
+   SET end_date = '2025-04-15'
+ WHERE station_id = (SELECT id FROM public.camera_stations WHERE station_key = 'SJ-CAM-01')
+   AND end_date IS NULL;
+```
+
+## Compute trap-nights
+
+```sql
+-- Total trap-nights for the station, all periods
+SELECT public.station_trap_nights(
+  (SELECT id FROM public.camera_stations WHERE station_key = 'SJ-CAM-01')
+);
+
+-- Bounded to a date range
+SELECT public.station_trap_nights(
+  (SELECT id FROM public.camera_stations WHERE station_key = 'SJ-CAM-01'),
+  p_from := '2025-04-01',
+  p_to   := '2025-04-15'
+);
+```
+
+`NULL` `end_date` is counted up to `current_date` (or the supplied
+`p_to`).
+
+## Tag observations to a station
+
+In v1, observations are tagged via direct UPDATE since the API
+endpoints don't expose `camera_station_id` yet:
+
+```sql
+UPDATE public.observations o
+   SET camera_station_id = cs.id
+  FROM public.camera_stations cs
+ WHERE cs.station_key = 'SJ-CAM-01'
+   AND o.project_id = cs.project_id
+   AND o.observed_at::date BETWEEN '2025-04-01' AND '2025-04-15';
+```
+
+## Detection rate per 100 trap-nights (manual query)
+
+```sql
+WITH s AS (
+  SELECT id FROM public.camera_stations WHERE station_key = 'SJ-CAM-01'
+),
+n AS (
+  SELECT public.station_trap_nights((SELECT id FROM s)) AS trap_nights
+),
+det AS (
+  SELECT primary_taxon_id, COUNT(*) AS detections
+    FROM public.observations
+   WHERE camera_station_id = (SELECT id FROM s)
+   GROUP BY primary_taxon_id
+)
+SELECT t.scientific_name,
+       det.detections,
+       ROUND((det.detections::numeric / NULLIF(n.trap_nights, 0)) * 100, 2) AS rate_per_100_tn
+  FROM det
+  JOIN public.taxa t ON t.id = det.primary_taxon_id
+  CROSS JOIN n
+ ORDER BY rate_per_100_tn DESC;
+```
+
+## v1.1 follow-ups
+
+- UI under `/{en,es}/projects/[slug]/stations/` — list + create + period editor
+- CLI `--station-key <key>` flag for batch tagging at import time (M30)
+- Per-station detection-rate dashboard (RAI per species per period)
+- DwC-A export filter for "stations only" (vs the full project)
+- Multi-point / sampling-grid stations (current schema is one Point per station)
+- `/api/observe` accepts `camera_station_id` parameter

--- a/docs/runbooks/cli-batch-import.md
+++ b/docs/runbooks/cli-batch-import.md
@@ -1,0 +1,104 @@
+# CLI batch import (M30) — runbook
+
+> **Spec:** [`docs/specs/modules/30-cli-batch-import.md`](../specs/modules/30-cli-batch-import.md).
+> **Code:** [`cli/`](../../cli/) — Node 20+ TypeScript package.
+> **Edge Function endpoint:** `POST /functions/v1/api/upload-url` (added by PR #134).
+
+## Install on the operator machine
+
+```bash
+cd cli
+npm install
+npm run build
+# Optional: link globally so `rastrum-import` is on PATH
+npm link
+```
+
+The CLI is **not published to npm** in v1 — install from the repo
+checkout. Bundle size is small (~1 MB including `exifr`); no
+optimisation work is planned for v1.
+
+## Generate an API token
+
+`https://rastrum.org/{en,es}/profile/tokens` → **New token** with
+the `observe` scope. The plaintext is shown once at creation; copy
+it into the operator's `~/.rastrum/env` or pass via
+`RASTRUM_TOKEN` env var.
+
+```bash
+export RASTRUM_BASE_URL=https://reppvlqejgoqvitturxp.supabase.co/functions/v1
+export RASTRUM_TOKEN=rst_…
+```
+
+## Pre-import checklist
+
+1. **Project polygon registered (optional but recommended)** —
+   create a project at `/{en,es}/projects/new/` covering the
+   sampling area. Observations whose EXIF GPS falls inside auto-tag
+   to the project via the M29 trigger.
+2. **Camera-trap photos with EXIF GPS + DateTimeOriginal** — the CLI
+   reads both. Photos without GPS still upload but stay
+   project-untagged.
+3. **Sufficient pool / sponsorship credits** — each `--skip-identify`
+   call consumes the BYO/sponsor key once for `identify`. For 500+
+   photos, prefer `--skip-identify` and identify selectively from
+   the UI later.
+
+## Run
+
+```bash
+rastrum-import \
+  --dir /Volumes/SD_CARD/DCIM \
+  --baseUrl "$RASTRUM_BASE_URL" \
+  --token   "$RASTRUM_TOKEN" \
+  --notes   "Station SJ-CAM-01 — first deployment 2025-04-01..2025-04-15"
+```
+
+Default log location: `<dir>/import-log.json`. Override with
+`--log /var/log/rastrum/import.json`.
+
+## Resumability
+
+Re-running the same command skips files already at
+`status: 'uploaded'` in the log. Saved every 10 files so a Ctrl-C
+loses at most 9 in-flight entries.
+
+To force a re-upload of a single file: edit the log, remove that
+file's entry, re-run.
+
+To force a full re-upload: delete `import-log.json`. This will
+duplicate observations on the server.
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `FAIL upload-url: 401` | Token revoked or wrong scope | Generate a new token with `observe` scope |
+| `FAIL upload-url: 500` | R2 not configured on deploy | Verify `CF_ACCOUNT_ID` / `R2_BUCKET_NAME` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_PUBLIC_URL` Edge Function secrets |
+| Files with EXIF GPS upload as `lat=null lng=null` | EXIF stripped by camera or third-party tool | Run `exiftool -GPSLatitude -GPSLongitude photo.jpg` to confirm; if blank, the photo lost its metadata before reaching the CLI |
+| `OK` but no `project_id` assigned | Polygon doesn't cover the EXIF coords (≤1 km tolerance), or project visibility excludes the importing user | Verify polygon via `make db-psql` + `SELECT id FROM projects WHERE ST_Covers(polygon, ST_SetSRID(ST_MakePoint(<lng>,<lat>), 4326))` |
+| Spinner "Identifying…" hangs on a photo | Identify EF timed out | Re-run with `--skip-identify`; identify selectively from the UI |
+
+## Backfill `project_id` on already-imported observations
+
+The auto-tag trigger only fires on INSERT/UPDATE OF location. To
+re-tag historical imports against a freshly-created polygon:
+
+```sql
+UPDATE public.observations o
+   SET project_id = p.id
+  FROM public.projects p
+ WHERE o.project_id IS NULL
+   AND o.location  IS NOT NULL
+   AND ST_Covers(p.polygon, o.location);
+```
+
+(Same SQL as the M29 runbook. Idempotent.)
+
+## v1.1 follow-ups
+
+- Frame extraction for `.mp4`/`.mov` (currently `status: 'skipped'`)
+- `--station-key <key>` flag to populate `observations.camera_station_id` for M31
+- Web UI drag-and-drop ZIP upload using the same pipeline server-side
+- Concurrent uploads (sequential in v1)
+- HEIC → JPEG conversion (R2 stores any blob; PWA viewer falls back gracefully)

--- a/docs/runbooks/multi-provider-vision.md
+++ b/docs/runbooks/multi-provider-vision.md
@@ -1,0 +1,154 @@
+# Multi-provider vision (M32) — runbook
+
+> **Spec:** [`docs/specs/modules/32-multi-provider-vision.md`](../specs/modules/32-multi-provider-vision.md).
+> **Code:** `supabase/functions/_shared/vision-provider.ts`, `vision-validate.ts`.
+> **Status:** backend complete in v1; UI for credential creation is v1.1.
+
+The provider abstraction lets a sponsor route Anthropic-direct,
+AWS Bedrock, OpenAI, Azure OpenAI, Google Gemini, or Vertex AI calls
+through the same `identify` Edge Function cascade.
+
+## Apply schema
+
+```bash
+make db-apply
+```
+
+Adds 5 enum values to `ai_provider`, 4 to `ai_credential_kind`,
+the `preferred_model` + `endpoint` columns on `sponsor_credentials`,
+and the `consume_pool_slot` RPC for #115. Idempotent.
+
+## Register a credential (no UI yet)
+
+The UI for picking provider/model in `SponsoringView` is v1.1.
+Until then, register credentials via `make db-psql` + Vault. The
+Vault decrypted view (`vault.decrypted_secrets`) is service-role
+only; Supabase Studio's Vault UI is the recommended path for human
+operators.
+
+### Anthropic direct (existing path, no change)
+
+`kind = 'api_key'` or `'oauth_token'`. Secret is the literal API
+key / OAT. `preferred_model` defaults to `claude-haiku-4-5` (the
+direct API accepts the shorthand).
+
+### AWS Bedrock
+
+`kind = 'bedrock'`. The secret is a **JSON envelope**:
+
+```json
+{
+  "region":          "us-east-1",
+  "accessKeyId":     "AKIA…",
+  "secretAccessKey": "…",
+  "sessionToken":    "…optional, for assumed roles…"
+}
+```
+
+Set `preferred_model = 'claude-haiku-4-5'` (Anthropic shorthand —
+the `bedrockModelId()` helper auto-translates to
+`us.anthropic.claude-haiku-4-5-v1:0`) or use the explicit Bedrock
+ID. Set `endpoint` to override the region embedded in the JSON
+(falls back to `us-east-1` if neither is set).
+
+### OpenAI direct
+
+`kind = 'openai_api_key'`. Secret is `sk-…`.
+`preferred_model = 'gpt-4o-mini'` (default) or `'gpt-4o'`.
+`endpoint` NULL → uses `https://api.openai.com/v1/chat/completions`.
+
+### Azure OpenAI
+
+`kind = 'azure_openai'`. Secret is the Azure API key (not a JWT).
+`endpoint` is the **full deployment URL**, e.g.
+
+```
+https://my-resource.openai.azure.com/openai/deployments/my-deployment/chat/completions?api-version=2024-02-01
+```
+
+`preferred_model` is unused at request time (Azure routes by
+deployment name in the URL) but the column is required by the
+schema; set to the deployment name for documentation.
+
+### Google Gemini direct
+
+`kind = 'gemini_api_key'`. Secret is the `AIza…` API key.
+`preferred_model = 'gemini-2.0-flash-exp'` (default).
+`endpoint` NULL → `generativelanguage.googleapis.com`.
+
+### Google Vertex AI
+
+`kind = 'vertex_ai'`. **Operator must mint an OAuth2 access token
+offline** from the service-account JSON (Vertex tokens last 1 hour;
+auto-rotation is a v1.1 follow-up). Secret is the literal access
+token (`ya29.…`).
+
+`preferred_model` is the full model resource path:
+
+```
+projects/<project-id>/locations/us-central1/publishers/google/models/gemini-2.0-flash
+```
+
+`endpoint` is the region (defaults to `us-central1`).
+
+## Validate a credential before storing
+
+`supabase/functions/_shared/vision-validate.ts` exposes
+`validateCredential(kind, secret, opts)` which runs a 1×1-PNG probe
+against the provider's endpoint. Use it from any privileged write
+path that creates a `sponsor_credentials` row:
+
+```typescript
+import { validateCredential } from '../_shared/vision-validate.ts';
+
+const r = await validateCredential('bedrock', jsonEnvelope, {
+  model: 'us.anthropic.claude-haiku-4-5-v1:0',
+});
+if (!r.valid) throw new Error(r.error);
+```
+
+## Resolution order in `identify`
+
+```
+1. BYO key (client_keys.anthropic) — always wins (legacy direct path)
+2. User's personal sponsorship → uses preferred_model + endpoint via buildProvider()
+3. Platform pool — consume_pool_slot() round-robin
+4. Skip Claude (PlantNet only)
+```
+
+## Pool resolution debugging
+
+```sql
+-- Active pools the cascade can pick from
+SELECT id, sponsor_id, used, total_cap, daily_user_cap, preferred_model
+  FROM public.sponsor_pools
+ WHERE status = 'active' AND used < total_cap
+ ORDER BY created_at ASC;
+
+-- A user's daily consumption
+SELECT * FROM public.pool_consumption WHERE user_id = '<uuid>' ORDER BY day DESC LIMIT 7;
+
+-- Force-mark a pool exhausted (operator)
+UPDATE public.sponsor_pools SET status = 'exhausted' WHERE id = '<uuid>';
+```
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Bedrock provider returns null on every call | Sig V4 signing wrong region OR JSON envelope malformed | Verify `parseBedrockSecret(secret)` returns a non-null result; check `region` field matches the Bedrock endpoint URL |
+| Vertex AI returns 401 after working for ~1h | Access token expired | Re-mint the OAuth2 access token from the service-account JSON; v1.1 will auto-rotate |
+| Azure OpenAI 404 | `endpoint` URL doesn't include the deployment path or `?api-version=…` | Copy the full URL including query string from the Azure portal |
+| Pool resolution skips a healthy pool | RLS gate on `sponsor_pools` is owner-only — service role bypasses, but check `status = 'active'` and `used < total_cap` | Toggle status, run `consume_pool_slot()` manually as service_role to confirm |
+| `preferred_model` mismatched for provider type | DEFAULT `'claude-haiku-4-5'` is Anthropic shorthand; non-Anthropic providers need explicit model ID | UPDATE the `preferred_model` after creation; Bedrock auto-translates the shorthand |
+
+## v1.1 follow-ups
+
+- **UI**: provider radio + filtered model dropdown in `SponsoringView`
+- **UI**: "Donate to platform pool" tab + cost-per-100-calls table
+- **Sponsor-facing pool dashboard**: capacity / utilisation / top taxa (no beneficiary breakdown)
+- **Vertex AI auto-rotation**: derive access token from service-account JWT inside the EF
+- **Per-pool monthly reset cron**: honour `sponsor_pools.monthly_reset = true`
+- **`pool_consumption` vacuum cron**: delete rows older than 90 days
+- **Vertex token expiry alert**: notify sponsor 5 minutes before expiry
+- **Pool karma incentives**: "donate calls, earn karma" loop

--- a/docs/runbooks/sponsor-pools.md
+++ b/docs/runbooks/sponsor-pools.md
@@ -1,0 +1,145 @@
+# Platform-wide AI sponsor pool (M32, #115) — runbook
+
+> **Spec:** [`docs/specs/modules/32-multi-provider-vision.md`](../specs/modules/32-multi-provider-vision.md) (M32 includes both multi-provider + the pool).
+> **Schema:** `sponsor_pools`, `pool_consumption`, `consume_pool_slot()` RPC.
+> **Status:** backend complete; UI for sponsor controls is v1.1.
+
+A sponsor donates N calls to a shared pool that any user of the
+platform can draw from — without a 1-to-1 sponsorship. Pool
+beneficiaries are anonymous to the sponsor (only aggregate stats
+visible).
+
+## Resolution order in `identify`
+
+```
+1. BYO key (client_keys.anthropic) — always wins
+2. User's personal M27 sponsorship → uses preferred_model + endpoint
+3. Platform pool — consume_pool_slot() round-robin
+4. Skip Claude (PlantNet only)
+```
+
+`consume_pool_slot()` is `SECURITY DEFINER` + `FOR UPDATE SKIP
+LOCKED`, atomically picks an active pool with capacity AND the
+caller is under their `daily_user_cap`. Returns NULL if either
+check fails — no error thrown, the cascade falls through.
+
+## Create a pool (no UI yet)
+
+The "Donate to platform pool" tab in `SponsoringView` is v1.1.
+Until then, create pools via SQL while signed in as the sponsor:
+
+```sql
+INSERT INTO public.sponsor_pools (
+  sponsor_id, credential_id, total_cap, monthly_reset,
+  preferred_model, daily_user_cap, status
+)
+SELECT auth.uid(),
+       (SELECT id FROM public.sponsor_credentials WHERE label = 'My Anthropic key'),
+       1000,                       -- total_cap: donate 1000 calls
+       true,                       -- monthly_reset: HONORIFIC in v1; cron is v1.1
+       'claude-haiku-4-5',         -- preferred_model
+       10,                         -- daily_user_cap per beneficiary
+       'active';
+```
+
+Note: `monthly_reset = true` does NOT auto-reset `used` to 0 in v1
+(the cron is a v1.1 follow-up). Setting it now is forward-compat;
+the field is honoured the day the cron lands.
+
+## Read aggregate stats (sponsor view)
+
+```sql
+SELECT id, total_cap, used, daily_user_cap, status, created_at
+  FROM public.sponsor_pools
+ WHERE sponsor_id = auth.uid();
+```
+
+Top-detected taxa via this pool (privacy-safe — no beneficiary IDs):
+
+```sql
+SELECT t.scientific_name, COUNT(*) AS detections
+  FROM public.observations o
+  JOIN public.taxa t ON t.id = o.primary_taxon_id
+  -- Pool consumption isn't joined to ai_usage in v1 — this query
+  -- assumes the operator filters by date/sponsor manually. v1.1
+  -- adds a join column on ai_usage.pool_id.
+ WHERE o.created_at >= now() - interval '30 days'
+ GROUP BY t.scientific_name
+ ORDER BY detections DESC
+ LIMIT 20;
+```
+
+## Pause / resume a pool
+
+```sql
+-- Pause (calls fall through to "skip Claude" until resumed)
+UPDATE public.sponsor_pools SET status = 'paused' WHERE id = '<uuid>' AND sponsor_id = auth.uid();
+
+-- Resume
+UPDATE public.sponsor_pools SET status = 'active' WHERE id = '<uuid>' AND sponsor_id = auth.uid();
+
+-- Mark exhausted manually (when the underlying credential is being revoked)
+UPDATE public.sponsor_pools SET status = 'exhausted' WHERE id = '<uuid>' AND sponsor_id = auth.uid();
+```
+
+## Per-user daily cap
+
+Default: 10 calls/day per beneficiary. Anti-Sybil floor — heavy
+users hit the cap and fall through to "skip Claude".
+
+To raise the cap for a specific pool (e.g. researcher pool with
+trusted users):
+
+```sql
+UPDATE public.sponsor_pools
+   SET daily_user_cap = 50
+ WHERE id = '<uuid>' AND sponsor_id = auth.uid();
+```
+
+The cap is enforced atomically by `consume_pool_slot()` — no
+client-side check is honoured. A user can read their own
+`pool_consumption` rows but cannot write to them (RLS
+default-deny on INSERT for `authenticated`; only `service_role`
+writes via the RPC).
+
+## Vacuum the consumption ledger
+
+`pool_consumption` accumulates one row per (user, day) pair. Old
+rows past the rolling reset window are dead weight. Until the v1.1
+cron lands, run periodically:
+
+```sql
+DELETE FROM public.pool_consumption
+ WHERE day < current_date - 90;
+```
+
+90 days is generous; a 30-day window is also reasonable since the
+daily cap only consults `day = current_date`.
+
+## Privacy invariant
+
+Sponsors **never** see which user_ids consumed their pool. The
+`pool_consumption` table is queryable by service_role only (writes)
+and self-only (reads). No RPC joins `pool_consumption` to
+`auth.users`. Aggregate-only sponsor dashboards must use
+`observations` joined to `taxa`.
+
+If a sponsor demands beneficiary-level visibility for compliance
+reasons (e.g. NPO grant reporting), open a separate spec — v1
+deliberately doesn't support this.
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `consume_pool_slot()` always returns empty | No pool with `status='active'` AND `used < total_cap`, OR caller hit their daily cap | Verify a pool exists; check `pool_consumption` for the caller's day |
+| Sponsor-side dashboard shows `used` not incrementing | `consume_pool_slot()` raised an exception inside the EF — check `[identify] consume_pool_slot failed` warnings in EF logs | Ensure `service_role` has EXECUTE on the RPC; check Vault decryption isn't failing |
+| Pool exhausted but `status` still `active` | The "mark exhausted" UPDATE inside the RPC is best-effort and races with the `used + 1` UPDATE in pathological concurrency | Run the manual exhaust UPDATE above |
+
+## v1.1 follow-ups
+
+- UI for "Donate to platform pool" + sponsor dashboard
+- `monthly_reset` cron — first-of-month resets `used` to 0 where flag is true
+- `pool_consumption` vacuum cron — drop rows > 90 days old
+- Pool karma incentives (donate calls → earn karma)
+- `ai_usage.pool_id` column so per-pool taxon stats can join cleanly


### PR DESCRIPTION
## Summary

Closes the documentation gap from the v1.2 research-workflow + multi-provider-vision push. The modules shipped in PRs #132 / #134 / #141 / #143 / #145 had specs and roadmap entries but no operator runbooks and no agent-briefing sections.

## What's new

- **4 runbooks**: `cli-batch-import.md`, `camera-stations.md`, `multi-provider-vision.md`, `sponsor-pools.md`
- **CLAUDE.md** sections under Conventions for M29 / M30 / M31 / M32 with the load-bearing rules each module enforces
- **architecture.md** — two new sections with ASCII diagrams: research-workflow (polygon trigger + station tagging + CLI flow) and multi-provider-vision (buildProvider dispatch + pool resolution waterfall)
- CLAUDE.md `cli/` directory now appears in the architecture cheatsheet, doc-sync date bumped

## Why these 4 runbooks specifically

Operators creating a Bedrock credential need to know the JSON envelope shape (not in any current doc), Azure operators need to know the full-deployment-URL convention, Vertex operators need to know about the offline-token requirement. The CLI runbook captures the install + token-generation flow that's currently only in the README. The pool runbook captures the SQL-only creation path that exists until the v1.1 UI lands.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` — 168 pages, EN/ES paired
- [x] All new markdown links verified manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)