### PR TITLE
test(e2e): update settings redirect tests to match PR #261 fix

### DIFF
--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -115,6 +115,23 @@ test.describe('Legacy redirects → settings (PR-2)', () => {
     }
   }
 
+  // Asserts a route resolves to a real (non-redirecting) page that contains
+  // an expected marker — used to lock the PR #261 fix that removed 4 stale
+  // redirects which had been creating loops with the Settings-tab buttons.
+  async function expectServesRealPage(
+    request: import('@playwright/test').APIRequestContext,
+    path: string,
+    markerSubstring: string,
+  ) {
+    const response = await request.get(path, { maxRedirects: 0 });
+    expect(response.status(), `Expected ${path} to serve 200, got ${response.status()}`).toBe(200);
+    const html = await response.text();
+    // The Astro redirect stub uses <meta http-equiv="refresh"> — its absence
+    // is what we're locking against future regression.
+    expect(html, `Expected ${path} to NOT be a meta-refresh redirect stub`).not.toContain('http-equiv="refresh"');
+    expect(html, `Expected ${path} to render real UI containing "${markerSubstring}"`).toContain(markerSubstring);
+  }
+
   test('/en/profile/edit redirects to settings/profile', async ({ request }) => {
     await expectRedirectMarkup(request, '/en/profile/edit', 'settings/profile');
   });
@@ -123,19 +140,23 @@ test.describe('Legacy redirects → settings (PR-2)', () => {
     await expectRedirectMarkup(request, '/es/perfil/editar', 'ajustes/profile');
   });
 
-  test('/en/profile/tokens redirects to settings/developer', async ({ request }) => {
-    await expectRedirectMarkup(request, '/en/profile/tokens', 'settings/developer');
+  // PR #261 — these 4 routes used to redirect to their /settings/<tab>/ pages,
+  // but the Settings tabs themselves had buttons pointing AT these URLs,
+  // creating a click-loop. The redirects were removed; the standalone pages
+  // serve directly. These tests lock the fix.
+  test('/en/profile/tokens serves the real tokens UI (no redirect loop)', async ({ request }) => {
+    await expectServesRealPage(request, '/en/profile/tokens/', 'create-form');
   });
 
-  test('/en/profile/export redirects to settings/data', async ({ request }) => {
-    await expectRedirectMarkup(request, '/en/profile/export', 'settings/data');
+  test('/en/profile/export serves the real export UI', async ({ request }) => {
+    await expectServesRealPage(request, '/en/profile/export/', 'Darwin Core');
   });
 
-  test('/en/profile/import redirects to settings/data', async ({ request }) => {
-    await expectRedirectMarkup(request, '/en/profile/import', 'settings/data');
+  test('/en/profile/import serves the real import UI', async ({ request }) => {
+    await expectServesRealPage(request, '/en/profile/import/', 'Bulk-import');
   });
 
-  test('/en/profile/expert-apply redirects to settings/developer', async ({ request }) => {
-    await expectRedirectMarkup(request, '/en/profile/expert-apply', 'settings/developer');
+  test('/en/profile/expert-apply serves the real apply UI', async ({ request }) => {
+    await expectServesRealPage(request, '/en/profile/expert-apply/', 'expert');
   });
 });


### PR DESCRIPTION
## Summary

PR #261 removed 4 stale redirects (\`/profile/tokens\`, \`/profile/export\`, \`/profile/import\`, \`/profile/expert-apply\`) that were creating a click-loop with the Settings-tab buttons. The existing e2e suite [was asserting the BUGGY behavior](https://github.com/ArtemioPadilla/rastrum/blob/main/tests/e2e/settings.spec.ts#L96-L141) — that those URLs redirect back to \`/settings/<tab>/\`. With the redirects gone, those 4 tests correctly failed on the post-merge \`test\` run.

## Fix

Replace the 4 redirect assertions with **inverted assertions**: each route now serves a real page (HTTP 200, NOT a meta-refresh stub) AND contains a marker substring proving real UI rendered.

\`\`\`ts
async function expectServesRealPage(request, path, markerSubstring) {
  const response = await request.get(path, { maxRedirects: 0 });
  expect(response.status()).toBe(200);
  const html = await response.text();
  expect(html).not.toContain('http-equiv=\"refresh\"');  // catches re-added redirects
  expect(html).toContain(markerSubstring);                // catches missing UI
}
\`\`\`

If anyone re-adds the redirect rules without first inlining the page UI into Settings tabs, these tests fail loudly — exactly the symptom the user hit.

Kept the \`/profile/edit\` redirect tests — that one IS genuinely consolidated into the Settings shell.

## Verified

- [x] All 14 \`settings.spec.ts\` cases pass locally (chromium)
- [x] The 4 modified tests use markers actually present in the HTML (\`create-form\`, \`Darwin Core\`, \`Bulk-import\`, \`expert\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)