### PR TITLE
docs(roadmap): flip M31 + M32 status notes after v1.1 follow-ups landed

### DIFF
--- a/docs/specs/modules/00-index.md
+++ b/docs/specs/modules/00-index.md
@@ -87,8 +87,8 @@ narrative source.
 | 28 | Community discovery (observers page, leaderboards, nearby, experts, country filter) | v1.2 | shipped 2026-04-29 (PR1 #92 + PR2 #96 + PR4 #102 + PR5+PR6 atomic landing; PR3 manual cron fire = operator action) | [`28-community-discovery.md`](28-community-discovery.md) |
 | 29 | Projects (ANP polygon protocols + auto-tagging) | v1.3 | shipped 2026-04-29 (PR #132 — schema + RLS + `upsert_project` SECURITY DEFINER + auto-tagging trigger + UI) | [`29-projects-anp.md`](29-projects-anp.md) |
 | 30 | CLI batch import for camera-trap memory cards | v1.3 | shipped 2026-04-29 (PR #134 — `rastrum-import` Node CLI + `/api/upload-url` Edge Function endpoint + EXIF GPS/timestamp walker; depends on M29) | [`30-cli-batch-import.md`](30-cli-batch-import.md) |
-| 31 | Camera stations + sampling-effort tracking | v1.3 | shipped 2026-04-29 (PR #141 — schema only; UI is v1.1 follow-up; depends on M29) | [`31-camera-stations.md`](31-camera-stations.md) |
-| 32 | Multi-provider vision + per-sponsor model + platform pool | v1.3 | shipped 2026-04-29 (PR #143 — closes #115/#116/#118; bundles AWS Bedrock + OpenAI/Azure/Gemini providers + platform-wide `sponsor_pools` call pool atop `_shared/vision-provider.ts`) | [`32-multi-provider-vision.md`](32-multi-provider-vision.md) |
+| 31 | Camera stations + sampling-effort tracking | v1.3 | shipped 2026-04-29 schema (PR #141) + 2026-04-30 v1.1 follow-ups (create-station UI #213, `/api/observe` + CLI `--station-key` #208). Period management + detection-rate dashboard tracked in #224. | [`31-camera-stations.md`](31-camera-stations.md) |
+| 32 | Multi-provider vision + per-sponsor model + platform pool | v1.3 | shipped 2026-04-29 backend (PR #143 closes #115/#116/#118) + 2026-04-30 v1.1 follow-ups (sponsor UI #215, Vertex auto-rotation #209, ops crons #207, smoke probe workflow #210). Pool dashboard with top-taxa + cost-per-100 picker + pool karma incentives tracked in #226/#227/#228. | [`32-multi-provider-vision.md`](32-multi-provider-vision.md) |
 
 ## v1.5 — Territory layer — planned
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -201,12 +201,16 @@ A second wave landed the same day, focused on the CONANP-Oaxaca / DRFSIPS / PROR
   Resumable via state file. PR #134. _(✓ shipped)_
 
 - `camera-stations-m31` — **Module 31 (Camera stations + sampling effort).**
-  Schema only for v1; UI is a v1.1 follow-up. A camera station is a fixed
-  deployment with one or more **active periods** (start/end). Standardised
-  wildlife indices (RAI, detection rate per 100 trap-nights, species richness)
-  all depend on knowing how long the camera was sampling — this module
-  captures that ground truth. Schema: `camera_stations` +
-  `camera_station_active_periods`. Depends on M29. PR #141. _(✓ shipped — UI = v1.1 follow-up)_
+  Schema (PR #141) + create-station UI on the project-detail page
+  (PR #213) + `/api/observe camera_station_id` server-side resolution +
+  CLI `--project-slug --station-key` flags (PR #208). A camera station is a
+  fixed deployment with one or more **active periods** (start/end).
+  Standardised wildlife indices (RAI, detection rate per 100 trap-nights,
+  species richness) all depend on knowing how long the camera was
+  sampling — this module captures that ground truth. Schema:
+  `camera_stations` + `camera_station_active_periods`. Depends on M29.
+  _(✓ shipped — period management + per-station detection-rate dashboard
+  tracked in #224 / #225 as v1.2 follow-ups)_
 
 - `multi-provider-vision-m32` — **Module 32 (Multi-provider vision + per-sponsor
   model + platform pool).** Bundles three closely-coupled M27 extensions that
@@ -215,5 +219,10 @@ A second wave landed the same day, focused on the CONANP-Oaxaca / DRFSIPS / PROR
   Vertex AI providers; (c) platform-wide call pool (`sponsor_pools` +
   `consume_pool_slot` RPC). `_shared/vision-provider.ts` exports a
   `VisionProvider` interface implemented by 6 concrete providers;
-  `buildProvider(credential)` is the single dispatcher. Closes #115/#116/#118.
-  PR #143. _(✓ shipped)_
+  `buildProvider(credential)` is the single dispatcher. Closes
+  #115/#116/#118. PR #143. v1.1 follow-ups all shipped 2026-04-30:
+  sponsor UI + Donate-to-pool tab (PR #215), Vertex AI service-account
+  auto-rotation (PR #209), pool monthly-reset + ledger-vacuum + Vertex
+  expiry-monitor crons (PR #207), nightly per-provider smoke probe
+  (PR #210). _(✓ shipped — pool dashboard with top-taxa, cost-per-100
+  picker, pool karma incentives tracked as #226/#227/#228)_


### PR DESCRIPTION
Two-line cleanup. After #207/#208/#209/#210/#213/#215/#218 merged, `00-index.md:90` still said "M31: schema only; UI is v1.1 follow-up" and `tasks.md:205` had the same claim. Both now reflect the post-merge reality with cross-refs to v1.2 follow-up issues (#224-#228).

Closes the trifecta of "all merged? PR comments addressed? everything documented?" — yes / yes / yes after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)