### PR TITLE
docs(community): sync PR17 community-observers UX fixes to roadmap surfaces

### DIFF
--- a/docs/progress.json
+++ b/docs/progress.json
@@ -849,6 +849,12 @@
           "label": "Admin console PR16 — read-only entity browsers (Identifications, Notifications, Media, Follows, Watchlists, Projects, Taxon changes) on shared ConsoleEntityBrowser template + entity-browser.ts runtime; server-side paginated, URL-driven filter state, lazy FK lookups, auto-populated dropdown facets, indexed hot-paths",
           "label_es": "Consola admin PR16 — navegadores de entidades de solo lectura (Identificaciones, Notificaciones, Medios, Seguimientos, Listas de vigilancia, Proyectos, Cambios de taxón) sobre plantilla compartida ConsoleEntityBrowser + runtime entity-browser.ts; paginación servidor, estado de filtros via URL, lookups lazy, dropdowns auto-poblados, índices hot-path",
           "done": true
+        },
+        {
+          "id": "community-observers-pr17-ux-fixes",
+          "label": "Community observers UX fixes — privacy-default explainer banner (with viewer-state-aware copy), set-country inline CTA, GPS-based Nearby (community_observers_nearby_at SECURITY INVOKER RPC, sessionStorage-only coords for Referer-leak prevention), regression guard test",
+          "label_es": "Fixes de UX en observadores comunidad — banner explicativo de privacidad por defecto (copy según estado del viewer), CTA inline para fijar país, modo Cercanos con GPS real (RPC community_observers_nearby_at SECURITY INVOKER, coords solo en sessionStorage para prevenir filtración por Referer), test de regresión",
+          "done": true
         }
       ]
     },

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -4686,6 +4686,24 @@
         }
       ]
     },
+    "community-observers-pr17-ux-fixes": {
+      "phase": "v1.1",
+      "title_en": "Community observers UX fixes — privacy explainer + country CTA + GPS-based Nearby",
+      "title_es": "Fixes UX en observadores comunidad — explicador de privacidad + CTA país + Cercanos con GPS",
+      "modules": ["28-community-discovery.md"],
+      "subtasks": [
+        { "label_en": "Privacy-default explainer banner — viewer-state-aware copy (private vs public profile); renders on 0 rows + signed in", "label_es": "Banner explicativo de privacidad por defecto — copy según el viewer (privado vs público); aparece con 0 filas + sesión iniciada", "status": "done" },
+        { "label_en": "Set-country inline CTA — only when viewer is signed in AND country_code IS NULL; links to /profile/edit/", "label_es": "CTA inline para fijar país — sólo si viewer en sesión y country_code IS NULL; enlaza a /profile/edit/", "status": "done" },
+        { "label_en": "community_observers_nearby_at(lat, lng, radius_m, …) SECURITY INVOKER RPC; granted to authenticated only; reuses GiST index on centroid_geog", "label_es": "RPC community_observers_nearby_at(lat, lng, radius_m, …) SECURITY INVOKER; sólo a authenticated; reutiliza índice GiST en centroid_geog", "status": "done" },
+        { "label_en": "📍 Use my location pill via navigator.geolocation; coords stored in sessionStorage (key rastrum.community.gps), NEVER URL — Referer-leak prevention", "label_es": "📍 Botón Usar mi ubicación con navigator.geolocation; coords en sessionStorage (clave rastrum.community.gps), NUNCA en la URL — prevención de filtración por Referer", "status": "done" },
+        { "label_en": "Fallback to centroid Nearby on geolocation deny; friendly toast", "label_es": "Fallback a Cercanos por centroide al denegar geolocalización; toast amigable", "status": "done" },
+        { "label_en": "loadGps / saveGps / clearGps helpers in community-url.ts (testable, dependency-injected)", "label_es": "Helpers loadGps / saveGps / clearGps en community-url.ts (testeable, inyección de dependencias)", "status": "done" },
+        { "label_en": "Regression-guard test: 'NEVER serializes GPS coords into the URL' + 9 sessionStorage round-trip / malformed / out-of-range cases", "label_es": "Test de regresión: 'NUNCA serializa coords GPS en la URL' + 9 casos de round-trip / malformado / fuera de rango", "status": "done" },
+        { "label_en": "loadViewerCommunityMeta() — single query for {signedIn, profilePublic, countryCode}; no N+1", "label_es": "loadViewerCommunityMeta() — una sola consulta para {signedIn, profilePublic, countryCode}; sin N+1", "status": "done" },
+        { "label_en": "Sentinel verify entries for both nearby RPCs", "label_es": "Entradas en sentinel verify para los dos RPCs de Cercanos", "status": "done" },
+        { "label_en": "CLAUDE.md M28 4th load-bearing rule + docs/runbooks/community-discovery.md UX clarifications section", "label_es": "Regla 4 del M28 en CLAUDE.md + sección de aclaraciones UX en docs/runbooks/community-discovery.md", "status": "done" }
+      ]
+    },
     "social-graph-m26": {
       "phase": "v1.2",
       "title_en": "Social graph + reactions (Module 26)",

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,7 +17,7 @@
 | v0.5 | Beta | shipped (partial) | 11 / 13 |
 | v1.0 | Public Launch | shipped (partial) | 18 / 21 |
 | v1.0.x | Post-launch polish | in_progress | 8 / 24 |
-| v1.1 | UX polish + admin console + M22/M26/M27 | shipped (mostly) | 37 / 42 |
+| v1.1 | UX polish + admin console + M22/M26/M27 | shipped (mostly) | 38 / 43 |
 | v1.2 | Research workflow (M28-M32 + obs-detail + privacy) | shipped 2026-04-30 | 17 / 17 |
 | **v0.1 → v1.0** | **Public launch** | **shipped 2026-04-26** | **54 / 59** |
 


### PR DESCRIPTION
## Summary

PR #216 (community observers UX fixes — privacy explainer + country CTA + GPS Nearby) merged but the roadmap surfaces weren't updated. This catches them up.

- `progress.json` — adds `community-observers-pr17-ux-fixes` v1.1 entry (done:true)
- `tasks.json` — full subtask checklist (10 items including the regression-guard test, sessionStorage helpers, the new RPC, and the CLAUDE.md 4th rule)
- `tasks.md` — v1.1 count `37 / 42` → `38 / 43`

Verified: `npm run build` re-renders `/en/docs/tasks/` HTML with the new entry visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)