### PR TITLE
docs: refresh runbooks + CLAUDE.md for v1.1 follow-ups landing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 > Briefing for AI coding agents (Claude Code, Copilot, Cursor, Codex, …)
 > working in this repo. Read this before making changes.
 >
-> **Last full doc sync:** 2026-04-30 (v1.2 — research workflow M29/M30/M31, multi-provider vision + pool M32).
+> **Last full doc sync:** 2026-04-30 (v1.2 — research workflow M29/M30/M31, multi-provider vision + pool M32, plus all v1.1 follow-ups #152/#153/#154/#155/#156/#157/#158/#159).
 
 ---
 
@@ -461,8 +461,12 @@ indices like RAI / detection-rate-per-100-trap-nights need to know
   counts. NULL `end_date` is counted up to `current_date` (or
   `p_to`).
 
-UI is a v1.1 follow-up; until then, create stations via SQL (see
-runbook).
+Create-station UI shipped on the project-detail page (PR #213) —
+`/{en,es}/projects/detail/?slug=<slug>` shows a Camera stations
+section with Add station + inline trap-night counts. CLI also
+takes `--project-slug --station-key` for batch tagging at import
+time (PR #208 / issue #156). Period editor + per-station
+detection-rate dashboard remain v1.1 follow-ups.
 
 Spec: [`docs/specs/modules/31-camera-stations.md`](docs/specs/modules/31-camera-stations.md).
 Runbook: [`docs/runbooks/camera-stations.md`](docs/runbooks/camera-stations.md).
@@ -496,8 +500,12 @@ Three load-bearing rules:
 Resolution order: BYO key → personal sponsorship → platform pool →
 skip Claude (PlantNet only).
 
-UI for credential creation + pool donation is a v1.1 follow-up;
-until then, register credentials via Supabase Vault + SQL.
+UI shipped 2026-04-30 in `SponsoringView` (PR #215 / issue #152) —
+provider radio (7 kinds, auto-detected from secret prefix) + model
+field + conditional endpoint field for Azure/Bedrock/Vertex, plus
+a "Donate to platform pool" section with progress bar +
+Pause/Resume. Vertex AI tokens auto-rotate via service-account JWT
+(PR #209 / issue #155). Pool maintenance crons live (#207).
 
 Spec: [`docs/specs/modules/32-multi-provider-vision.md`](docs/specs/modules/32-multi-provider-vision.md).
 Runbooks: [`docs/runbooks/multi-provider-vision.md`](docs/runbooks/multi-provider-vision.md),

--- a/docs/runbooks/camera-stations.md
+++ b/docs/runbooks/camera-stations.md
@@ -1,7 +1,7 @@
 # Camera stations (M31) — runbook
 
 > **Spec:** [`docs/specs/modules/31-camera-stations.md`](../specs/modules/31-camera-stations.md).
-> **Status:** schema only in v1; UI is a v1.1 follow-up.
+> **Status:** schema + create-station UI shipped 2026-04-30 (PRs #141 + #213); period management + per-station detection-rate dashboard remain v1.1 follow-ups.
 > **Depends on:** M29 (Projects).
 
 ## Apply schema
@@ -24,11 +24,25 @@ make db-psql
 SELECT public.station_trap_nights('00000000-0000-0000-0000-000000000000'::uuid);
 ```
 
-## Create a station + active period (no UI in v1)
+## Create a station via the UI (PR #213)
 
-The UI lands in v1.1. Until then, use SQL via `make db-psql` while
-signed in as the project owner (RLS gates writes by
-`project.owner_user_id = auth.uid()`):
+Sign in as the project owner, navigate to
+`/{en,es}/projects/detail/?slug=<your-slug>`, scroll to the
+**Camera stations** section, click **Add station**, fill in the
+station_key + name + lat/lng + (optional) habitat / camera model /
+notes, and **Save**. The station appears in the inline list with
+its trap-night count (computed live via the
+`station_trap_nights()` RPC).
+
+Non-owners see the section read-only with a "Only the project
+owner can add stations" notice — RLS enforces the same gate
+server-side.
+
+## Create a station + active period via SQL
+
+For batch operations, scripted setup, or operators preparing
+deployments ahead of time, use SQL via `make db-psql` while signed
+in as the project owner:
 
 ```sql
 -- 1. Create the station, anchored to an existing M29 project
@@ -114,11 +128,15 @@ SELECT t.scientific_name,
  ORDER BY rate_per_100_tn DESC;
 ```
 
-## v1.1 follow-ups
+## Shipped 2026-04-30
 
-- UI under `/{en,es}/projects/[slug]/stations/` — list + create + period editor
-- CLI `--station-key <key>` flag for batch tagging at import time (M30)
+- Create-station UI on `/{en,es}/projects/detail/?slug=<slug>` (PR #213)
+- CLI `--project-slug` + `--station-key` flags for batch tagging at import time (PR #208 / issue #156)
+- `/api/observe` accepts `camera_station_id` (or the slug+key pair) (PR #208)
+
+## v1.1 follow-ups (still open)
+
+- Period management UI (open / close periods) — embedded inline in the same project page
 - Per-station detection-rate dashboard (RAI per species per period)
 - DwC-A export filter for "stations only" (vs the full project)
 - Multi-point / sampling-grid stations (current schema is one Point per station)
-- `/api/observe` accepts `camera_station_id` parameter

--- a/docs/runbooks/cli-batch-import.md
+++ b/docs/runbooks/cli-batch-import.md
@@ -95,10 +95,28 @@ UPDATE public.observations o
 
 (Same SQL as the M29 runbook. Idempotent.)
 
-## v1.1 follow-ups
+## Camera-station tagging at import time (#156, shipped 2026-04-30)
+
+Pass `--project-slug <slug> --station-key <key>` and the EF looks
+up the station by the (slug, key) pair under RLS, populating
+`observations.camera_station_id` for every photo. Both flags must
+be supplied together.
+
+```bash
+rastrum-import \
+  --dir          /Volumes/SD_CARD/DCIM \
+  --baseUrl      "$RASTRUM_BASE_URL" \
+  --token        "$RASTRUM_TOKEN" \
+  --project-slug anp-sierra-juarez \
+  --station-key  SJ-CAM-01
+```
+
+Pre-#156 you had to UPDATE rows manually after the import; that
+step is no longer needed.
+
+## v1.1 follow-ups (still open)
 
 - Frame extraction for `.mp4`/`.mov` (currently `status: 'skipped'`)
-- `--station-key <key>` flag to populate `observations.camera_station_id` for M31
 - Web UI drag-and-drop ZIP upload using the same pipeline server-side
 - Concurrent uploads (sequential in v1)
 - HEIC → JPEG conversion (R2 stores any blob; PWA viewer falls back gracefully)

--- a/docs/runbooks/multi-provider-vision.md
+++ b/docs/runbooks/multi-provider-vision.md
@@ -78,10 +78,27 @@ schema; set to the deployment name for documentation.
 
 ### Google Vertex AI
 
-`kind = 'vertex_ai'`. **Operator must mint an OAuth2 access token
-offline** from the service-account JSON (Vertex tokens last 1 hour;
-auto-rotation is a v1.1 follow-up). Secret is the literal access
-token (`ya29.…`).
+`kind = 'vertex_ai'`. **Recommended: store the service-account JSON
+envelope as the secret** (PR #209 / issue #155). The provider mints
+an OAuth2 access token via JWT-bearer flow inside the Edge Function,
+caches it for ~50 minutes, and refreshes transparently. Secret
+shape:
+
+```json
+{
+  "type": "service_account",
+  "project_id": "my-proj",
+  "private_key_id": "kid-1",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n…\n-----END PRIVATE KEY-----\n",
+  "client_email": "svc@my-proj.iam.gserviceaccount.com"
+}
+```
+
+**Legacy (operator-mints-offline) path still works:** when the
+secret looks like `ya29.…` instead of JSON, the provider uses it
+as-is. Operators on this path own rotation themselves; the
+`vertex_token_expiry_monitor` cron (PR #207) emails 5 minutes
+before expiry to give them a chance to refresh.
 
 `preferred_model` is the full model resource path:
 
@@ -137,18 +154,27 @@ UPDATE public.sponsor_pools SET status = 'exhausted' WHERE id = '<uuid>';
 | Symptom | Cause | Fix |
 |---|---|---|
 | Bedrock provider returns null on every call | Sig V4 signing wrong region OR JSON envelope malformed | Verify `parseBedrockSecret(secret)` returns a non-null result; check `region` field matches the Bedrock endpoint URL |
-| Vertex AI returns 401 after working for ~1h | Access token expired | Re-mint the OAuth2 access token from the service-account JSON; v1.1 will auto-rotate |
+| Vertex AI returns 401 after working for ~1h | Access token expired | Migrate the credential to a service-account JSON envelope (PR #209) — auto-rotation kicks in. Legacy `ya29.…` secrets still need manual re-mint. |
 | Azure OpenAI 404 | `endpoint` URL doesn't include the deployment path or `?api-version=…` | Copy the full URL including query string from the Azure portal |
 | Pool resolution skips a healthy pool | RLS gate on `sponsor_pools` is owner-only — service role bypasses, but check `status = 'active'` and `used < total_cap` | Toggle status, run `consume_pool_slot()` manually as service_role to confirm |
 | `preferred_model` mismatched for provider type | DEFAULT `'claude-haiku-4-5'` is Anthropic shorthand; non-Anthropic providers need explicit model ID | UPDATE the `preferred_model` after creation; Bedrock auto-translates the shorthand |
 
-## v1.1 follow-ups
+## Shipped 2026-04-30 (v1.1 follow-ups)
 
-- **UI**: provider radio + filtered model dropdown in `SponsoringView`
-- **UI**: "Donate to platform pool" tab + cost-per-100-calls table
-- **Sponsor-facing pool dashboard**: capacity / utilisation / top taxa (no beneficiary breakdown)
-- **Vertex AI auto-rotation**: derive access token from service-account JWT inside the EF
-- **Per-pool monthly reset cron**: honour `sponsor_pools.monthly_reset = true`
-- **`pool_consumption` vacuum cron**: delete rows older than 90 days
-- **Vertex token expiry alert**: notify sponsor 5 minutes before expiry
-- **Pool karma incentives**: "donate calls, earn karma" loop
+- **UI** — provider radio + filtered model dropdown in `SponsoringView` (PR #215 / issue #152)
+- **UI** — "Donate to platform pool" section with capacity bar + Pause/Resume (PR #215)
+- **Vertex AI auto-rotation** — service-account JWT minted inside the EF, cached ~50 min (PR #209 / issue #155)
+- **Vertex token expiry alert** — 10-min cron emails 5 min before expiry for legacy literal-token credentials (PR #207 / issue #159)
+- **`monthly_reset` cron** — first-of-month at 00:05 UTC (PR #207 / issue #153)
+- **`pool_consumption` vacuum** — daily at 03:30 UTC, drops rows > 90 days (PR #207 / issue #154)
+- **End-to-end provider smoke probe** — manual + nightly workflow that calls `validateCredential()` against each real API (PR #210 / issue #158)
+
+Run the smoke workflow on demand from the GitHub Actions UI under
+**vision-providers-smoke** (operator must have the
+`VISION_PROVIDERS_TEST_*` secrets set).
+
+## v1.1 follow-ups (still open)
+
+- **Sponsor-facing pool dashboard**: capacity / utilisation / **top taxa** (no beneficiary breakdown). Needs `ai_usage.pool_id` column landing first.
+- **Cost-per-100-calls table** in the model picker (static, manual updates).
+- **Pool karma incentives**: "donate calls, earn karma" loop.

--- a/docs/runbooks/sponsor-pools.md
+++ b/docs/runbooks/sponsor-pools.md
@@ -2,7 +2,7 @@
 
 > **Spec:** [`docs/specs/modules/32-multi-provider-vision.md`](../specs/modules/32-multi-provider-vision.md) (M32 includes both multi-provider + the pool).
 > **Schema:** `sponsor_pools`, `pool_consumption`, `consume_pool_slot()` RPC.
-> **Status:** backend complete; UI for sponsor controls is v1.1.
+> **Status:** backend + UI shipped 2026-04-30 (PRs #143 + #215). Crons for monthly reset + ledger vacuum shipped (PR #207).
 
 A sponsor donates N calls to a shared pool that any user of the
 platform can draw from — without a 1-to-1 sponsorship. Pool
@@ -23,10 +23,20 @@ LOCKED`, atomically picks an active pool with capacity AND the
 caller is under their `daily_user_cap`. Returns NULL if either
 check fails — no error thrown, the cascade falls through.
 
-## Create a pool (no UI yet)
+## Create a pool from the UI (PR #215)
 
-The "Donate to platform pool" tab in `SponsoringView` is v1.1.
-Until then, create pools via SQL while signed in as the sponsor:
+Navigate to `/{en,es}/profile/sponsoring/`, scroll to the
+**Platform pool** section, click **Donate to pool**. Pick a
+credential, set total cap + preferred model + per-user daily cap,
+optionally tick **Reset `used` on the 1st of every month**.
+
+The pool appears in the inline list with a progress bar. Use the
+inline **Pause** / **Resume** buttons to toggle its status without
+revoking the credential.
+
+## Create a pool via SQL (alternative)
+
+For batch operations or scripted setup:
 
 ```sql
 INSERT INTO public.sponsor_pools (
@@ -36,15 +46,16 @@ INSERT INTO public.sponsor_pools (
 SELECT auth.uid(),
        (SELECT id FROM public.sponsor_credentials WHERE label = 'My Anthropic key'),
        1000,                       -- total_cap: donate 1000 calls
-       true,                       -- monthly_reset: HONORIFIC in v1; cron is v1.1
+       true,                       -- monthly_reset: cron auto-resets `used` on the 1st (PR #207)
        'claude-haiku-4-5',         -- preferred_model
        10,                         -- daily_user_cap per beneficiary
        'active';
 ```
 
-Note: `monthly_reset = true` does NOT auto-reset `used` to 0 in v1
-(the cron is a v1.1 follow-up). Setting it now is forward-compat;
-the field is honoured the day the cron lands.
+`monthly_reset = true` is now honoured by the
+`sponsor_pools_monthly_reset` cron (00:05 UTC on the 1st of each
+month). The cron resets `used = 0` and flips `exhausted` →
+`active` for any pool with the flag.
 
 ## Read aggregate stats (sponsor view)
 
@@ -136,10 +147,14 @@ deliberately doesn't support this.
 | Sponsor-side dashboard shows `used` not incrementing | `consume_pool_slot()` raised an exception inside the EF — check `[identify] consume_pool_slot failed` warnings in EF logs | Ensure `service_role` has EXECUTE on the RPC; check Vault decryption isn't failing |
 | Pool exhausted but `status` still `active` | The "mark exhausted" UPDATE inside the RPC is best-effort and races with the `used + 1` UPDATE in pathological concurrency | Run the manual exhaust UPDATE above |
 
-## v1.1 follow-ups
+## Shipped 2026-04-30 (v1.1 follow-ups)
 
-- UI for "Donate to platform pool" + sponsor dashboard
-- `monthly_reset` cron — first-of-month resets `used` to 0 where flag is true
-- `pool_consumption` vacuum cron — drop rows > 90 days old
+- UI for "Donate to platform pool" + inline progress bar + Pause/Resume (PR #215 / issue #152)
+- `sponsor_pools_monthly_reset` cron — 1st of month at 00:05 UTC, resets `used` to 0 + flips `exhausted` → `active` (PR #207 / issue #153)
+- `pool_consumption_vacuum` cron — daily at 03:30 UTC, drops rows > 90 days (PR #207 / issue #154)
+
+## v1.1 follow-ups (still open)
+
+- Sponsor dashboard with top-detected-taxa breakdown — needs `ai_usage.pool_id` column
 - Pool karma incentives (donate calls → earn karma)
 - `ai_usage.pool_id` column so per-pool taxon stats can join cleanly


### PR DESCRIPTION
## Summary

PRs #207, #208, #209, #210, #213, #215 close all 8 v1.1 follow-up issues. This docs PR flips the language across the four runbooks + the CLAUDE.md briefing so they reflect the post-merge state.

## Changes

- `cli-batch-import.md` — adds `--project-slug --station-key` example (PR #208)
- `camera-stations.md` — adds UI section (PR #213); shipped items moved out of v1.1 list
- `multi-provider-vision.md` — Vertex section leads with service-account JSON + auto-rotation (PR #209); shipped section enumerates the 6 closing PRs
- `sponsor-pools.md` — UI section first (PR #215), SQL as alternative; monthly_reset cron honoured (PR #207)
- `CLAUDE.md` — M31 + M32 paragraphs updated; doc-sync date references the v1.1 issue numbers

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` — 186 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)