### PR TITLE
ci(vision): end-to-end probe workflow per provider (M32 v1.1, #158)

### DIFF
--- a/.github/workflows/vision-providers-smoke.yml
+++ b/.github/workflows/vision-providers-smoke.yml
@@ -1,0 +1,79 @@
+name: vision-providers-smoke
+
+# End-to-end probe of every M32 vision provider against its real API
+# (issue #158). The goal is to catch silent breakage in any provider's
+# auth-header / request-shape / response-shape handling — the unit
+# tests in `_shared/vision-provider.test.ts` only cover pure helpers.
+#
+# Triggers:
+#   - Manual workflow_dispatch (any time)
+#   - Nightly cron at 04:00 UTC (after the daily db-apply settles)
+#
+# Required secrets (per-provider, set under VISION_PROVIDERS_TEST_*):
+#   ANTHROPIC_API_KEY     — sk-ant-api03-…
+#   ANTHROPIC_OAT         — sk-ant-oat01-…  (optional; falls back to api key path)
+#   BEDROCK_JSON          — {"region":"us-east-1","accessKeyId":"…","secretAccessKey":"…"}
+#   OPENAI_API_KEY        — sk-…
+#   AZURE_OPENAI_KEY + AZURE_OPENAI_ENDPOINT
+#   GEMINI_API_KEY        — AIza…
+#   VERTEX_SA_JSON        — service-account JSON envelope
+#
+# Each probe is allowed to fail independently — the workflow reports
+# per-provider PASS / FAIL but doesn't fail the whole job unless ALL
+# providers fail (catching a regression in the abstraction itself).
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v1.x
+
+      - name: Run per-provider probe
+        env:
+          ANTHROPIC_API_KEY:    ${{ secrets.VISION_PROVIDERS_TEST_ANTHROPIC_API_KEY }}
+          ANTHROPIC_OAT:        ${{ secrets.VISION_PROVIDERS_TEST_ANTHROPIC_OAT }}
+          BEDROCK_JSON:         ${{ secrets.VISION_PROVIDERS_TEST_BEDROCK_JSON }}
+          OPENAI_API_KEY:       ${{ secrets.VISION_PROVIDERS_TEST_OPENAI_API_KEY }}
+          AZURE_OPENAI_KEY:     ${{ secrets.VISION_PROVIDERS_TEST_AZURE_OPENAI_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.VISION_PROVIDERS_TEST_AZURE_OPENAI_ENDPOINT }}
+          GEMINI_API_KEY:       ${{ secrets.VISION_PROVIDERS_TEST_GEMINI_API_KEY }}
+          VERTEX_SA_JSON:       ${{ secrets.VISION_PROVIDERS_TEST_VERTEX_SA_JSON }}
+        run: deno run --allow-net --allow-env scripts/vision-providers-smoke.ts | tee smoke-results.txt
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo '## Vision providers smoke test'
+            echo ''
+            echo '```'
+            cat smoke-results.txt 2>/dev/null || echo '(no results)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail when ALL providers failed
+        if: always()
+        run: |
+          if [ ! -f smoke-results.txt ]; then
+            echo "no results file — failing"
+            exit 1
+          fi
+          # The script writes one line per provider: PASS|FAIL <provider> <message>
+          if ! grep -q '^PASS' smoke-results.txt; then
+            echo "all providers failed — abstraction-level regression"
+            exit 1
+          fi

--- a/scripts/vision-providers-smoke.ts
+++ b/scripts/vision-providers-smoke.ts
@@ -1,0 +1,69 @@
+/**
+ * Vision-providers end-to-end smoke probe (#158).
+ *
+ * For each provider whose secrets are present in env, calls
+ * `validateCredential(kind, secret, opts)` against the real API and
+ * prints PASS / FAIL on stdout. Exit code is set by the caller
+ * workflow based on whether at least one provider passed.
+ *
+ * Run locally:
+ *   ANTHROPIC_API_KEY=… deno run --allow-net --allow-env scripts/vision-providers-smoke.ts
+ */
+
+import { validateCredential } from '../supabase/functions/_shared/vision-validate.ts';
+import type { CredentialKind } from '../supabase/functions/_shared/vision-provider.ts';
+
+interface Probe {
+  name: string;
+  kind: CredentialKind;
+  envKey: string;
+  endpointEnvKey?: string;
+  /** Optional model override; defaults via defaultModelFor() in the validator. */
+  model?: string;
+  /** Optional secret transformer (e.g. for Azure: pull from a different env). */
+  resolveSecret?: (env: Record<string, string | undefined>) => string | null;
+}
+
+const probes: Probe[] = [
+  { name: 'anthropic-direct (api_key)', kind: 'api_key',     envKey: 'ANTHROPIC_API_KEY' },
+  { name: 'anthropic-direct (oat)',     kind: 'oauth_token', envKey: 'ANTHROPIC_OAT'     },
+  { name: 'bedrock',                    kind: 'bedrock',     envKey: 'BEDROCK_JSON'      },
+  { name: 'openai',                     kind: 'openai_api_key', envKey: 'OPENAI_API_KEY' },
+  {
+    name: 'azure-openai',
+    kind: 'azure_openai',
+    envKey: 'AZURE_OPENAI_KEY',
+    endpointEnvKey: 'AZURE_OPENAI_ENDPOINT',
+    resolveSecret: (env) => env['AZURE_OPENAI_KEY'] ?? null,
+  },
+  { name: 'gemini-direct',              kind: 'gemini_api_key', envKey: 'GEMINI_API_KEY' },
+  { name: 'vertex-ai (sa-json)',        kind: 'vertex_ai',      envKey: 'VERTEX_SA_JSON' },
+];
+
+const env = Deno.env.toObject();
+let anyPresent = false;
+
+for (const p of probes) {
+  const secret = (p.resolveSecret ? p.resolveSecret(env) : env[p.envKey]) ?? null;
+  if (!secret) {
+    console.log(`SKIP ${p.name} (env ${p.envKey} unset)`);
+    continue;
+  }
+  anyPresent = true;
+  const endpoint = p.endpointEnvKey ? env[p.endpointEnvKey] : undefined;
+  try {
+    const r = await validateCredential(p.kind, secret, { model: p.model, endpoint });
+    if (r.valid) {
+      console.log(`PASS ${p.name}`);
+    } else {
+      console.log(`FAIL ${p.name} (${r.error ?? 'unknown'})`);
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.log(`FAIL ${p.name} (exception: ${msg})`);
+  }
+}
+
+if (!anyPresent) {
+  console.log('SKIP all (no provider secrets present in env)');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist", "supabase/functions"]
+  "exclude": [
+    "dist",
+    "supabase/functions",
+    "scripts/vision-providers-smoke.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- `scripts/vision-providers-smoke.ts` runs `validateCredential()` against each of the 6 M32 providers when its secret is in env
- `.github/workflows/vision-providers-smoke.yml` triggers on `workflow_dispatch` + nightly 04:00 UTC
- Per-provider PASS/FAIL/SKIP reported in job summary; whole job only fails when EVERY provider fails (signals abstraction-level regression)

Closes #158.

## Operator setup

Set these as repository secrets under `VISION_PROVIDERS_TEST_*`:

| Provider | Secret(s) |
|---|---|
| Anthropic direct (api_key) | `ANTHROPIC_API_KEY` |
| Anthropic direct (oat) | `ANTHROPIC_OAT` |
| AWS Bedrock | `BEDROCK_JSON` (`{"region":"us-east-1","accessKeyId":"…","secretAccessKey":"…"}`) |
| OpenAI | `OPENAI_API_KEY` |
| Azure OpenAI | `AZURE_OPENAI_KEY` + `AZURE_OPENAI_ENDPOINT` |
| Gemini | `GEMINI_API_KEY` |
| Vertex AI | `VERTEX_SA_JSON` (service-account JSON) |

Missing secrets → that provider is skipped, not failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)