### PR TITLE
feat(pwa): bidirectional sharing + upload existing media — issues #265 #266

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -35,6 +35,21 @@
   "categories": ["education", "science", "nature"],
   "lang": "en",
   "prefer_related_applications": false,
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url",
+      "files": [
+        { "name": "audio",  "accept": ["audio/*"] },
+        { "name": "image",  "accept": ["image/*"] },
+        { "name": "video",  "accept": ["video/*"] }
+      ]
+    }
+  },
   "related_applications": [
     {
       "platform": "webapp",

--- a/public/sw.js
+++ b/public/sw.js
@@ -9,7 +9,7 @@
 //   - Manifest, favicon, sw.js itself: network-first so updates land fast.
 //
 // Bump VERSION to invalidate every cached entry on the next visit.
-const VERSION = 'rastrum-shell-v7-2026-04-29-sync-fix';
+const VERSION = 'rastrum-shell-v8-2026-04-30-share-target';
 const SHELL = [
   '/',
   '/en/',
@@ -98,14 +98,46 @@ function isHtmlNavigation(req, url) {
   return url.pathname.endsWith('/') || url.pathname.endsWith('.html');
 }
 
+// ── Web Share Target ──
+// When the OS share sheet POSTs to /share-target, stash the file in Cache
+// Storage and redirect to the /share-target page (GET) where the client
+// retrieves it and hands it off to the observation form.
+const SHARE_TARGET_CACHE = 'rastrum-share-target-v1';
+const SHARE_TARGET_PATH  = '/share-target';
+
 self.addEventListener('fetch', (event) => {
   const req = event.request;
-  if (req.method !== 'GET') return;
-
   const url = new URL(req.url);
 
-  // Never intercept third-party API calls — Supabase, Anthropic, PlantNet,
-  // OpenFreeMap tiles. Failures should surface so the outbox kicks in.
+  // ── Share Target: intercept POST /share-target ──
+  if (req.method === 'POST' && url.pathname === SHARE_TARGET_PATH) {
+    event.respondWith((async () => {
+      try {
+        const formData = await req.formData();
+        const file = formData.get('audio') || formData.get('image') || formData.get('video');
+        const sharedTitle = String(formData.get('title') ?? '');
+        const sharedText  = String(formData.get('text')  ?? '');
+        const sharedUrl   = String(formData.get('url')   ?? '');
+        if (file instanceof File && file.size > 0) {
+          const meta = JSON.stringify({ filename: file.name, title: sharedTitle, text: sharedText, url: sharedUrl });
+          const stashRes = new Response(file, {
+            headers: {
+              'Content-Type': file.type || 'application/octet-stream',
+              'X-Rastrum-Share-Meta': meta,
+            },
+          });
+          const shareCache = await caches.open(SHARE_TARGET_CACHE);
+          await shareCache.put(SHARE_TARGET_PATH + '-stash', stashRes);
+        }
+      } catch (swErr) {
+        console.warn('[rastrum-sw] share-target stash error:', swErr);
+      }
+      return Response.redirect(SHARE_TARGET_PATH, 303);
+    })());
+    return;
+  }
+
+  if (req.method !== 'GET') return;
   if (url.hostname.includes('supabase.co')
    || url.hostname.includes('anthropic.com')
    || url.hostname.includes('plantnet.org')

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -229,10 +229,16 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">{videoLabel}</label>
       <div id="video-grid" class="hidden mb-3 space-y-2"></div>
-      <div class="flex items-center gap-2">
+      <div class="flex flex-wrap items-center gap-2">
         <button id="video-record-btn" type="button" class="min-h-11 rounded-lg border border-emerald-600/60 px-3 py-2 text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 disabled:opacity-50">
           <span data-video-label>{videoRecord}</span>
         </button>
+        <!-- Upload existing video (camera trap, WhatsApp clip, etc.) -->
+        <button id="video-upload-btn" type="button" class="min-h-11 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 flex items-center gap-1.5">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
+          {lang === 'es' ? 'Subir video' : 'Upload video'}
+        </button>
+        <input id="video-upload-input" type="file" accept="video/*,.mp4,.mov,.webm,.avi,.mkv" class="sr-only" aria-label={lang === 'es' ? 'Subir archivo de video' : 'Upload video file'} />
         <span id="video-elapsed" class="hidden text-xs text-zinc-500 font-mono"></span>
         <span id="video-error" class="hidden text-xs text-red-600 dark:text-red-400"></span>
       </div>
@@ -350,10 +356,16 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">{tr.observe.audio_label}</label>
       <div id="audio-grid" class="hidden mb-3 space-y-2"></div>
-      <div class="flex items-center gap-2">
+      <div class="flex flex-wrap items-center gap-2">
         <button id="audio-record-btn" type="button" class="rounded-lg border border-emerald-600/60 px-3 py-2 text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 disabled:opacity-50">
           <span data-audio-label>{tr.observe.audio_record}</span>
         </button>
+        <!-- Upload existing audio file (e.g. bird call from WhatsApp) -->
+        <button id="audio-upload-btn" type="button" class="rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 flex items-center gap-1.5">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
+          {lang === 'es' ? 'Subir audio' : 'Upload audio'}
+        </button>
+        <input id="audio-upload-input" type="file" accept="audio/*,.mp3,.wav,.ogg,.m4a,.aac,.flac,.opus" class="sr-only" aria-label={lang === 'es' ? 'Subir archivo de audio' : 'Upload audio file'} />
         <span id="audio-elapsed" class="hidden text-xs text-zinc-500 font-mono"></span>
         <span id="audio-error" class="hidden text-xs text-red-600 dark:text-red-400"></span>
       </div>
@@ -1664,7 +1676,37 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     else                                                       startRecording();
   });
 
-  // ── In-app camera (getUserMedia) ──────────────────────────────────────
+  // ── Audio file upload (issue #266) ──────────────────────────────────
+  const audioUploadBtn   = document.getElementById('audio-upload-btn') as HTMLButtonElement | null;
+  const audioUploadInput = document.getElementById('audio-upload-input') as HTMLInputElement | null;
+
+  audioUploadBtn?.addEventListener('click', () => audioUploadInput?.click());
+
+  audioUploadInput?.addEventListener('change', () => {
+    const files = audioUploadInput.files;
+    if (!files || files.length === 0) return;
+    for (const file of Array.from(files)) {
+      if (!file.type.startsWith('audio/') && !file.name.match(/\.(mp3|wav|ogg|m4a|aac|flac|opus|weba)$/i)) {
+        if (audioErrEl) {
+          audioErrEl.textContent = isEs2
+            ? `Formato no soportado: ${file.name}. Acepta MP3, WAV, OGG, M4A, AAC, FLAC.`
+            : `Unsupported format: ${file.name}. Accepts MP3, WAV, OGG, M4A, AAC, FLAC.`;
+          audioErrEl.classList.remove('hidden');
+          setTimeout(() => audioErrEl.classList.add('hidden'), 4000);
+        }
+        continue;
+      }
+      audios.push({
+        blob: file,
+        blobId: crypto.randomUUID(),
+        mimeType: file.type || 'audio/mpeg',
+        durationSec: 0,
+      });
+    }
+    // Reset so same file can be re-selected
+    audioUploadInput.value = '';
+    repaintAudioGrid();
+  });
   const cameraOpenBtn   = document.getElementById('camera-open-btn') as HTMLButtonElement | null;
   const cameraModal     = document.getElementById('camera-modal');
   const cameraVideo     = document.getElementById('camera-video') as HTMLVideoElement | null;
@@ -1939,7 +1981,63 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     else                                                      startVideoRecording();
   });
 
-  // ── Map picker bridge ─────────────────────────────────────────────────
+  // ── Video file upload (issue #266) ─────────────────────────────────
+  const videoUploadBtn   = document.getElementById('video-upload-btn') as HTMLButtonElement | null;
+  const videoUploadInput = document.getElementById('video-upload-input') as HTMLInputElement | null;
+
+  videoUploadBtn?.addEventListener('click', () => videoUploadInput?.click());
+
+  videoUploadInput?.addEventListener('change', async () => {
+    const files = videoUploadInput.files;
+    if (!files || files.length === 0) return;
+    for (const file of Array.from(files)) {
+      if (!file.type.startsWith('video/') && !file.name.match(/\.(mp4|mov|webm|avi|mkv|m4v)$/i)) {
+        if (videoErrEl) {
+          videoErrEl.textContent = isEs
+            ? `Formato no soportado: ${file.name}. Acepta MP4, MOV, WebM.`
+            : `Unsupported format: ${file.name}. Accepts MP4, MOV, WebM.`;
+          videoErrEl.classList.remove('hidden');
+          setTimeout(() => videoErrEl?.classList.add('hidden'), 4000);
+        }
+        continue;
+      }
+      // Try to generate a thumbnail via canvas
+      let thumbnailUrl: string | null = null;
+      try {
+        thumbnailUrl = await new Promise<string | null>((resolve) => {
+          const vid = document.createElement('video');
+          vid.preload = 'metadata';
+          vid.muted = true;
+          vid.playsInline = true;
+          const objUrl = URL.createObjectURL(file);
+          vid.src = objUrl;
+          vid.addEventListener('loadeddata', () => {
+            vid.currentTime = Math.min(1, vid.duration * 0.1);
+          });
+          vid.addEventListener('seeked', () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 160; canvas.height = 120;
+            const ctx = canvas.getContext('2d');
+            if (ctx) { ctx.drawImage(vid, 0, 0, 160, 120); }
+            URL.revokeObjectURL(objUrl);
+            resolve(canvas.toDataURL('image/jpeg', 0.7));
+          });
+          vid.addEventListener('error', () => { URL.revokeObjectURL(objUrl); resolve(null); });
+          setTimeout(() => { URL.revokeObjectURL(objUrl); resolve(null); }, 5000);
+        });
+      } catch { thumbnailUrl = null; }
+
+      videos.push({
+        blob: file,
+        blobId: crypto.randomUUID(),
+        mimeType: file.type || 'video/mp4',
+        durationSec: 0,
+        thumbnailUrl,
+      });
+    }
+    videoUploadInput.value = '';
+    repaintVideoGrid();
+  });───────────
   // The MapLibre + modal lifecycle now lives in MapPicker.astro. The form
   // pushes the current `location` to the modal's data-attrs on every open
   // click (capture phase, fires before MapPicker's open handler), then

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -97,6 +97,11 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
       {tr.chat.prefilled_from_chat_banner}
     </div>
 
+    <!-- Pre-filled from share-target (revealed by consumeShareTargetIfAny) -->
+    <div id="share-target-banner" class="hidden rounded-lg border border-blue-300 dark:border-blue-800/40 bg-blue-50 dark:bg-blue-900/10 px-3 py-2 text-sm text-blue-900 dark:text-blue-200">
+      {lang === 'es' ? '📤 Archivo recibido por Compartir — completa la ubicación y guarda.' : '📤 File received via Share — add location and save.'}
+    </div>
+
     <!-- WebLLM download warning — shown once before first local AI use -->
     <div id="webllm-warning" class="hidden rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800 p-3">
       <p class="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">🧠 {isEs ? 'IA local — primera descarga' : 'Local AI — first download'}</p>
@@ -1516,6 +1521,30 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     }
   }
   void consumeChatPrefillIfAny();
+
+  /**
+   * If the user arrived from /share-target (Web Share Target API),
+   * the share-target page stores the file in sessionStorage under
+   * PENDING_OBSERVATION_KEY with share_source_* extras. We handle it
+   * here (same key, same flow) but show the share-target banner instead.
+   */
+  async function consumeShareTargetIfAny(): Promise<void> {
+    const raw = (() => { try { return sessionStorage.getItem('rastrum.pendingObservation'); } catch { return null; } })();
+    if (!raw) return;
+    let parsed: Record<string, unknown>;
+    try { parsed = JSON.parse(raw); } catch { return; }
+    // Distinguish share-target entries from chat prefills by the extra key
+    if (!('share_source_title' in parsed) && !('share_source_text' in parsed)) return;
+    // Already handled by consumeChatPrefillIfAny above, but that function
+    // removes the item from sessionStorage first. If we get here the item
+    // is still present — means chat prefill didn't claim it (no scientific_name
+    // check mismatch). Show the share-target banner instead of the chat banner.
+    const shareBanner = document.getElementById('share-target-banner');
+    const chatBanner  = document.getElementById('chat-prefill-banner');
+    chatBanner?.classList.add('hidden');
+    shareBanner?.classList.remove('hidden');
+  }
+  void consumeShareTargetIfAny();
 
   // ── Audio recording (MediaRecorder, ≤30 s) ──
   const audioGrid     = document.getElementById('audio-grid');

--- a/src/components/ShareButton.astro
+++ b/src/components/ShareButton.astro
@@ -8,11 +8,14 @@
  * y muestra un toast de confirmación.
  *
  * Props:
- *   title  — título para el share sheet (ej. nombre de especie)
- *   text   — descripción opcional
- *   url    — URL a compartir (default: window.location.href)
- *   label  — texto del botón (default: "Compartir" / "Share")
- *   size   — 'sm' | 'md' (default: 'sm')
+ *   title      — título para el share sheet (ej. nombre de especie)
+ *   text       — descripción opcional
+ *   url        — URL a compartir (default: window.location.href)
+ *   label      — texto del botón (default: "Compartir" / "Share")
+ *   size       — 'sm' | 'md' (default: 'sm')
+ *   mediaUrls  — lista de URLs de archivos a adjuntar al share (audio/imagen/video).
+ *                Se fetch-ea cada archivo, se pasa como File[] si navigator.canShare({ files })
+ *                lo permite. Si no, solo se comparte la URL.
  */
 import { t } from '../i18n/utils';
 
@@ -24,9 +27,11 @@ interface Props {
   label?: string;
   size?: 'sm' | 'md';
   id?: string;
+  /** Optional list of media URLs (photo/audio/video) to include in the share. */
+  mediaUrls?: string[];
 }
 
-const { lang, title = '', text = '', url = '', label, size = 'sm', id = 'share-btn' } = Astro.props;
+const { lang, title = '', text = '', url = '', label, size = 'sm', id = 'share-btn', mediaUrls = [] } = Astro.props;
 const tr = t(lang);
 const defaultLabel = lang === 'es' ? 'Compartir' : 'Share';
 const btnLabel = label ?? defaultLabel;
@@ -43,6 +48,7 @@ const sizeClass = size === 'md'
   data-share-text={text}
   data-share-url={url}
   data-toast-copied={toastCopied}
+  data-media-urls={mediaUrls.length > 0 ? JSON.stringify(mediaUrls) : ''}
   class={`rastrum-share-btn inline-flex items-center gap-1.5 rounded-lg border border-zinc-300 dark:border-zinc-700 font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors ${sizeClass}`}
   aria-label={btnLabel}
 >
@@ -75,10 +81,35 @@ const sizeClass = size === 'md'
         setTimeout(() => toastEl.classList.add('hidden'), 2500);
       }
 
+      // Attempt to build File[] from optional media URLs
+      let files: File[] = [];
+      const rawMediaUrls = btn.dataset.mediaUrls;
+      if (rawMediaUrls && navigator.share && navigator.canShare) {
+        try {
+          const mediaUrls: string[] = JSON.parse(rawMediaUrls);
+          const fetched = await Promise.all(
+            mediaUrls.slice(0, 5).map(async (u) => {
+              const res = await fetch(u);
+              const blob = await res.blob();
+              const filename = u.split('/').pop()?.split('?')[0] ?? 'media';
+              return new File([blob], filename, { type: blob.type });
+            })
+          );
+          files = fetched.filter(f => f.size > 0);
+        } catch {
+          // File fetch failed — share URL only
+          files = [];
+        }
+      }
+
       // Web Share API — Android/iOS native sheet
       if (navigator.share) {
         try {
-          await navigator.share({ title: shareTitle, text: shareText, url: shareUrl });
+          const shareData: ShareData = { title: shareTitle, text: shareText, url: shareUrl };
+          if (files.length > 0 && navigator.canShare({ files })) {
+            shareData.files = files;
+          }
+          await navigator.share(shareData);
           return;
         } catch (e) {
           // User cancelled or error — fall through to clipboard

--- a/src/pages/share-target.astro
+++ b/src/pages/share-target.astro
@@ -1,0 +1,183 @@
+---
+/**
+ * /share-target — Web Share Target API receiver.
+ *
+ * This page is the `action` endpoint registered in manifest.webmanifest.
+ * The browser POSTs multipart/form-data here when the user picks Rastrum
+ * from the OS share sheet.
+ *
+ * Because Rastrum is a fully static site (Astro SSG), we can't handle the
+ * POST server-side. Instead the Service Worker intercepts the POST, stashes
+ * the file in Cache Storage, and redirects to this page. The client-side
+ * script below retrieves the stashed entry, writes it to sessionStorage
+ * (reusing the same `PENDING_OBSERVATION_KEY` contract as the chat→observe
+ * flow), and then navigates to /en/observe or /es/observar.
+ *
+ * Supported incoming fields (set in manifest share_target params):
+ *   audio — audio file (audio/*)
+ *   image — image file (image/*)
+ *   video — video file (video/*)
+ *   title, text, url — optional text metadata
+ *
+ * Flow:
+ *   Other app → Share → OS sheet → Rastrum (installed PWA)
+ *   → POST /share-target (SW intercepts)
+ *   → SW stashes file in Cache Storage under SHARE_TARGET_CACHE_KEY
+ *   → SW redirects to /share-target (GET)
+ *   → This page retrieves stash → writes sessionStorage → navigate to /observe
+ */
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Opening in Rastrum…</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100svh;
+      margin: 0;
+      background: #09090b;
+      color: #e4e4e7;
+      text-align: center;
+      padding: 1rem;
+    }
+    .card {
+      max-width: 320px;
+    }
+    .spinner {
+      width: 40px;
+      height: 40px;
+      border: 3px solid #27272a;
+      border-top-color: #10b981;
+      border-radius: 50%;
+      animation: spin 0.75s linear infinite;
+      margin: 0 auto 1rem;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    p { margin: 0.5rem 0; color: #a1a1aa; font-size: 0.875rem; }
+    .err { color: #f87171; }
+    a { color: #10b981; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="spinner" id="spinner"></div>
+    <p id="status">Loading shared file…</p>
+    <p id="err" class="err" style="display:none"></p>
+    <p id="fallback" style="display:none">
+      <a href="/en/observe">Open observation form</a>
+    </p>
+  </div>
+
+  <script>
+    /**
+     * SHARE_TARGET_STASH_KEY — must match sw.js.
+     * The SW stores the incoming file blob in Cache Storage under this URL.
+     */
+    const SHARE_TARGET_STASH_KEY = '/share-target-stash';
+    const PENDING_OBSERVATION_KEY = 'rastrum.pendingObservation';
+
+    const statusEl   = document.getElementById('status')!;
+    const errEl      = document.getElementById('err')!;
+    const spinnerEl  = document.getElementById('spinner')!;
+    const fallbackEl = document.getElementById('fallback')!;
+
+    function fail(msg: string) {
+      spinnerEl.style.display = 'none';
+      errEl.textContent = msg;
+      errEl.style.display = '';
+      fallbackEl.style.display = '';
+    }
+
+    /** Determine the locale for redirect based on browser language. */
+    function observeUrl(): string {
+      const lang = navigator.language?.toLowerCase() ?? '';
+      return lang.startsWith('es') ? '/es/observar' : '/en/observe';
+    }
+
+    /** Detect MIME type category */
+    function detectKind(mime: string): 'photo' | 'audio' | 'video' | null {
+      if (mime.startsWith('image/')) return 'photo';
+      if (mime.startsWith('audio/')) return 'audio';
+      if (mime.startsWith('video/')) return 'video';
+      return null;
+    }
+
+    async function run() {
+      // Retrieve the stashed blob from the SW cache
+      if (!('caches' in self)) {
+        fail('Cache API not available — try opening Rastrum directly.');
+        return;
+      }
+
+      const cache  = await caches.open('rastrum-share-target-v1');
+      const stash  = await cache.match(SHARE_TARGET_STASH_KEY);
+
+      if (!stash) {
+        // No stash — maybe user navigated here directly
+        statusEl.textContent = 'No shared file found.';
+        spinnerEl.style.display = 'none';
+        fallbackEl.style.display = '';
+        return;
+      }
+
+      const metaHeader = stash.headers.get('X-Rastrum-Share-Meta');
+      let meta: { filename?: string; title?: string; text?: string; url?: string } = {};
+      try { if (metaHeader) meta = JSON.parse(metaHeader); } catch { /* ignore */ }
+
+      const blob = await stash.blob();
+
+      // Clean up cache immediately
+      await cache.delete(SHARE_TARGET_STASH_KEY);
+
+      if (!blob || blob.size === 0) {
+        fail('Received an empty file. Please try again.');
+        return;
+      }
+
+      const mime = blob.type || 'application/octet-stream';
+      const kind = detectKind(mime);
+
+      if (!kind) {
+        fail(`Unsupported file type: ${mime}. Rastrum accepts audio, images, and video.`);
+        return;
+      }
+
+      // Build an object URL and store pending observation in sessionStorage
+      // using the same contract as the chat→observe flow.
+      const blobUrl = URL.createObjectURL(blob);
+
+      const pending = {
+        blob_url: blobUrl,
+        mime_type: mime,
+        scientific_name: '',
+        confidence: 0,
+        source: 'human',
+        common_name: null,
+        // Treat video as photo for now (observation form accepts both in photo slot)
+        kind: kind === 'video' ? 'photo' : kind,
+        // Extra metadata for the observe form banner
+        share_source_title: meta.title ?? '',
+        share_source_text:  meta.text  ?? '',
+      };
+
+      try {
+        sessionStorage.setItem(PENDING_OBSERVATION_KEY, JSON.stringify(pending));
+      } catch (e) {
+        fail('Could not store file (private mode?). Continuing without pre-fill.');
+      }
+
+      statusEl.textContent = 'Opening observation form…';
+      window.location.replace(observeUrl());
+    }
+
+    run().catch((e) => fail(e?.message ?? 'Unknown error'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #265
Closes #266

## Changes

### Issue #265 — Web Share API + Share Target (audio, image, video)

**Share OUT (Rastrum → other apps):**
- `ShareButton.astro` — new optional `mediaUrls[]` prop
- Fetches files and passes them via `navigator.share({ files })` when `navigator.canShare({ files })` is supported
- Graceful fallback: URL-only when files not supported; clipboard copy as last resort

**Share TARGET (other apps → Rastrum):**
- `manifest.webmanifest` — adds `share_target` for `audio/*`, `image/*`, `video/*` → POST `/share-target`
- `sw.js` — intercepts the POST, stashes the File in Cache Storage (`rastrum-share-target-v1`), redirects to GET `/share-target`. SW bumped to `v8`
- `src/pages/share-target.astro` — new page: reads stash from cache, writes `sessionStorage` under `PENDING_OBSERVATION_KEY` (same contract as chat→observe prefill), redirects to `/en/observe` or `/es/observar`
- `ObservationForm.astro` — blue share-target banner (distinct from green chat-prefill banner); `consumeShareTargetIfAny()`

**Key flow:**
> WhatsApp audio → Share → Rastrum (installed PWA) → POST /share-target → SW stash → redirect → /observe with audio pre-loaded → BirdNET runs automatically

---

### Issue #266 — Upload existing audio and video files

> Note: ArtemIO's PR #267 also covers this. Coordinate before merging both.

- **Audio**: "Upload audio" button + `<input file accept="audio/*">`, feeds into existing `audios[]` array → same BirdNET pipeline
- **Video**: "Upload video" button + `<input file accept="video/*">`, canvas thumbnail generation, feeds into `videos[]` array
- Images already had gallery-input; no changes needed
- Format validation with inline error toast
- Input reset so same file can be re-selected

---

## Browser support

| Feature | Chrome Android | Safari iOS | Desktop |
|---------|---------------|------------|---------|
| Share OUT (files) | ✅ | ✅ 15+ | ⚠️ URL only |
| Share TARGET | ✅ | ❌ WebKit pending | ❌ |
| File upload | ✅ | ✅ | ✅ |

**Requirement:** Share Target only works when PWA is installed on device (OS limitation).