### PR TITLE
feat: upload existing media files in observation form (#266)

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -63,6 +63,10 @@ const cameraStarting    = observeStrings.camera_starting     ?? (isEs ? 'Inician
 const videoRecord       = observeStrings.video_record        ?? (isEs ? 'Grabar video' : 'Record video');
 const videoLabel        = observeStrings.video_label         ?? 'Video';
 const videoMaxDuration  = observeStrings.video_max_duration  ?? (isEs ? 'Máximo 30 segundos' : 'Maximum 30 seconds');
+const videoUpload       = observeStrings.video_upload        ?? (isEs ? 'Subir video' : 'Upload video');
+const videoUploadAccepted = observeStrings.video_upload_accepted ?? 'mp4, mov, webm';
+const audioUpload       = observeStrings.audio_upload        ?? (isEs ? 'Subir archivo de audio' : 'Upload audio file');
+const audioUploadAccepted = observeStrings.audio_upload_accepted ?? 'mp3, ogg, wav, m4a';
 const gpsErrPermission  = observeStrings.gps_error_permission_denied ?? (isEs ? 'Permiso de ubicación denegado. Actívalo en ajustes.' : 'Location permission denied. Enable it in settings.');
 const gpsErrUnavailable = observeStrings.gps_error_unavailable       ?? (isEs ? 'Ubicación no disponible.' : 'Location unavailable.');
 const gpsErrTimeout     = observeStrings.gps_error_timeout           ?? (isEs ? 'Tiempo de espera agotado.' : 'Location timed out.');
@@ -224,14 +228,19 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">{videoLabel}</label>
       <div id="video-grid" class="hidden mb-3 space-y-2"></div>
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-2 flex-wrap">
         <button id="video-record-btn" type="button" class="min-h-11 rounded-lg border border-emerald-600/60 px-3 py-2 text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 disabled:opacity-50">
           <span data-video-label>{videoRecord}</span>
         </button>
+        <button id="video-upload-btn" type="button" class="min-h-11 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 flex items-center justify-center gap-2">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
+          {videoUpload}
+        </button>
+        <input id="video-upload-input" type="file" accept="video/mp4,video/quicktime,video/webm,video/*" class="sr-only" aria-label={videoUpload} />
         <span id="video-elapsed" class="hidden text-xs text-zinc-500 font-mono"></span>
         <span id="video-error" class="hidden text-xs text-red-600 dark:text-red-400"></span>
       </div>
-      <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{videoMaxDuration}</p>
+      <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{videoMaxDuration} · <span class="opacity-70">{videoUploadAccepted}</span></p>
     </div>
 
     <!-- Identification block (overhauled: parallel cascade + progressive disclosure + tooltip) -->
@@ -345,14 +354,19 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">{tr.observe.audio_label}</label>
       <div id="audio-grid" class="hidden mb-3 space-y-2"></div>
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-2 flex-wrap">
         <button id="audio-record-btn" type="button" class="rounded-lg border border-emerald-600/60 px-3 py-2 text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 disabled:opacity-50">
           <span data-audio-label>{tr.observe.audio_record}</span>
         </button>
+        <button id="audio-upload-btn" type="button" class="min-h-11 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 flex items-center justify-center gap-2">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
+          {audioUpload}
+        </button>
+        <input id="audio-upload-input" type="file" accept="audio/mpeg,audio/ogg,audio/wav,audio/x-m4a,audio/mp4,audio/*" class="sr-only" aria-label={audioUpload} />
         <span id="audio-elapsed" class="hidden text-xs text-zinc-500 font-mono"></span>
         <span id="audio-error" class="hidden text-xs text-red-600 dark:text-red-400"></span>
       </div>
-      <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{tr.observe.audio_max_duration} · {tr.observe.audio_pending_id}</p>
+      <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{tr.observe.audio_max_duration} · {tr.observe.audio_pending_id} · <span class="opacity-70">{audioUploadAccepted}</span></p>
     </div>
 
     <!-- Evidence type -->
@@ -1635,6 +1649,31 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     else                                                       startRecording();
   });
 
+  // ── Audio file upload ──────────────────────────────────────────────────
+  const audioUploadBtn   = document.getElementById('audio-upload-btn') as HTMLButtonElement | null;
+  const audioUploadInput = document.getElementById('audio-upload-input') as HTMLInputElement | null;
+
+  audioUploadBtn?.addEventListener('click', () => {
+    audioUploadInput?.click();
+  });
+
+  audioUploadInput?.addEventListener('change', async () => {
+    if (!audioUploadInput.files?.length) return;
+    const files = Array.from(audioUploadInput.files);
+    for (const file of files) {
+      const mimeType = file.type || 'audio/mpeg';
+      audios.push({
+        blob: file,
+        blobId: crypto.randomUUID(),
+        mimeType,
+        durationSec: 0,  // unknown until decoded
+      });
+    }
+    repaintAudioGrid();
+    // Reset so the same file can be re-selected if removed
+    audioUploadInput.value = '';
+  });
+
   // ── In-app camera (getUserMedia) ──────────────────────────────────────
   const cameraOpenBtn   = document.getElementById('camera-open-btn') as HTMLButtonElement | null;
   const cameraModal     = document.getElementById('camera-modal');
@@ -1908,6 +1947,33 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
   videoRecBtn?.addEventListener('click', () => {
     if (videoRecorder && videoRecorder.state === 'recording') stopVideoRecording();
     else                                                      startVideoRecording();
+  });
+
+  // ── Video file upload ──────────────────────────────────────────────────
+  const videoUploadBtn   = document.getElementById('video-upload-btn') as HTMLButtonElement | null;
+  const videoUploadInput = document.getElementById('video-upload-input') as HTMLInputElement | null;
+
+  videoUploadBtn?.addEventListener('click', () => {
+    videoUploadInput?.click();
+  });
+
+  videoUploadInput?.addEventListener('change', async () => {
+    if (!videoUploadInput.files?.length) return;
+    const files = Array.from(videoUploadInput.files);
+    for (const file of files) {
+      const mimeType = file.type || 'video/mp4';
+      const thumbnailUrl = await extractVideoThumbnail(file).catch(() => null);
+      videos.push({
+        blob: file,
+        blobId: crypto.randomUUID(),
+        mimeType,
+        durationSec: 0,  // unknown until decoded
+        thumbnailUrl,
+      });
+    }
+    repaintVideoGrid();
+    // Reset so the same file can be re-selected if removed
+    videoUploadInput.value = '';
   });
 
   // ── Map picker bridge ─────────────────────────────────────────────────

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -495,6 +495,8 @@
     "audio_unsupported": "Audio recording isn't supported on this browser.",
     "audio_permission": "Microphone access denied. Allow it in your browser settings to record.",
     "audio_pending_id": "Audio observations are identified with BirdNET-Lite once you download the model in Profile → Edit → AI settings.",
+    "audio_upload": "Upload audio file",
+    "audio_upload_accepted": "mp3, ogg, wav, m4a",
     "use_camera": "Take photo",
     "choose_file": "Upload from gallery",
     "gps_label": "Location",
@@ -578,6 +580,8 @@
     "video_unsupported": "Video recording isn't supported on this browser.",
     "video_permission": "Camera/microphone access denied. Allow it in your browser settings to record.",
     "video_label": "Video",
+    "video_upload": "Upload video",
+    "video_upload_accepted": "mp4, mov, webm",
     "video_thumbnail_alt": "Recorded video preview",
     "taxon_hint": {
       "label": "What did you see?",
@@ -2547,7 +2551,6 @@
       "topCodes": "Top codes",
       "filterByCode": "Filter by code"
     },
-
     "entityBrowser": {
       "clearFilters": "Clear filters",
       "empty": "No rows match the current filter set.",
@@ -2557,7 +2560,6 @@
       "expand": "Expand row",
       "anyOption": "— any —"
     },
-
     "identificationsView": {
       "title": "Identifications",
       "description": "Every identification ever recorded — AI cascade picks, human IDs, validations. Filter by identifier, taxon, validation state, or research-grade status.",
@@ -2578,7 +2580,6 @@
       "colObservation": "Observation",
       "drillObs": "Open observation"
     },
-
     "notificationsView": {
       "title": "Notifications",
       "description": "All notifications fanned out by social-graph triggers (follow, reaction, comment, identification, badge, digest). Filter by recipient, kind, or read state.",
@@ -2597,7 +2598,6 @@
       "colRead": "Read",
       "drillFull": "Full payload"
     },
-
     "mediaView": {
       "title": "Media",
       "description": "All photos, audio and video files registered against observations. Filter by media type, deletion state, or owner.",
@@ -2618,7 +2618,6 @@
       "colState": "State",
       "drillR2Url": "R2 URL"
     },
-
     "followsView": {
       "title": "Follows",
       "description": "Social-graph follow edges. Filter by follower, followee, status (pending vs accepted), or tier (collaborator vs follower). Useful for spam audits.",
@@ -2638,7 +2637,6 @@
       "drillProfileFollower": "View follower's profile",
       "drillProfileFollowee": "View followee's profile"
     },
-
     "watchlistsView": {
       "title": "Watchlists",
       "description": "Per-user species or scientific-name watch entries with optional radius. Filter by user, taxon, or scientific name.",
@@ -2653,7 +2651,6 @@
       "yes": "Yes",
       "no": "No"
     },
-
     "projectsView": {
       "title": "Projects",
       "description": "Named polygons (typically ANPs or sampling grids) under M29. Filter by visibility, owner, or name.",
@@ -2672,7 +2669,6 @@
       "drillView": "Open project",
       "drillObs": "Tagged observations"
     },
-
     "taxonChangesView": {
       "title": "Taxon changes",
       "description": "Audit log of taxon-related admin actions (conservation status, future renames/synonyms). Backed by admin_audit filtered to taxon_* operations. Filter by taxon, action, actor, or date range.",
@@ -2688,7 +2684,6 @@
       "colDiff": "Diff",
       "drillFull": "Full diff"
     },
-
     "audit_op": {
       "role_grant": "Role granted",
       "role_revoke": "Role revoked",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -495,6 +495,8 @@
     "audio_unsupported": "La grabación de audio no está disponible en este navegador.",
     "audio_permission": "Acceso al micrófono denegado. Habilítalo en la configuración del navegador para grabar.",
     "audio_pending_id": "Las observaciones de audio se identifican con BirdNET-Lite una vez que descargues el modelo en Perfil → Editar → Ajustes de IA.",
+    "audio_upload": "Subir archivo de audio",
+    "audio_upload_accepted": "mp3, ogg, wav, m4a",
     "use_camera": "Tomar foto",
     "choose_file": "Subir de galería",
     "gps_label": "Ubicación",
@@ -578,6 +580,8 @@
     "video_unsupported": "La grabación de video no está disponible en este navegador.",
     "video_permission": "Acceso a la cámara/micrófono denegado. Habilítalo en la configuración del navegador para grabar.",
     "video_label": "Video",
+    "video_upload": "Subir video",
+    "video_upload_accepted": "mp4, mov, webm",
     "video_thumbnail_alt": "Previsualización del video grabado",
     "taxon_hint": {
       "label": "¿Qué viste?",
@@ -2547,7 +2551,6 @@
       "topCodes": "Códigos más frecuentes",
       "filterByCode": "Filtrar por código"
     },
-
     "entityBrowser": {
       "clearFilters": "Limpiar filtros",
       "empty": "Ninguna fila coincide con los filtros actuales.",
@@ -2557,7 +2560,6 @@
       "expand": "Expandir fila",
       "anyOption": "— cualquiera —"
     },
-
     "identificationsView": {
       "title": "Identificaciones",
       "description": "Cada identificación registrada — picks del cascade IA, IDs humanos, validaciones. Filtra por identificador, taxón, estado de validación o calidad de investigación.",
@@ -2578,7 +2580,6 @@
       "colObservation": "Observación",
       "drillObs": "Abrir observación"
     },
-
     "notificationsView": {
       "title": "Notificaciones",
       "description": "Todas las notificaciones distribuidas por triggers del grafo social (follow, reacción, comentario, identificación, insignia, digest). Filtra por destinatario, tipo o estado de lectura.",
@@ -2597,7 +2598,6 @@
       "colRead": "Leída",
       "drillFull": "Payload completo"
     },
-
     "mediaView": {
       "title": "Medios",
       "description": "Todos los archivos de foto, audio y video registrados contra observaciones. Filtra por tipo, estado de borrado o propietario.",
@@ -2618,7 +2618,6 @@
       "colState": "Estado",
       "drillR2Url": "URL R2"
     },
-
     "followsView": {
       "title": "Seguimientos",
       "description": "Aristas de seguimiento del grafo social. Filtra por seguidor, seguido, estado (pendiente vs aceptado) o nivel (colaborador vs seguidor). Útil para auditorías anti-spam.",
@@ -2638,7 +2637,6 @@
       "drillProfileFollower": "Ver perfil del seguidor",
       "drillProfileFollowee": "Ver perfil del seguido"
     },
-
     "watchlistsView": {
       "title": "Listas de vigilancia",
       "description": "Entradas de seguimiento de especies o nombres científicos por usuario, con radio opcional. Filtra por usuario, taxón o nombre científico.",
@@ -2653,7 +2651,6 @@
       "yes": "Sí",
       "no": "No"
     },
-
     "projectsView": {
       "title": "Proyectos",
       "description": "Polígonos con nombre (típicamente ANPs o cuadrículas de muestreo) de M29. Filtra por visibilidad, propietario o nombre.",
@@ -2672,7 +2669,6 @@
       "drillView": "Abrir proyecto",
       "drillObs": "Observaciones etiquetadas"
     },
-
     "taxonChangesView": {
       "title": "Cambios de taxón",
       "description": "Bitácora de auditoría de acciones administrativas sobre taxones (estado de conservación, futuras renombramientos/sinónimos). Respaldada por admin_audit filtrada a operaciones taxon_*. Filtra por taxón, acción, actor o rango de fechas.",
@@ -2688,7 +2684,6 @@
       "colDiff": "Diff",
       "drillFull": "Diff completo"
     },
-
     "audit_op": {
       "role_grant": "Rol otorgado",
       "role_revoke": "Rol revocado",


### PR DESCRIPTION
Closes #266

Adds file upload support for audio and video in the observation form alongside existing record/capture options.

## Changes

### Audio
- New **Upload audio file** button next to the recorder
- Hidden `<input type='file' accept='audio/*'>` (mp3, ogg, wav, m4a)
- Uploaded `File` is pushed into the `audios[]` array as a `Blob` entry
- Feeds through existing BirdNET pipeline unchanged (`media.kind='blob'` path already supported)

### Video  
- New **Upload video** button next to the recorder
- Hidden `<input type='file' accept='video/*'>` (mp4, mov, webm)
- Thumbnail extracted via existing `extractVideoThumbnail()` on upload
- Uploaded `File` pushed into `videos[]` array — same path as recorded video

### Images
- Already supported via `gallery-btn`/`gallery-input` (no changes needed)

### i18n
- Added `audio_upload` / `audio_upload_accepted` keys (es + en)
- Added `video_upload` / `video_upload_accepted` keys (es + en)

## UX
- Mobile: `<input type='file'>` opens camera roll natively
- Accepted formats shown as hint text below each section
- Upload buttons styled consistently with the existing gallery button (secondary border style)
- No changes to submit/save/outbox pipeline — `File` extends `Blob`, so everything works transparently