### PR TITLE
chore(ops): M32 pool crons + Vertex token monitor + CLI in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,20 @@ jobs:
       - name: Unit tests (Vitest)
         run: npm test
 
+      - name: CLI build + tests (cli/, M30)
+        # Skipped if cli/ is missing on the branch; otherwise installs,
+        # builds, and runs the Node native test runner. Matches what
+        # operators run locally — keeps the M30 surface gated by CI.
+        run: |
+          if [ -d cli ]; then
+            cd cli
+            npm install --no-audit --no-fund
+            npm run build
+            npm test
+          else
+            echo "cli/ not present on this branch — skipping"
+          fi
+
       - name: Build (static site)
         run: npm run build
         env:

--- a/docs/specs/infra/cron-schedules.sql
+++ b/docs/specs/infra/cron-schedules.sql
@@ -239,3 +239,62 @@ SELECT cron.unschedule('ai_errors_log_cleanup')
   WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ai_errors_log_cleanup');
 SELECT cron.schedule('ai_errors_log_cleanup', '23 3 * * *',
   $$DELETE FROM public.ai_errors_log WHERE occurred_at < now() - interval '30 days'$$);
+
+-- ─────────────────────────────────────────────────────────────────
+-- M32 — sponsor_pools.monthly_reset (#153)
+-- First-of-month at 00:05 UTC: reset `used` to 0 + flip exhausted →
+-- active for any pool with monthly_reset = true. Idempotent —
+-- pools without the flag are untouched.
+-- ─────────────────────────────────────────────────────────────────
+SELECT cron.unschedule('sponsor_pools_monthly_reset')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'sponsor_pools_monthly_reset');
+SELECT cron.schedule('sponsor_pools_monthly_reset', '5 0 1 * *',
+  $$UPDATE public.sponsor_pools
+       SET used = 0,
+           status = CASE WHEN status = 'exhausted' THEN 'active' ELSE status END,
+           updated_at = now()
+     WHERE monthly_reset = true
+       AND status IN ('active','exhausted')$$);
+
+-- ─────────────────────────────────────────────────────────────────
+-- M32 — pool_consumption vacuum (#154)
+-- Daily at 03:30 UTC: drop rows older than 90 days. The daily-cap
+-- check in `consume_pool_slot()` only consults `day = current_date`,
+-- so older rows are pure dead weight.
+-- ─────────────────────────────────────────────────────────────────
+SELECT cron.unschedule('pool_consumption_vacuum')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pool_consumption_vacuum');
+SELECT cron.schedule('pool_consumption_vacuum', '30 3 * * *',
+  $$DELETE FROM public.pool_consumption WHERE day < current_date - 90$$);
+
+-- ─────────────────────────────────────────────────────────────────
+-- M32 — Vertex AI access-token expiry monitor (#159)
+-- Every 10 min: notify the sponsor if any vertex_ai credential's
+-- stored access token expires within the next 5 minutes. A no-op if
+-- the credential is already covered by the auto-rotation work
+-- (#155); operator should disable this cron once #155 lands.
+-- ─────────────────────────────────────────────────────────────────
+SELECT cron.unschedule('vertex_token_expiry_monitor')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'vertex_token_expiry_monitor');
+SELECT cron.schedule('vertex_token_expiry_monitor', '*/10 * * * *',
+  $$INSERT INTO public.notifications (user_id, kind, payload)
+    SELECT c.user_id, 'vertex_token_expiring',
+           jsonb_build_object(
+             'credential_id', c.id,
+             'label', c.label,
+             'expires_at', c.token_expires_at,
+             'minutes_left', EXTRACT(EPOCH FROM (c.token_expires_at - now())) / 60
+           )
+      FROM public.sponsor_credentials c
+     WHERE c.kind = 'vertex_ai'
+       AND c.revoked_at IS NULL
+       AND c.token_expires_at IS NOT NULL
+       AND c.token_expires_at < now() + interval '5 minutes'
+       AND c.token_expires_at > now()
+       AND NOT EXISTS (
+         SELECT 1 FROM public.notifications n
+          WHERE n.user_id = c.user_id
+            AND n.kind = 'vertex_token_expiring'
+            AND n.payload->>'credential_id' = c.id::text
+            AND n.created_at > now() - interval '15 minutes'
+       )$$);

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3065,7 +3065,8 @@ CREATE TABLE IF NOT EXISTS public.notifications (
   user_id     uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
   kind        text        NOT NULL
                           CHECK (kind IN ('follow','follow_accepted','reaction','comment','mention',
-                                          'identification','badge','digest')),
+                                          'identification','badge','digest',
+                                          'vertex_token_expiring')),
   payload     jsonb       NOT NULL DEFAULT '{}',
   read_at     timestamptz,
   created_at  timestamptz NOT NULL DEFAULT now()
@@ -3074,6 +3075,21 @@ CREATE INDEX IF NOT EXISTS idx_notifications_user_unread
   ON public.notifications(user_id, read_at) WHERE read_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_notifications_user_created
   ON public.notifications(user_id, created_at DESC);
+
+-- M32 v1.1 (#159): widen the kind CHECK to include
+-- 'vertex_token_expiring'. Idempotent — drops the existing
+-- constraint by name (auto-named when CREATE TABLE first ran) then
+-- adds the new one. Existing rows are unchanged.
+DO $$
+BEGIN
+  ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_kind_check;
+EXCEPTION WHEN others THEN NULL; END $$;
+ALTER TABLE public.notifications
+  ADD CONSTRAINT notifications_kind_check CHECK (
+    kind IN ('follow','follow_accepted','reaction','comment','mention',
+             'identification','badge','digest',
+             'vertex_token_expiring')
+  );
 
 ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
 
@@ -3633,7 +3649,11 @@ ALTER TABLE public.sponsor_credentials
   ADD COLUMN IF NOT EXISTS preferred_model text NOT NULL DEFAULT 'claude-haiku-4-5'
     CHECK (length(preferred_model) BETWEEN 1 AND 64),
   ADD COLUMN IF NOT EXISTS endpoint        text
-    CHECK (endpoint IS NULL OR length(endpoint) <= 512);
+    CHECK (endpoint IS NULL OR length(endpoint) <= 512),
+  -- M32 v1.1 (#159): track when a Vertex AI access token expires
+  -- so the `vertex_token_expiry_monitor` cron can notify the
+  -- sponsor 5 minutes before. NULL for non-Vertex credentials.
+  ADD COLUMN IF NOT EXISTS token_expires_at timestamptz;
 
 ALTER TABLE public.sponsor_credentials ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS sponsor_credentials_owner_read ON public.sponsor_credentials;


### PR DESCRIPTION
## Summary

Bundles four small ops follow-ups:
- **#153** — `sponsor_pools_monthly_reset` cron (1st of month at 00:05 UTC)
- **#154** — `pool_consumption_vacuum` cron (daily at 03:30 UTC, drops rows > 90 days)
- **#159** — Vertex AI token-expiry monitor (every 10 min, notifies sponsor 5 min before expiry; stop-gap until #155 lands)
- **#157** — Root CI now runs `cd cli && npm test` after the Vitest gate

## Schema

- `sponsor_credentials.token_expires_at timestamptz` (NULL for non-Vertex; populated by the credential-storage path when #155 lands or by the operator on manual rotation today)
- `notifications.kind` CHECK extended with `'vertex_token_expiring'` via idempotent DROP+ADD constraint

## Test plan

- [x] `npm run typecheck` clean
- [x] Root vitest 660/660
- [x] `cd cli && npm test` 14/14
- [ ] Schema CI gate verifies the new constraint + columns apply twice
- [ ] After deploy, `make db-cron-test` shows the new jobs registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)