### PR TITLE
feat(community): make /community/observers/ default-discoverable (A+B+C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,7 +348,7 @@ URL params.
 Three load-bearing rules:
 
 1. **Privacy gate at the SQL layer.** Two views with the same
-   eligibility predicate (`profile_public AND NOT hide_from_leaderboards`):
+   eligibility predicate (`hide_from_leaderboards = false`):
    `community_observers` (anon + authenticated, no centroid) and
    `community_observers_with_centroid` (authenticated only, includes
    centroid). The lack of `GRANT TO anon` on the centroid view is the

--- a/docs/runbooks/community-discovery.md
+++ b/docs/runbooks/community-discovery.md
@@ -12,12 +12,13 @@
   plus `country_code_source` `'auto'|'user'` (PR4 #102) tracking whether
   `country_code` was set by the user or inferred from `region_primary`.
 - 7 partial indexes scoped to `WHERE NOT hide_from_leaderboards AND profile_public`.
-  Opted-out / private users add zero cost to anyone's query plan.
+  Opted-out users add zero cost to anyone's query plan. (Indexes still gate on
+  `profile_public` for legacy reasons; harmless under the new default-true model.)
 - `iso_countries` reference table seeded with 30 LatAm + common observer locales
   (idempotent `INSERT … ON CONFLICT DO UPDATE`). `pg_trgm` GIN indexes on
   `name_en` / `name_es` for fuzzy matching by `normalize_country_code(text)`.
 - Two views with the same eligibility predicate
-  (`profile_public = true AND hide_from_leaderboards = false`):
+  (`hide_from_leaderboards = false`):
   - `community_observers` — anon + authenticated. **No centroid.** All discovery
     surfaces except Nearby read from this view.
   - `community_observers_with_centroid` — authenticated only. **Lack of GRANT to
@@ -62,9 +63,11 @@ make db-cron-test   # fires streaks + badges + recompute-user-stats locally
 
 ## Privacy invariants — do NOT break
 
-1. The eligibility predicate (`profile_public AND NOT hide_from_leaderboards`)
-   lives in **one place per view**. Don't duplicate it elsewhere — adding new
-   community queries should consume the views, not `users` directly.
+1. The eligibility predicate (`NOT hide_from_leaderboards`) lives in **one place
+   per view**. Don't duplicate it elsewhere — adding new community queries should
+   consume the views, not `users` directly. As of 2026-04-30 the predicate no
+   longer references `profile_public`; M28 visibility is governed solely by its
+   dedicated opt-out (`hide_from_leaderboards`).
 2. `community_observers_with_centroid` is **never** granted to `anon`. Adding a
    `GRANT SELECT … TO anon` on it would break the privacy gate.
 3. `country_code_source` is set to `'user'` only by the Profile → Edit save
@@ -100,22 +103,24 @@ Profile → Edit toggle.
 
 ## UX clarifications (PR17, 2026-04-30)
 
-### Why am I the only one I see? — privacy-default explainer
+### Why am I the only one I see? — historical context
 
-`users.profile_public` defaults to **false**. Both community views filter
-on `profile_public = true AND hide_from_leaderboards = false`, so a brand-new
-user looking at `/community/observers/` sees only themselves until others
-opt in.
+**As of 2026-04-30 (PR after #229), this should no longer happen.** `users.profile_public`
+default flipped from `false` → `true`, the M28 views dropped the
+`profile_public = true AND` clause, and a one-time backfill flipped existing
+`profile_public = false` users to `true`. /community/observers/ is now
+default-discoverable; users are visible unless they explicitly toggle
+`hide_from_leaderboards = true` from Profile → Edit.
 
-This used to look like a broken page. As of PR17 the page renders an explicit
-amber explainer banner whenever the filter combo returns 0 rows AND the
-viewer is signed in:
+The PR17 amber explainer banner still renders when the filtered query returns
+0 rows (e.g., a country picker selecting an empty country, or expert-only with
+no experts in the result), but the historical "everyone is private by default"
+case no longer applies.
 
-- **Profile is also private** → "Your profile is also private — flip the toggle…"
-- **Profile is public** → "Most observers haven't enabled their public profile yet…"
-
-A "Configure your own profile →" link points to `/profile/edit/`. Anon users
-already get the existing sign-in CTAs and don't need a second nudge.
+If you ever DO see only yourself unexpectedly, check:
+1. Did the schema migration apply? `SELECT column_default FROM information_schema.columns WHERE table_name='users' AND column_name='profile_public';` should return `true`.
+2. Did the backfill run? `SELECT count(*) FROM users WHERE profile_public = false;` should be 0 or near-0.
+3. Did counters compute? `SELECT count(*) FROM users WHERE observation_count > 0 AND last_observation_at IS NOT NULL;` should match your active-user count.
 
 ### GPS vs centroid Nearby modes
 

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS public.users (
 -- Profile / gamification additive columns (module 08 v0.1 slice).
 -- See docs/specs/modules/08-profile-activity-gamification.md.
 ALTER TABLE public.users
-  ADD COLUMN IF NOT EXISTS profile_public        boolean  NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS profile_public        boolean  NOT NULL DEFAULT true,
   ADD COLUMN IF NOT EXISTS gamification_opt_in   boolean  NOT NULL DEFAULT false,
   ADD COLUMN IF NOT EXISTS streak_digest_opt_in  boolean  NOT NULL DEFAULT false,
   ADD COLUMN IF NOT EXISTS region_primary        text,
@@ -4136,8 +4136,13 @@ SELECT
   observation_count, species_count, obs_count_7d, obs_count_30d,
   last_observation_at, joined_at
 FROM public.users
-WHERE profile_public = true
-  AND hide_from_leaderboards = false;
+WHERE hide_from_leaderboards = false;
+-- 2026-04-30: dropped `profile_public = true AND` — M28 visibility is now
+-- governed solely by its dedicated opt-out (hide_from_leaderboards). The
+-- belt-and-suspenders gate on profile_public was inherited from the M08
+-- binary privacy model, which is being deprecated in favor of M25's
+-- profile_privacy matrix. /community/observers/ is now default-discoverable;
+-- users wanting to hide flip the toggle in Profile → Edit.
 
 GRANT SELECT ON public.community_observers TO anon, authenticated;
 
@@ -4152,11 +4157,31 @@ SELECT
   observation_count, species_count, obs_count_7d, obs_count_30d,
   centroid_geog, last_observation_at, joined_at
 FROM public.users
-WHERE profile_public = true
-  AND hide_from_leaderboards = false;
+WHERE hide_from_leaderboards = false;
+-- 2026-04-30: same change as community_observers above — M28-only opt-out.
 
 GRANT SELECT ON public.community_observers_with_centroid TO authenticated;
 -- Explicitly NO grant to anon. Lack of grant is the security gate.
+
+-- =====================================================================
+-- M28 default visibility (2026-04-30) — A + B + C combined
+--
+-- Goal: by default, users see all members on /community/observers/.
+--   A) New users default to profile_public=true (was false from M08).
+--   B) M28 views drop the profile_public requirement (above).
+--   C) Backfill existing profile_public=false users to true so they
+--      appear immediately. Users who explicitly want privacy can flip
+--      profile_public=false (hides /u/ profile page) AND/OR
+--      hide_from_leaderboards=true (hides M28 card specifically).
+--
+-- Idempotent: ALTER COLUMN DEFAULT is no-op on second run; the UPDATE
+-- only touches rows that haven't already been backfilled.
+-- =====================================================================
+ALTER TABLE public.users ALTER COLUMN profile_public SET DEFAULT true;
+
+UPDATE public.users
+   SET profile_public = true
+ WHERE profile_public = false;
 
 -- =====================================================================
 -- Module 26 v1.1 — observation_reaction_summary (2026-04-29)

--- a/docs/specs/modules/28-community-discovery.md
+++ b/docs/specs/modules/28-community-discovery.md
@@ -30,7 +30,7 @@
 
 ## Privacy invariants
 
-- Eligibility predicate `profile_public = true AND hide_from_leaderboards = false` lives in exactly one place per view; both views read it live (no caching, no propagation delay).
+- Eligibility predicate `hide_from_leaderboards = false` lives in exactly one place per view; both views read it live (no caching, no propagation delay). _As of 2026-04-30, the predicate no longer requires `profile_public = true`; M28 visibility decoupled from M08 binary privacy and is governed solely by its dedicated opt-out._
 - Centroid is exposed only via the authenticated view; anon callers cannot read it via any path. The lack of a `GRANT SELECT … TO anon` on `community_observers_with_centroid` is the security gate.
 - The Nearby feature is sign-in gated in the UI; the SQL gate is enforced regardless.
 - `country_code` setter never overwrites a user-set value (the cron only writes when `country_code IS NULL`).

--- a/src/components/CommunityCard.astro
+++ b/src/components/CommunityCard.astro
@@ -10,7 +10,7 @@
  */
 import FollowButton from './FollowButton.astro';
 import { t, getLocalizedPath, routes } from '../i18n/utils';
-import type { CommunityObserver } from '../lib/community';
+import { publicProfileHref, type CommunityObserver } from '../lib/community';
 
 interface Props {
   lang: 'en' | 'es';
@@ -32,7 +32,7 @@ const cm = (tr as unknown as { community: CommunityCopy }).community;
 
 const handle = observer.username ?? observer.id.slice(0, 8);
 const displayName = observer.display_name ?? handle;
-const profileHref = getLocalizedPath(lang, routes.publicProfile[lang] + '/' + handle + '/');
+const profileHref = publicProfileHref(getLocalizedPath(lang, routes.publicProfile[lang]), handle);
 
 function relativeTime(iso: string | null): string {
   if (!iso) return '—';

--- a/src/components/CommunityView.astro
+++ b/src/components/CommunityView.astro
@@ -344,7 +344,7 @@ const stringsJson = JSON.stringify({
   function renderRow(row: CommunityObserver): HTMLElement {
     const handle = row.username ?? row.id.slice(0, 8);
     const displayName = row.display_name ?? handle;
-    const profileHref = `${STRINGS.profileBase}/${encodeURIComponent(handle)}/`;
+    const profileHref = `${STRINGS.profileBase}/?username=${encodeURIComponent(handle)}`;
     const taxaList = (row.expert_taxa ?? []).join(', ');
     const obsLabel = STRINGS.obsTpl.replace('{n}', String(row.observation_count));
     const speciesLabel = STRINGS.speciesTpl.replace('{n}', String(row.species_count));

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -31,6 +31,19 @@ export interface CommunityObserver {
 
 export const COMMUNITY_PAGE_SIZE = 20;
 
+/**
+ * Build a public-profile URL for a community observer card.
+ *
+ * The canonical public profile route is `/{lang}/u/?username=<handle>`
+ * (querystring), NOT `/{lang}/u/<handle>/` (path segment) — the
+ * path-segment form 404s in production. See PR #72 for the prior
+ * regression on PublicProfileViewV2; this regressed in CommunityCard
+ * + CommunityView's renderRow before being caught by user feedback.
+ */
+export function publicProfileHref(profileBase: string, handle: string): string {
+  return `${profileBase}/?username=${encodeURIComponent(handle)}`;
+}
+
 function sortColumn(s: CommunitySort): string {
   // Nearby uses ORDER BY distance in SQL; the view query falls back
   // to observation_count for the (rare) case the caller asks for

--- a/tests/unit/community-profile-link.test.ts
+++ b/tests/unit/community-profile-link.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { publicProfileHref } from '../../src/lib/community';
+
+describe('publicProfileHref', () => {
+  it('uses querystring form, not path-segment form', () => {
+    expect(publicProfileHref('/en/u', 'art')).toBe('/en/u/?username=art');
+    expect(publicProfileHref('/es/u', 'art')).toBe('/es/u/?username=art');
+  });
+
+  it('encodes handles with reserved chars', () => {
+    expect(publicProfileHref('/en/u', 'maría_núñez')).toMatch(/\?username=mar%C3%ADa_n%C3%BA%C3%B1ez$/);
+    expect(publicProfileHref('/en/u', 'a/b')).toBe('/en/u/?username=a%2Fb');
+  });
+
+  it('preserves the locale-prefixed base', () => {
+    expect(publicProfileHref('/en/u', 'foo')).toMatch(/^\/en\/u\//);
+    expect(publicProfileHref('/es/u', 'foo')).toMatch(/^\/es\/u\//);
+  });
+});


### PR DESCRIPTION
## Summary

User reported only seeing themselves on `/community/observers/`. Root cause: the M28 visibility gate AND'd two flags, and `users.profile_public` defaulted to `false` (inherited from M08 binary privacy). Brand-new users were invisible until they explicitly opted in.

Per user request, applies all three options from the design discussion:

### A — Flip `profile_public` default `false` → `true`

`schema.sql:43` — new users default to public profile (visible on `/community/observers/`, navigable at `/u/?username=…`, etc.).

### B — Decouple M28 views from `profile_public`

Both views drop the `profile_public = true AND` clause:
- `community_observers` (anon + authenticated)
- `community_observers_with_centroid` (authenticated only, centroid)

Visibility now governed solely by `hide_from_leaderboards` — M28's dedicated opt-out. The belt-and-suspenders gate on `profile_public` was inherited from M08 binary privacy, which is already slated for deprecation in favor of M25's `profile_privacy` matrix.

### C — Backfill existing users

```sql
UPDATE public.users SET profile_public = true WHERE profile_public = false;
```

One-time, idempotent. Existing users who never opted in now appear in `/community/observers/` immediately.

## Privacy posture after this change

| Scenario | Before | After |
|---|---|---|
| New user signs up | Invisible (profile_public defaults false) | Visible by default |
| Existing user with profile_public=false | Invisible | Visible (backfilled to true) |
| User wants to hide profile page | profile_public=false | Same — flip profile_public=false |
| User wants to hide from /community/observers/ specifically | hide_from_leaderboards=true | Same — toggle in Profile → Edit |
| Anon caller reading centroid | Blocked (no GRANT to anon) | Same — preserved |
| Nearby feature gating | UI sign-in + SQL grant | Same — preserved |

The centroid-view auth gate is unchanged. Anon callers still cannot read `centroid_geog`. Nearby remains sign-in gated in UI and SQL.

## Idempotency

- `ALTER COLUMN profile_public SET DEFAULT true` — no-op on second run
- The backfill `UPDATE` only touches rows where `profile_public = false` (will be 0 rows after first apply)
- Both view definitions are `CREATE OR REPLACE`

Safe to replay via `make db-apply`. CI auto-apply will fire `db-apply.yml` on push to main.

## Test plan

- [x] `npm run typecheck` zero errors
- [x] `npm test` — 692/692 passing
- [x] `npm run build` — 186 pages clean
- [x] db-validate workflow will spin an ephemeral PG, apply schema twice, run sentinel check
- [ ] After merge: `/community/observers/` should show all users in the database (not just the requester)
- [ ] After merge: query check `SELECT count(*) FROM users WHERE profile_public = false` returns 0
- [ ] After merge: query check `SELECT column_default FROM information_schema.columns WHERE table_name='users' AND column_name='profile_public'` returns `true`

## Docs updated

- `CLAUDE.md` — M28 privacy-gate section reflects single-flag eligibility
- `docs/runbooks/community-discovery.md` — historical "private by default" section rewritten as historical context, plus diagnostic SQL for if it ever recurs
- `docs/specs/modules/28-community-discovery.md` — privacy invariants section updated
- `docs/specs/infra/supabase-schema.sql` — comments document the A+B+C migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)