### PR TITLE
feat(vision): Vertex AI access-token auto-rotation (M32 v1.1, #155)

### DIFF
--- a/supabase/functions/_shared/vertex-token.test.ts
+++ b/supabase/functions/_shared/vertex-token.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { parseServiceAccount, clearCache } from './vertex-token.ts';
+
+Deno.test('parseServiceAccount — accepts a well-formed envelope', () => {
+  const sa = parseServiceAccount(JSON.stringify({
+    type: 'service_account',
+    project_id: 'my-proj',
+    private_key_id: 'kid-1',
+    private_key: '-----BEGIN PRIVATE KEY-----\n…\n-----END PRIVATE KEY-----\n',
+    client_email: 'svc@my-proj.iam.gserviceaccount.com',
+  }));
+  assertEquals(sa?.project_id, 'my-proj');
+  assertEquals(sa?.client_email, 'svc@my-proj.iam.gserviceaccount.com');
+});
+
+Deno.test('parseServiceAccount — rejects when type is not service_account', () => {
+  const sa = parseServiceAccount(JSON.stringify({
+    type: 'authorized_user',
+    project_id: 'x',
+    private_key: 'x',
+    client_email: 'x',
+  }));
+  assertEquals(sa, null);
+});
+
+Deno.test('parseServiceAccount — rejects when required fields are missing', () => {
+  assertEquals(parseServiceAccount('{}'), null);
+  assertEquals(parseServiceAccount('{"type":"service_account"}'), null);
+  assertEquals(parseServiceAccount(JSON.stringify({
+    type: 'service_account',
+    project_id: 'x',
+    private_key_id: 'k',
+    private_key: 'pk',
+    // missing client_email
+  })), null);
+});
+
+Deno.test('parseServiceAccount — null on malformed JSON', () => {
+  assertEquals(parseServiceAccount(''), null);
+  assertEquals(parseServiceAccount('not json'), null);
+  assertEquals(parseServiceAccount('ya29.legacy-access-token'), null);
+});
+
+Deno.test('clearCache — does not throw on empty cache', () => {
+  clearCache();
+  clearCache();
+});

--- a/supabase/functions/_shared/vertex-token.ts
+++ b/supabase/functions/_shared/vertex-token.ts
@@ -1,0 +1,149 @@
+/**
+ * Google Vertex AI access-token auto-rotation (#155).
+ *
+ * Vertex tokens last 1 hour; v1 of M32 expected operators to mint
+ * the token offline and store the literal `ya29.…` string. This
+ * helper instead accepts a service-account JSON envelope, signs a
+ * JWT inside the Edge Function, exchanges it at
+ * `https://oauth2.googleapis.com/token`, and caches the resulting
+ * access token in-process for ~50 minutes (5-minute safety margin).
+ *
+ * Cache key is `client_email + scope` so multiple beneficiaries on
+ * the same Vertex credential share a token. Cache is per-EF-instance
+ * (Deno isolates) — there's no cross-instance shared cache; a cold
+ * isolate just mints a fresh token.
+ */
+
+export interface ServiceAccountJSON {
+  type: 'service_account';
+  project_id: string;
+  private_key_id: string;
+  /** PEM-encoded RSA private key, with `\n` newlines. */
+  private_key: string;
+  client_email: string;
+  client_id?: string;
+  token_uri?: string;
+}
+
+export interface VertexAccessToken {
+  access_token: string;
+  expires_at: number; // ms epoch
+}
+
+/**
+ * Parse a service-account JSON envelope. Returns null when the
+ * required fields are missing or the input is malformed.
+ */
+export function parseServiceAccount(secret: string): ServiceAccountJSON | null {
+  try {
+    const o = JSON.parse(secret) as Partial<ServiceAccountJSON>;
+    if (o.type !== 'service_account') return null;
+    if (typeof o.private_key  !== 'string') return null;
+    if (typeof o.client_email !== 'string') return null;
+    if (typeof o.project_id   !== 'string') return null;
+    return o as ServiceAccountJSON;
+  } catch {
+    return null;
+  }
+}
+
+const tokenCache = new Map<string, VertexAccessToken>();
+const SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+/** Refresh when the cached token has < 5 minutes of life left. */
+const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+/**
+ * Get a valid access token for the supplied service-account.
+ * Mints a new one when the cache is empty or the cached token is
+ * close to expiry. Throws on JWT signing or token-exchange failure.
+ */
+export async function getAccessToken(sa: ServiceAccountJSON): Promise<VertexAccessToken> {
+  const key = `${sa.client_email}|${SCOPE}`;
+  const cached = tokenCache.get(key);
+  if (cached && cached.expires_at - Date.now() > REFRESH_MARGIN_MS) {
+    return cached;
+  }
+  const fresh = await mintAccessToken(sa);
+  tokenCache.set(key, fresh);
+  return fresh;
+}
+
+/** Force-refresh — used by validators that need to confirm the
+ *  service-account works without consulting the cache. */
+export async function mintAccessToken(sa: ServiceAccountJSON): Promise<VertexAccessToken> {
+  const now  = Math.floor(Date.now() / 1000);
+  const exp  = now + 3600;  // GCP allows up to 1 hour
+  const header  = { alg: 'RS256', typ: 'JWT', kid: sa.private_key_id };
+  const payload = {
+    iss: sa.client_email,
+    scope: SCOPE,
+    aud: sa.token_uri ?? 'https://oauth2.googleapis.com/token',
+    exp,
+    iat: now,
+  };
+
+  const encodedHeader  = base64url(new TextEncoder().encode(JSON.stringify(header)));
+  const encodedPayload = base64url(new TextEncoder().encode(JSON.stringify(payload)));
+  const toSign = `${encodedHeader}.${encodedPayload}`;
+  const signature = await rsaSha256Sign(toSign, sa.private_key);
+  const jwt = `${toSign}.${signature}`;
+
+  const res = await fetch(sa.token_uri ?? 'https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Vertex token exchange failed: ${res.status} ${text.slice(0, 200)}`);
+  }
+  const json = await res.json() as { access_token: string; expires_in: number };
+  return {
+    access_token: json.access_token,
+    expires_at: Date.now() + (json.expires_in * 1000),
+  };
+}
+
+/** Drop a cached token — used in tests or after a credential is revoked. */
+export function clearCache(): void {
+  tokenCache.clear();
+}
+
+// ── PEM + crypto helpers ────────────────────────────────────────────
+
+function base64url(bytes: Uint8Array): string {
+  let s = '';
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function pemToDer(pem: string): Uint8Array {
+  const cleaned = pem
+    .replace(/-----BEGIN [^-]+-----/g, '')
+    .replace(/-----END [^-]+-----/g,   '')
+    .replace(/\s+/g, '');
+  const bin = atob(cleaned);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+async function rsaSha256Sign(data: string, pem: string): Promise<string> {
+  const der = pemToDer(pem);
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    der as unknown as ArrayBuffer,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    new TextEncoder().encode(data),
+  );
+  return base64url(new Uint8Array(sig));
+}

--- a/supabase/functions/_shared/vision-provider.ts
+++ b/supabase/functions/_shared/vision-provider.ts
@@ -16,6 +16,8 @@
  * downstream parser sees the same shape regardless of vendor.
  */
 
+import { parseServiceAccount, getAccessToken } from './vertex-token.ts';
+
 export type CredentialKind =
   | 'api_key'              // Anthropic direct
   | 'oauth_token'          // Anthropic direct (OAT)
@@ -407,19 +409,38 @@ class GeminiProvider implements VisionProvider {
 class VertexAIProvider implements VisionProvider {
   constructor(private readonly cred: ResolvedCredential) {}
 
-  // Vertex AI requires an OAuth2 access token derived from a service-
-  // account JSON. Deriving the JWT inside an Edge Function is non-
-  // trivial; v1 expects the operator to mint the access token offline
-  // and store it as `secret`. We bump validity in the validator (see
-  // vision-validate.ts).
+  // Vertex AI auto-rotation (#155): when the secret is a
+  // service-account JSON envelope, the provider mints an OAuth2
+  // access token via JWT-bearer flow and caches it for ~50 min in
+  // the EF instance. When the secret is a literal `ya29.…` access
+  // token (legacy v1 path), we use it directly — operators on the
+  // legacy path are responsible for rotation themselves until they
+  // migrate to the JSON envelope.
   async identify(input: VisionInput): Promise<VisionResult | null> {
     const region = this.cred.endpoint || 'us-central1';
     const url = `https://${region}-aiplatform.googleapis.com/v1/${this.cred.model}:streamGenerateContent`;
+    const accessToken = await this.resolveAccessToken();
+    if (!accessToken) return null;
     const headers: Record<string, string> = {
-      'Authorization': `Bearer ${this.cred.secret}`,
+      'Authorization': `Bearer ${accessToken}`,
       'Content-Type':  'application/json',
     };
     return await callGeminiCompatible(url, headers, input, 'vertex_ai');
+  }
+
+  private async resolveAccessToken(): Promise<string | null> {
+    const sa = parseServiceAccount(this.cred.secret);
+    if (sa) {
+      try {
+        const t = await getAccessToken(sa);
+        return t.access_token;
+      } catch (err) {
+        console.warn(`[vertex] auto-rotation failed: ${(err as Error).message}`);
+        return null;
+      }
+    }
+    // Legacy: secret is a literal access token.
+    return this.cred.secret.trim().length > 0 ? this.cred.secret : null;
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces the operator-mints-offline contract with auto-rotation when the Vertex credential secret is a service-account JSON envelope.

Closes #155.

## What's new

- `_shared/vertex-token.ts` — `parseServiceAccount`, `getAccessToken`, hand-rolled RS256 JWT signing via `crypto.subtle`. Cache per (client_email, scope) with 5-min refresh margin. ~150 LOC.
- `VertexAIProvider.resolveAccessToken()` tries the service-account path first, falls back to the legacy literal access token.
- 5 unit tests for `parseServiceAccount`.

## Backwards-compat

Operators on the legacy path (literal `ya29.…` token) keep working — `parseServiceAccount` returns null for non-JSON secrets and the provider falls through. No coercion required.

## Test plan

- [x] `npm run typecheck` clean
- [x] Root vitest 660/660
- [ ] Manual: create a service-account, store its JSON as a Vertex credential, run `force_provider=claude_haiku` against `identify` for 90+ minutes; first call mints, subsequent calls hit cache, eventual refresh happens transparently
- [ ] Verify cached token is dropped 5 min before expiry (no early-401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)