### PR TITLE
fix(tokens): allow status/admin scopes + surface errors on create

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -44,6 +44,7 @@ on:
           - follow
           - react
           - report
+          - tokens
       sync_secrets:
         description: 'Sync GitHub Actions secrets → Supabase Edge Function secrets before deploy'
         required: false

--- a/src/pages/en/profile/tokens.astro
+++ b/src/pages/en/profile/tokens.astro
@@ -136,13 +136,16 @@ const tr = t(lang) as any;
     const scopes = Array.from(document.querySelectorAll<HTMLInputElement>('input[name="scope"]:checked')).map(el => el.value);
     const expiresEl = document.getElementById('token-expires') as HTMLSelectElement;
     const expires_in_days = expiresEl.value ? parseInt(expiresEl.value) : undefined;
-    const res = await fetch(TOKENS_URL, {
-      method: 'POST',
-      headers: { Authorization: await getAuthHeader(), 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, scopes, expires_in_days }),
-    });
-    const data = await res.json();
-    if (data.token) {
+    const btn = e.currentTarget?.querySelector('button[type=submit]') as HTMLButtonElement | null;
+    if (btn) { btn.disabled = true; btn.textContent = 'Creating…'; }
+    try {
+      const res = await fetch(TOKENS_URL, {
+        method: 'POST',
+        headers: { Authorization: await getAuthHeader(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, scopes, expires_in_days }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? `Error ${res.status}`);
       const banner = document.getElementById('new-token-banner')!;
       document.getElementById('new-token-value')!.textContent = data.token;
       banner.classList.remove('hidden');
@@ -153,6 +156,10 @@ const tr = t(lang) as any;
       };
       (document.getElementById('token-name') as HTMLInputElement).value = '';
       loadTokens();
+    } catch (err) {
+      alert(`Failed to create token: ${err instanceof Error ? err.message : err}`);
+    } finally {
+      if (btn) { btn.disabled = false; btn.textContent = 'Create token'; }
     }
   });
 

--- a/src/pages/es/perfil/tokens.astro
+++ b/src/pages/es/perfil/tokens.astro
@@ -179,30 +179,34 @@ const tr = t(lang) as any;
     const expiresEl = document.getElementById('token-expires') as HTMLSelectElement;
     const expires_in_days = expiresEl.value ? parseInt(expiresEl.value) : undefined;
 
-    const res = await fetch(TOKENS_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: await getAuthHeader(),
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ name, scopes, expires_in_days }),
-    });
-
-    const data = await res.json();
-    if (data.token) {
+    const btn = e.currentTarget?.querySelector('button[type=submit]') as HTMLButtonElement | null;
+    if (btn) { btn.disabled = true; btn.textContent = 'Creando…'; }
+    try {
+      const res = await fetch(TOKENS_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: await getAuthHeader(),
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name, scopes, expires_in_days }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? `Error ${res.status}`);
       const banner = document.getElementById('new-token-banner')!;
       const val = document.getElementById('new-token-value')!;
       val.textContent = data.token;
       banner.classList.remove('hidden');
       banner.scrollIntoView({ behavior: 'smooth' });
-
       document.getElementById('copy-btn')!.onclick = () => {
         navigator.clipboard.writeText(data.token);
         (document.getElementById('copy-btn') as HTMLButtonElement).textContent = '✓';
       };
-
       (document.getElementById('token-name') as HTMLInputElement).value = '';
       loadTokens();
+    } catch (err) {
+      alert(`Error al crear el token: ${err instanceof Error ? err.message : err}`);
+    } finally {
+      if (btn) { btn.disabled = false; btn.textContent = 'Crear token'; }
     }
   });
 

--- a/supabase/functions/tokens/index.ts
+++ b/supabase/functions/tokens/index.ts
@@ -77,7 +77,7 @@ Deno.serve(async (req: Request) => {
     if (!Array.isArray(scopes) || !scopes.every((s): s is string => typeof s === 'string')) {
       return json({ error: 'scopes must be an array of strings' }, 400);
     }
-    const ALLOWED_SCOPES = ['observe', 'identify', 'export', 'read_all'];
+    const ALLOWED_SCOPES = ['observe', 'identify', 'export', 'read_all', 'status', 'admin'];
     const invalidScopes = scopes.filter((s: string) => !ALLOWED_SCOPES.includes(s));
     if (invalidScopes.length > 0) {
       return json({ error: `Invalid scopes: ${invalidScopes.join(', ')}` }, 400);


### PR DESCRIPTION
## Summary

Followup to #294 — these two commits were pushed after that PR merged so they weren't included.

- `tokens` Edge Function: `status` and `admin` were not in `ALLOWED_SCOPES` → any attempt to create a token with those scopes returned 400 silently
- Submit handler: no error branch existed — any failure (wrong scopes, 401, network error) was invisible to the user
- Button now shows "Creating…" / disabled state while the request is in flight, re-enables on failure
- Adds `tokens` to the `deploy-functions.yml` manual dispatch dropdown