### PR TITLE
fix(console): identifier_id/quality_grade → validated_by/is_research_grade (#281)

### DIFF
--- a/src/components/ConsoleUsersView.astro
+++ b/src/components/ConsoleUsersView.astro
@@ -242,7 +242,9 @@ const tr = t(lang);
     try {
       const [obsResult, rgResult, trustResult] = await Promise.all([
         supabase.from('observations').select('id', { count: 'exact', head: true }).eq('observer_id', userId),
-        supabase.from('identifications').select('id', { count: 'exact', head: true }).eq('identifier_id', userId).eq('quality_grade', 'research'),
+        // identifications table uses validated_by (uuid) and is_research_grade (boolean)
+        // identifier_id and quality_grade do not exist in this schema
+        supabase.from('identifications').select('id', { count: 'exact', head: true }).eq('validated_by', userId).eq('is_research_grade', true),
         supabase.rpc('compute_moderator_trust_score', { p_user_id: userId }),
       ]);
 


### PR DESCRIPTION
## Bug

`/console/users/` fires a 400 on every user row click:
```
HEAD .../identifications?select=id&identifier_id=eq.{uuid}&quality_grade=eq.research → 400
```

## Root cause

`ConsoleUsersView` → `loadActivity()` queries `identifications` using columns that don't exist:
- `identifier_id` — does not exist
- `quality_grade` — does not exist

## Actual schema (M07)

```sql
CREATE TABLE public.identifications (
  ...
  validated_by    uuid REFERENCES users(id),
  is_research_grade boolean DEFAULT false,
  ...
);
```

## Fix

```ts
// Before:
.eq('identifier_id', userId).eq('quality_grade', 'research')

// After:
.eq('validated_by', userId).eq('is_research_grade', true)
```

This correctly counts research-grade identifications validated by the user.

tsc --noEmit: clean.