### PR TITLE
fix(community): observers UX — privacy explainer + country CTA + GPS-based Nearby

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,6 +363,14 @@ Three load-bearing rules:
    cron sets `country_code` from `region_primary` only when NULL;
    Profile → Edit save flips `country_code_source` to `'user'`. Badge
    shows in the picker when `source='auto' AND country_code IS NOT NULL`.
+4. **GPS coords for "Use my location" Nearby live in `sessionStorage`
+   only — NEVER the URL querystring.** Putting them in `?lat=…&lng=…`
+   would leak via the `Referer` header and the browser's history. The
+   storage key is `rastrum.community.gps`; cleared on tab close. The
+   `community_observers_nearby_at(lat, lng, …)` RPC takes coords
+   per-call, never persisting server-side. Regression guard:
+   `tests/unit/community-url.test.ts` asserts the serializer drops
+   any `lat`/`lng`/`gps` keys.
 
 Cron + manual fire: [`docs/runbooks/community-discovery.md`](docs/runbooks/community-discovery.md).
 

--- a/docs/runbooks/community-discovery.md
+++ b/docs/runbooks/community-discovery.md
@@ -98,6 +98,53 @@ Profile → Edit toggle.
 | #102 | merged 2026-04-29 | PR4 — Profile → Edit country picker + `hide_from_leaderboards` toggle + `country_code_source` |
 | PR5+PR6 | merged 2026-04-29 | Atomic landing — `/community/observers/` page (CSR) + composable filter chips + URL-state serializer + `community_observers_nearby` SQL RPC + MegaMenu split (Biodiversity / Community columns) + MobileDrawer subheading + atomic i18n rewrite of the two production "no leaderboards" strings + OG card + Vitest + Playwright e2e + module status flip to "shipped" |
 
+## UX clarifications (PR17, 2026-04-30)
+
+### Why am I the only one I see? — privacy-default explainer
+
+`users.profile_public` defaults to **false**. Both community views filter
+on `profile_public = true AND hide_from_leaderboards = false`, so a brand-new
+user looking at `/community/observers/` sees only themselves until others
+opt in.
+
+This used to look like a broken page. As of PR17 the page renders an explicit
+amber explainer banner whenever the filter combo returns 0 rows AND the
+viewer is signed in:
+
+- **Profile is also private** → "Your profile is also private — flip the toggle…"
+- **Profile is public** → "Most observers haven't enabled their public profile yet…"
+
+A "Configure your own profile →" link points to `/profile/edit/`. Anon users
+already get the existing sign-in CTAs and don't need a second nudge.
+
+### GPS vs centroid Nearby modes
+
+The Nearby filter (`?nearby=true`) has two underlying paths:
+
+1. **Centroid mode (default)** — calls `community_observers_nearby()`,
+   which reads the viewer's stored `centroid_geog` (recomputed nightly
+   from their observations). Brand-new users with zero observations see
+   the empty-state CTA "Log an observation to find observers near you."
+2. **GPS mode (PR17)** — clicking the "📍 Use my location" pill triggers
+   `navigator.geolocation.getCurrentPosition()`, then calls
+   `community_observers_nearby_at(lat, lng, …)` with caller-supplied
+   coords. This unlocks Nearby for new users. On geolocation deny / not
+   available, the page falls back to centroid mode and shows a friendly
+   notice.
+
+**Privacy: coords NEVER touch the URL.** Putting `?lat=…&lng=…` in the
+querystring would leak via the `Referer` header on every outbound link
+and bake into the user's browser history. Instead, coords live in
+`sessionStorage` (key `rastrum.community.gps`), cleared automatically
+when the tab closes. Regression guarded by `tests/unit/community-url.test.ts`
+("NEVER serializes GPS coords into the URL").
+
+The new RPC `community_observers_nearby_at(lat, lng, …)` is a sibling
+of the existing centroid RPC: same `community_observers_with_centroid`
+view, same `authenticated`-only `GRANT EXECUTE`, same SECURITY INVOKER.
+The lack of `GRANT TO anon` is the security gate; the function body is
+unreachable for anon callers regardless of the UI sign-in check.
+
 ## Future work (v1.1)
 
 - Observer heatmap / community map view.

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4254,6 +4254,42 @@ $$;
 REVOKE ALL ON FUNCTION public.community_observers_nearby(numeric, int, int, text, text[], boolean) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.community_observers_nearby(numeric, int, int, text, text[], boolean) TO authenticated;
 
+-- 10) Nearby helper at an arbitrary point — authenticated only. Same
+-- privacy gate as community_observers_nearby (reads the centroid view,
+-- which is not granted to anon), but uses caller-supplied coords
+-- instead of the viewer's stored centroid. Lets a brand-new user with
+-- no observations still discover nearby observers via GPS. Coords
+-- never persist server-side; the client passes them per-call.
+CREATE OR REPLACE FUNCTION public.community_observers_nearby_at(
+  p_lat      double precision,
+  p_lng      double precision,
+  p_radius_m numeric  DEFAULT 200000,
+  p_limit    int      DEFAULT 20,
+  p_offset   int      DEFAULT 0,
+  p_country  text     DEFAULT NULL,
+  p_taxa     text[]   DEFAULT NULL,
+  p_experts  boolean  DEFAULT false
+)
+RETURNS SETOF public.community_observers_with_centroid
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT v.*
+    FROM public.community_observers_with_centroid v
+   WHERE v.centroid_geog IS NOT NULL
+     AND ST_DWithin(
+       v.centroid_geog,
+       ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
+       p_radius_m
+     )
+     AND (p_country IS NULL OR v.country_code = p_country)
+     AND (p_taxa    IS NULL OR v.expert_taxa @> p_taxa)
+     AND (p_experts = false OR v.is_expert = true)
+   ORDER BY v.centroid_geog <-> ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography
+   LIMIT p_limit OFFSET p_offset;
+$$;
+
+REVOKE ALL ON FUNCTION public.community_observers_nearby_at(double precision, double precision, numeric, int, int, text, text[], boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.community_observers_nearby_at(double precision, double precision, numeric, int, int, text, text[], boolean) TO authenticated;
+
 -- ============================================================
 -- Observation detail redesign — material edit tracking + soft-delete
 -- (2026-04-29) — see docs/superpowers/specs/2026-04-29-obs-detail-redesign-design.md

--- a/scripts/db-sentinel.sql
+++ b/scripts/db-sentinel.sql
@@ -146,6 +146,10 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'dispatch_admin_webhooks')     THEN missing := array_append(missing, 'public.dispatch_admin_webhooks()'); END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'compute_moderator_trust_score') THEN missing := array_append(missing, 'public.compute_moderator_trust_score()'); END IF;
 
+  -- Module 28 — Community discovery (Nearby RPCs, both centroid- and GPS-based)
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'community_observers_nearby')    THEN missing := array_append(missing, 'public.community_observers_nearby()'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'community_observers_nearby_at') THEN missing := array_append(missing, 'public.community_observers_nearby_at()'); END IF;
+
   -- PR16 — admin entity browser hot-path indexes. If a future schema
   -- change drops one of these the corresponding admin browser tab silently
   -- regresses to a sequential scan. Sentinel keeps that observable.

--- a/src/components/CommunityView.astro
+++ b/src/components/CommunityView.astro
@@ -20,6 +20,18 @@ interface Props {
 const { lang } = Astro.props;
 const tr = t(lang);
 
+interface PrivacyExplainerCopy {
+  heading: string;
+  body_public: string;
+  body_anon: string;
+  cta_edit_profile: string;
+}
+interface CommunityEmptyCopy {
+  no_match: string;
+  nearby_no_centroid: string;
+  nearby_anon: string;
+  privacy_explainer: PrivacyExplainerCopy;
+}
 interface CommunityCopy {
   page_title: string;
   page_subtitle: string;
@@ -35,7 +47,7 @@ interface CommunityCopy {
   sort: Record<string, string>;
   filter: Record<string, string>;
   card: Record<string, string>;
-  empty: Record<string, string>;
+  empty: CommunityEmptyCopy;
   leaderboards_optout_link: string;
   edit_profile_optout: string;
 }
@@ -62,6 +74,16 @@ const stringsJson = JSON.stringify({
   emptyNoMatch: cm.empty.no_match,
   emptyNearbyNoCentroid: cm.empty.nearby_no_centroid,
   emptyNearbyAnon: cm.empty.nearby_anon,
+  privacyHeading: cm.empty.privacy_explainer.heading,
+  privacyBodyPublic: cm.empty.privacy_explainer.body_public,
+  privacyBodyAnon: cm.empty.privacy_explainer.body_anon,
+  privacyCtaEditProfile: cm.empty.privacy_explainer.cta_edit_profile,
+  countryUnsetCta: cm.filter.country_unset_cta,
+  useLocationLabel: cm.filter.use_location,
+  locationGranted: cm.filter.location_granted,
+  locationDenied: cm.filter.location_denied,
+  locationUnavailable: cm.filter.location_unavailable,
+  editProfileHref,
   profileBase,
 });
 ---
@@ -123,13 +145,51 @@ const stringsJson = JSON.stringify({
       <input id="cf-nearby" type="checkbox" />
       {cm.filter.nearby}
     </label>
+    <button
+      id="cf-use-location"
+      type="button"
+      class="hidden text-xs px-2 py-1 rounded-lg border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/50"
+      aria-label={cm.filter.use_location}
+    >
+      <span aria-hidden="true">📍</span>
+      <span data-label>{cm.filter.use_location}</span>
+    </button>
   </div>
+
+  <p
+    id="cf-country-cta"
+    class="hidden mt-2 text-xs text-amber-700 dark:text-amber-400"
+  >
+    <a href={editProfileHref} class="underline hover:text-amber-800 dark:hover:text-amber-300">
+      {cm.filter.country_unset_cta}
+    </a>
+  </p>
+
+  <p
+    id="cf-location-status"
+    class="hidden mt-2 text-xs text-zinc-500 dark:text-zinc-400"
+    aria-live="polite"
+  ></p>
 
   <div id="community-list" class="mt-4 space-y-2">
     <p class="text-sm text-zinc-500 italic" data-loading>{cm.loading}</p>
   </div>
 
   <div id="community-empty" class="hidden mt-8 text-center text-sm text-zinc-500"></div>
+
+  <aside
+    id="community-privacy-banner"
+    class="hidden mt-4 rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/30 p-4 text-sm text-amber-900 dark:text-amber-200"
+    role="note"
+  >
+    <p class="font-semibold mb-1" data-privacy-heading></p>
+    <p class="mb-2" data-privacy-body></p>
+    <a
+      href={editProfileHref}
+      class="inline-block text-emerald-700 dark:text-emerald-400 font-medium hover:underline"
+      data-privacy-cta
+    ></a>
+  </aside>
 
   <nav id="community-pager" class="hidden mt-6 flex items-center justify-between text-sm">
     <button
@@ -149,8 +209,8 @@ const stringsJson = JSON.stringify({
 </section>
 
 <script>
-  import { parseFilters, serializeFilters, type CommunityFilters } from '../lib/community-url';
-  import { loadCommunity, viewerHasCentroid, loadIsoCountries, COMMUNITY_PAGE_SIZE, type CommunityObserver } from '../lib/community';
+  import { parseFilters, serializeFilters, loadGps, saveGps, clearGps, type CommunityFilters, type CommunityGps } from '../lib/community-url';
+  import { loadCommunity, loadCommunityNearbyAt, viewerHasCentroid, loadViewerCommunityMeta, loadIsoCountries, COMMUNITY_PAGE_SIZE, type CommunityObserver } from '../lib/community';
   import { getSupabase } from '../lib/supabase';
 
   interface Strings {
@@ -168,6 +228,16 @@ const stringsJson = JSON.stringify({
     emptyNoMatch: string;
     emptyNearbyNoCentroid: string;
     emptyNearbyAnon: string;
+    privacyHeading: string;
+    privacyBodyPublic: string;
+    privacyBodyAnon: string;
+    privacyCtaEditProfile: string;
+    countryUnsetCta: string;
+    useLocationLabel: string;
+    locationGranted: string;
+    locationDenied: string;
+    locationUnavailable: string;
+    editProfileHref: string;
     profileBase: string;
   }
 
@@ -190,11 +260,34 @@ const stringsJson = JSON.stringify({
   const taxonEl = document.getElementById('cf-taxon') as HTMLInputElement | null;
   const expertsEl = document.getElementById('cf-experts') as HTMLInputElement | null;
   const nearbyEl = document.getElementById('cf-nearby') as HTMLInputElement | null;
+  const useLocationBtn = document.getElementById('cf-use-location') as HTMLButtonElement | null;
+  const locationStatus = document.getElementById('cf-location-status') as HTMLParagraphElement | null;
+  const countryCta = document.getElementById('cf-country-cta') as HTMLParagraphElement | null;
+  const privacyBanner = document.getElementById('community-privacy-banner') as HTMLElement | null;
 
   if (!list || !empty || !pager || !pageLabel || !prev || !next ||
-      !sortEl || !countryEl || !taxonEl || !expertsEl || !nearbyEl) {
+      !sortEl || !countryEl || !taxonEl || !expertsEl || !nearbyEl ||
+      !useLocationBtn || !locationStatus || !countryCta || !privacyBanner) {
     throw new Error('CommunityView: missing required DOM nodes');
   }
+
+  const privacyHeadingEl = privacyBanner.querySelector('[data-privacy-heading]') as HTMLElement | null;
+  const privacyBodyEl = privacyBanner.querySelector('[data-privacy-body]') as HTMLElement | null;
+  const privacyCtaEl = privacyBanner.querySelector('[data-privacy-cta]') as HTMLAnchorElement | null;
+  if (privacyHeadingEl) privacyHeadingEl.textContent = STRINGS.privacyHeading;
+  if (privacyCtaEl) {
+    privacyCtaEl.textContent = STRINGS.privacyCtaEditProfile;
+    privacyCtaEl.href = STRINGS.editProfileHref;
+  }
+
+  // Viewer meta is loaded once on mount and again after auth-state
+  // changes. Initial nulls = unknown / anon. Used by the empty-state
+  // banner and the country CTA.
+  let viewerSignedIn = false;
+  let viewerProfilePublic: boolean | null = null;
+  let viewerCountryCode: string | null = null;
+  // GPS coords from "Use my location" — never serialized to URL.
+  let gpsCoords: CommunityGps | null = loadGps();
 
   // Populate the country dropdown async — non-blocking. If Supabase is
   // unconfigured (preview/test env), the dropdown stays at just "Any"
@@ -293,6 +386,7 @@ const stringsJson = JSON.stringify({
     list!.innerHTML = `<p class="text-sm text-zinc-500 italic" data-loading>${escapeHtml(STRINGS.loading)}</p>`;
     empty!.classList.add('hidden');
     pager!.classList.add('hidden');
+    privacyBanner!.classList.add('hidden');
   }
 
   function showEmpty(msg: string): void {
@@ -300,6 +394,54 @@ const stringsJson = JSON.stringify({
     empty!.textContent = msg;
     empty!.classList.remove('hidden');
     pager!.classList.add('hidden');
+  }
+
+  function maybeShowPrivacyExplainer(): void {
+    if (!privacyBodyEl) return;
+    if (!viewerSignedIn) {
+      // Anon user: existing empty-state CTAs (sign-in) are sufficient.
+      // The explainer is only for the "I'm signed in but I see nothing"
+      // confusion described in the PR brief.
+      privacyBanner!.classList.add('hidden');
+      return;
+    }
+    privacyBodyEl.textContent = viewerProfilePublic === false
+      ? STRINGS.privacyBodyAnon
+      : STRINGS.privacyBodyPublic;
+    privacyBanner!.classList.remove('hidden');
+  }
+
+  function maybeShowCountryCta(): void {
+    const showCta = viewerSignedIn && viewerCountryCode == null;
+    countryCta!.classList.toggle('hidden', !showCta);
+  }
+
+  function setLocationStatus(msg: string | null, tone: 'info' | 'warn' = 'info'): void {
+    if (!msg) {
+      locationStatus!.classList.add('hidden');
+      locationStatus!.textContent = '';
+      return;
+    }
+    locationStatus!.textContent = msg;
+    locationStatus!.classList.remove('hidden');
+    locationStatus!.classList.toggle('text-amber-700', tone === 'warn');
+    locationStatus!.classList.toggle('dark:text-amber-400', tone === 'warn');
+    locationStatus!.classList.toggle('text-emerald-700', tone === 'info');
+    locationStatus!.classList.toggle('dark:text-emerald-400', tone === 'info');
+    locationStatus!.classList.toggle('text-zinc-500', false);
+    locationStatus!.classList.toggle('dark:text-zinc-400', false);
+  }
+
+  function syncUseLocationButton(): void {
+    if (filters.nearby) {
+      useLocationBtn!.classList.remove('hidden');
+    } else {
+      useLocationBtn!.classList.add('hidden');
+      // Don't clear gpsCoords here — operators may flip nearby off and
+      // on; coords stay in sessionStorage until the tab closes or the
+      // user explicitly revokes.
+      setLocationStatus(null);
+    }
   }
 
   async function refresh(): Promise<void> {
@@ -314,8 +456,11 @@ const stringsJson = JSON.stringify({
       try {
         const { data: { user } } = await getSupabase().auth.getUser();
         if (!user) { showEmpty(STRINGS.emptyNearbyAnon); return; }
-        const has = await viewerHasCentroid();
-        if (!has) { showEmpty(STRINGS.emptyNearbyNoCentroid); return; }
+        // Only require centroid when no GPS overlay is set.
+        if (!gpsCoords) {
+          const has = await viewerHasCentroid();
+          if (!has) { showEmpty(STRINGS.emptyNearbyNoCentroid); return; }
+        }
       } catch {
         showEmpty(STRINGS.emptyNearbyAnon);
         return;
@@ -323,9 +468,12 @@ const stringsJson = JSON.stringify({
     }
 
     try {
-      const { rows, total } = await loadCommunity(filters);
+      const { rows, total } = (filters.nearby && gpsCoords)
+        ? await loadCommunityNearbyAt(filters, gpsCoords.lat, gpsCoords.lng)
+        : await loadCommunity(filters);
       if (rows.length === 0) {
         showEmpty(filters.nearby ? STRINGS.emptyNearbyNoCentroid : STRINGS.emptyNoMatch);
+        maybeShowPrivacyExplainer();
         return;
       }
       list!.innerHTML = '';
@@ -344,6 +492,7 @@ const stringsJson = JSON.stringify({
   function pushAndRefresh(): void {
     filters = { ...readUI(), page: 1 };
     history.replaceState(null, '', window.location.pathname + serializeFilters(filters));
+    syncUseLocationButton();
     void refresh();
   }
 
@@ -362,5 +511,43 @@ const stringsJson = JSON.stringify({
     void refresh();
   });
 
-  void refresh();
+  useLocationBtn.addEventListener('click', () => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setLocationStatus(STRINGS.locationUnavailable, 'warn');
+      return;
+    }
+    setLocationStatus(STRINGS.useLocationLabel + '…', 'info');
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        gpsCoords = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+        saveGps(gpsCoords);
+        setLocationStatus(STRINGS.locationGranted, 'info');
+        void refresh();
+      },
+      () => {
+        gpsCoords = null;
+        clearGps();
+        setLocationStatus(STRINGS.locationDenied, 'warn');
+        void refresh();
+      },
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 60_000 },
+    );
+  });
+
+  // Boot: load viewer meta once, then render. Don't block on it; if it
+  // fails (anon, unconfigured Supabase, network), the explainer just
+  // doesn't render — page still works.
+  void (async () => {
+    try {
+      const meta = await loadViewerCommunityMeta();
+      viewerSignedIn = meta.signedIn;
+      viewerProfilePublic = meta.profilePublic;
+      viewerCountryCode = meta.countryCode;
+    } catch {
+      // non-fatal
+    }
+    maybeShowCountryCta();
+    syncUseLocationButton();
+    await refresh();
+  })();
 </script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -361,7 +361,12 @@
       "taxon": "Taxon",
       "nearby": "Nearby",
       "experts_only": "Experts only",
-      "any": "Any"
+      "any": "Any",
+      "country_unset_cta": "Your country isn't set yet — set it in Profile → Edit so others can find you by country.",
+      "use_location": "Use my location",
+      "location_granted": "Using your current location",
+      "location_denied": "Location access denied — using your observation centroid instead",
+      "location_unavailable": "Location not available on this device"
     },
     "card": {
       "obs": "{n} obs",
@@ -373,7 +378,13 @@
     "empty": {
       "no_match": "No observers match these filters. Try removing one.",
       "nearby_no_centroid": "Log an observation to find observers near you.",
-      "nearby_anon": "Sign in to find observers near you."
+      "nearby_anon": "Sign in to find observers near you.",
+      "privacy_explainer": {
+        "heading": "Most observers haven't enabled their public profile yet.",
+        "body_public": "Profiles are private by default. Other observers show up here once they turn on their public profile in Profile → Edit.",
+        "body_anon": "Profiles are private by default. Your profile is also private — flip the toggle in Profile → Edit to be discoverable, and others will appear once they do the same.",
+        "cta_edit_profile": "Configure your own profile →"
+      }
     },
     "leaderboards_optout_link": "Hide me from community leaderboards",
     "edit_profile_optout": "Profile → Edit"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -361,7 +361,12 @@
       "taxon": "Taxón",
       "nearby": "Cerca",
       "experts_only": "Solo expertos",
-      "any": "Cualquiera"
+      "any": "Cualquiera",
+      "country_unset_cta": "Tu país aún no está configurado — configúralo en Perfil → Editar para que otros puedan encontrarte por país.",
+      "use_location": "Usar mi ubicación",
+      "location_granted": "Usando tu ubicación actual",
+      "location_denied": "Acceso a ubicación denegado — usando el centro de tus observaciones",
+      "location_unavailable": "Ubicación no disponible en este dispositivo"
     },
     "card": {
       "obs": "{n} obs",
@@ -373,7 +378,13 @@
     "empty": {
       "no_match": "Ningún observador coincide con estos filtros. Prueba quitar uno.",
       "nearby_no_centroid": "Registra una observación para encontrar observadores cerca.",
-      "nearby_anon": "Inicia sesión para encontrar observadores cerca."
+      "nearby_anon": "Inicia sesión para encontrar observadores cerca.",
+      "privacy_explainer": {
+        "heading": "La mayoría de los observadores aún no han activado su perfil público.",
+        "body_public": "Los perfiles son privados por defecto. Otros observadores aparecerán aquí cuando activen su perfil público en Perfil → Editar.",
+        "body_anon": "Los perfiles son privados por defecto. Tu perfil también es privado — activa el interruptor en Perfil → Editar para ser visible, y otros aparecerán cuando hagan lo mismo.",
+        "cta_edit_profile": "Configurar mi perfil →"
+      }
     },
     "leaderboards_optout_link": "Ocultarme de las clasificaciones de la comunidad",
     "edit_profile_optout": "Perfil → Editar"

--- a/src/lib/community-url.ts
+++ b/src/lib/community-url.ts
@@ -85,3 +85,69 @@ export function serializeFilters(f: CommunityFilters): string {
   const out = sp.toString();
   return out ? `?${out}` : '';
 }
+
+/**
+ * GPS coords used by the "Use my location" Nearby flow.
+ *
+ * Privacy invariant: coords NEVER appear in the URL querystring (which
+ * would leak via `Referer` and browser history). They live in
+ * `sessionStorage` only — cleared when the tab closes.
+ *
+ * The serializer / parser are intentionally unaware of these coords; the
+ * only path to them is through these explicit helpers.
+ */
+export interface CommunityGps {
+  lat: number;
+  lng: number;
+}
+
+const GPS_STORAGE_KEY = 'rastrum.community.gps';
+
+interface SessionStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function getSessionStorage(): SessionStorageLike | null {
+  try {
+    if (typeof globalThis === 'undefined') return null;
+    const ss = (globalThis as unknown as { sessionStorage?: SessionStorageLike }).sessionStorage;
+    return ss ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadGps(storage: SessionStorageLike | null = getSessionStorage()): CommunityGps | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(GPS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { lat?: unknown; lng?: unknown };
+    if (typeof parsed.lat !== 'number' || typeof parsed.lng !== 'number') return null;
+    if (!Number.isFinite(parsed.lat) || !Number.isFinite(parsed.lng)) return null;
+    if (Math.abs(parsed.lat) > 90 || Math.abs(parsed.lng) > 180) return null;
+    return { lat: parsed.lat, lng: parsed.lng };
+  } catch {
+    return null;
+  }
+}
+
+export function saveGps(gps: CommunityGps, storage: SessionStorageLike | null = getSessionStorage()): void {
+  if (!storage) return;
+  try {
+    storage.setItem(GPS_STORAGE_KEY, JSON.stringify({ lat: gps.lat, lng: gps.lng }));
+  } catch {
+    // non-fatal — storage may be full or unavailable
+  }
+}
+
+export function clearGps(storage: SessionStorageLike | null = getSessionStorage()): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(GPS_STORAGE_KEY);
+  } catch {
+    // non-fatal
+  }
+}

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -86,6 +86,32 @@ async function loadCommunityNearby(filters: CommunityFilters): Promise<{
 }
 
 /**
+ * GPS-based Nearby — calls community_observers_nearby_at(lat, lng).
+ * Coords come from navigator.geolocation; never persisted server-side.
+ * Same auth gate as the centroid path (RPC reads the auth-only view).
+ */
+export async function loadCommunityNearbyAt(
+  filters: CommunityFilters,
+  lat: number,
+  lng: number,
+): Promise<{ rows: CommunityObserver[]; total: number }> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('community_observers_nearby_at', {
+    p_lat: lat,
+    p_lng: lng,
+    p_radius_m: 200_000,
+    p_limit: COMMUNITY_PAGE_SIZE,
+    p_offset: (filters.page - 1) * COMMUNITY_PAGE_SIZE,
+    p_country: filters.country,
+    p_taxa: filters.taxa.length > 0 ? filters.taxa : null,
+    p_experts: filters.experts,
+  });
+  if (error) throw error;
+  const rows = (data ?? []) as CommunityObserver[];
+  return { rows, total: rows.length };
+}
+
+/**
  * Fetch the viewer's own centroid from the auth-only view, used to
  * decide whether to render the "log an observation" empty state vs
  * a meaningful Nearby list.
@@ -103,6 +129,36 @@ export async function viewerHasCentroid(): Promise<boolean> {
     .eq('id', user.id)
     .maybeSingle();
   return data != null;
+}
+
+/**
+ * Viewer metadata used by the empty-state explainer + country CTA.
+ * Returns nulls in unconfigured / anon envs — non-fatal.
+ */
+export interface ViewerCommunityMeta {
+  signedIn: boolean;
+  profilePublic: boolean | null;
+  countryCode: string | null;
+}
+
+export async function loadViewerCommunityMeta(): Promise<ViewerCommunityMeta> {
+  try {
+    const supabase = getSupabase();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { signedIn: false, profilePublic: null, countryCode: null };
+    const { data } = await supabase
+      .from('users')
+      .select('profile_public, country_code')
+      .eq('id', user.id)
+      .maybeSingle();
+    return {
+      signedIn: true,
+      profilePublic: (data?.profile_public as boolean | undefined) ?? null,
+      countryCode: (data?.country_code as string | null | undefined) ?? null,
+    };
+  } catch {
+    return { signedIn: false, profilePublic: null, countryCode: null };
+  }
 }
 
 export interface IsoCountry {

--- a/tests/unit/community-url.test.ts
+++ b/tests/unit/community-url.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   parseFilters,
   serializeFilters,
+  loadGps,
+  saveGps,
+  clearGps,
   type CommunityFilters,
 } from '../../src/lib/community-url';
 
@@ -96,5 +99,93 @@ describe('community-url', () => {
       page: 1,
     };
     expect(parseFilters(serializeFilters(f))).toEqual(f);
+  });
+
+  it('NEVER serializes GPS coords into the URL — privacy invariant', () => {
+    // Even if GPS is set in sessionStorage, the filter serializer must
+    // not leak coords into ?lat=…&lng=… (would leak via Referer header
+    // and browser history). Coords are an out-of-band mode toggle, not
+    // a URL filter. Regression guard.
+    const f: CommunityFilters = {
+      sort: 'distance',
+      country: 'MX',
+      taxa: [],
+      experts: false,
+      nearby: true,
+      page: 1,
+    };
+    const qs = serializeFilters(f);
+    expect(qs).not.toMatch(/\blat\b/);
+    expect(qs).not.toMatch(/\blng\b/);
+    expect(qs).not.toMatch(/\bgps\b/);
+    expect(qs).not.toMatch(/\d+\.\d+/); // No floats anywhere
+  });
+
+  it('parseFilters ignores any lat/lng/gps querystring values', () => {
+    // Hand-crafted attack URL — even if a user pastes coords manually
+    // (or another tool generates them), the parser drops them. The
+    // round-trip never carries them.
+    const f = parseFilters('?nearby=true&lat=19.43&lng=-99.13&gps=on');
+    // Filter shape is unchanged — no lat/lng fields exist on the type
+    // and serializing it produces only the known keys.
+    const out = serializeFilters(f);
+    expect(out).toContain('nearby=true');
+    expect(out).toContain('sort=distance');
+    expect(out).not.toMatch(/\blat\b/);
+    expect(out).not.toMatch(/\blng\b/);
+    expect(out).not.toMatch(/\bgps\b/);
+  });
+});
+
+describe('community-url GPS sessionStorage', () => {
+  let store: Map<string, string>;
+  let storage: { getItem: (k: string) => string | null; setItem: (k: string, v: string) => void; removeItem: (k: string) => void };
+
+  beforeEach(() => {
+    store = new Map<string, string>();
+    storage = {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, v); },
+      removeItem: (k: string) => { store.delete(k); },
+    };
+  });
+
+  it('round-trips lat/lng through saveGps + loadGps', () => {
+    saveGps({ lat: 19.4326, lng: -99.1332 }, storage);
+    expect(loadGps(storage)).toEqual({ lat: 19.4326, lng: -99.1332 });
+  });
+
+  it('returns null when no coords are stored', () => {
+    expect(loadGps(storage)).toBeNull();
+  });
+
+  it('rejects malformed payloads', () => {
+    storage.setItem('rastrum.community.gps', 'not-json');
+    expect(loadGps(storage)).toBeNull();
+
+    storage.setItem('rastrum.community.gps', JSON.stringify({ lat: 'foo', lng: 0 }));
+    expect(loadGps(storage)).toBeNull();
+
+    storage.setItem('rastrum.community.gps', JSON.stringify({ lat: 0 }));
+    expect(loadGps(storage)).toBeNull();
+  });
+
+  it('rejects out-of-range coords', () => {
+    storage.setItem('rastrum.community.gps', JSON.stringify({ lat: 95, lng: 0 }));
+    expect(loadGps(storage)).toBeNull();
+    storage.setItem('rastrum.community.gps', JSON.stringify({ lat: 0, lng: -200 }));
+    expect(loadGps(storage)).toBeNull();
+  });
+
+  it('clearGps wipes the slot', () => {
+    saveGps({ lat: 1, lng: 2 }, storage);
+    clearGps(storage);
+    expect(loadGps(storage)).toBeNull();
+  });
+
+  it('returns null when storage is unavailable (no throw)', () => {
+    expect(loadGps(null)).toBeNull();
+    expect(() => saveGps({ lat: 1, lng: 2 }, null)).not.toThrow();
+    expect(() => clearGps(null)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Fixes 4 UX issues reported on `https://rastrum.org/es/comunidad/observadores/`:

1. **"Only shows me, no one else"** — `users.profile_public` defaults to `false`, so the `community_observers` view filters out everyone but the few users who opted in. The page looked broken; now it explains.

2. **`?country=` empty + "how do I set my country?"** — country picker exists in Profile → Edit but isn't discoverable from the community page.

3. **`?nearby=true` should use GPS** — today it reads the user's nightly-computed `centroid_geog` from past observations. New users with no observations get an empty state forever.

4. **0 rows after sort change** — same root cause as #1.

## Fixes

### Privacy-default explainer banner
When the filter returns 0 rows AND the viewer is signed in, render a friendly banner instead of the bare empty state:

> **"Most observers haven't enabled their public profile yet."**
> Profiles are private by default. They appear here once their owners turn on public profile in Profile → Edit.
>
> [Configure your own profile →]

Copy varies by whether the viewer's own `profile_public` is on (gentle "set yours up too" nudge) vs already on (just "most are private").

### Set-country inline CTA
Above the country dropdown, when the viewer is signed in AND has no `country_code` set, show:

> "Your country isn't set yet — set it in Profile → Edit so others can find you by country."

Doesn't change filter behavior; just surfaces the path.

### GPS-based Nearby (real-time)
New "📍 Use my location" pill alongside the Nearby checkbox.

- Click → `navigator.geolocation.getCurrentPosition()` prompt
- On grant: stores `{lat, lng}` in **sessionStorage only** (never the URL — Referer-leak prevention) and switches to a new `community_observers_nearby_at(lat, lng, …)` RPC
- On deny: friendly toast, falls back to the existing centroid-based path
- On unavailable: helpful "Sign in or grant location" copy

The new RPC is `SECURITY INVOKER`, only granted to `authenticated`, and reads from `community_observers_with_centroid` (which already enforces `profile_public AND NOT hide_from_leaderboards`). Reuses the existing GiST index on `centroid_geog`.

## Privacy invariant

GPS coords are stored only in `sessionStorage` (key `rastrum.community.gps`), cleared on tab close. **Never** the URL querystring — that would leak via `Referer` and browser history. Regression guard in `tests/unit/community-url.test.ts` asserts the serializer drops any `lat`/`lng`/`gps` keys.

## Schema

- New `community_observers_nearby_at(p_lat, p_lng, p_radius_m, p_limit, p_offset, p_country, p_taxa, p_experts)` RPC — idempotent (`CREATE OR REPLACE`)
- Sentinel verify updated for both nearby RPCs
- No new tables, no new RLS policies, no new crons

## Tests

- `tests/unit/community-url.test.ts` — 9 new tests including the regression guard "NEVER serializes GPS coords into the URL" + sessionStorage round-trip + malformed/out-of-range/missing-storage edge cases
- 689 vitest tests pass (was 681); zero typecheck errors; 186 pages built

## Documentation

- `docs/runbooks/community-discovery.md` — new "UX clarifications (PR17)" section
- `CLAUDE.md` "Community discovery (M28)" — added 4th load-bearing rule documenting the sessionStorage-only privacy invariant

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 689 passed
- [x] `npm run build` — clean
- [ ] Validate gate green
- [ ] Manual: anon visits `/community/observers/` → still gets sign-in CTA
- [ ] Manual: signed-in user with private profile sees banner with "Your profile is also private — flip the toggle"
- [ ] Manual: signed-in user with public profile but few peers sees "Most observers haven't enabled..." banner
- [ ] Manual: click "Use my location" → grant → see GPS-radius results
- [ ] Manual: deny → fallback to centroid Nearby with toast
- [ ] Manual: refresh tab → GPS coords still in sessionStorage; close tab → gone
- [ ] Manual: confirm coords never appear in URL after grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)