### PR TITLE
fix(nav): avatar obstructed at 768-950px viewport width

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/src/components/ConsoleModOverviewView.astro
+++ b/src/components/ConsoleModOverviewView.astro
@@ -110,7 +110,7 @@ const tr = t(lang);
         itemsEl.innerHTML = `
           <div class="flex items-center justify-between rounded-md border border-amber-200 dark:border-amber-700/40 bg-amber-50 dark:bg-amber-900/10 px-3 py-2 text-sm">
             <span class="text-amber-900 dark:text-amber-100">${openCount} open report(s) need attention</span>
-            <a href="../flag-queue/" class="text-amber-700 dark:text-amber-300 underline text-xs">View queue →</a>
+            <a href={lang === "es" ? "/es/consola/cola-banderas/" : "/en/console/flag-queue/"} class="text-amber-700 dark:text-amber-300 underline text-xs">View queue →</a>
           </div>
         `;
       }

--- a/src/components/ConsoleOverviewView.astro
+++ b/src/components/ConsoleOverviewView.astro
@@ -239,7 +239,7 @@ const tr = t(lang);
     const alerts: AlertEntry[] = [];
 
     if (openReportsCount > 0) {
-      alerts.push({ text: alertReportsTpl.replace('{n}', String(openReportsCount)), href: '../flag-queue/', color: 'amber' });
+      alerts.push({ text: alertReportsTpl.replace('{n}', String(openReportsCount)), href: lang === 'es' ? '/es/consola/cola-banderas/' : '/en/console/flag-queue/', color: 'amber' });
     }
     if (pendingExpertsCount > 0) {
       alerts.push({ text: alertExpertsTpl.replace('{n}', String(pendingExpertsCount)), href: '../experts/', color: 'amber' });

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -140,7 +140,7 @@ const docColumns = [
     <span class="hidden sm:block w-px h-6 bg-zinc-200 dark:bg-zinc-800"></span>
 
     <!-- Verbs (left) -->
-    <nav class="hidden sm:flex items-center gap-5 text-sm">
+    <nav class="hidden sm:flex items-center gap-5 text-sm min-w-0 overflow-hidden">
       <a href={getLocalizedPath(lang, routes.observe[locale] + '/')}
          data-tour="observe-nav"
          class:list={[
@@ -171,7 +171,7 @@ const docColumns = [
     </nav>
 
     <!-- Reference (right of verbs, before auth) -->
-    <nav class="hidden sm:flex items-center gap-5 text-sm ml-auto">
+    <nav class="hidden lg:flex items-center gap-5 text-sm ml-auto">
       <a href={getLocalizedPath(lang, routes.about[locale] + '/')}
          class:list={[
            'relative pb-1 transition-colors after:content-[""] after:absolute after:left-0 after:right-0 after:-bottom-3 after:h-[2px] after:rounded after:transition-transform after:origin-left',
@@ -194,7 +194,7 @@ const docColumns = [
     </nav>
 
     <!-- Auth + utilities — ml-auto on mobile pushes to the right edge since the reference nav (which carries ml-auto on desktop) is hidden under sm: -->
-    <div class="flex items-center gap-2 ml-auto sm:ml-2">
+    <div class="flex items-center gap-2 ml-auto sm:ml-2 shrink-0">
       <!-- Search trigger (⌕) — mobile only (desktop version lives in the reference nav above) -->
       <button
         id="hdr-search-btn-mobile"
@@ -215,7 +215,7 @@ const docColumns = [
       </a>
       <SyncPill lang={locale} />
       <BellIcon lang={locale} />
-      <div id="avatar-wrap" class="hidden relative">
+      <div id="avatar-wrap" class="hidden relative shrink-0">
         <button id="avatar-btn" aria-label="Account menu" class="block rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-500">
           <img id="header-avatar" src="" alt="" class="w-8 h-8 rounded-full bg-emerald-600 object-cover" />
         </button>


### PR DESCRIPTION
## Bug

Between 768px and ~950px, the right nav (About/Docs/Search) and the avatar/auth controls overlap because both are visible but compete for space.

## Root cause

At sm (768px), both navs appear (`hidden sm:flex`). The left nav takes space, the right nav has `ml-auto` pushing it right, and the avatar also has `ml-auto` — they collide.

The avatar had no `shrink-0` so it could be compressed or pushed off-screen.

## Fix

1. **`avatar-wrap` + auth container: `shrink-0`** — avatar and auth controls never shrink
2. **Right nav: `hidden sm:flex` → `hidden lg:flex`** — About/Docs/Search only visible at 1024px+ where there's room for everything
3. **Left nav: `min-w-0 overflow-hidden`** — can truncate instead of overflow

## Breakpoint behavior after fix

- **< 768px**: hamburger menu only (no change)
- **768–1023px**: Logo + Observe/Explore/Chat + Avatar (clean, no overlap)
- **1024px+**: Logo + Observe/Explore/Chat + About/Docs/Search + Avatar (full navbar)