### PR TITLE
fix(rls): EXISTS instead of IN subquery in id_owner + media_owner — resolves 42P17

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -427,10 +427,22 @@ CREATE POLICY "obs_credentialed_read" ON public.observations FOR SELECT
 
 -- Identifications: tied to observation access
 DROP POLICY IF EXISTS "id_owner" ON public.identifications;
+-- Fixed 2026-04-30: IN (SELECT id FROM observations ...) → EXISTS to prevent 42P17
+-- recursion. The IN subquery re-evaluates RLS on observations during INSERT,
+-- causing infinite recursion (42P17). EXISTS breaks the cycle.
 CREATE POLICY "id_owner" ON public.identifications FOR ALL
   USING (
-    observation_id IN (
-      SELECT id FROM observations WHERE (SELECT auth.uid()) = observer_id
+    EXISTS (
+      SELECT 1 FROM public.observations o
+      WHERE o.id = observation_id
+        AND (SELECT auth.uid()) = o.observer_id
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.observations o
+      WHERE o.id = observation_id
+        AND (SELECT auth.uid()) = o.observer_id
     )
   );
 
@@ -442,10 +454,20 @@ CREATE POLICY "id_public_read" ON public.identifications FOR SELECT
 
 -- Media: same as observations
 DROP POLICY IF EXISTS "media_owner" ON public.media_files;
+-- Fixed 2026-04-30: same EXISTS fix as id_owner (42P17 recursion prevention)
 CREATE POLICY "media_owner" ON public.media_files FOR ALL
   USING (
-    observation_id IN (
-      SELECT id FROM observations WHERE (SELECT auth.uid()) = observer_id
+    EXISTS (
+      SELECT 1 FROM public.observations o
+      WHERE o.id = observation_id
+        AND (SELECT auth.uid()) = o.observer_id
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.observations o
+      WHERE o.id = observation_id
+        AND (SELECT auth.uid()) = o.observer_id
     )
   );
 


### PR DESCRIPTION
## Root cause

Marcela's observations failed to sync all day with error 42P17 (infinite recursion in RLS policy).

The root cause was **two policies** using correlated `IN (SELECT FROM observations)` subqueries:

- `id_owner` on `identifications`
- `media_owner` on `media_files`

```sql
-- The bad pattern:
observation_id IN (SELECT id FROM observations WHERE auth.uid() = observer_id)
```

When Postgres evaluates RLS during INSERT into `observations`, it evaluates all permissive policies. `id_owner` and `media_owner` both do `SELECT FROM observations`, which triggers RLS evaluation of `observations` again → infinite recursion.

## Fix

Replace `IN (SELECT id FROM observations ...)` with `EXISTS (SELECT 1 FROM observations ...)`:

```sql
-- The fix:
EXISTS (
  SELECT 1 FROM public.observations o
  WHERE o.id = observation_id
    AND (SELECT auth.uid()) = o.observer_id
)
```

`EXISTS` breaks the recursion because Postgres can short-circuit evaluation without re-entering the full RLS policy stack.

Also added explicit `WITH CHECK` to both policies to avoid the Supabase dashboard generating an empty `WITH CHECK ()` which caused syntax errors.

## What was applied manually as hotfix

1. `obs_owner` — added `WITH CHECK` (PR #272, applied this morning)
2. `obs_credentialed_read` — replaced `SELECT column` with `EXISTS` (applied ~20:10 UTC)
3. `update_user_obs_count` trigger — added `SET row_security = off` (applied ~21:04 UTC)
4. `id_owner` + `media_owner` — **this PR** — not yet applied in prod, needs db-apply run

## When merged, db-apply will apply automatically

The `db-apply.yml` workflow triggers on push to main when SQL files change.