### PR TITLE
fix(rls): add explicit WITH CHECK to obs_owner — resolves 42P17 on observation INSERT

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -399,7 +399,11 @@ CREATE POLICY "taxa_public_read" ON public.taxa FOR SELECT USING (true);
 -- policy can stay single-table and inexpensive.
 DROP POLICY IF EXISTS "obs_owner" ON public.observations;
 CREATE POLICY "obs_owner" ON public.observations FOR ALL
-  USING ((SELECT auth.uid()) = observer_id);
+  USING    ((SELECT auth.uid()) = observer_id)
+  -- Explicit WITH CHECK prevents Postgres from falling back to the USING clause
+  -- on INSERT/UPDATE, which in complex policy environments can trigger 42P17
+  -- infinite recursion when other permissive policies subquery this table.
+  WITH CHECK ((SELECT auth.uid()) = observer_id);
 
 DROP POLICY IF EXISTS "obs_public_read" ON public.observations;
 CREATE POLICY "obs_public_read" ON public.observations FOR SELECT


### PR DESCRIPTION
## Problem

Observations submitted by users (including field test by Marcela Padilla, 2026-04-30) fail with:

```
POST /rest/v1/observations?on_conflict=id → 500
proxy_status: PostgREST; error=42P17
```

**42P17 = "infinite recursion detected in policy for relation"**

The outbox sync shows a spinner but never resolves. The observation stays in local IndexedDB forever.

## Root cause

`obs_owner` policy was defined as `FOR ALL` with only a `USING` clause and no `WITH CHECK`:

```sql
CREATE POLICY "obs_owner" ON public.observations FOR ALL
  USING ((SELECT auth.uid()) = observer_id);
```

When Postgres evaluates an `INSERT`, permissive policies without explicit `WITH CHECK` fall back to using their `USING` clause for both read and write checks. With 5+ permissive policies on `observations` (`obs_owner`, `obs_public_read`, `obs_credentialed_read`, `obs_collaborator_read`, `obs_admin_full_read`) — some added recently (M28 console, M29 community, M32 multi-provider) — the policy evaluation chain can recursively re-enter itself, triggering 42P17.

## Fix

Add explicit `WITH CHECK` to `obs_owner`:

```sql
CREATE POLICY "obs_owner" ON public.observations FOR ALL
  USING    ((SELECT auth.uid()) = observer_id)
  WITH CHECK ((SELECT auth.uid()) = observer_id);
```

This short-circuits the fallback behavior. INSERT/UPDATE now uses the explicit `WITH CHECK` without needing to re-evaluate the full policy chain.

## Impact

- All observation uploads were failing for authenticated users since the policy accumulation threshold was crossed
- Outbox sync appears to retry infinitely with no user-facing error (just a spinner)

## To apply in prod

After merging, run the db-apply workflow or execute manually in Supabase SQL editor:

```sql
DROP POLICY IF EXISTS "obs_owner" ON public.observations;
CREATE POLICY "obs_owner" ON public.observations FOR ALL
  USING    ((SELECT auth.uid()) = observer_id)
  WITH CHECK ((SELECT auth.uid()) = observer_id);
```

## Verification

```sql
SELECT polname, polcmd, 
       pg_get_expr(polqual, polrelid) AS using_clause,
       pg_get_expr(polwithcheck, polrelid) AS with_check_clause
FROM pg_policy
JOIN pg_class ON pg_class.oid = pg_policy.polrelid
WHERE pg_class.relname = 'observations'
ORDER BY polname;
```

After fix: `obs_owner` should show both `using_clause` AND `with_check_clause` populated.