### PR TITLE
feat(kml): KMZ support — CONANP/CONABIO format (Boquerón de Tonalá)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dexie": "^4.4.2",
         "exifr": "^7.1.3",
         "fuse.js": "^7.3.0",
+        "jszip": "^3.10.1",
         "maplibre-gl": "^5.24.0",
         "onnxruntime-web": "^1.20.1",
         "papaparse": "^5.5.3",
@@ -4423,6 +4424,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/crossws": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
@@ -6193,7 +6200,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-meta-resolve": {
@@ -6232,7 +6238,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/inquirer": {
@@ -6600,6 +6605,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
@@ -6774,6 +6785,33 @@
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/kdbush": {
       "version": "4.0.2",
@@ -9204,6 +9242,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -9447,6 +9491,27 @@
       "dependencies": {
         "pify": "^2.3.0"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -10060,6 +10125,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -10389,6 +10460,21 @@
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dexie": "^4.4.2",
     "exifr": "^7.1.3",
     "fuse.js": "^7.3.0",
+    "jszip": "^3.10.1",
     "maplibre-gl": "^5.24.0",
     "onnxruntime-web": "^1.20.1",
     "papaparse": "^5.5.3",

--- a/src/components/ProjectNewView.astro
+++ b/src/components/ProjectNewView.astro
@@ -83,7 +83,7 @@ const projectsBase = routes.projects[lang];
           <span>{proj.form_polygon_upload}</span>
         </label>
         <label class="inline-flex items-center gap-2 text-xs text-emerald-700 dark:text-emerald-400 cursor-pointer hover:underline" title={proj.kml_upload_label}>
-          <input type="file" id="project-kml-file" accept=".kml,application/vnd.google-earth.kml+xml" class="sr-only" aria-label={proj.kml_upload_label} />
+          <input type="file" id="project-kml-file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz,application/zip" class="sr-only" aria-label={proj.kml_upload_label} />
           <svg class="h-3.5 w-3.5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
           <span>{proj.kml_upload_button}</span>
         </label>
@@ -103,7 +103,7 @@ const projectsBase = routes.projects[lang];
 
 <script>
   import { upsertProject, validatePolygonGeoJSON, isValidSlug } from '../lib/projects';
-  import { validateKML } from '../lib/kml-parser';
+  import { validateKMLOrKMZ } from '../lib/kml-parser';
   import { getSupabase } from '../lib/supabase';
 
   const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
@@ -140,12 +140,11 @@ const projectsBase = routes.projects[lang];
     kmlFileEl?.addEventListener('change', async () => {
       const f = kmlFileEl.files?.[0];
       if (!f) return;
-      const text = await f.text();
-      const result = validateKML(text);
+      const result = await validateKMLOrKMZ(f);
       if (!kmlStatus) return;
       const proj = (await import('../i18n/' + lang + '.json')).default.projects;
       if (result.ok) {
-        const displayName = result.name ?? f.name.replace(/\.kml$/i, '');
+        const displayName = result.name ?? f.name.replace(/\.(kml|kmz)$/i, '');
         const msg = proj.kml_parse_success
           .replace('{name}', displayName)
           .replace('{n}', String(result.vertexCount));

--- a/src/lib/kml-parser.test.ts
+++ b/src/lib/kml-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseKML, extractKMLName, validateKML } from './kml-parser';
+import { parseKML, extractKMLName, validateKML, isKMZ } from './kml-parser';
 
 const SIMPLE_KML = `<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
@@ -173,5 +173,16 @@ describe('validateKML', () => {
     const result = validateKML(FEW_COORDS_KML);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toBe('no_polygon');
+  });
+});
+
+describe('isKMZ', () => {
+  it('detects .kmz extension', () => {
+    expect(isKMZ({ name: 'zona.kmz', type: '', size: 100 } as unknown as File)).toBe(true);
+    expect(isKMZ({ name: 'zona.kml', type: '', size: 100 } as unknown as File)).toBe(false);
+  });
+
+  it('detects kmz MIME type', () => {
+    expect(isKMZ({ name: 'f', type: 'application/vnd.google-earth.kmz', size: 100 } as unknown as File)).toBe(true);
   });
 });

--- a/src/lib/kml-parser.ts
+++ b/src/lib/kml-parser.ts
@@ -13,6 +13,8 @@ export type KMLValidationResult =
   | { ok: false; error: 'no_polygon' | 'too_large' | 'invalid_xml' };
 
 const MAX_KML_BYTES = 500_000;
+/** Maximum size for KMZ files (ZIP-compressed KML). 5MB = MAX_KML_BYTES * 10. */
+const MAX_KMZ_BYTES = 5_000_000;
 
 /**
  * Parse the first (or largest) polygon found in a KML string into GeoJSON.
@@ -117,12 +119,16 @@ export async function extractKMLFromKMZ(file: File | Blob): Promise<string | nul
   return kmlFile.async('string');
 }
 
-/** Returns true if the file is a KMZ (by extension or MIME type). */
+/** Returns true if the file is a KMZ (by extension or MIME type).
+ * Note: `application/zip` is guarded by extension check to avoid false positives
+ * (iOS/Android sometimes report .kmz files as application/zip). */
 export function isKMZ(file: File): boolean {
+  const name = file.name.toLowerCase();
   return (
-    file.name.toLowerCase().endsWith('.kmz') ||
+    name.endsWith('.kmz') ||
     file.type === 'application/vnd.google-earth.kmz' ||
-    file.type === 'application/zip'
+    // application/zip only counts if the extension is .kmz (iOS/Android quirk)
+    (file.type === 'application/zip' && name.endsWith('.kmz'))
   );
 }
 
@@ -131,7 +137,7 @@ export function isKMZ(file: File): boolean {
  * For KMZ, extracts doc.kml first, then validates the KML content.
  */
 export async function validateKMLOrKMZ(file: File): Promise<KMLValidationResult> {
-  if (file.size > MAX_KML_BYTES * 10) {
+  if (file.size > MAX_KMZ_BYTES) {
     // KMZ can be larger than 500KB when compressed; limit to 5MB for KMZ
     return { ok: false, error: 'too_large' };
   }

--- a/src/lib/kml-parser.ts
+++ b/src/lib/kml-parser.ts
@@ -94,3 +94,56 @@ export function validateKML(text: string): KMLValidationResult {
     return { ok: false, error: 'invalid_xml' };
   }
 }
+
+// ── KMZ support ────────────────────────────────────────────────────────────
+
+/**
+ * Extract the KML text from a KMZ file (ZIP archive containing doc.kml).
+ * Uses JSZip (dynamically imported to keep the bundle lazy).
+ *
+ * @param file - A File or Blob with .kmz extension or application/vnd.google-earth.kmz MIME type
+ * @returns The KML text content, or null if no .kml file found inside the archive
+ */
+export async function extractKMLFromKMZ(file: File | Blob): Promise<string | null> {
+  // Dynamic import so JSZip is only loaded when a KMZ is actually uploaded
+  const JSZip = (await import('jszip')).default;
+  const zip = await JSZip.loadAsync(file);
+
+  // KMZ spec: primary document is doc.kml; fall back to first .kml file found
+  const docKml = zip.file('doc.kml');
+  const kmlFile = docKml ?? Object.values(zip.files).find(f => f.name.endsWith('.kml') && !f.dir);
+
+  if (!kmlFile) return null;
+  return kmlFile.async('string');
+}
+
+/** Returns true if the file is a KMZ (by extension or MIME type). */
+export function isKMZ(file: File): boolean {
+  return (
+    file.name.toLowerCase().endsWith('.kmz') ||
+    file.type === 'application/vnd.google-earth.kmz' ||
+    file.type === 'application/zip'
+  );
+}
+
+/**
+ * Validate a KML or KMZ file. Handles both formats transparently.
+ * For KMZ, extracts doc.kml first, then validates the KML content.
+ */
+export async function validateKMLOrKMZ(file: File): Promise<KMLValidationResult> {
+  if (file.size > MAX_KML_BYTES * 10) {
+    // KMZ can be larger than 500KB when compressed; limit to 5MB for KMZ
+    return { ok: false, error: 'too_large' };
+  }
+
+  let text: string;
+  if (isKMZ(file)) {
+    const extracted = await extractKMLFromKMZ(file);
+    if (!extracted) return { ok: false, error: 'no_polygon' };
+    text = extracted;
+  } else {
+    text = await file.text();
+  }
+
+  return validateKML(text);
+}


### PR DESCRIPTION
## Context

Eugenio Padilla (field tester, Oaxaca) uploaded a real CONANP KMZ file: **Boquerón de Tonalá APFF** (Área de Protección de Flora y Fauna, 3,912 ha, Oaxaca). All official CONANP/CONABIO exports are `.kmz`, not `.kml` — so KMZ support was always needed for real-world use.

## What is KMZ?

KMZ = ZIP archive containing `doc.kml` (the polygon) + optional images/metadata. Our KML parser already handles the content; this PR adds the extraction step.

## Changes

- **`kml-parser.ts`** — new functions:
  - `isKMZ(file)` — detects by extension or MIME type
  - `extractKMLFromKMZ(file)` — decompresses ZIP, extracts `doc.kml` (jszip, dynamically imported)
  - `validateKMLOrKMZ(file)` — transparent wrapper: handles both .kml and .kmz

- **`ProjectNewView.astro`** — file input now accepts `.kml,.kmz`, uses `validateKMLOrKMZ()`

- **`jszip`** — added as dependency (dynamic import so it only loads when a KMZ is actually uploaded)

- **Tests** — 718 passing (+2 isKMZ tests)

## Tested with

The actual APFFBT KMZ from CONANP (Boquerón de Tonalá, Oaxaca): single `<Polygon>` with 63 vertices, correctly parsed to GeoJSON.