### PR TITLE
docs(console): sync PR230 console-chrome-rendering-fix to roadmap surfaces

### DIFF
--- a/docs/progress.json
+++ b/docs/progress.json
@@ -855,6 +855,12 @@
           "label": "Community observers UX fixes — privacy-default explainer banner (with viewer-state-aware copy), set-country inline CTA, GPS-based Nearby (community_observers_nearby_at SECURITY INVOKER RPC, sessionStorage-only coords for Referer-leak prevention), regression guard test",
           "label_es": "Fixes de UX en observadores comunidad — banner explicativo de privacidad por defecto (copy según estado del viewer), CTA inline para fijar país, modo Cercanos con GPS real (RPC community_observers_nearby_at SECURITY INVOKER, coords solo en sessionStorage para prevenir filtración por Referer), test de regresión",
           "done": true
+        },
+        {
+          "id": "console-chrome-rendering-fix",
+          "label": "Console chrome rendering fix — all 70 /console + /consola pages were using BaseLayout instead of ConsoleLayout, so admins saw page content with no sidebar / role pills / keybindings; ConsoleLayout was dead code. Refactored ConsoleLayout for static SSG (optional auth props, server-renders all 3 role tab lists hidden, client script reveals based on getUserRoles()), wrapped all 70 pages, added build-time console.warn in BaseLayout to prevent regression",
+          "label_es": "Fix del chrome de la consola — las 70 páginas /console + /consola usaban BaseLayout en vez de ConsoleLayout, así que los admins veían el contenido sin sidebar / role pills / keybindings; ConsoleLayout era código muerto. Se refactorizó ConsoleLayout para SSG estático (props de auth opcionales, renderiza las 3 listas de rol ocultas, script cliente las revela según getUserRoles()), se envolvieron las 70 páginas, se añadió console.warn en BaseLayout para prevenir regresiones",
+          "done": true
         }
       ]
     },

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -4704,6 +4704,24 @@
         { "label_en": "CLAUDE.md M28 4th load-bearing rule + docs/runbooks/community-discovery.md UX clarifications section", "label_es": "Regla 4 del M28 en CLAUDE.md + sección de aclaraciones UX en docs/runbooks/community-discovery.md", "status": "done" }
       ]
     },
+    "console-chrome-rendering-fix": {
+      "phase": "v1.1",
+      "title_en": "Console chrome rendering fix — restore sidebar + role pills (70 console pages were using BaseLayout, ConsoleLayout was dead code)",
+      "title_es": "Fix del chrome de la consola — restaurar sidebar + role pills (70 páginas usaban BaseLayout, ConsoleLayout era código muerto)",
+      "modules": ["24-admin-console.md"],
+      "subtasks": [
+        { "label_en": "Diagnose: ConsoleLayout existed but unused; all 70 /console + /consola pages imported BaseLayout, leaving the chrome unrendered", "label_es": "Diagnóstico: ConsoleLayout existía pero sin uso; las 70 páginas /console + /consola importaban BaseLayout dejando el chrome sin renderizar", "status": "done" },
+        { "label_en": "Refactor ConsoleLayout to be SSG-safe: props (allRoles, activeRole, currentPath, identity) made optional with sensible defaults", "label_es": "Refactor de ConsoleLayout para SSG: props (allRoles, activeRole, currentPath, identity) ahora opcionales con defaults sensatos", "status": "done" },
+        { "label_en": "Server-render all 3 role tab lists with data-role attributes, all initially hidden; client script reveals based on getUserRoles()", "label_es": "Renderiza en server las 3 listas de tabs por rol con data-role, todas ocultas; script cliente las revela según getUserRoles()", "status": "done" },
+        { "label_en": "Same pattern for role pills: all 3 ship hidden, JS reveals only those held by the viewer; active role styled with role accent", "label_es": "Mismo patrón para los role pills: las 3 ocultas, JS revela las del viewer; rol activo con acento de su rol", "status": "done" },
+        { "label_en": "Active tab highlighting via currentPath = Astro.url.pathname (works at build time since each route has its own static HTML)", "label_es": "Resaltado del tab activo via currentPath = Astro.url.pathname (funciona en build estático porque cada ruta tiene su propio HTML)", "status": "done" },
+        { "label_en": "Swap BaseLayout → ConsoleLayout in all 35 EN console pages + 35 ES consola pages (70 total)", "label_es": "Reemplazar BaseLayout → ConsoleLayout en las 35 páginas EN console + 35 ES consola (70 total)", "status": "done" },
+        { "label_en": "BaseLayout: console.warn at build time if a /console/* or /consola/* path slips through using BaseLayout (regression guard)", "label_es": "BaseLayout: console.warn en build si una ruta /console/* o /consola/* pasa por BaseLayout (guard de regresión)", "status": "done" },
+        { "label_en": "Verification: grep dist/ confirms <aside + data-console-pill + data-role admin/moderator/expert present on all sampled pages", "label_es": "Verificación: grep en dist/ confirma <aside + data-console-pill + data-role admin/moderator/expert en todas las páginas muestreadas", "status": "done" },
+        { "label_en": "New runbook: docs/runbooks/admin-chrome-rendering.md (the ConsoleLayout-only invariant)", "label_es": "Nuevo runbook: docs/runbooks/admin-chrome-rendering.md (la invariante 'sólo ConsoleLayout')", "status": "done" },
+        { "label_en": "CLAUDE.md Console section: 4th load-bearing rule documenting the ConsoleLayout-only contract + chrome-rendering runbook cross-link", "label_es": "Sección Console de CLAUDE.md: 4ª regla load-bearing documentando el contrato 'sólo ConsoleLayout' + cross-link al runbook de chrome rendering", "status": "done" }
+      ]
+    },
     "social-graph-m26": {
       "phase": "v1.2",
       "title_en": "Social graph + reactions (Module 26)",

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,7 +17,7 @@
 | v0.5 | Beta | shipped (partial) | 11 / 13 |
 | v1.0 | Public Launch | shipped (partial) | 18 / 21 |
 | v1.0.x | Post-launch polish | in_progress | 8 / 24 |
-| v1.1 | UX polish + admin console + M22/M26/M27 | shipped (mostly) | 38 / 43 |
+| v1.1 | UX polish + admin console + M22/M26/M27 | shipped (mostly) | 39 / 44 |
 | v1.2 | Research workflow (M28-M32 + obs-detail + privacy) | shipped 2026-04-30 | 17 / 17 |
 | **v0.1 → v1.0** | **Public launch** | **shipped 2026-04-26** | **54 / 59** |
 


### PR DESCRIPTION
## Summary

PR #230 (the critical sidebar/role-pills restoration that fixed all 70 console pages) merged but the roadmap surfaces weren't updated. This catches them up.

- `progress.json` — adds `console-chrome-rendering-fix` v1.1 entry (done:true)
- `tasks.json` — full subtask checklist (10 items): diagnose, ConsoleLayout SSG-safe refactor, server-render all 3 role tab lists hidden, JS reveal pattern, role pill same pattern, swap all 70 pages, BaseLayout build-time guard, dist/ verification, runbook, CLAUDE.md rule
- `tasks.md` — v1.1 count `38 / 43` → `39 / 44`

Verified: `npm run build` re-renders `/en/docs/tasks/` HTML with the new entry visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)