### PR TITLE
fix(observe): capability banner flash + sessionStorage for collapsed state (closes #297)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -43,7 +43,8 @@ const weathers = WEATHERS;
   </div>
 
   <!-- AI Capability Status Banner (#274) -->
-  <div id="obs2-capability-banner" class="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/60 px-4 py-3 text-xs space-y-1">
+  <!-- Banner starts hidden to prevent SSR flash; JS reveals it after checking localStorage/sessionStorage -->
+  <div id="obs2-capability-banner" class="hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/60 px-4 py-3 text-xs space-y-1">
     <div class="flex items-center justify-between">
       <span class="font-medium text-zinc-700 dark:text-zinc-300">
         {isEs ? "🤖 Modelos disponibles:" : "🤖 Available AI:"}
@@ -337,12 +338,15 @@ const collapseBtn = document.getElementById('obs2-banner-collapse');
 const fileHint    = document.getElementById('obs2-file-hint');
 
 // Collapse banner if user has dismissed it before
+// Use sessionStorage so the banner shows once per session.
+// localStorage was permanent — users could never re-check their config status.
 const BANNER_COLLAPSED_KEY = 'rastrum.obs2.banner_collapsed';
-if (localStorage.getItem(BANNER_COLLAPSED_KEY)) {
-  capBanner?.classList.add('hidden');
+if (!sessionStorage.getItem(BANNER_COLLAPSED_KEY)) {
+  // Show the banner this session (not previously dismissed in this session)
+  capBanner?.classList.remove('hidden');
 }
 collapseBtn?.addEventListener('click', () => {
-  localStorage.setItem(BANNER_COLLAPSED_KEY, '1');
+  sessionStorage.setItem(BANNER_COLLAPSED_KEY, '1');
   capBanner?.classList.add('hidden');
 });
 
@@ -366,11 +370,11 @@ collapseBtn?.addEventListener('click', () => {
       </span>
     `).join('');
     if (allOk && capBanner) {
-      // All configured — collapse banner after 3s
+      // All configured — collapse banner after 10s, use sessionStorage (not permanent)
       setTimeout(() => {
         capBanner.classList.add('hidden');
-        localStorage.setItem(BANNER_COLLAPSED_KEY, '1');
-      }, 3000);
+        sessionStorage.setItem(BANNER_COLLAPSED_KEY, '1');
+      }, 10000);
     }
   } catch { /* silent */ }
 })();


### PR DESCRIPTION
## Fixes

### 1. SSR flash (banner visible for ~1 frame then hidden)

Banner now renders `hidden` in SSR. JS reveals it after checking sessionStorage. Previously it rendered visible and JS hid it after hydration — that caused the flash.

### 2. Permanent dismissal → session-scoped dismissal

Changed `localStorage` → `sessionStorage` for the `BANNER_COLLAPSED_KEY`. Previously, closing the banner once made it permanently invisible until the user cleared browser storage manually. Now it resets each browser session — users can always see their AI config status when they open a new tab.

### 3. Auto-collapse delay: 3s → 10s

When all runners are configured, the banner used to auto-collapse after 3 seconds — not enough time to read which models are active. Now waits 10 seconds.

tsc --noEmit: clean