### PR TITLE
feat(ux): Observe 2.0 — Drop & Discover with live pipeline graph (#270)

### DIFF
--- a/src/components/DropZone.astro
+++ b/src/components/DropZone.astro
@@ -1,0 +1,188 @@
+---
+/**
+ * DropZone.astro — Unified media drop zone for Observe 2.0
+ *
+ * Accepts files via:
+ *   - Drag and drop (desktop)
+ *   - Tap to pick (mobile/desktop)
+ *   - Paste from clipboard (Ctrl+V, Chrome desktop)
+ *   - PWA Share Target (pre-populated via rastrum:files-dropped event)
+ *
+ * Dispatches `rastrum:files-dropped` CustomEvent with `{ files: File[] }`.
+ */
+
+interface Props {
+  lang: 'en' | 'es';
+  /** Optional extra CSS classes for the container */
+  class?: string;
+}
+
+const { lang, class: extraClass = '' } = Astro.props;
+const isEs = lang === 'es';
+
+const dropLabel      = isEs ? 'Suelta fotos, audio o video aquí' : 'Drop photos, audio, or video here';
+const tapLabel       = isEs ? 'Toca para seleccionar archivos' : 'Tap to select files';
+const orLabel        = isEs ? 'o' : 'or';
+const captureLabel   = isEs ? 'Capturar' : 'Capture';
+const galleryLabel   = isEs ? 'Galería' : 'Gallery';
+const audioLabel     = isEs ? 'Grabar audio' : 'Record audio';
+const dragOverLabel  = isEs ? 'Suelta los archivos' : 'Drop files here';
+const pasteHint      = isEs ? 'También puedes pegar (Ctrl+V)' : 'You can also paste (Ctrl+V)';
+---
+
+<div
+  id="drop-zone-root"
+  class={`relative rounded-2xl border-2 border-dashed border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/40 transition-all ${extraClass}`}
+  aria-label={dropLabel}
+  role="region"
+>
+  <!-- Hidden file inputs -->
+  <input id="dz-capture-input" type="file" accept="image/*,audio/*,video/*" capture="environment" multiple class="sr-only" />
+  <input id="dz-gallery-input" type="file" accept="image/*,audio/*,video/*" multiple class="sr-only" />
+  <input id="dz-audio-input"   type="file" accept="audio/*" class="sr-only" />
+
+  <!-- Default state -->
+  <div id="dz-default" class="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+    <!-- Upload icon -->
+    <div class="w-14 h-14 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+      <svg class="w-7 h-7 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"/>
+      </svg>
+    </div>
+
+    <div>
+      <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300">{dropLabel}</p>
+      <p class="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5">{tapLabel}</p>
+    </div>
+
+    <!-- Action buttons row -->
+    <div class="flex flex-wrap items-center justify-center gap-2 mt-1">
+      <button id="dz-capture-btn" type="button"
+        class="flex items-center gap-1.5 rounded-lg border border-emerald-600/50 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors"
+      >
+        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
+        </svg>
+        {captureLabel}
+      </button>
+
+      <span class="text-xs text-zinc-400">{orLabel}</span>
+
+      <button id="dz-gallery-btn" type="button"
+        class="flex items-center gap-1.5 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 transition-colors"
+      >
+        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"/>
+        </svg>
+        {galleryLabel}
+      </button>
+
+      <button id="dz-audio-btn" type="button"
+        class="flex items-center gap-1.5 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 transition-colors"
+      >
+        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"/>
+        </svg>
+        {audioLabel}
+      </button>
+    </div>
+
+    <p class="text-[10px] text-zinc-400 dark:text-zinc-600 mt-1">{pasteHint}</p>
+  </div>
+
+  <!-- Drag-over overlay -->
+  <div id="dz-dragover" class="hidden absolute inset-0 rounded-2xl flex items-center justify-center bg-emerald-500/10 border-2 border-emerald-500">
+    <p class="text-sm font-semibold text-emerald-700 dark:text-emerald-300">{dragOverLabel}</p>
+  </div>
+
+  <!-- Preview thumbnails (populated by JS) -->
+  <div id="dz-previews" class="hidden px-4 pb-4 flex flex-wrap gap-2"></div>
+</div>
+
+<script>
+const root      = document.getElementById('drop-zone-root');
+const defaultEl = document.getElementById('dz-default');
+const dragover  = document.getElementById('dz-dragover');
+const previews  = document.getElementById('dz-previews');
+const capBtn    = document.getElementById('dz-capture-btn');
+const galBtn    = document.getElementById('dz-gallery-btn');
+const audBtn    = document.getElementById('dz-audio-btn');
+const capInput  = document.getElementById('dz-capture-input') as HTMLInputElement | null;
+const galInput  = document.getElementById('dz-gallery-input') as HTMLInputElement | null;
+const audInput  = document.getElementById('dz-audio-input')   as HTMLInputElement | null;
+
+// ── Button → input wiring ──────────────────────────────────────────────────
+capBtn?.addEventListener('click', () => capInput?.click());
+galBtn?.addEventListener('click', () => galInput?.click());
+audBtn?.addEventListener('click', () => audInput?.click());
+
+function onInputChange(input: HTMLInputElement | null) {
+  return () => {
+    if (!input?.files?.length) return;
+    dispatch(Array.from(input.files));
+    input.value = '';
+  };
+}
+capInput?.addEventListener('change', onInputChange(capInput));
+galInput?.addEventListener('change', onInputChange(galInput));
+audInput?.addEventListener('change', onInputChange(audInput));
+
+// ── Drag & drop ────────────────────────────────────────────────────────────
+root?.addEventListener('dragenter', (e) => { e.preventDefault(); dragover?.classList.remove('hidden'); });
+root?.addEventListener('dragleave', (e) => { if (!root.contains(e.relatedTarget as Node)) dragover?.classList.add('hidden'); });
+root?.addEventListener('dragover', (e) => e.preventDefault());
+root?.addEventListener('drop', (e) => {
+  e.preventDefault();
+  dragover?.classList.add('hidden');
+  const files = Array.from(e.dataTransfer?.files ?? []);
+  if (files.length) dispatch(files);
+});
+
+// ── Paste (Ctrl+V) — desktop Chrome ────────────────────────────────────────
+document.addEventListener('paste', (e) => {
+  // Only if drop-zone is visible/relevant
+  if (!root) return;
+  const items = Array.from(e.clipboardData?.items ?? []);
+  const files = items
+    .filter(i => i.kind === 'file')
+    .map(i => i.getAsFile())
+    .filter(Boolean) as File[];
+  if (files.length) dispatch(files);
+});
+
+// ── Dispatch event ─────────────────────────────────────────────────────────
+function dispatch(files: File[]) {
+  document.dispatchEvent(new CustomEvent('rastrum:files-dropped', { detail: { files } }));
+  showPreviews(files);
+}
+
+// ── Thumbnail previews ─────────────────────────────────────────────────────
+function showPreviews(files: File[]) {
+  if (!previews || !defaultEl) return;
+  defaultEl.classList.add('hidden');
+  previews.classList.remove('hidden');
+  previews.classList.add('flex');
+
+  for (const file of files) {
+    const thumb = document.createElement('div');
+    thumb.className = 'relative w-16 h-16 rounded-lg overflow-hidden bg-zinc-200 dark:bg-zinc-800 shrink-0';
+
+    if (file.type.startsWith('image/')) {
+      const img = document.createElement('img');
+      img.src = URL.createObjectURL(file);
+      img.className = 'w-full h-full object-cover';
+      img.alt = file.name;
+      thumb.appendChild(img);
+    } else if (file.type.startsWith('audio/')) {
+      thumb.innerHTML = '<div class="w-full h-full flex items-center justify-center text-2xl">🎵</div>';
+    } else if (file.type.startsWith('video/')) {
+      thumb.innerHTML = '<div class="w-full h-full flex items-center justify-center text-2xl">🎬</div>';
+    } else {
+      thumb.innerHTML = '<div class="w-full h-full flex items-center justify-center text-2xl">📄</div>';
+    }
+
+    previews.appendChild(thumb);
+  }
+}
+</script>

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -1,0 +1,544 @@
+---
+import DropZone from "./DropZone.astro";
+import PipelineGraph from "./PipelineGraph.astro";
+import MapPicker from "./MapPicker.astro";
+import { t } from "../i18n/utils";
+import { HABITATS, WEATHERS } from "../lib/observation-enums";
+
+interface Props { lang: "en" | "es"; }
+const { lang } = Astro.props;
+const isEs = lang === "es";
+const tr = t(lang);
+
+const observeStr = tr.observe as Record<string, string>;
+const habitats = HABITATS;
+const weathers = WEATHERS;
+---
+
+<div class="max-w-2xl mx-auto space-y-6">
+  <!-- Header -->
+  <div class="flex items-start justify-between gap-4">
+    <h1 class="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {isEs ? "Registrar observación" : "Log observation"}
+    </h1>
+    <a
+      href={isEs ? "/es/observar/clasico" : "/en/observe/classic"}
+      class="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline underline-offset-2 shrink-0 mt-1"
+    >
+      {isEs ? "Formulario clásico" : "Classic form"}
+    </a>
+  </div>
+
+  <!-- Resume in-progress banner -->
+  <div id="obs2-resume-banner" class="hidden rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 p-4 flex items-center gap-3">
+    <span class="text-amber-700 dark:text-amber-300 text-sm flex-1">
+      {isEs ? "Tienes una observación en progreso." : "You have an observation in progress."}
+    </span>
+    <button id="obs2-resume-btn" type="button" class="text-xs font-semibold text-amber-700 dark:text-amber-300 underline">
+      {isEs ? "Retomar" : "Resume"}
+    </button>
+    <button id="obs2-resume-dismiss" type="button" class="text-xs text-zinc-400 hover:text-zinc-600">
+      {isEs ? "Descartar" : "Dismiss"}
+    </button>
+  </div>
+
+  <!-- Drop Zone -->
+  <DropZone lang={lang} />
+
+  <!-- Pipeline section (hidden until files added) -->
+  <div id="obs2-pipeline-section" class="hidden space-y-3">
+    <div class="flex items-center justify-between">
+      <h2 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+        {isEs ? "Procesando archivos" : "Processing files"}
+      </h2>
+      <span id="obs2-pipeline-status" class="text-xs text-zinc-500 dark:text-zinc-400"></span>
+    </div>
+    <PipelineGraph lang={lang} />
+  </div>
+
+  <!-- Post-process form (hidden until pipeline done) -->
+  <form id="obs2-post-form" class="hidden space-y-5" novalidate>
+    <h2 class="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+      {isEs ? "Ültimos detalles" : "Almost done"}
+    </h2>
+
+    <!-- Identification result card -->
+    <div id="obs2-id-card" class="hidden rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 p-4">
+      <div class="flex items-start justify-between gap-2">
+        <div>
+          <p id="obs2-species" class="font-semibold italic text-zinc-900 dark:text-zinc-100"></p>
+          <p id="obs2-common" class="text-sm text-zinc-500 dark:text-zinc-400"></p>
+        </div>
+        <span id="obs2-conf" class="text-xs font-mono text-emerald-600 dark:text-emerald-400 shrink-0"></span>
+      </div>
+      <button type="button" id="obs2-id-edit" class="mt-2 text-xs text-zinc-400 underline">
+        {isEs ? "Editar identificación" : "Edit identification"}
+      </button>
+      <div id="obs2-id-manual" class="hidden mt-2">
+        <input
+          id="obs2-taxon-input"
+          type="text"
+          class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm"
+          placeholder={isEs ? "Nombre científico (opcional)" : "Scientific name (optional)"}
+        />
+      </div>
+    </div>
+
+    <!-- Location -->
+    <div>
+      <div class="flex items-center justify-between mb-2">
+        <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+          {isEs ? "Ubicación" : "Location"}
+        </label>
+        <button type="button" id="obs2-skip-location" class="text-xs text-zinc-400 underline">
+          {isEs ? "Omitir ubicación" : "Skip location"}
+        </button>
+      </div>
+      <div id="obs2-gps-status" class="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
+        {isEs ? "Obteniendo GPS..." : "Acquiring GPS..."}
+      </div>
+      <MapPicker mode="edit" lang={lang} pickerId="obs2-map" initialCoords={null} />
+    </div>
+
+    <!-- Notes -->
+    <div>
+      <label for="obs2-notes" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+        {isEs ? "Notas" : "Notes"} <span class="text-zinc-400">{isEs ? "(opcional)" : "(optional)"}</span>
+      </label>
+      <textarea
+        id="obs2-notes"
+        rows="3"
+        class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm resize-none"
+        placeholder={isEs ? "¿Qué observaste? Contexto adicional..." : "What did you observe? Any additional context..."}
+      ></textarea>
+    </div>
+
+    <!-- Advanced fields (collapsed) -->
+    <details class="rounded-lg border border-zinc-200 dark:border-zinc-800">
+      <summary class="px-4 py-3 text-sm font-medium text-zinc-600 dark:text-zinc-400 cursor-pointer select-none">
+        {isEs ? "Campos avanzados" : "Advanced fields"}
+      </summary>
+      <div class="px-4 pb-4 pt-2 space-y-4 border-t border-zinc-100 dark:border-zinc-800">
+        <!-- Habitat -->
+        <div>
+          <label for="obs2-habitat" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+            {observeStr.habitat_label ?? (isEs ? "Hábitat" : "Habitat")}
+          </label>
+          <select id="obs2-habitat" class="block w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm">
+            <option value="">{isEs ? "No especificado" : "Not specified"}</option>
+            {habitats.map(h => <option value={h}>{h}</option>)}
+          </select>
+        </div>
+        <!-- Weather -->
+        <div>
+          <label for="obs2-weather" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+            {observeStr.weather_label ?? (isEs ? "Clima" : "Weather")}
+          </label>
+          <select id="obs2-weather" class="block w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm">
+            <option value="">{isEs ? "No especificado" : "Not specified"}</option>
+            {weathers.map(w => <option value={w}>{w}</option>)}
+          </select>
+        </div>
+      </div>
+    </details>
+
+    <!-- Error box -->
+    <div id="obs2-error" class="hidden rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/40 px-4 py-3 text-sm text-red-700 dark:text-red-300"></div>
+
+    <!-- Save button -->
+    <button
+      type="submit"
+      id="obs2-save-btn"
+      class="w-full min-h-[48px] rounded-xl bg-emerald-700 hover:bg-emerald-800 active:bg-emerald-900 text-white font-semibold text-sm transition-colors disabled:opacity-50"
+    >
+      {isEs ? "Guardar observación" : "Save observation"}
+    </button>
+  </form>
+
+  <!-- Success state -->
+  <div id="obs2-success" class="hidden rounded-xl border border-emerald-200 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 p-6 text-center space-y-3">
+    <div class="text-4xl">✅</div>
+    <p class="font-semibold text-emerald-800 dark:text-emerald-300">
+      {isEs ? "¡Observación guardada!" : "Observation saved!"}
+    </p>
+    <div id="obs2-success-link"></div>
+    <button type="button" id="obs2-new-btn" class="text-sm text-emerald-700 dark:text-emerald-400 underline">
+      {isEs ? "Registrar otra" : "Log another"}
+    </button>
+  </div>
+</div>
+
+<script>
+import type { PipelineFile, PipelineNode, PipelineState } from '../lib/pipeline-engine';
+import {
+  triageFile, buildGraph, savePipelineState, loadPipelineState,
+} from '../lib/pipeline-engine';
+import { saveObservationToOutbox, resolveObserverRef } from '../lib/observe';
+import { syncOutbox } from '../lib/sync';
+
+// ── State ──────────────────────────────────────────────────────────────────
+const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
+const isEs = lang === 'es';
+
+let pipelineState: PipelineState | null = null;
+let location: { lat: number; lng: number; accuracyM: number; altitudeM: number | null } | null = null;
+let bestResult: { scientific_name: string; common_name_en: string | null; confidence: number; source: string } | null = null;
+
+// DOM refs
+const pipelineSection = document.getElementById('obs2-pipeline-section');
+const pipelineStatus  = document.getElementById('obs2-pipeline-status');
+const postForm        = document.getElementById('obs2-post-form') as HTMLFormElement | null;
+const successEl       = document.getElementById('obs2-success');
+const errorEl         = document.getElementById('obs2-error');
+const saveBtn         = document.getElementById('obs2-save-btn') as HTMLButtonElement | null;
+const resumeBanner    = document.getElementById('obs2-resume-banner');
+const gpsStatus       = document.getElementById('obs2-gps-status');
+const idCard          = document.getElementById('obs2-id-card');
+const speciesEl       = document.getElementById('obs2-species');
+const commonEl        = document.getElementById('obs2-common');
+const confEl          = document.getElementById('obs2-conf');
+
+// ── Resume banner ──────────────────────────────────────────────────────────
+(async () => {
+  try {
+    const db = await loadPipelineState('__latest__');
+    if (db && db.status !== 'done' && db.status !== 'failed') {
+      resumeBanner?.classList.remove('hidden');
+      document.getElementById('obs2-resume-btn')?.addEventListener('click', () => {
+        resumePipeline(db);
+        resumeBanner?.classList.add('hidden');
+      });
+      document.getElementById('obs2-resume-dismiss')?.addEventListener('click', () => {
+        resumeBanner?.classList.add('hidden');
+      });
+    }
+  } catch { /* no prior pipeline */ }
+})();
+
+// ── Files dropped ──────────────────────────────────────────────────────────
+document.addEventListener('rastrum:files-dropped', async (e: Event) => {
+  const ev = e as CustomEvent<{ files: File[] }>;
+  const files: File[] = ev.detail.files;
+  if (!files.length) return;
+
+  const pipelineFiles: PipelineFile[] = files.map(f => ({
+    id: crypto.randomUUID(),
+    file: f,
+    kind: triageFile(f),
+    blobUrl: URL.createObjectURL(f),
+  }));
+
+  // Detect available runners
+  const runners = await detectRunners();
+  const nodes = buildGraph(pipelineFiles, runners);
+
+  pipelineState = {
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    files: pipelineFiles,
+    nodes,
+    mode: 'full',
+    status: 'processing',
+  };
+
+  // Save to IndexedDB eagerly
+  await savePipelineState(pipelineState).catch(() => {});
+
+  // Show pipeline section
+  pipelineSection?.classList.remove('hidden');
+  updatePipelineUI();
+
+  // Start GPS in parallel
+  startGPS();
+
+  // Run pipeline
+  await runPipeline(pipelineState);
+});
+
+// ── Available runners detection ────────────────────────────────────────────
+async function detectRunners() {
+  const { getBirdNETCacheStatus, getBirdNETWeightsBaseUrl } = await import('../lib/identifiers/birdnet-cache');
+  const { resolvePlantNetKey } = await import('../lib/identify-runners');
+  const { hasAnthropicKey } = await import('../lib/anthropic-key');
+
+  const [birdnetStatus, plantnetKey, claudeKey] = await Promise.all([
+    getBirdNETWeightsBaseUrl()
+      ? getBirdNETCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
+      : Promise.resolve(false),
+    resolvePlantNetKey().then(k => !!k).catch(() => false),
+    hasAnthropicKey().catch(() => false),
+  ]);
+
+  let phi = false;
+  try {
+    const { getModelCacheStatus, VISION_MODEL_ID, localAISupported } = await import('../lib/local-ai');
+    if (localAISupported()) {
+      const s = await getModelCacheStatus(VISION_MODEL_ID);
+      phi = s.cached && (localStorage.getItem('rastrum.prefs.usePhiVision') === 'true');
+    }
+  } catch { /* unavailable */ }
+
+  return { plantnet: plantnetKey, birdnet: birdnetStatus, claude: claudeKey, phi };
+}
+
+// ── Pipeline runner ────────────────────────────────────────────────────────
+async function runPipeline(state: PipelineState) {
+  const { runParallelIdentify } = await import('../lib/identify-cascade-client');
+  const { makePlantNetRunner, makeClaudeRunner, makePhiRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
+  const { hasAnthropicKey } = await import('../lib/anthropic-key');
+
+  for (const node of state.nodes) {
+    if (node.kind !== 'identify' || node.state === 'skipped') continue;
+    const pf = state.files.find(f => f.id === node.fileId);
+    if (!pf) continue;
+
+    setNodeState(state, node.id, 'running');
+
+    try {
+      if (pf.kind === 'photo') {
+        // Build runners dynamically
+        const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
+        if (await resolvePlantNetKey()) runners.plantnet = (await import('../lib/identify-runners')).makePlantNetRunner(lang as 'en' | 'es');
+        if (await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+
+        if (Object.keys(runners).length === 0) {
+          setNodeState(state, node.id, 'skipped', undefined, 'No runner available');
+        } else {
+          const abort = new AbortController();
+          const out = await runParallelIdentify(pf.file as File, { runners }, abort.signal);
+          if (out.kind === 'winner' || out.kind === 'uncertain') {
+            const r = out.result;
+            setNodeState(state, node.id, 'done', {
+              scientific_name: r.scientific_name,
+              common_name_en: r.common_name_en,
+              confidence: r.confidence,
+              source: r.source,
+            });
+            if (!bestResult || r.confidence > (bestResult.confidence ?? 0)) {
+              bestResult = { scientific_name: r.scientific_name, common_name_en: r.common_name_en ?? null, confidence: r.confidence, source: r.source };
+            }
+          } else {
+            setNodeState(state, node.id, 'failed', undefined, 'No identification result');
+          }
+        }
+      } else if (pf.kind === 'audio') {
+        const { birdnetIdentifier } = await import('../lib/identifiers/birdnet');
+        const av = await birdnetIdentifier.isAvailable();
+        if (!av.ready) {
+          setNodeState(state, node.id, 'skipped', undefined, av.message ?? 'BirdNET not available');
+        } else {
+          const result = await birdnetIdentifier.identify({
+            media: { kind: 'blob', blob: pf.file as Blob },
+            mediaKind: 'audio',
+            locale: lang as 'en' | 'es',
+          });
+          setNodeState(state, node.id, 'done', {
+            scientific_name: result.scientific_name,
+            common_name_en: result.common_name_en,
+            confidence: result.confidence,
+            source: result.source,
+          });
+          if (!bestResult || result.confidence > (bestResult.confidence ?? 0)) {
+            bestResult = { scientific_name: result.scientific_name, common_name_en: result.common_name_en ?? null, confidence: result.confidence, source: result.source };
+          }
+        }
+      }
+    } catch (err) {
+      setNodeState(state, node.id, 'failed', undefined, (err as Error).message);
+    }
+  }
+
+  // Merge node
+  const mergeNode = state.nodes.find(n => n.kind === 'merge');
+  if (mergeNode) setNodeState(state, mergeNode.id, 'done');
+
+  // Location node — mark running, GPS already in progress
+  const locNode = state.nodes.find(n => n.kind === 'location');
+  if (locNode) setNodeState(state, locNode.id, location ? 'done' : 'running');
+
+  state.status = 'done';
+  await savePipelineState(state).catch(() => {});
+
+  // Show post-process form
+  showPostForm();
+}
+
+// ── Node state helpers ─────────────────────────────────────────────────────
+function setNodeState(
+  state: PipelineState,
+  nodeId: string,
+  newState: import('../lib/pipeline-engine').NodeState,
+  output?: import('../lib/pipeline-engine').PipelineResult,
+  error?: string,
+) {
+  const node = state.nodes.find(n => n.id === nodeId);
+  if (!node) return;
+  node.state = newState;
+  if (output) node.output = output;
+  if (error) node.error = error;
+  if (newState === 'running') node.startedAt = Date.now();
+  if (newState === 'done' || newState === 'failed') node.completedAt = Date.now();
+  updatePipelineUI();
+  savePipelineState(state).catch(() => {});
+}
+
+function updatePipelineUI() {
+  if (!pipelineState) return;
+  document.dispatchEvent(new CustomEvent('rastrum:pipeline-update', { detail: { nodes: pipelineState.nodes } }));
+
+  // Status text
+  const running = pipelineState.nodes.filter(n => n.state === 'running').length;
+  const done    = pipelineState.nodes.filter(n => n.state === 'done').length;
+  const total   = pipelineState.nodes.length;
+  if (pipelineStatus) {
+    pipelineStatus.textContent = running > 0
+      ? (isEs ? `Procesando... (${done}/${total})` : `Processing... (${done}/${total})`)
+      : (isEs ? `Listo (${done}/${total})` : `Ready (${done}/${total})`);
+  }
+}
+
+// ── GPS ────────────────────────────────────────────────────────────────────
+function startGPS() {
+  if (!navigator.geolocation) {
+    if (gpsStatus) gpsStatus.textContent = isEs ? 'GPS no disponible' : 'GPS not available';
+    return;
+  }
+  if (gpsStatus) gpsStatus.textContent = isEs ? 'Obteniendo GPS...' : 'Acquiring GPS...';
+  navigator.geolocation.getCurrentPosition(
+    pos => {
+      location = {
+        lat: pos.coords.latitude,
+        lng: pos.coords.longitude,
+        accuracyM: pos.coords.accuracy,
+        altitudeM: pos.coords.altitude,
+      };
+      if (gpsStatus) gpsStatus.textContent = `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)} (±${Math.round(location.accuracyM)}m)`;
+      // Notify map picker
+      window.dispatchEvent(new CustomEvent('rastrum:mappicker-set', {
+        detail: { id: 'obs2-map', coords: { lat: location.lat, lng: location.lng } },
+      }));
+      // Update location node
+      if (pipelineState) {
+        const locNode = pipelineState.nodes.find(n => n.kind === 'location');
+        if (locNode) setNodeState(pipelineState, locNode.id, 'done');
+      }
+    },
+    () => {
+      if (gpsStatus) gpsStatus.textContent = isEs ? 'No se pudo obtener ubicación' : 'Could not get location';
+    },
+    { enableHighAccuracy: true, timeout: 20000 },
+  );
+}
+
+// ── Show post form ─────────────────────────────────────────────────────────
+function showPostForm() {
+  postForm?.classList.remove('hidden');
+  if (bestResult) {
+    idCard?.classList.remove('hidden');
+    if (speciesEl) speciesEl.textContent = bestResult.scientific_name;
+    if (commonEl) commonEl.textContent = bestResult.common_name_en ?? '';
+    if (confEl) confEl.textContent = `${Math.round(bestResult.confidence * 100)}%`;
+  }
+
+  // Edit identification toggle
+  document.getElementById('obs2-id-edit')?.addEventListener('click', () => {
+    document.getElementById('obs2-id-manual')?.classList.toggle('hidden');
+  });
+}
+
+// ── Skip location ──────────────────────────────────────────────────────────
+document.getElementById('obs2-skip-location')?.addEventListener('click', () => {
+  location = { lat: 0, lng: 0, accuracyM: 0, altitudeM: null };
+  if (gpsStatus) gpsStatus.textContent = isEs ? 'Ubicación omitida' : 'Location skipped';
+});
+
+// ── Save ───────────────────────────────────────────────────────────────────
+postForm?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  if (!pipelineState) return;
+  if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = isEs ? 'Guardando...' : 'Saving...'; }
+  if (errorEl) errorEl.classList.add('hidden');
+
+  try {
+    const observerRef = await resolveObserverRef();
+    const notes = (document.getElementById('obs2-notes') as HTMLTextAreaElement | null)?.value.trim() || null;
+    const habitatVal = (document.getElementById('obs2-habitat') as HTMLSelectElement | null)?.value || null;
+    const weatherVal = (document.getElementById('obs2-weather') as HTMLSelectElement | null)?.value || null;
+    const taxonInput = (document.getElementById('obs2-taxon-input') as HTMLInputElement | null)?.value.trim();
+
+    const mediaInputs = pipelineState.files.map(pf => ({
+      blob: pf.file,
+      blobId: pf.id,
+      mimeType: pf.file.type || 'application/octet-stream',
+      sizeBytes: pf.file.size,
+      mediaType: pf.kind === 'audio' ? 'audio' as const : pf.kind === 'video' ? 'video' as const : 'photo' as const,
+    }));
+
+    const identifiedSpecies = taxonInput || bestResult?.scientific_name || '';
+
+    const obs = await saveObservationToOutbox({
+      observerRef,
+      media: mediaInputs,
+      location: location ?? { lat: 0, lng: 0, accuracyM: 0, altitudeM: null, capturedFrom: 'gps' },
+      identification: identifiedSpecies ? {
+        scientificName: identifiedSpecies,
+        confidence: bestResult?.confidence ?? 0,
+        source: (bestResult?.source ?? 'human') as never,
+        status: 'accepted',
+      } : undefined,
+      habitat: habitatVal as never,
+      weather: weatherVal as never,
+      notes,
+    });
+
+    await syncOutbox().catch(() => {});
+
+    // Update pipeline
+    const saveNode = pipelineState.nodes.find(n => n.kind === 'save');
+    if (saveNode) setNodeState(pipelineState, saveNode.id, 'done');
+    pipelineState.status = 'done';
+    await savePipelineState(pipelineState).catch(() => {});
+
+    // Show success
+    postForm?.classList.add('hidden');
+    successEl?.classList.remove('hidden');
+    const linkEl = document.getElementById('obs2-success-link');
+    if (linkEl && obs.id) {
+      const href = `/share/obs/?id=${obs.id}`;
+      linkEl.innerHTML = `<a href="${href}" class="text-emerald-700 dark:text-emerald-400 underline text-sm">${isEs ? 'Ver observaci\u00f3n' : 'View observation'}</a>`;
+    }
+  } catch (err) {
+    if (errorEl) {
+      errorEl.textContent = (err as Error).message ?? (isEs ? 'Error al guardar' : 'Error saving');
+      errorEl.classList.remove('hidden');
+    }
+    if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = isEs ? 'Guardar observaci\u00f3n' : 'Save observation'; }
+  }
+});
+
+// ── New observation ────────────────────────────────────────────────────────
+document.getElementById('obs2-new-btn')?.addEventListener('click', () => {
+  location = null;
+  bestResult = null;
+  pipelineState = null;
+  pipelineSection?.classList.add('hidden');
+  postForm?.classList.add('hidden');
+  successEl?.classList.add('hidden');
+  if (idCard) idCard.classList.add('hidden');
+  window.scrollTo(0, 0);
+});
+
+// ── Resume pipeline ────────────────────────────────────────────────────────
+async function resumePipeline(state: PipelineState) {
+  pipelineState = state;
+  pipelineSection?.classList.remove('hidden');
+  updatePipelineUI();
+  startGPS();
+
+  if (state.status !== 'done') {
+    await runPipeline(state);
+  } else {
+    showPostForm();
+  }
+}
+</script>

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -59,7 +59,7 @@ const weathers = WEATHERS;
   <!-- Post-process form (hidden until pipeline done) -->
   <form id="obs2-post-form" class="hidden space-y-5" novalidate>
     <h2 class="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-      {isEs ? "Ültimos detalles" : "Almost done"}
+      {isEs ? "Últimos detalles" : "Almost done"}
     </h2>
 
     <!-- Identification result card -->

--- a/src/components/PipelineGraph.astro
+++ b/src/components/PipelineGraph.astro
@@ -1,0 +1,264 @@
+---
+/**
+ * PipelineGraph.astro — Animated SVG DAG for Observe 2.0 pipeline visualization
+ *
+ * Listens for `rastrum:pipeline-update` CustomEvent and re-renders node states.
+ * Nodes: grey=pending, blue pulse=running, green=done, red=failed, dim=skipped.
+ *
+ * Layout: inputs (left) → identify (center) → merge → location → save (right).
+ * For N > 3 files of same type, collapses into a single grouped node.
+ */
+
+interface Props {
+  lang: 'en' | 'es';
+}
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+
+const labels = {
+  pending:  isEs ? 'Pendiente'    : 'Pending',
+  running:  isEs ? 'Procesando'   : 'Processing',
+  done:     isEs ? 'Listo'        : 'Done',
+  failed:   isEs ? 'Error'        : 'Failed',
+  skipped:  isEs ? 'Omitido'      : 'Skipped',
+  tapHint:  isEs ? 'Toca un nodo para detalles' : 'Tap a node for details',
+  noNodes:  isEs ? 'Esperando archivos…' : 'Waiting for files…',
+};
+---
+
+<div class="pipeline-graph-wrapper relative">
+  <!-- SVG canvas — resized by JS -->
+  <svg
+    id="pipeline-svg"
+    class="w-full overflow-visible"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-label={isEs ? 'Grafo del pipeline de identificación' : 'Identification pipeline graph'}
+    role="img"
+  >
+    <!-- Rendered by JS -->
+    <text id="pg-empty-msg" x="50%" y="50%" text-anchor="middle" dominant-baseline="middle"
+      class="text-xs fill-zinc-400 dark:fill-zinc-500" font-size="12">
+      {labels.noNodes}
+    </text>
+  </svg>
+
+  <!-- Node detail tooltip -->
+  <div id="pg-tooltip"
+    class="hidden absolute z-10 rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg p-3 text-xs max-w-[220px] pointer-events-none"
+    role="tooltip"
+  ></div>
+
+  <!-- Tap hint -->
+  <p class="text-[10px] text-center text-zinc-400 dark:text-zinc-600 mt-1">{labels.tapHint}</p>
+</div>
+
+<style>
+  @keyframes pg-pulse {
+    0%, 100% { opacity: 1; r: 6px; }
+    50%       { opacity: 0.6; r: 8px; }
+  }
+  .pg-pulse-ring { animation: pg-pulse 1.2s ease-in-out infinite; }
+</style>
+
+<script>
+import type { PipelineNode } from '../lib/pipeline-engine';
+
+const svg     = document.getElementById('pipeline-svg') as SVGSVGElement | null;
+const tooltip = document.getElementById('pg-tooltip');
+const emptyMsg = document.getElementById('pg-empty-msg');
+
+// Color palette (dark-mode safe via CSS vars via hardcoded safe values)
+const COLORS = {
+  pending:  { fill: '#d4d4d8', stroke: '#a1a1aa', text: '#71717a' },  // zinc-300/400/500
+  running:  { fill: '#93c5fd', stroke: '#3b82f6', text: '#1d4ed8' },  // blue
+  done:     { fill: '#6ee7b7', stroke: '#10b981', text: '#065f46' },  // emerald
+  failed:   { fill: '#fca5a5', stroke: '#ef4444', text: '#991b1b' },  // red
+  skipped:  { fill: '#e4e4e7', stroke: '#d4d4d8', text: '#a1a1aa' },  // dim zinc
+};
+
+interface LayoutNode {
+  node: PipelineNode;
+  x: number;
+  y: number;
+  col: number;
+  row: number;
+}
+
+function layoutNodes(nodes: PipelineNode[]): LayoutNode[] {
+  if (!nodes.length) return [];
+
+  // Group by column: inputs(0), identify(1), merge(2), location(3), save(4)
+  const COL: Record<string, number> = {
+    input: 0, identify: 1, merge: 2, location: 3, save: 4,
+  };
+
+  const cols: PipelineNode[][] = [[], [], [], [], []];
+  for (const n of nodes) {
+    const c = COL[n.kind] ?? 2;
+    cols[c].push(n);
+  }
+
+  const COL_X = [60, 160, 280, 380, 480];
+  const ROW_H = 60;
+  const BASE_Y = 40;
+
+  const layout: LayoutNode[] = [];
+  for (let c = 0; c < cols.length; c++) {
+    const col = cols[c];
+    for (let r = 0; r < col.length; r++) {
+      const totalH = (col.length - 1) * ROW_H;
+      const y = BASE_Y + r * ROW_H - totalH / 2 + 80;
+      layout.push({ node: col[r], x: COL_X[c], y, col: c, row: r });
+    }
+  }
+  return layout;
+}
+
+function ns(tag: string): SVGElement {
+  return document.createElementNS('http://www.w3.org/2000/svg', tag);
+}
+
+function renderGraph(nodes: PipelineNode[]) {
+  if (!svg) return;
+
+  // Clear previous render (keep empty msg)
+  Array.from(svg.children).forEach(c => {
+    if (c.id !== 'pg-empty-msg') c.remove();
+  });
+
+  if (!nodes.length) {
+    emptyMsg?.removeAttribute('display');
+    return;
+  }
+  emptyMsg?.setAttribute('display', 'none');
+
+  const layout = layoutNodes(nodes);
+  const byId = new Map(layout.map(l => [l.node.id, l]));
+
+  // Height
+  const maxY = Math.max(...layout.map(l => l.y)) + 60;
+  svg.setAttribute('height', String(maxY));
+  svg.setAttribute('viewBox', `0 0 540 ${maxY}`);
+
+  // Draw edges first
+  for (const l of layout) {
+    for (const depId of l.node.dependsOn) {
+      const dep = byId.get(depId);
+      if (!dep) continue;
+      const line = ns('line') as SVGLineElement;
+      line.setAttribute('x1', String(dep.x + 24));
+      line.setAttribute('y1', String(dep.y));
+      line.setAttribute('x2', String(l.x - 24));
+      line.setAttribute('y2', String(l.y));
+      line.setAttribute('stroke', '#d4d4d8');
+      line.setAttribute('stroke-width', '1.5');
+      line.setAttribute('stroke-dasharray', l.node.state === 'pending' ? '4 3' : 'none');
+      svg.appendChild(line);
+    }
+  }
+
+  // Draw nodes
+  for (const l of layout) {
+    const n = l.node;
+    const color = COLORS[n.state] ?? COLORS.pending;
+    const g = ns('g') as SVGGElement;
+    g.setAttribute('transform', `translate(${l.x},${l.y})`);
+    g.style.cursor = 'pointer';
+    g.setAttribute('role', 'button');
+    g.setAttribute('tabindex', '0');
+    g.setAttribute('aria-label', `${n.label}: ${n.state}`);
+
+    // Pulse ring for running
+    if (n.state === 'running') {
+      const pulse = ns('circle') as SVGCircleElement;
+      pulse.setAttribute('r', '20');
+      pulse.setAttribute('fill', color.stroke);
+      pulse.setAttribute('opacity', '0.2');
+      pulse.classList.add('pg-pulse-ring');
+      g.appendChild(pulse);
+    }
+
+    // Main circle
+    const circle = ns('circle') as SVGCircleElement;
+    circle.setAttribute('r', '18');
+    circle.setAttribute('fill', color.fill);
+    circle.setAttribute('stroke', color.stroke);
+    circle.setAttribute('stroke-width', '2');
+    g.appendChild(circle);
+
+    // State icon
+    const icon = stateIcon(n.state);
+    if (icon) {
+      const iconEl = ns('text') as SVGTextElement;
+      iconEl.setAttribute('text-anchor', 'middle');
+      iconEl.setAttribute('dominant-baseline', 'middle');
+      iconEl.setAttribute('font-size', '12');
+      iconEl.textContent = icon;
+      g.appendChild(iconEl);
+    }
+
+    // Label below
+    const label = ns('text') as SVGTextElement;
+    label.setAttribute('text-anchor', 'middle');
+    label.setAttribute('dominant-baseline', 'middle');
+    label.setAttribute('y', '30');
+    label.setAttribute('font-size', '9');
+    label.setAttribute('fill', color.text);
+    label.textContent = truncate(n.label, 14);
+    g.appendChild(label);
+
+    // Tooltip on click/tap
+    g.addEventListener('click', (e) => {
+      e.stopPropagation();
+      showTooltip(n, l.x, l.y);
+    });
+
+    svg.appendChild(g);
+  }
+}
+
+function stateIcon(state: string): string {
+  if (state === 'done')    return '✓';
+  if (state === 'failed')  return '✗';
+  if (state === 'running') return '⟳';
+  if (state === 'skipped') return '–';
+  return '';
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
+function showTooltip(node: PipelineNode, x: number, y: number) {
+  if (!tooltip || !svg) return;
+  const svgRect = svg.getBoundingClientRect();
+  const scale = svgRect.width / (parseFloat(svg.getAttribute('viewBox')?.split(' ')[2] ?? '540') || 540);
+
+  tooltip.style.left = `${x * scale + 20}px`;
+  tooltip.style.top  = `${y * scale - 20}px`;
+  tooltip.classList.remove('hidden');
+
+  let html = `<strong class="text-zinc-900 dark:text-zinc-100">${node.label}</strong>`;
+  html += `<br><span class="text-zinc-500 capitalize">${node.state}</span>`;
+  if (node.runner)  html += `<br><span class="text-zinc-400">Runner: ${node.runner}</span>`;
+  if (node.output) {
+    html += `<br><span class="italic text-emerald-700 dark:text-emerald-400">${node.output.scientific_name}</span>`;
+    if (node.output.confidence) {
+      html += ` <span class="text-zinc-400">${Math.round(node.output.confidence * 100)}%</span>`;
+    }
+  }
+  if (node.error) {
+    html += `<br><span class="text-red-500">${node.error}</span>`;
+  }
+  tooltip.innerHTML = html;
+}
+
+// Dismiss tooltip on outside click
+document.addEventListener('click', () => tooltip?.classList.add('hidden'));
+
+// ── Listen for pipeline updates ─────────────────────────────────────────────
+document.addEventListener('rastrum:pipeline-update', (e: Event) => {
+  const ev = e as CustomEvent<{ nodes: PipelineNode[] }>;
+  renderGraph(ev.detail.nodes);
+});
+</script>

--- a/src/components/QuickObserveSheet.astro
+++ b/src/components/QuickObserveSheet.astro
@@ -1,0 +1,342 @@
+---
+import DropZone from "./DropZone.astro";
+import { t } from "../i18n/utils";
+
+interface Props { lang: "en" | "es"; }
+const { lang } = Astro.props;
+const isEs = lang === "es";
+---
+
+<!-- FAB -->
+<button
+  id="quick-fab"
+  type="button"
+  aria-label={isEs ? "Captura rápida" : "Quick capture"}
+  class="fixed bottom-6 right-4 z-30 w-14 h-14 rounded-full bg-emerald-600 hover:bg-emerald-700 active:bg-emerald-800 text-white shadow-lg flex items-center justify-center transition-colors"
+  style="bottom: calc(5rem + env(safe-area-inset-bottom))"
+>
+  <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
+  </svg>
+</button>
+
+<!-- Backdrop -->
+<div
+  id="quick-backdrop"
+  class="hidden fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+  aria-hidden="true"
+></div>
+
+<!-- Bottom sheet -->
+<div
+  id="quick-sheet"
+  role="dialog"
+  aria-modal="true"
+  aria-label={isEs ? "Captura rápida" : "Quick capture"}
+  class="hidden fixed bottom-0 left-0 right-0 z-50 bg-white dark:bg-zinc-900 rounded-t-2xl shadow-xl max-h-[90svh] overflow-y-auto transition-transform duration-300 translate-y-full"
+  style="padding-bottom: env(safe-area-inset-bottom)"
+>
+  <!-- Handle -->
+  <div class="flex justify-center pt-3 pb-1 cursor-grab active:cursor-grabbing" id="quick-handle">
+    <div class="w-10 h-1 rounded-full bg-zinc-300 dark:bg-zinc-600"></div>
+  </div>
+
+  <div class="px-4 pb-6 space-y-4">
+    <!-- Header -->
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        {isEs ? "Captura rápida" : "Quick capture"}
+      </h2>
+      <button id="quick-close" type="button" aria-label={isEs ? "Cerrar" : "Close"}
+        class="w-8 h-8 rounded-full bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center text-zinc-600 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700"
+      >
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Direct camera button -->
+    <button
+      id="quick-camera-btn"
+      type="button"
+      class="w-full min-h-[56px] rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-base flex items-center justify-center gap-2 transition-colors"
+    >
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
+      </svg>
+      {isEs ? "Abrir cámara" : "Open camera"}
+    </button>
+    <input id="quick-camera-input" type="file" accept="image/*" capture="environment" class="sr-only" />
+
+    <!-- Or drop other files -->
+    <div class="relative flex items-center">
+      <div class="flex-1 border-t border-zinc-200 dark:border-zinc-700"></div>
+      <span class="mx-3 text-xs text-zinc-400">{isEs ? "o sube otro archivo" : "or upload a file"}</span>
+      <div class="flex-1 border-t border-zinc-200 dark:border-zinc-700"></div>
+    </div>
+    <DropZone lang={lang} />
+
+    <!-- Processing status (mini) -->
+    <div id="quick-status" class="hidden flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+      <span class="inline-block w-4 h-4 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin"></span>
+      <span id="quick-status-text">{isEs ? "Identificando..." : "Identifying..."}</span>
+    </div>
+
+    <!-- Confirmation card (hidden until done) -->
+    <div id="quick-confirm-card" class="hidden rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 p-4 space-y-3">
+      <div>
+        <p id="quick-species" class="font-semibold italic text-zinc-900 dark:text-zinc-100"></p>
+        <p id="quick-common" class="text-sm text-zinc-500 dark:text-zinc-400"></p>
+        <p id="quick-conf" class="text-xs font-mono text-emerald-600 dark:text-emerald-400 mt-0.5"></p>
+      </div>
+      <p id="quick-loc" class="text-xs text-zinc-500 dark:text-zinc-400">
+        {isEs ? "Obteniendo ubicación..." : "Acquiring location..."}
+      </p>
+      <div class="flex flex-col gap-2">
+        <button id="quick-save-btn" type="button"
+          class="w-full min-h-[44px] rounded-xl bg-emerald-700 hover:bg-emerald-800 text-white font-semibold text-sm transition-colors disabled:opacity-50"
+        >
+          {isEs ? "Confirmar y guardar" : "Confirm \u0026 save"}
+        </button>
+        <button id="quick-edit-btn" type="button"
+          class="w-full min-h-[40px] rounded-xl border border-zinc-300 dark:border-zinc-700 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors"
+        >
+          {isEs ? "Editar en formulario completo" : "Edit in full form"}
+        </button>
+        <button id="quick-discard-btn" type="button"
+          class="text-xs text-zinc-400 hover:text-zinc-600 underline mx-auto"
+        >
+          {isEs ? "Descartar" : "Discard"}
+        </button>
+      </div>
+    </div>
+
+    <!-- Success -->
+    <div id="quick-success" class="hidden text-center py-4 space-y-2">
+      <div class="text-3xl">✅</div>
+      <p class="font-semibold text-emerald-700 dark:text-emerald-300">
+        {isEs ? "¡Guardada!" : "Saved!"}
+      </p>
+    </div>
+  </div>
+</div>
+
+<script>
+import { triageFile, buildGraph, savePipelineState } from '../lib/pipeline-engine';
+import type { PipelineFile, PipelineState } from '../lib/pipeline-engine';
+import { saveObservationToOutbox, resolveObserverRef } from '../lib/observe';
+import { syncOutbox } from '../lib/sync';
+import { PENDING_OBSERVATION_KEY } from '../lib/chat-attachment-helpers';
+
+const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
+const isEs = lang === 'es';
+
+// DOM
+const fab        = document.getElementById('quick-fab');
+const backdrop   = document.getElementById('quick-backdrop');
+const sheet      = document.getElementById('quick-sheet');
+const closeBtn   = document.getElementById('quick-close');
+const camBtn     = document.getElementById('quick-camera-btn');
+const camInput   = document.getElementById('quick-camera-input') as HTMLInputElement | null;
+const statusEl   = document.getElementById('quick-status');
+const statusText = document.getElementById('quick-status-text');
+const confirmCard= document.getElementById('quick-confirm-card');
+const speciesEl  = document.getElementById('quick-species');
+const commonEl   = document.getElementById('quick-common');
+const confEl     = document.getElementById('quick-conf');
+const locEl      = document.getElementById('quick-loc');
+const saveBtn    = document.getElementById('quick-save-btn') as HTMLButtonElement | null;
+const editBtn    = document.getElementById('quick-edit-btn');
+const discardBtn = document.getElementById('quick-discard-btn');
+const successEl  = document.getElementById('quick-success');
+
+let pipelineState: PipelineState | null = null;
+let location: { lat: number; lng: number; accuracyM: number; altitudeM: number | null } | null = null;
+let bestResult: { scientific_name: string; common_name_en: string | null; confidence: number; source: string; blobUrl: string; mimeType: string } | null = null;
+
+// ── Open / Close ───────────────────────────────────────────────────────────
+function openSheet() {
+  backdrop?.classList.remove('hidden');
+  sheet?.classList.remove('hidden');
+  requestAnimationFrame(() => sheet?.classList.remove('translate-y-full'));
+  document.addEventListener('keydown', onEsc);
+  startGPS();
+}
+
+function closeSheet() {
+  sheet?.classList.add('translate-y-full');
+  setTimeout(() => {
+    backdrop?.classList.add('hidden');
+    sheet?.classList.add('hidden');
+    resetSheet();
+  }, 300);
+  document.removeEventListener('keydown', onEsc);
+}
+
+function onEsc(e: KeyboardEvent) {
+  if (e.key === 'Escape') closeSheet();
+}
+
+fab?.addEventListener('click', openSheet);
+closeBtn?.addEventListener('click', closeSheet);
+backdrop?.addEventListener('click', closeSheet);
+
+// ── Camera ─────────────────────────────────────────────────────────────────
+camBtn?.addEventListener('click', () => camInput?.click());
+camInput?.addEventListener('change', () => {
+  const files = Array.from(camInput.files ?? []);
+  if (files.length > 0) handleFiles(files);
+  camInput.value = '';
+});
+
+// ── Files from DropZone ────────────────────────────────────────────────────
+document.addEventListener('rastrum:files-dropped', (e: Event) => {
+  const ev = e as CustomEvent<{ files: File[] }>;
+  if (!sheet?.contains(document.activeElement) && sheet?.classList.contains('hidden')) return;
+  handleFiles(ev.detail.files);
+});
+
+// ── Handle files ───────────────────────────────────────────────────────────
+async function handleFiles(files: File[]) {
+  if (!files.length) return;
+  const pf: PipelineFile[] = files.map(f => ({
+    id: crypto.randomUUID(),
+    file: f,
+    kind: triageFile(f),
+    blobUrl: URL.createObjectURL(f),
+  }));
+
+  statusEl?.classList.remove('hidden');
+  confirmCard?.classList.add('hidden');
+
+  // Simple pipeline — no full graph UI in quick mode
+  for (const file of pf) {
+    if (statusText) statusText.textContent = isEs ? 'Identificando...' : 'Identifying...';
+    try {
+      if (file.kind === 'photo') {
+        const { runParallelIdentify } = await import('../lib/identify-cascade-client');
+        const { makePlantNetRunner, makeClaudeRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
+        const { hasAnthropicKey } = await import('../lib/anthropic-key');
+        const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
+        if (await resolvePlantNetKey()) runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
+        if (await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+        if (Object.keys(runners).length > 0) {
+          const out = await runParallelIdentify(file.file as File, { runners }, new AbortController().signal);
+          if (out.kind === 'winner' || out.kind === 'uncertain') {
+            const r = out.result;
+            bestResult = { scientific_name: r.scientific_name, common_name_en: r.common_name_en ?? null, confidence: r.confidence, source: r.source, blobUrl: file.blobUrl, mimeType: file.file.type };
+          }
+        }
+      } else if (file.kind === 'audio') {
+        const { birdnetIdentifier } = await import('../lib/identifiers/birdnet');
+        const av = await birdnetIdentifier.isAvailable();
+        if (av.ready) {
+          const r = await birdnetIdentifier.identify({ media: { kind: 'blob', blob: file.file as Blob }, mediaKind: 'audio', locale: lang as 'en' | 'es' });
+          bestResult = { scientific_name: r.scientific_name, common_name_en: r.common_name_en ?? null, confidence: r.confidence, source: r.source, blobUrl: file.blobUrl, mimeType: file.file.type };
+        }
+      }
+    } catch { /* silent — show confirm card anyway */ }
+  }
+
+  statusEl?.classList.add('hidden');
+  confirmCard?.classList.remove('hidden');
+
+  if (bestResult) {
+    if (speciesEl) speciesEl.textContent = bestResult.scientific_name;
+    if (commonEl)  commonEl.textContent  = bestResult.common_name_en ?? '';
+    if (confEl)    confEl.textContent    = `${Math.round(bestResult.confidence * 100)}%`;
+  } else {
+    if (speciesEl) speciesEl.textContent = isEs ? 'Sin identificar' : 'Unidentified';
+  }
+
+  // Store pipelineFiles for save
+  pipelineState = {
+    id: crypto.randomUUID(),
+    createdAt: Date.now(),
+    files: pf,
+    nodes: [],
+    mode: 'quick',
+    status: 'processing',
+  };
+}
+
+// ── GPS ────────────────────────────────────────────────────────────────────
+function startGPS() {
+  if (!navigator.geolocation) return;
+  navigator.geolocation.getCurrentPosition(
+    pos => {
+      location = { lat: pos.coords.latitude, lng: pos.coords.longitude, accuracyM: pos.coords.accuracy, altitudeM: pos.coords.altitude };
+      if (locEl) locEl.textContent = `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)}`;
+    },
+    () => { if (locEl) locEl.textContent = isEs ? 'Ubicaci\u00f3n no disponible' : 'Location unavailable'; },
+    { enableHighAccuracy: true, timeout: 20000 },
+  );
+}
+
+// ── Save ───────────────────────────────────────────────────────────────────
+saveBtn?.addEventListener('click', async () => {
+  if (!pipelineState) return;
+  if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = isEs ? 'Guardando...' : 'Saving...'; }
+  try {
+    const observerRef = await resolveObserverRef();
+    const mediaInputs = pipelineState.files.map(pf => ({
+      blob: pf.file,
+      blobId: pf.id,
+      mimeType: pf.file.type || 'application/octet-stream',
+      sizeBytes: pf.file.size,
+      mediaType: pf.kind === 'audio' ? 'audio' as const : pf.kind === 'video' ? 'video' as const : 'photo' as const,
+    }));
+    await saveObservationToOutbox({
+      observerRef,
+      media: mediaInputs,
+      location: location ?? { lat: 0, lng: 0, accuracyM: 0, altitudeM: null, capturedFrom: 'gps' },
+      identification: bestResult ? { scientificName: bestResult.scientific_name, confidence: bestResult.confidence, source: bestResult.source as never, status: 'accepted' } : undefined,
+      asDraft: !location,
+    });
+    await syncOutbox().catch(() => {});
+    confirmCard?.classList.add('hidden');
+    successEl?.classList.remove('hidden');
+    document.dispatchEvent(new CustomEvent('rastrum:quick-saved'));
+    setTimeout(closeSheet, 1800);
+  } catch (err) {
+    if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = isEs ? 'Confirmar y guardar' : 'Confirm & save'; }
+    alert((err as Error).message);
+  }
+});
+
+// ── Edit in full form ──────────────────────────────────────────────────────
+editBtn?.addEventListener('click', () => {
+  if (!bestResult) return;
+  const pending = JSON.stringify({
+    blob_url: bestResult.blobUrl,
+    mime_type: bestResult.mimeType,
+    scientific_name: bestResult.scientific_name,
+    confidence: bestResult.confidence,
+    source: bestResult.source,
+    common_name: bestResult.common_name_en,
+    kind: bestResult.mimeType.startsWith('audio/') ? 'audio' : 'photo',
+  });
+  try { sessionStorage.setItem(PENDING_OBSERVATION_KEY, pending); } catch { /* private mode */ }
+  closeSheet();
+  window.location.href = isEs ? '/es/observar' : '/en/observe';
+});
+
+// ── Discard ────────────────────────────────────────────────────────────────
+discardBtn?.addEventListener('click', () => {
+  pipelineState?.files.forEach(pf => URL.revokeObjectURL(pf.blobUrl));
+  closeSheet();
+});
+
+// ── Reset ──────────────────────────────────────────────────────────────────
+function resetSheet() {
+  pipelineState = null;
+  bestResult = null;
+  location = null;
+  statusEl?.classList.add('hidden');
+  confirmCard?.classList.add('hidden');
+  successEl?.classList.add('hidden');
+}
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2547,7 +2547,6 @@
       "topCodes": "Top codes",
       "filterByCode": "Filter by code"
     },
-
     "entityBrowser": {
       "clearFilters": "Clear filters",
       "empty": "No rows match the current filter set.",
@@ -2557,7 +2556,6 @@
       "expand": "Expand row",
       "anyOption": "— any —"
     },
-
     "identificationsView": {
       "title": "Identifications",
       "description": "Every identification ever recorded — AI cascade picks, human IDs, validations. Filter by identifier, taxon, validation state, or research-grade status.",
@@ -2578,7 +2576,6 @@
       "colObservation": "Observation",
       "drillObs": "Open observation"
     },
-
     "notificationsView": {
       "title": "Notifications",
       "description": "All notifications fanned out by social-graph triggers (follow, reaction, comment, identification, badge, digest). Filter by recipient, kind, or read state.",
@@ -2597,7 +2594,6 @@
       "colRead": "Read",
       "drillFull": "Full payload"
     },
-
     "mediaView": {
       "title": "Media",
       "description": "All photos, audio and video files registered against observations. Filter by media type, deletion state, or owner.",
@@ -2618,7 +2614,6 @@
       "colState": "State",
       "drillR2Url": "R2 URL"
     },
-
     "followsView": {
       "title": "Follows",
       "description": "Social-graph follow edges. Filter by follower, followee, status (pending vs accepted), or tier (collaborator vs follower). Useful for spam audits.",
@@ -2638,7 +2633,6 @@
       "drillProfileFollower": "View follower's profile",
       "drillProfileFollowee": "View followee's profile"
     },
-
     "watchlistsView": {
       "title": "Watchlists",
       "description": "Per-user species or scientific-name watch entries with optional radius. Filter by user, taxon, or scientific name.",
@@ -2653,7 +2647,6 @@
       "yes": "Yes",
       "no": "No"
     },
-
     "projectsView": {
       "title": "Projects",
       "description": "Named polygons (typically ANPs or sampling grids) under M29. Filter by visibility, owner, or name.",
@@ -2672,7 +2665,6 @@
       "drillView": "Open project",
       "drillObs": "Tagged observations"
     },
-
     "taxonChangesView": {
       "title": "Taxon changes",
       "description": "Audit log of taxon-related admin actions (conservation status, future renames/synonyms). Backed by admin_audit filtered to taxon_* operations. Filter by taxon, action, actor, or date range.",
@@ -2688,7 +2680,6 @@
       "colDiff": "Diff",
       "drillFull": "Full diff"
     },
-
     "audit_op": {
       "role_grant": "Role granted",
       "role_revoke": "Role revoked",
@@ -2814,5 +2805,30 @@
     "default_confirm": "Confirm",
     "default_cancel": "Cancel",
     "aria_dialog_label": "Confirmation dialog"
+  },
+  "observe2": {
+    "heading": "Log observation",
+    "classic_link": "Use classic form",
+    "pipeline_heading": "Processing your files",
+    "pipeline_ready": "Ready to save",
+    "pipeline_processing": "Identifying species...",
+    "post_form_heading": "Almost done",
+    "location_label": "Location",
+    "location_skip": "Skip location",
+    "notes_label": "Notes",
+    "notes_placeholder": "What did you observe? Any additional context...",
+    "advanced_toggle": "Advanced fields",
+    "save_btn": "Save observation",
+    "saving": "Saving...",
+    "saved_heading": "Observation saved!",
+    "saved_view": "View observation",
+    "resume_banner": "You have an observation in progress.",
+    "resume_btn": "Resume",
+    "resume_dismiss": "Dismiss",
+    "quick_heading": "Quick capture",
+    "quick_camera": "Open camera",
+    "quick_confirm": "Confirm & save",
+    "quick_edit": "Edit in full form",
+    "quick_discard": "Discard"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2547,7 +2547,6 @@
       "topCodes": "Códigos más frecuentes",
       "filterByCode": "Filtrar por código"
     },
-
     "entityBrowser": {
       "clearFilters": "Limpiar filtros",
       "empty": "Ninguna fila coincide con los filtros actuales.",
@@ -2557,7 +2556,6 @@
       "expand": "Expandir fila",
       "anyOption": "— cualquiera —"
     },
-
     "identificationsView": {
       "title": "Identificaciones",
       "description": "Cada identificación registrada — picks del cascade IA, IDs humanos, validaciones. Filtra por identificador, taxón, estado de validación o calidad de investigación.",
@@ -2578,7 +2576,6 @@
       "colObservation": "Observación",
       "drillObs": "Abrir observación"
     },
-
     "notificationsView": {
       "title": "Notificaciones",
       "description": "Todas las notificaciones distribuidas por triggers del grafo social (follow, reacción, comentario, identificación, insignia, digest). Filtra por destinatario, tipo o estado de lectura.",
@@ -2597,7 +2594,6 @@
       "colRead": "Leída",
       "drillFull": "Payload completo"
     },
-
     "mediaView": {
       "title": "Medios",
       "description": "Todos los archivos de foto, audio y video registrados contra observaciones. Filtra por tipo, estado de borrado o propietario.",
@@ -2618,7 +2614,6 @@
       "colState": "Estado",
       "drillR2Url": "URL R2"
     },
-
     "followsView": {
       "title": "Seguimientos",
       "description": "Aristas de seguimiento del grafo social. Filtra por seguidor, seguido, estado (pendiente vs aceptado) o nivel (colaborador vs seguidor). Útil para auditorías anti-spam.",
@@ -2638,7 +2633,6 @@
       "drillProfileFollower": "Ver perfil del seguidor",
       "drillProfileFollowee": "Ver perfil del seguido"
     },
-
     "watchlistsView": {
       "title": "Listas de vigilancia",
       "description": "Entradas de seguimiento de especies o nombres científicos por usuario, con radio opcional. Filtra por usuario, taxón o nombre científico.",
@@ -2653,7 +2647,6 @@
       "yes": "Sí",
       "no": "No"
     },
-
     "projectsView": {
       "title": "Proyectos",
       "description": "Polígonos con nombre (típicamente ANPs o cuadrículas de muestreo) de M29. Filtra por visibilidad, propietario o nombre.",
@@ -2672,7 +2665,6 @@
       "drillView": "Abrir proyecto",
       "drillObs": "Observaciones etiquetadas"
     },
-
     "taxonChangesView": {
       "title": "Cambios de taxón",
       "description": "Bitácora de auditoría de acciones administrativas sobre taxones (estado de conservación, futuras renombramientos/sinónimos). Respaldada por admin_audit filtrada a operaciones taxon_*. Filtra por taxón, acción, actor o rango de fechas.",
@@ -2688,7 +2680,6 @@
       "colDiff": "Diff",
       "drillFull": "Diff completo"
     },
-
     "audit_op": {
       "role_grant": "Rol otorgado",
       "role_revoke": "Rol revocado",
@@ -2814,5 +2805,30 @@
     "default_confirm": "Confirmar",
     "default_cancel": "Cancelar",
     "aria_dialog_label": "Diálogo de confirmación"
+  },
+  "observe2": {
+    "heading": "Registrar observación",
+    "classic_link": "Usar formulario clásico",
+    "pipeline_heading": "Procesando archivos",
+    "pipeline_ready": "Listo para guardar",
+    "pipeline_processing": "Identificando especies...",
+    "post_form_heading": "Últimos detalles",
+    "location_label": "Ubicación",
+    "location_skip": "Omitir ubicación",
+    "notes_label": "Notas",
+    "notes_placeholder": "¿Qué observaste? Contexto adicional...",
+    "advanced_toggle": "Campos avanzados",
+    "save_btn": "Guardar observación",
+    "saving": "Guardando...",
+    "saved_heading": "¡Observación guardada!",
+    "saved_view": "Ver observación",
+    "resume_banner": "Tienes una observación en progreso.",
+    "resume_btn": "Retomar",
+    "resume_dismiss": "Descartar",
+    "quick_heading": "Captura rápida",
+    "quick_camera": "Abrir cámara",
+    "quick_confirm": "Confirmar y guardar",
+    "quick_edit": "Editar en formulario completo",
+    "quick_discard": "Descartar"
   }
 }

--- a/src/lib/pipeline-engine.ts
+++ b/src/lib/pipeline-engine.ts
@@ -1,0 +1,257 @@
+/**
+ * pipeline-engine.ts — Observe 2.0 pipeline DAG engine
+ *
+ * Provides types, file triage, graph construction, and IndexedDB persistence
+ * for the Drop & Discover observation pipeline. All processing is client-side.
+ *
+ * The engine is intentionally separate from UI rendering so that
+ * ObserveView2 (full) and QuickObserveSheet (quick) can share the same logic.
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type FileKind = 'photo' | 'audio' | 'video' | 'unknown';
+export type NodeState = 'pending' | 'running' | 'done' | 'failed' | 'skipped';
+export type NodeKind = 'input' | 'identify' | 'merge' | 'location' | 'save';
+
+export interface PipelineResult {
+  scientific_name: string;
+  common_name_en: string | null;
+  confidence: number;
+  source: string;
+}
+
+export interface PipelineFile {
+  id: string;
+  file: File;
+  kind: FileKind;
+  blobUrl: string;
+}
+
+export interface PipelineNode {
+  id: string;
+  label: string;
+  kind: NodeKind;
+  state: NodeState;
+  /** For identify nodes: which file this processes */
+  fileId?: string;
+  /** Which runner: plantnet, birdnet, claude, phi */
+  runner?: string;
+  dependsOn: string[];
+  output?: PipelineResult;
+  error?: string;
+  startedAt?: number;
+  completedAt?: number;
+}
+
+export interface PipelineState {
+  id: string;
+  createdAt: number;
+  files: PipelineFile[];
+  nodes: PipelineNode[];
+  mode: 'full' | 'quick';
+  status: 'idle' | 'processing' | 'done' | 'failed';
+}
+
+export interface AvailableRunners {
+  plantnet: boolean;
+  birdnet: boolean;
+  claude: boolean;
+  phi: boolean;
+}
+
+// ── File triage ────────────────────────────────────────────────────────────
+
+/**
+ * Determine the media kind from MIME type.
+ * Falls back to file extension if MIME is missing or generic.
+ */
+export function triageFile(file: File): FileKind {
+  const mime = (file.type ?? '').toLowerCase();
+  if (mime.startsWith('image/')) return 'photo';
+  if (mime.startsWith('audio/')) return 'audio';
+  if (mime.startsWith('video/')) return 'video';
+
+  // Fallback: extension sniff
+  const ext = (file.name ?? '').split('.').pop()?.toLowerCase() ?? '';
+  if (['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif', 'gif', 'avif', 'bmp'].includes(ext)) return 'photo';
+  if (['mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac', 'opus', 'weba'].includes(ext)) return 'audio';
+  if (['mp4', 'mov', 'webm', 'avi', 'mkv', 'm4v', '3gp'].includes(ext)) return 'video';
+
+  return 'unknown';
+}
+
+// ── Graph construction ─────────────────────────────────────────────────────
+
+/**
+ * Build the pipeline DAG for a given set of files and available runners.
+ * Returns the node list in topological order (inputs → processors → merge → save).
+ */
+export function buildGraph(files: PipelineFile[], runners: AvailableRunners): PipelineNode[] {
+  const nodes: PipelineNode[] = [];
+
+  // Input nodes — one per file
+  for (const pf of files) {
+    nodes.push({
+      id: `input-${pf.id}`,
+      label: pf.file.name ?? kindLabel(pf.kind),
+      kind: 'input',
+      state: 'done', // inputs are "done" immediately
+      fileId: pf.id,
+      dependsOn: [],
+    });
+  }
+
+  // Identify nodes — one per file (depends on its input node)
+  for (const pf of files) {
+    const runner = pickRunner(pf.kind, runners);
+    const available = runner !== null;
+    nodes.push({
+      id: `identify-${pf.id}`,
+      label: identifyLabel(pf.kind, runner),
+      kind: 'identify',
+      state: available ? 'pending' : 'skipped',
+      fileId: pf.id,
+      runner: runner ?? undefined,
+      dependsOn: [`input-${pf.id}`],
+      error: available ? undefined : noRunnerMsg(pf.kind),
+    });
+  }
+
+  // Merge node — depends on all identify nodes
+  const identifyIds = files.map(pf => `identify-${pf.id}`);
+  nodes.push({
+    id: 'merge',
+    label: 'Merge results',
+    kind: 'merge',
+    state: 'pending',
+    dependsOn: identifyIds,
+  });
+
+  // Location node — depends on merge
+  nodes.push({
+    id: 'location',
+    label: 'GPS location',
+    kind: 'location',
+    state: 'pending',
+    dependsOn: ['merge'],
+  });
+
+  // Save node — depends on merge and location
+  nodes.push({
+    id: 'save',
+    label: 'Save observation',
+    kind: 'save',
+    state: 'pending',
+    dependsOn: ['merge', 'location'],
+  });
+
+  return nodes;
+}
+
+function kindLabel(kind: FileKind): string {
+  if (kind === 'photo') return 'Photo';
+  if (kind === 'audio') return 'Audio';
+  if (kind === 'video') return 'Video';
+  return 'File';
+}
+
+function identifyLabel(kind: FileKind, runner: string | null): string {
+  if (kind === 'audio') return runner ? 'BirdNET' : 'Audio (no runner)';
+  if (kind === 'photo') return runner === 'plantnet' ? 'PlantNet' : runner === 'claude' ? 'Claude Haiku' : runner === 'phi' ? 'Phi Vision' : 'Photo ID';
+  if (kind === 'video') return 'Video frames';
+  return 'Identify';
+}
+
+function pickRunner(kind: FileKind, runners: AvailableRunners): string | null {
+  if (kind === 'audio') return runners.birdnet ? 'birdnet' : null;
+  if (kind === 'photo') {
+    if (runners.plantnet) return 'plantnet';
+    if (runners.claude) return 'claude';
+    if (runners.phi) return 'phi';
+    return null;
+  }
+  if (kind === 'video') return runners.plantnet || runners.claude ? 'frames' : null;
+  return null;
+}
+
+function noRunnerMsg(kind: FileKind): string {
+  if (kind === 'audio') return 'BirdNET not cached';
+  if (kind === 'photo') return 'No ID runner available (set PlantNet key or Anthropic key)';
+  if (kind === 'video') return 'No runner for video';
+  return 'Unsupported file type';
+}
+
+// ── IndexedDB persistence ──────────────────────────────────────────────────
+
+const DB_NAME = 'rastrum-pipeline';
+const DB_VERSION = 1;
+const STORE = 'states';
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function savePipelineState(state: PipelineState): Promise<void> {
+  // Files contain File objects which can't be serialized to IDB directly.
+  // Store a stripped version with just metadata.
+  const serializable = {
+    ...state,
+    files: state.files.map(f => ({
+      id: f.id,
+      kind: f.kind,
+      blobUrl: f.blobUrl,
+      fileName: f.file.name,
+      fileSize: f.file.size,
+      fileType: f.file.type,
+      // file object omitted — can't serialize File to IDB
+    })),
+  };
+  // Also save under '__latest__' key for easy resume lookup
+  const db = await openDB();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    const store = tx.objectStore(STORE);
+    store.put(serializable);
+    store.put({ ...serializable, id: '__latest__' });
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function loadPipelineState(id: string): Promise<PipelineState | null> {
+  try {
+    const db = await openDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readonly');
+      const req = tx.objectStore(STORE).get(id);
+      req.onsuccess = () => resolve((req.result as PipelineState) ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function clearPipelineState(id: string): Promise<void> {
+  try {
+    const db = await openDB();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.objectStore(STORE).delete(id);
+      tx.objectStore(STORE).delete('__latest__');
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch { /* ignore */ }
+}

--- a/src/pages/en/observe.astro
+++ b/src/pages/en/observe.astro
@@ -1,12 +1,16 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import ObservationForm from '../../components/ObservationForm.astro';
+import ObserveView2 from '../../components/ObserveView2.astro';
 import { t } from '../../i18n/utils';
 
 const lang = 'en';
 const tr = t(lang);
 ---
 
-<BaseLayout title={`${tr.observe.title} — Rastrum`} description="Capture biodiversity observations with photos, audio, GPS, and Darwin Core fields. Offline-first; syncs to GBIF and CONABIO when online." lang={lang}>
-  <ObservationForm lang={lang} />
+<BaseLayout
+  title={`${tr.observe.title} — Rastrum`}
+  description="Log biodiversity observations. Drop photos, audio, or video — AI identifies species instantly. Offline-first, syncs to GBIF and CONABIO."
+  lang={lang}
+>
+  <ObserveView2 lang={lang} />
 </BaseLayout>

--- a/src/pages/en/observe/classic.astro
+++ b/src/pages/en/observe/classic.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import ObservationForm from '../../../components/ObservationForm.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+---
+
+<BaseLayout title={`${tr.observe.title} (Classic) — Rastrum`} description="Classic observation form with all fields." lang={lang}>
+  <div class="mb-4">
+    <a href="/en/observe" class="text-sm text-emerald-600 dark:text-emerald-400 hover:underline">
+      ← Try the new Drop &amp; Discover form
+    </a>
+  </div>
+  <ObservationForm lang={lang} />
+</BaseLayout>

--- a/src/pages/es/observar.astro
+++ b/src/pages/es/observar.astro
@@ -1,12 +1,16 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import ObservationForm from '../../components/ObservationForm.astro';
+import ObserveView2 from '../../components/ObserveView2.astro';
 import { t } from '../../i18n/utils';
 
 const lang = 'es';
 const tr = t(lang);
 ---
 
-<BaseLayout title={`${tr.observe.title} — Rastrum`} description="Captura observaciones de biodiversidad con fotos, audio, GPS y campos Darwin Core. Offline-first; sincroniza con GBIF y CONABIO cuando hay red." lang={lang}>
-  <ObservationForm lang={lang} />
+<BaseLayout
+  title={`${tr.observe.title} — Rastrum`}
+  description="Registra observaciones de biodiversidad. Sube fotos, audio o video — la IA identifica la especie al instante. Offline-first, sincroniza con GBIF y CONABIO."
+  lang={lang}
+>
+  <ObserveView2 lang={lang} />
 </BaseLayout>

--- a/src/pages/es/observar/clasico.astro
+++ b/src/pages/es/observar/clasico.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import ObservationForm from '../../../components/ObservationForm.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+---
+
+<BaseLayout title={`${tr.observe.title} (Clásico) — Rastrum`} description="Formulario clásico de observación con todos los campos." lang={lang}>
+  <div class="mb-4">
+    <a href="/es/observar" class="text-sm text-emerald-600 dark:text-emerald-400 hover:underline">
+      ← Probar el nuevo formulario Drop &amp; Discover
+    </a>
+  </div>
+  <ObservationForm lang={lang} />
+</BaseLayout>


### PR DESCRIPTION
Closes #270

## What's new

### ObserveView2 — Drop & Discover

Replaces the complex `/observe` form with a streamlined UX:

1. **Single drop zone** at the top — drag, tap, paste, or Share Target
2. **MIME triage automatic** — no type selector, no form fields initially
3. **Live PipelineGraph** appears after files are dropped
   - Nodes animate: grey=pending → blue pulse=running → green=done → red=failed
   - All processing client-side (PlantNet, BirdNET, Claude Haiku, Phi Vision)
   - GPS runs in parallel while identification runs
4. **Minimal post-process form** after pipeline completes
   - Location + notes + save
   - Darwin Core fields (habitat, weather) collapsed in Advanced
5. **Resume banner** — detects in-progress pipelines in IndexedDB on page load

### QuickObserveSheet — FAB capture

- Fixed emerald FAB button (camera icon) visible on all pages
- Bottom sheet slides up, primary action = camera (one tap)
- Mini status (spinner) while identifying
- Confirmation card: species + confidence + location
- 'Edit in full form' → sessionStorage handoff to /observe
- 'Confirm & save' → saves to outbox, closes sheet

### Routes

| Path | Before | After |
|------|--------|-------|
| /en/observe | ObservationForm (full) | ObserveView2 (new) |
| /es/observar | ObservationForm (full) | ObserveView2 (new) |
| /en/observe/classic | — | ObservationForm (classic fallback) |
| /es/observar/clasico | — | ObservationForm (classic fallback) |

## Engineering

- Zero new dependencies — reuses wavesurfer, dexie, onnxruntime-web already in package.json
- All inference client-side — SW used only for blob storage and Supabase sync
- Same pipeline engine in full and quick mode
- TypeScript strict: `tsc --noEmit` passes clean
- i18n: `observe2` key added to en.json + es.json

## Built on

- pipeline-engine.ts (already in main)
- DropZone.astro (already in main)  
- PipelineGraph.astro (already in main)