### PR TITLE
feat(api,cli): /api/observe + camera_station_id (M31 v1.1, #156)

### DIFF
--- a/cli/src/api-client.ts
+++ b/cli/src/api-client.ts
@@ -61,6 +61,11 @@ export class ApiClient {
     habitat?: string | null;
     evidence_type?: string;
     scientific_name?: string;
+    /** M31 v1.1 (#156): server-side station lookup via (slug, key). */
+    project_slug?: string;
+    station_key?: string;
+    /** Or pass the UUID directly if you already have it. */
+    camera_station_id?: string;
   }): Promise<ObserveResponse> {
     return this.post<ObserveResponse>('observe', input);
   }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -24,6 +24,11 @@ export interface RunOpts {
   skipIdentify: boolean;
   /** Notes string applied to every observation (e.g. station code). */
   notes?: string;
+  /** Camera station tagging (M31 / issue #156). The CLI passes
+   *  `(project_slug, station_key)` to `/api/observe`; the EF
+   *  resolves the station UUID server-side under RLS. */
+  projectSlug?: string;
+  stationKey?: string;
   /** Print 1-line per file instead of just summary every 10. */
   verbose: boolean;
 }
@@ -109,6 +114,8 @@ async function processOne(
       observed_at: exif.capturedAtIso,
       photo_url: presigned.public_url,
       notes: opts.notes,
+      project_slug: opts.projectSlug,
+      station_key: opts.stationKey,
     });
     obsId = obs.id;
   } catch (err) {
@@ -191,6 +198,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const token = String(args.token ?? process.env.RASTRUM_TOKEN ?? '');
   if (!token.startsWith('rst_')) throw new Error('Missing --token rst_… or RASTRUM_TOKEN env (must start with rst_)');
   const logPath = String(args.log ?? `${dir.replace(/\/$/, '')}/import-log.json`);
+  const projectSlug = pickString(args, 'project-slug', 'projectSlug');
+  const stationKey  = pickString(args, 'station-key',  'stationKey');
+  if (stationKey && !projectSlug) {
+    throw new Error('--station-key requires --project-slug (the EF resolves stations by project + key pair)');
+  }
   return {
     dir,
     logPath,
@@ -199,6 +211,16 @@ export function parseArgs(argv: string[]): ParsedArgs {
     dryRun: args['dry-run'] === true || args.dryRun === true,
     skipIdentify: args['skip-identify'] === true || args.skipIdentify === true,
     notes: typeof args.notes === 'string' ? args.notes : undefined,
+    projectSlug,
+    stationKey,
     verbose: args.verbose === true || args.v === true,
   };
+}
+
+function pickString(args: Record<string, string | boolean>, ...keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = args[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
 }

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -66,4 +66,26 @@ describe('parseArgs', () => {
     delete process.env.RASTRUM_BASE_URL;
     delete process.env.RASTRUM_TOKEN;
   });
+
+  it('accepts --project-slug and --station-key together', () => {
+    const args = parseArgs([
+      '--dir', '/sd',
+      '--baseUrl', 'https://x/',
+      '--token', FAKE_TOKEN,
+      '--project-slug', 'anp-sierra-juarez',
+      '--station-key',  'SJ-CAM-01',
+    ]);
+    assert.equal(args.projectSlug, 'anp-sierra-juarez');
+    assert.equal(args.stationKey,  'SJ-CAM-01');
+  });
+
+  it('rejects --station-key without --project-slug', () => {
+    assert.throws(
+      () => parseArgs([
+        '--dir', '/sd', '--baseUrl', 'https://x/', '--token', FAKE_TOKEN,
+        '--station-key', 'SJ-CAM-01',
+      ]),
+      /project-slug/
+    );
+  });
 });

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -74,8 +74,33 @@ Deno.serve(async (req: Request) => {
     const body = await req.json().catch(() => null);
     if (!body) return json({ error: 'Invalid JSON body' }, 400);
 
-    const { lat, lng, observed_at, notes, photo_url, habitat, evidence_type = 'direct_sighting' } = body;
+    const { lat, lng, observed_at, notes, photo_url, habitat, evidence_type = 'direct_sighting',
+            camera_station_id, project_slug } = body;
     if (lat == null || lng == null) return json({ error: 'lat and lng are required' }, 400);
+
+    // M31 v1.1 (#156): resolve a camera station explicitly by UUID,
+    // or by (project_slug, station_key) — the second form is what the
+    // CLI uses so the importer doesn't need to know the UUIDs ahead
+    // of time. RLS gates the lookup; if the caller can't see the
+    // station, we silently drop the assignment instead of leaking the
+    // existence of a private station.
+    let resolvedStationId: string | null = null;
+    if (typeof camera_station_id === 'string' && camera_station_id.length > 0) {
+      const { data: stationRow } = await supabase
+        .from('camera_stations')
+        .select('id')
+        .eq('id', camera_station_id)
+        .maybeSingle();
+      resolvedStationId = (stationRow as { id?: string } | null)?.id ?? null;
+    } else if (typeof project_slug === 'string' && typeof body.station_key === 'string') {
+      const { data: stationRow } = await supabase
+        .from('camera_stations')
+        .select('id, project_id, projects!inner(slug)')
+        .eq('station_key', body.station_key)
+        .eq('projects.slug', project_slug)
+        .maybeSingle();
+      resolvedStationId = (stationRow as { id?: string } | null)?.id ?? null;
+    }
 
     // observations table has no scientific_name — insert bare observation,
     // then create an identification row if a name was supplied.
@@ -89,10 +114,11 @@ Deno.serve(async (req: Request) => {
         notes,
         habitat,
         evidence_type,
+        camera_station_id: resolvedStationId,
         app_version: 'api/v1',
         sync_status: 'synced',
       })
-      .select('id, observed_at, created_at')
+      .select('id, observed_at, created_at, camera_station_id')
       .single();
 
     if (obsErr) return json({ error: obsErr.message }, 500);


### PR DESCRIPTION
## Summary

- `/api/observe` accepts `camera_station_id` (UUID) OR `(project_slug, station_key)` pair; server resolves under RLS
- CLI `rastrum-import` adds `--project-slug` + `--station-key` flags (validated together)
- `ApiClient.observe()` extended; 2 new parser tests

Closes #156.

## Test plan

- [x] `npm run typecheck` clean
- [x] Root vitest 660/660
- [x] CLI: 16/16 (was 14/14, +2 new for the flag pair)
- [ ] Manual: register an M31 station via SQL, run `rastrum-import` with the flags, confirm `observations.camera_station_id` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)