### PR TITLE
fix(ci): add recompute-user-stats to NO_JWT list (was returning 401 to community-backfill workflow)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -204,14 +204,15 @@ jobs:
         run: |
           set -e
           # Functions that don't require a user JWT at the Edge layer:
-          #   share-card        — OG scrapers fetch anonymously
-          #   recompute-streaks — cron-only; gates internally on service-role
-          #   award-badges      — cron-only; gates internally on service-role
-          #   plantnet-monitor  — cron-only; gates internally on service-role
-          #   streak-push       — cron-only; gates internally on service-role
-          #   mcp / api         — gate internally on rst_ tokens (not JWTs)
+          #   share-card            — OG scrapers fetch anonymously
+          #   recompute-streaks     — cron-only; gates internally on service-role
+          #   award-badges          — cron-only; gates internally on service-role
+          #   recompute-user-stats  — cron-only (M28); gates internally on service-role
+          #   plantnet-monitor      — cron-only; gates internally on service-role
+          #   streak-push           — cron-only; gates internally on service-role
+          #   mcp / api             — gate internally on rst_ tokens (not JWTs)
           # Module 26 functions (follow / react / report) DO verify JWT.
-          NO_JWT="share-card recompute-streaks award-badges plantnet-monitor streak-push mcp api"
+          NO_JWT="share-card recompute-streaks award-badges recompute-user-stats plantnet-monitor streak-push mcp api"
           deploy_one() {
             local fn="$1"
             local flag=""


### PR DESCRIPTION
## Summary

\`community-backfill.yml\` workflow_dispatch fired in production after PR #231 merged and returned **HTTP 401** from the deployed \`recompute-user-stats\` Edge Function:

```
::error::Edge Function returned HTTP 401
```

## Root cause

\`recompute-user-stats/index.ts:15\` says: _"Cron-only; deployed --no-verify-jwt like recompute-streaks/award-badges."_ But \`.github/workflows/deploy-functions.yml:214\` (the NO_JWT list) never included it. So every CI auto-deploy since M28 shipped the function with **default JWT verification on**, blocking the documented operator backfill workflow.

## Fix

Add \`recompute-user-stats\` to the NO_JWT list, same as the other cron-only functions (\`recompute-streaks\`, \`award-badges\`, etc.). Function code itself doesn't change — it already gates internally on service_role via the \`SECURITY DEFINER\` SQL wrapper.

## How it lands via CI/CD

This PR changes \`.github/workflows/deploy-functions.yml\`. Per the workflow's own change-detection logic, **this PR will trigger an auto-redeploy of all detected-changed functions** when it merges to main. Since the workflow YAML changed but no function source did, the workflow may re-deploy nothing OR re-deploy all functions depending on the diff logic.

If no function gets redeployed automatically, the operator runs:
```
gh workflow run deploy-functions.yml --ref main -f function=recompute-user-stats
```

Then re-fire \`community-backfill.yml\` workflow_dispatch.

## Test plan

- [x] Local: \`grep NO_JWT .github/workflows/deploy-functions.yml\` shows \`recompute-user-stats\` in the list
- [ ] After merge: \`deploy-functions.yml\` either auto-fires (if change detection picks it up) OR is manually fired with \`-f function=recompute-user-stats\`
- [ ] After redeploy: \`gh workflow run community-backfill.yml --ref main\` succeeds (HTTP 200, surfaces \`rows_updated\` notice)
- [ ] After backfill: visit \`/community/observers/\`, confirm all users with computed stats appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)