### PR TITLE
fix(schema): DROP validation_queue before CREATE OR REPLACE (db-apply failure)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -1342,6 +1342,14 @@ GRANT SELECT ON public.sync_failures TO authenticated;
 --   (primary ID is not research-grade AND its confidence is < 0.5)
 -- The two-clause "needs help" test avoids re-queueing already-promoted
 -- rows whose confidence happens to sit between 0.4 and 0.5.
+--
+-- DROP VIEW first because the column shape evolved (PR #258 reordered
+-- columns to add `current_taxon_id` before `current_scientific_name`)
+-- and Postgres CREATE OR REPLACE VIEW does not permit column renames /
+-- reordering. Without this DROP, db-apply.yml fails on existing DBs
+-- with "cannot change name of view column …". Idempotent: IF EXISTS
+-- makes the DROP safe on first apply.
+DROP VIEW IF EXISTS public.validation_queue CASCADE;
 CREATE OR REPLACE VIEW public.validation_queue AS
 SELECT
   o.id                               AS observation_id,


### PR DESCRIPTION
## Summary

\`db-apply.yml\` failed at 04:23:17 UTC after PR #258 with:

\`\`\`
ERROR: cannot change name of view column \"current_scientific_name\"
       to \"current_taxon_id\"
\`\`\`

[PR #258](https://github.com/ArtemioPadilla/rastrum/pull/258) reordered the columns in \`validation_queue\` to add \`current_taxon_id\` before \`current_scientific_name\`. Postgres \`CREATE OR REPLACE VIEW\` does not permit column renames or reordering — it only allows **appending** new columns at the end. Without an explicit \`DROP\`, db-apply fails on every existing DB where the old shape lives.

## Fix

Prepend \`DROP VIEW IF EXISTS public.validation_queue CASCADE;\` above the \`CREATE OR REPLACE\`. Idempotent: \`IF EXISTS\` makes first-apply safe; \`CASCADE\` handles any future dependent views (today there are none — only \`GRANT SELECT … TO authenticated, anon\` re-runs after the CREATE).

Same pattern PR #145 used for \`resolve_sponsorship\` — \`DROP\` before re-\`CREATE\` when the signature evolves.

## Test plan

- [x] db-validate.yml will spin an ephemeral PG, apply schema twice, catch any further idempotency drift
- [x] Code-level audit: no other views/RPCs depend on \`validation_queue\` per \`grep -n validation_queue docs/specs/infra/supabase-schema.sql\`
- [ ] After merge: db-apply.yml fires automatically on push to main, applies cleanly to prod DB
- [ ] After apply: \`SELECT column_name FROM information_schema.columns WHERE table_name='validation_queue' ORDER BY ordinal_position\` returns the new ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)