### PR TITLE
fix(community): observers cards 404'd by linking to /u/<handle>/ instead of /u/?username=<handle>

### DIFF
--- a/src/components/CommunityCard.astro
+++ b/src/components/CommunityCard.astro
@@ -10,7 +10,7 @@
  */
 import FollowButton from './FollowButton.astro';
 import { t, getLocalizedPath, routes } from '../i18n/utils';
-import type { CommunityObserver } from '../lib/community';
+import { publicProfileHref, type CommunityObserver } from '../lib/community';
 
 interface Props {
   lang: 'en' | 'es';
@@ -32,7 +32,7 @@ const cm = (tr as unknown as { community: CommunityCopy }).community;
 
 const handle = observer.username ?? observer.id.slice(0, 8);
 const displayName = observer.display_name ?? handle;
-const profileHref = getLocalizedPath(lang, routes.publicProfile[lang] + '/' + handle + '/');
+const profileHref = publicProfileHref(getLocalizedPath(lang, routes.publicProfile[lang]), handle);
 
 function relativeTime(iso: string | null): string {
   if (!iso) return '—';

--- a/src/components/CommunityView.astro
+++ b/src/components/CommunityView.astro
@@ -344,7 +344,7 @@ const stringsJson = JSON.stringify({
   function renderRow(row: CommunityObserver): HTMLElement {
     const handle = row.username ?? row.id.slice(0, 8);
     const displayName = row.display_name ?? handle;
-    const profileHref = `${STRINGS.profileBase}/${encodeURIComponent(handle)}/`;
+    const profileHref = `${STRINGS.profileBase}/?username=${encodeURIComponent(handle)}`;
     const taxaList = (row.expert_taxa ?? []).join(', ');
     const obsLabel = STRINGS.obsTpl.replace('{n}', String(row.observation_count));
     const speciesLabel = STRINGS.speciesTpl.replace('{n}', String(row.species_count));

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -31,6 +31,19 @@ export interface CommunityObserver {
 
 export const COMMUNITY_PAGE_SIZE = 20;
 
+/**
+ * Build a public-profile URL for a community observer card.
+ *
+ * The canonical public profile route is `/{lang}/u/?username=<handle>`
+ * (querystring), NOT `/{lang}/u/<handle>/` (path segment) — the
+ * path-segment form 404s in production. See PR #72 for the prior
+ * regression on PublicProfileViewV2; this regressed in CommunityCard
+ * + CommunityView's renderRow before being caught by user feedback.
+ */
+export function publicProfileHref(profileBase: string, handle: string): string {
+  return `${profileBase}/?username=${encodeURIComponent(handle)}`;
+}
+
 function sortColumn(s: CommunitySort): string {
   // Nearby uses ORDER BY distance in SQL; the view query falls back
   // to observation_count for the (rare) case the caller asks for

--- a/tests/unit/community-profile-link.test.ts
+++ b/tests/unit/community-profile-link.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { publicProfileHref } from '../../src/lib/community';
+
+describe('publicProfileHref', () => {
+  it('uses querystring form, not path-segment form', () => {
+    expect(publicProfileHref('/en/u', 'art')).toBe('/en/u/?username=art');
+    expect(publicProfileHref('/es/u', 'art')).toBe('/es/u/?username=art');
+  });
+
+  it('encodes handles with reserved chars', () => {
+    expect(publicProfileHref('/en/u', 'maría_núñez')).toMatch(/\?username=mar%C3%ADa_n%C3%BA%C3%B1ez$/);
+    expect(publicProfileHref('/en/u', 'a/b')).toBe('/en/u/?username=a%2Fb');
+  });
+
+  it('preserves the locale-prefixed base', () => {
+    expect(publicProfileHref('/en/u', 'foo')).toMatch(/^\/en\/u\//);
+    expect(publicProfileHref('/es/u', 'foo')).toMatch(/^\/es\/u\//);
+  });
+});


### PR DESCRIPTION
## Summary

User reported `https://rastrum.org/en/u/art/` 404s when clicked from the `/community/observers/` cards. The canonical public-profile URL is **`/u/?username=<handle>` (querystring)**, not `/u/<handle>/` (path segment) — same regression PR #72 caught for `PublicProfileViewV2`'s "View public profile" link.

## Root cause

Two M28 surfaces built the wrong URL shape:

- `src/components/CommunityCard.astro:35` — server-rendered observer cards
- `src/components/CommunityView.astro:347` — client-side `renderRow()` that paints filter results

Both fixed. Extracted a shared `publicProfileHref(profileBase, handle)` helper in `src/lib/community.ts` with the canonical pattern documented in the JSDoc + 3 vitest cases locking the URL shape against future regression.

## On the "I only see myself" report

This is the **privacy gate working as designed**, not a bug. The M28 eligibility predicate (`supabase-schema.sql:4139-4140`) is:

```sql
WHERE profile_public = true AND hide_from_leaderboards = false
```

`users.profile_public` defaults to `false`. Users only appear in `/community/observers/` after they opt in via Profile → Edit ("Show me in community discovery"). If you're the only one who's opted in, you're the only one who appears — by design.

This PR does not change visibility — it just ensures the link targets a valid URL when there ARE other eligible users.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm test -- community-profile-link` — 3/3 cases pass
- [x] `npm run build` — clean
- [ ] After deploy: visit `/en/community/observers/`, click any observer card, lands on `/en/u/?username=<handle>` (200, not 404)
- [ ] After deploy: same for `/es/comunidad/observadores/` cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)