### PR TITLE
feat(projects): KML polygon import for project boundaries (closes #279)

### DIFF
--- a/src/components/ProjectNewView.astro
+++ b/src/components/ProjectNewView.astro
@@ -77,10 +77,18 @@ const projectsBase = routes.projects[lang];
         placeholder='{"type":"Polygon","coordinates":[[[-96.7,17.0],[-96.6,17.0],[-96.6,17.1],[-96.7,17.1],[-96.7,17.0]]]}'
       ></textarea>
       <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{proj.form_polygon_hint}</p>
-      <label class="mt-2 inline-flex items-center gap-2 text-xs text-emerald-700 dark:text-emerald-400 cursor-pointer hover:underline">
-        <input type="file" id="project-polygon-file" accept=".geojson,application/geo+json,application/json" class="hidden" />
-        <span>{proj.form_polygon_upload}</span>
-      </label>
+      <div class="mt-2 flex flex-wrap items-center gap-3">
+        <label class="inline-flex items-center gap-2 text-xs text-emerald-700 dark:text-emerald-400 cursor-pointer hover:underline">
+          <input type="file" id="project-polygon-file" accept=".geojson,application/geo+json,application/json" class="hidden" />
+          <span>{proj.form_polygon_upload}</span>
+        </label>
+        <label class="inline-flex items-center gap-2 text-xs text-emerald-700 dark:text-emerald-400 cursor-pointer hover:underline" title={proj.kml_upload_label}>
+          <input type="file" id="project-kml-file" accept=".kml,application/vnd.google-earth.kml+xml" class="sr-only" />
+          <svg class="h-3.5 w-3.5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+          <span>{proj.kml_upload_button}</span>
+        </label>
+      </div>
+      <div id="project-kml-status" class="hidden mt-1 text-xs"></div>
     </div>
 
     <p id="project-form-error" class="hidden text-sm text-rose-600 dark:text-rose-400"></p>
@@ -94,6 +102,7 @@ const projectsBase = routes.projects[lang];
 
 <script>
   import { upsertProject, validatePolygonGeoJSON, isValidSlug } from '../lib/projects';
+  import { validateKML } from '../lib/kml-parser';
   import { getSupabase } from '../lib/supabase';
 
   const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
@@ -102,7 +111,9 @@ const projectsBase = routes.projects[lang];
     const projectsBase = root.dataset.projectsBase ?? '/projects';
     const signInWarn = document.getElementById('project-signin-required');
     const form    = document.getElementById('project-form') as HTMLFormElement | null;
-    const fileEl  = document.getElementById('project-polygon-file') as HTMLInputElement | null;
+    const fileEl   = document.getElementById('project-polygon-file') as HTMLInputElement | null;
+    const kmlFileEl = document.getElementById('project-kml-file') as HTMLInputElement | null;
+    const kmlStatus = document.getElementById('project-kml-status');
     const polyTxt = document.getElementById('project-polygon-text') as HTMLTextAreaElement | null;
     const errEl   = document.getElementById('project-form-error');
     const submit  = document.getElementById('project-form-submit') as HTMLButtonElement | null;
@@ -122,6 +133,42 @@ const projectsBase = routes.projects[lang];
       if (!f) return;
       const text = await f.text();
       if (polyTxt) polyTxt.value = text;
+    });
+
+    kmlFileEl?.addEventListener('change', async () => {
+      const f = kmlFileEl.files?.[0];
+      if (!f) return;
+      const text = await f.text();
+      const result = validateKML(text);
+      if (!kmlStatus) return;
+      const proj = (await import('../i18n/' + lang + '.json')).default.projects;
+      if (result.ok) {
+        const displayName = result.name ?? f.name.replace(/\.kml$/i, '');
+        const msg = proj.kml_parse_success
+          .replace('{name}', displayName)
+          .replace('{n}', String(result.vertexCount));
+        kmlStatus.textContent = '✓ ' + msg;
+        kmlStatus.className = 'mt-1 text-xs text-emerald-700 dark:text-emerald-400';
+        // Populate the GeoJSON textarea with the parsed polygon
+        if (polyTxt) {
+          polyTxt.value = JSON.stringify(result.geojson, null, 2);
+          polyTxt.removeAttribute('required');
+        }
+      } else {
+        let errMsg: string;
+        switch (result.error) {
+          case 'too_large':   errMsg = proj.kml_parse_error_too_large;   break;
+          case 'no_polygon':  errMsg = proj.kml_parse_error_no_polygon;  break;
+          case 'invalid_xml': errMsg = proj.kml_parse_error_invalid;     break;
+          case 'empty':       errMsg = proj.kml_parse_error_empty;       break;
+          default:            errMsg = proj.kml_parse_error_invalid;     break;
+        }
+        kmlStatus.textContent = '✕ ' + errMsg;
+        kmlStatus.className = 'mt-1 text-xs text-rose-600 dark:text-rose-400';
+        // Reset file input
+        kmlFileEl.value = '';
+      }
+      kmlStatus.classList.remove('hidden');
     });
 
     function showError(msg: string) {

--- a/src/components/ProjectNewView.astro
+++ b/src/components/ProjectNewView.astro
@@ -83,12 +83,13 @@ const projectsBase = routes.projects[lang];
           <span>{proj.form_polygon_upload}</span>
         </label>
         <label class="inline-flex items-center gap-2 text-xs text-emerald-700 dark:text-emerald-400 cursor-pointer hover:underline" title={proj.kml_upload_label}>
-          <input type="file" id="project-kml-file" accept=".kml,application/vnd.google-earth.kml+xml" class="sr-only" />
+          <input type="file" id="project-kml-file" accept=".kml,application/vnd.google-earth.kml+xml" class="sr-only" aria-label={proj.kml_upload_label} />
           <svg class="h-3.5 w-3.5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
           <span>{proj.kml_upload_button}</span>
         </label>
       </div>
       <div id="project-kml-status" class="hidden mt-1 text-xs"></div>
+      <button type="button" id="project-kml-clear" class="hidden mt-1 text-[11px] text-zinc-400 hover:text-zinc-600 underline">{proj.kml_clear}</button>
     </div>
 
     <p id="project-form-error" class="hidden text-sm text-rose-600 dark:text-rose-400"></p>
@@ -114,6 +115,7 @@ const projectsBase = routes.projects[lang];
     const fileEl   = document.getElementById('project-polygon-file') as HTMLInputElement | null;
     const kmlFileEl = document.getElementById('project-kml-file') as HTMLInputElement | null;
     const kmlStatus = document.getElementById('project-kml-status');
+    const kmlClearBtn = document.getElementById('project-kml-clear') as HTMLButtonElement | null;
     const polyTxt = document.getElementById('project-polygon-text') as HTMLTextAreaElement | null;
     const errEl   = document.getElementById('project-form-error');
     const submit  = document.getElementById('project-form-submit') as HTMLButtonElement | null;
@@ -147,8 +149,14 @@ const projectsBase = routes.projects[lang];
         const msg = proj.kml_parse_success
           .replace('{name}', displayName)
           .replace('{n}', String(result.vertexCount));
-        kmlStatus.textContent = '✓ ' + msg;
+        let statusText = '\u2713 ' + msg;
+        // Warn when MultiGeometry detected (common in CONABIO/CONANP KML exports)
+        if (result.hadMultiGeometry) {
+          statusText += ' \u2014 ' + (proj.kml_multigeometry_warning ?? 'Multiple polygons detected, largest imported');
+        }
+        kmlStatus.textContent = statusText;
         kmlStatus.className = 'mt-1 text-xs text-emerald-700 dark:text-emerald-400';
+        kmlClearBtn?.classList.remove('hidden');
         // Populate the GeoJSON textarea with the parsed polygon
         if (polyTxt) {
           polyTxt.value = JSON.stringify(result.geojson, null, 2);
@@ -160,15 +168,23 @@ const projectsBase = routes.projects[lang];
           case 'too_large':   errMsg = proj.kml_parse_error_too_large;   break;
           case 'no_polygon':  errMsg = proj.kml_parse_error_no_polygon;  break;
           case 'invalid_xml': errMsg = proj.kml_parse_error_invalid;     break;
-          case 'empty':       errMsg = proj.kml_parse_error_empty;       break;
           default:            errMsg = proj.kml_parse_error_invalid;     break;
         }
-        kmlStatus.textContent = '✕ ' + errMsg;
+        kmlStatus.textContent = '\u2715 ' + errMsg;
         kmlStatus.className = 'mt-1 text-xs text-rose-600 dark:text-rose-400';
+        kmlClearBtn?.classList.add('hidden');
         // Reset file input
         kmlFileEl.value = '';
       }
       kmlStatus.classList.remove('hidden');
+    });
+
+    // Clear button: reset KML selection and GeoJSON textarea
+    kmlClearBtn?.addEventListener('click', () => {
+      if (kmlFileEl) kmlFileEl.value = '';
+      if (polyTxt) polyTxt.value = '';
+      if (kmlStatus) { kmlStatus.textContent = ''; kmlStatus.classList.add('hidden'); }
+      kmlClearBtn.classList.add('hidden');
     });
 
     function showError(msg: string) {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2806,8 +2806,8 @@
     "kml_parse_error_no_polygon": "No polygon found in KML file",
     "kml_parse_error_too_large": "File too large (max 500 KB)",
     "kml_parse_error_invalid": "Invalid or malformed KML file",
-    "kml_parse_error_empty": "KML polygon has too few coordinates",
-    "kml_clear": "Clear"
+    "kml_clear": "Clear",
+    "kml_multigeometry_warning": "Multiple polygons detected — largest area imported"
   },
   "confirm_dialog": {
     "default_confirm": "Confirm",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2799,7 +2799,15 @@
     "stations_error_key_taken": "A station with that key already exists in this project.",
     "stations_error_invalid_key": "Station key must be 1–64 alphanumerics, hyphens, or underscores.",
     "stations_error_invalid_coords": "Coords must be valid latitude/longitude in WGS84.",
-    "stations_error_save_failed": "Could not save the station."
+    "stations_error_save_failed": "Could not save the station.",
+    "kml_upload_label": "Upload KML boundary",
+    "kml_upload_button": "Choose KML file",
+    "kml_parse_success": "{name} — {n} vertices",
+    "kml_parse_error_no_polygon": "No polygon found in KML file",
+    "kml_parse_error_too_large": "File too large (max 500 KB)",
+    "kml_parse_error_invalid": "Invalid or malformed KML file",
+    "kml_parse_error_empty": "KML polygon has too few coordinates",
+    "kml_clear": "Clear"
   },
   "confirm_dialog": {
     "default_confirm": "Confirm",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2806,8 +2806,8 @@
     "kml_parse_error_no_polygon": "No se encontró polígono en el archivo KML",
     "kml_parse_error_too_large": "Archivo demasiado grande (máx 500 KB)",
     "kml_parse_error_invalid": "Archivo KML inválido o malformado",
-    "kml_parse_error_empty": "El polígono KML tiene muy pocas coordenadas",
-    "kml_clear": "Limpiar"
+    "kml_clear": "Limpiar",
+    "kml_multigeometry_warning": "Múltiples polígonos detectados — se importó el más grande"
   },
   "confirm_dialog": {
     "default_confirm": "Confirmar",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2799,7 +2799,15 @@
     "stations_error_key_taken": "Ya existe una estación con esa clave en este proyecto.",
     "stations_error_invalid_key": "La clave debe tener 1–64 caracteres alfanuméricos, guiones o guiones bajos.",
     "stations_error_invalid_coords": "Las coordenadas deben ser latitud/longitud válidas en WGS84.",
-    "stations_error_save_failed": "No se pudo guardar la estación."
+    "stations_error_save_failed": "No se pudo guardar la estación.",
+    "kml_upload_label": "Subir límite KML",
+    "kml_upload_button": "Elegir archivo KML",
+    "kml_parse_success": "{name} — {n} vértices",
+    "kml_parse_error_no_polygon": "No se encontró polígono en el archivo KML",
+    "kml_parse_error_too_large": "Archivo demasiado grande (máx 500 KB)",
+    "kml_parse_error_invalid": "Archivo KML inválido o malformado",
+    "kml_parse_error_empty": "El polígono KML tiene muy pocas coordenadas",
+    "kml_clear": "Limpiar"
   },
   "confirm_dialog": {
     "default_confirm": "Confirmar",

--- a/src/lib/kml-parser.test.ts
+++ b/src/lib/kml-parser.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { parseKML, extractKMLName, validateKML } from './kml-parser';
+
+const SIMPLE_KML = `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark>
+    <name>Test Zone</name>
+    <Polygon>
+      <outerBoundaryIs>
+        <LinearRing>
+          <coordinates>-96.72,17.06,0 -96.70,17.06,0 -96.70,17.08,0 -96.72,17.08,0 -96.72,17.06,0</coordinates>
+        </LinearRing>
+      </outerBoundaryIs>
+    </Polygon>
+  </Placemark>
+</kml>`;
+
+const NO_POLYGON_KML = `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark>
+    <name>Just a Point</name>
+    <Point><coordinates>-96.72,17.06,0</coordinates></Point>
+  </Placemark>
+</kml>`;
+
+const FEW_COORDS_KML = `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark>
+    <Polygon>
+      <outerBoundaryIs>
+        <LinearRing>
+          <coordinates>-96.72,17.06,0 -96.70,17.06,0</coordinates>
+        </LinearRing>
+      </outerBoundaryIs>
+    </Polygon>
+  </Placemark>
+</kml>`;
+
+const MALFORMED_XML = `<?xml version="1.0"?>
+<kml><Polygon><unclosed`;
+
+const NAMED_DOCUMENT_KML = `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>Sierra Juárez</name>
+    <Placemark>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>-96.72,17.06,0 -96.70,17.06,0 -96.70,17.08,0 -96.72,17.08,0 -96.72,17.06,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+  </Document>
+</kml>`;
+
+describe('parseKML', () => {
+  it('returns a GeoJSON Polygon for a valid KML', () => {
+    const result = parseKML(SIMPLE_KML);
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('Polygon');
+    expect(result?.coordinates[0]).toHaveLength(5);
+  });
+
+  it('returns [lon, lat] pairs (no axis swap needed)', () => {
+    const result = parseKML(SIMPLE_KML);
+    // First coord in KML: -96.72,17.06  → [lon=-96.72, lat=17.06]
+    expect(result?.coordinates[0][0]).toEqual([-96.72, 17.06]);
+  });
+
+  it('returns null when no Polygon element present', () => {
+    expect(parseKML(NO_POLYGON_KML)).toBeNull();
+  });
+
+  it('returns null when fewer than 3 coordinate pairs', () => {
+    expect(parseKML(FEW_COORDS_KML)).toBeNull();
+  });
+
+  it('returns null for malformed XML', () => {
+    expect(parseKML(MALFORMED_XML)).toBeNull();
+  });
+});
+
+describe('extractKMLName', () => {
+  it('returns the Placemark name', () => {
+    expect(extractKMLName(SIMPLE_KML)).toBe('Test Zone');
+  });
+
+  it('falls back to Document name if no Placemark name', () => {
+    expect(extractKMLName(NAMED_DOCUMENT_KML)).toBe('Sierra Juárez');
+  });
+
+  it('returns undefined if no name element', () => {
+    expect(extractKMLName(FEW_COORDS_KML)).toBeUndefined();
+  });
+});
+
+describe('validateKML', () => {
+  it('returns ok:true with geojson, vertexCount, and name for a valid KML', () => {
+    const result = validateKML(SIMPLE_KML);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.geojson.type).toBe('Polygon');
+      expect(result.vertexCount).toBe(5);
+      expect(result.name).toBe('Test Zone');
+    }
+  });
+
+  it('returns error:too_large for KML exceeding 500 KB', () => {
+    const bigKml = 'x'.repeat(500_001);
+    const result = validateKML(bigKml);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('too_large');
+  });
+
+  it('returns error:no_polygon when KML has no Polygon element', () => {
+    const result = validateKML(NO_POLYGON_KML);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('no_polygon');
+  });
+
+  it('returns error:no_polygon for malformed XML (DOMParser parseerror)', () => {
+    const result = validateKML(MALFORMED_XML);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(['no_polygon', 'invalid_xml']).toContain(result.error);
+  });
+
+  it('returns error:no_polygon when coordinate pairs are fewer than 3', () => {
+    const result = validateKML(FEW_COORDS_KML);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('no_polygon');
+  });
+});

--- a/src/lib/kml-parser.test.ts
+++ b/src/lib/kml-parser.test.ts
@@ -55,18 +55,43 @@ const NAMED_DOCUMENT_KML = `<?xml version="1.0" encoding="UTF-8"?>
   </Document>
 </kml>`;
 
+// MultiGeometry: two polygons — second one has more vertices (should be selected)
+const MULTI_GEOMETRY_KML = `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark>
+    <name>Sierra Norte</name>
+    <MultiGeometry>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>-96.70,17.06,0 -96.69,17.06,0 -96.69,17.07,0 -96.70,17.06,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>-96.72,17.06,0 -96.70,17.06,0 -96.70,17.08,0 -96.72,17.08,0 -96.71,17.09,0 -96.72,17.06,0</coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </MultiGeometry>
+  </Placemark>
+</kml>`;
+
 describe('parseKML', () => {
-  it('returns a GeoJSON Polygon for a valid KML', () => {
+  it('returns a GeoJSON Polygon and hadMultiGeometry=false for a simple KML', () => {
     const result = parseKML(SIMPLE_KML);
     expect(result).not.toBeNull();
-    expect(result?.type).toBe('Polygon');
-    expect(result?.coordinates[0]).toHaveLength(5);
+    expect(result?.geojson.type).toBe('Polygon');
+    expect(result?.geojson.coordinates[0]).toHaveLength(5);
+    expect(result?.hadMultiGeometry).toBe(false);
   });
 
   it('returns [lon, lat] pairs (no axis swap needed)', () => {
     const result = parseKML(SIMPLE_KML);
     // First coord in KML: -96.72,17.06  → [lon=-96.72, lat=17.06]
-    expect(result?.coordinates[0][0]).toEqual([-96.72, 17.06]);
+    expect(result?.geojson.coordinates[0][0]).toEqual([-96.72, 17.06]);
   });
 
   it('returns null when no Polygon element present', () => {
@@ -79,6 +104,14 @@ describe('parseKML', () => {
 
   it('returns null for malformed XML', () => {
     expect(parseKML(MALFORMED_XML)).toBeNull();
+  });
+
+  it('handles MultiGeometry: picks the polygon with most vertices, sets hadMultiGeometry=true', () => {
+    const result = parseKML(MULTI_GEOMETRY_KML);
+    expect(result).not.toBeNull();
+    expect(result?.hadMultiGeometry).toBe(true);
+    // The larger polygon (6 vertices) should be selected over the smaller (4 vertices)
+    expect(result?.geojson.coordinates[0]).toHaveLength(6);
   });
 });
 
@@ -97,13 +130,23 @@ describe('extractKMLName', () => {
 });
 
 describe('validateKML', () => {
-  it('returns ok:true with geojson, vertexCount, and name for a valid KML', () => {
+  it('returns ok:true with geojson, vertexCount, name, hadMultiGeometry for valid KML', () => {
     const result = validateKML(SIMPLE_KML);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.geojson.type).toBe('Polygon');
       expect(result.vertexCount).toBe(5);
       expect(result.name).toBe('Test Zone');
+      expect(result.hadMultiGeometry).toBe(false);
+    }
+  });
+
+  it('returns ok:true with hadMultiGeometry=true for MultiGeometry KML', () => {
+    const result = validateKML(MULTI_GEOMETRY_KML);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.hadMultiGeometry).toBe(true);
+      expect(result.vertexCount).toBe(6); // largest polygon selected
     }
   });
 

--- a/src/lib/kml-parser.ts
+++ b/src/lib/kml-parser.ts
@@ -1,44 +1,76 @@
 /**
  * kml-parser.ts — Client-side KML polygon parser for Rastrum project boundaries.
  * Parses KML files (standard format from CONABIO, CONANP, Google Earth) into GeoJSON.
+ *
+ * Coordinate order: KML uses "lon,lat,alt" tuples — GeoJSON also uses [lon,lat].
+ * Do NOT swap the order here; the values are already correct as-is.
  */
 
 export type KMLGeoJSON = { type: 'Polygon'; coordinates: number[][][] };
 
 export type KMLValidationResult =
-  | { ok: true; geojson: KMLGeoJSON; vertexCount: number; name?: string }
-  | { ok: false; error: 'no_polygon' | 'too_large' | 'invalid_xml' | 'empty' };
+  | { ok: true; geojson: KMLGeoJSON; vertexCount: number; name?: string; hadMultiGeometry?: boolean }
+  | { ok: false; error: 'no_polygon' | 'too_large' | 'invalid_xml' };
 
 const MAX_KML_BYTES = 500_000;
 
 /**
- * Parse the first polygon found in a KML string into GeoJSON.
- * KML coordinates are "lon,lat,alt" space-separated tuples.
+ * Parse the first (or largest) polygon found in a KML string into GeoJSON.
+ *
+ * Handles:
+ * - Simple <Polygon> placemarks (most common)
+ * - <MultiGeometry> with multiple polygons (common in CONABIO/CONANP exports)
+ *   → selects the polygon with the most vertices and warns the caller via hadMultiGeometry
+ *
+ * KML coordinate format: "lon,lat,alt" space-separated tuples.
+ * GeoJSON format: [[lon, lat], ...] — same order, altitude dropped.
  */
-export function parseKML(text: string): KMLGeoJSON | null {
+export function parseKML(text: string): { geojson: KMLGeoJSON; hadMultiGeometry: boolean } | null {
   const doc = new DOMParser().parseFromString(text, 'text/xml');
   if (doc.querySelector('parsererror')) return null;
 
-  // Try outer boundary first, fall back to any coordinates element
-  const coordsEl =
-    doc.querySelector('Polygon outerBoundaryIs LinearRing coordinates') ??
-    doc.querySelector('Polygon LinearRing coordinates') ??
-    doc.querySelector('coordinates');
-  if (!coordsEl?.textContent) return null;
+  const allPolygons = Array.from(doc.querySelectorAll('Polygon'));
+  if (allPolygons.length === 0) return null;
 
-  const pairs = coordsEl.textContent
+  const hadMultiGeometry =
+    allPolygons.length > 1 ||
+    doc.querySelector('MultiGeometry') !== null;
+
+  // For MultiGeometry: pick the polygon with the most vertices (largest area proxy)
+  let bestCoordEl: Element | null = null;
+  let bestCount = 0;
+  for (const poly of allPolygons) {
+    const coordsEl =
+      poly.querySelector('outerBoundaryIs LinearRing coordinates') ??
+      poly.querySelector('LinearRing coordinates') ??
+      poly.querySelector('coordinates');
+    if (!coordsEl?.textContent) continue;
+    const count = coordsEl.textContent.trim().split(/\s+/).length;
+    if (count > bestCount) {
+      bestCount = count;
+      bestCoordEl = coordsEl;
+    }
+  }
+
+  if (!bestCoordEl?.textContent) return null;
+
+  const pairs = bestCoordEl.textContent
     .trim()
     .split(/\s+/)
     .filter(Boolean)
     .map(pair => {
       const parts = pair.split(',').map(Number);
+      // KML: lon,lat,alt → GeoJSON: [lon, lat] (same order, drop altitude)
       return [parts[0], parts[1]] as [number, number];
     })
     .filter(([lon, lat]) => !isNaN(lon) && !isNaN(lat));
 
   if (pairs.length < 3) return null;
 
-  return { type: 'Polygon', coordinates: [pairs] };
+  return {
+    geojson: { type: 'Polygon', coordinates: [pairs] },
+    hadMultiGeometry,
+  };
 }
 
 /** Extract the first placemark name from KML (for display). */
@@ -52,12 +84,12 @@ export function extractKMLName(text: string): string | undefined {
 export function validateKML(text: string): KMLValidationResult {
   if (text.length > MAX_KML_BYTES) return { ok: false, error: 'too_large' };
   try {
-    const geojson = parseKML(text);
-    if (!geojson) return { ok: false, error: 'no_polygon' };
+    const result = parseKML(text);
+    if (!result) return { ok: false, error: 'no_polygon' };
+    const { geojson, hadMultiGeometry } = result;
     const vertexCount = geojson.coordinates[0].length;
-    if (vertexCount < 3) return { ok: false, error: 'empty' };
     const name = extractKMLName(text);
-    return { ok: true, geojson, vertexCount, name };
+    return { ok: true, geojson, vertexCount, name, hadMultiGeometry };
   } catch {
     return { ok: false, error: 'invalid_xml' };
   }

--- a/src/lib/kml-parser.ts
+++ b/src/lib/kml-parser.ts
@@ -1,0 +1,64 @@
+/**
+ * kml-parser.ts — Client-side KML polygon parser for Rastrum project boundaries.
+ * Parses KML files (standard format from CONABIO, CONANP, Google Earth) into GeoJSON.
+ */
+
+export type KMLGeoJSON = { type: 'Polygon'; coordinates: number[][][] };
+
+export type KMLValidationResult =
+  | { ok: true; geojson: KMLGeoJSON; vertexCount: number; name?: string }
+  | { ok: false; error: 'no_polygon' | 'too_large' | 'invalid_xml' | 'empty' };
+
+const MAX_KML_BYTES = 500_000;
+
+/**
+ * Parse the first polygon found in a KML string into GeoJSON.
+ * KML coordinates are "lon,lat,alt" space-separated tuples.
+ */
+export function parseKML(text: string): KMLGeoJSON | null {
+  const doc = new DOMParser().parseFromString(text, 'text/xml');
+  if (doc.querySelector('parsererror')) return null;
+
+  // Try outer boundary first, fall back to any coordinates element
+  const coordsEl =
+    doc.querySelector('Polygon outerBoundaryIs LinearRing coordinates') ??
+    doc.querySelector('Polygon LinearRing coordinates') ??
+    doc.querySelector('coordinates');
+  if (!coordsEl?.textContent) return null;
+
+  const pairs = coordsEl.textContent
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(pair => {
+      const parts = pair.split(',').map(Number);
+      return [parts[0], parts[1]] as [number, number];
+    })
+    .filter(([lon, lat]) => !isNaN(lon) && !isNaN(lat));
+
+  if (pairs.length < 3) return null;
+
+  return { type: 'Polygon', coordinates: [pairs] };
+}
+
+/** Extract the first placemark name from KML (for display). */
+export function extractKMLName(text: string): string | undefined {
+  const doc = new DOMParser().parseFromString(text, 'text/xml');
+  const nameEl = doc.querySelector('Placemark > name') ?? doc.querySelector('Document > name');
+  return nameEl?.textContent?.trim() || undefined;
+}
+
+/** Validate a KML text and return a typed result. */
+export function validateKML(text: string): KMLValidationResult {
+  if (text.length > MAX_KML_BYTES) return { ok: false, error: 'too_large' };
+  try {
+    const geojson = parseKML(text);
+    if (!geojson) return { ok: false, error: 'no_polygon' };
+    const vertexCount = geojson.coordinates[0].length;
+    if (vertexCount < 3) return { ok: false, error: 'empty' };
+    const name = extractKMLName(text);
+    return { ok: true, geojson, vertexCount, name };
+  } catch {
+    return { ok: false, error: 'invalid_xml' };
+  }
+}


### PR DESCRIPTION
Closes #279

## Changes

- New: `src/lib/kml-parser.ts` — client-side KML → GeoJSON parser
- New: `src/lib/kml-parser.test.ts` — 13 unit tests
- Updated: project form to accept KML file upload with validation feedback
- Updated: i18n en/es strings for KML UI

## How it works

KML is parsed entirely client-side using DOMParser (no server round-trip). The parsed GeoJSON polygon is stored and sent with the project save payload to the existing PostgREST endpoint, which stores it in `projects.polygon` (PostGIS geography column from M29).

## UI

A new "Choose KML file" button appears next to the existing ".geojson upload" link in the polygon field. On success, the GeoJSON textarea is populated with the parsed polygon and a success message shows the polygon name and vertex count. On error, a localized error message is shown (too_large / no_polygon / invalid_xml / empty).

## Supported formats

- Standard KML with `<Polygon>` / `<outerBoundaryIs>` / `<LinearRing>` (CONABIO, CONANP, Google Earth)
- Max file size: 500 KB client-side guard
