### PR TITLE
feat(docs): MCP server doc page + Cloudflare proxy runbook

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/docs/runbooks/mcp-proxy.md
+++ b/docs/runbooks/mcp-proxy.md
@@ -1,0 +1,54 @@
+# MCP Proxy — mcp.rastrum.org
+
+Cloudflare Worker that exposes the Supabase Edge Function at a clean URL:
+
+```
+https://mcp.rastrum.org  →  https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp
+```
+
+## Why a Worker (not a plain CNAME)
+
+Supabase uses SNI-based routing — it needs the `Host` header to match the project
+subdomain. A plain CNAME would send `Host: mcp.rastrum.org`, which Supabase doesn't
+recognise. The Worker rewrites the target URL so Cloudflare's fetch sets the correct
+host automatically.
+
+## Worker script
+
+Create a new Worker in the Cloudflare dashboard (Workers & Pages → Create) and paste:
+
+```javascript
+export default {
+  async fetch(request) {
+    const UPSTREAM = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
+
+    const url = new URL(request.url);
+    const target = new URL(UPSTREAM);
+    // Preserve any path suffix the client may add (e.g. /health)
+    target.pathname = UPSTREAM.replace('https://reppvlqejgoqvitturxp.supabase.co', '') + url.pathname.replace(/^\/$/, '');
+    target.search = url.search;
+
+    const proxied = new Request(target.toString(), {
+      method:  request.method,
+      headers: request.headers,
+      body:    request.method !== 'GET' && request.method !== 'HEAD' ? request.body : null,
+    });
+
+    return fetch(proxied);
+  },
+};
+```
+
+## Deploy steps
+
+1. **Cloudflare dashboard** → Workers & Pages → Create application → Create Worker
+2. Paste the script above → Save and deploy
+3. **Settings → Triggers → Custom Domains** → Add `mcp.rastrum.org`
+   - Cloudflare will provision the TLS certificate automatically
+4. Verify: `curl -X POST https://mcp.rastrum.org -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}'`
+   - Should return `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",...}}`
+
+## DNS
+
+No manual DNS record needed — adding the custom domain in Workers triggers Cloudflare
+to create a `AAAA` / `A` record pointing to Workers automatically (orange-cloud).

--- a/src/components/McpView.astro
+++ b/src/components/McpView.astro
@@ -1,0 +1,162 @@
+---
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+
+const MCP_URL = 'https://mcp.rastrum.org';
+const TOKENS_PATH = isEs ? '/es/perfil/tokens/' : '/en/profile/tokens/';
+
+const tools = [
+  { scope: 'observe',  name: 'submit_observation',  desc: isEs ? 'Crear una observación'                      : 'Create an observation' },
+  { scope: 'observe',  name: 'list_observations',   desc: isEs ? 'Listar tus observaciones'                   : 'List your observations' },
+  { scope: 'observe',  name: 'get_observation',     desc: isEs ? 'Obtener una observación por ID'             : 'Get a single observation by ID' },
+  { scope: 'identify', name: 'identify_species',    desc: isEs ? 'Identificar especie desde una foto'         : 'Identify species from a photo URL' },
+  { scope: 'export',   name: 'export_darwin_core',  desc: isEs ? 'Exportar CSV Darwin Core'                   : 'Export Darwin Core CSV' },
+  { scope: 'status',   name: 'get_platform_status', desc: isEs ? 'Métricas públicas de la plataforma'         : 'Aggregate public platform metrics' },
+  { scope: 'admin',    name: 'get_admin_metrics',   desc: isEs ? 'Métricas completas (requiere rol admin)'    : 'Full metrics (requires admin role)' },
+];
+
+function scopeBadge(scope: string): string {
+  if (scope === 'observe')  return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300';
+  if (scope === 'identify') return 'bg-teal-100 text-teal-800 dark:bg-teal-900/40 dark:text-teal-300';
+  if (scope === 'export')   return 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-300';
+  if (scope === 'status')   return 'bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-300';
+  return 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300';
+}
+
+const copyLabel = isEs ? 'Copiar' : 'Copy';
+const copiedLabel = isEs ? 'Copiado' : 'Copied';
+---
+
+<article class="prose prose-zinc dark:prose-invert max-w-none">
+
+  <h2>{isEs ? '¿Qué es el servidor MCP de Rastrum?' : 'What is the Rastrum MCP server?'}</h2>
+  <p>
+    {isEs
+      ? 'El servidor MCP (Model Context Protocol) permite que agentes de IA — Claude Desktop, Cursor, OpenClaw, Copilot y cualquier cliente compatible — accedan a tus datos de biodiversidad directamente, sin copiar y pegar.'
+      : 'The Rastrum MCP server lets AI agents — Claude Desktop, Cursor, OpenClaw, Copilot, and any compatible client — access your biodiversity data directly, without copy-pasting.'}
+  </p>
+
+  <h2>{isEs ? 'URL del servidor' : 'Server URL'}</h2>
+  <div class="not-prose flex items-center gap-3 rounded-lg border dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900 px-4 py-3 font-mono text-sm">
+    <span id="mcp-url" class="select-all">{MCP_URL}</span>
+    <button id="copy-url-btn"
+      class="ml-auto shrink-0 rounded bg-zinc-200 dark:bg-zinc-700 px-2 py-1 text-xs hover:bg-zinc-300 dark:hover:bg-zinc-600">
+      {copyLabel}
+    </button>
+  </div>
+
+  <h2>{isEs ? 'Paso 1 — Genera un token' : 'Step 1 — Generate a token'}</h2>
+  <p>
+    {isEs
+      ? 'Los tokens se crean en tu perfil. Elige los scopes que necesite tu agente:'
+      : 'Tokens are created in your profile. Pick the scopes your agent needs:'}
+  </p>
+  <div class="not-prose mb-4">
+    <a href={TOKENS_PATH}
+       class="inline-flex items-center gap-2 rounded-lg bg-emerald-700 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-800">
+      {isEs ? 'Ir a Tokens API →' : 'Go to API Tokens →'}
+    </a>
+  </div>
+
+  <h2>{isEs ? 'Herramientas disponibles' : 'Available tools'}</h2>
+  <div class="not-prose overflow-x-auto rounded-lg border dark:border-zinc-700">
+    <table class="w-full text-sm">
+      <thead class="bg-zinc-50 dark:bg-zinc-900 text-left text-xs uppercase tracking-wide text-zinc-500">
+        <tr>
+          <th class="px-4 py-2">{isEs ? 'Herramienta' : 'Tool'}</th>
+          <th class="px-4 py-2">Scope</th>
+          <th class="px-4 py-2">{isEs ? 'Descripción' : 'Description'}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
+        {tools.map(tool => (
+          <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-900/50">
+            <td class="px-4 py-2 font-mono text-xs">{tool.name}</td>
+            <td class="px-4 py-2">
+              <span class={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${scopeBadge(tool.scope)}`}>{tool.scope}</span>
+            </td>
+            <td class="px-4 py-2 text-zinc-600 dark:text-zinc-400">{tool.desc}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  <h2>{isEs ? 'Paso 2 — Configura tu cliente' : 'Step 2 — Configure your client'}</h2>
+
+  <h3>OpenClaw / Claude Desktop</h3>
+  <pre><code>{`{
+  "mcpServers": {
+    "rastrum": {
+      "type": "http",
+      "url": "${MCP_URL}",
+      "headers": { "Authorization": "Bearer rst_..." }
+    }
+  }
+}`}</code></pre>
+
+  <h3>Cursor</h3>
+  <p>{isEs ? 'En' : 'In'} <code>~/.cursor/mcp.json</code>:</p>
+  <pre><code>{`{
+  "rastrum": {
+    "url": "${MCP_URL}",
+    "headers": { "Authorization": "Bearer rst_..." }
+  }
+}`}</code></pre>
+
+  <h3>Claude Code (CLI)</h3>
+  <pre><code>{`claude mcp add rastrum --transport http "${MCP_URL}" \\
+  --header "Authorization: Bearer rst_..."`}</code></pre>
+
+  <h2>{isEs ? 'Scopes y permisos' : 'Scopes & permissions'}</h2>
+  <div class="not-prose overflow-x-auto rounded-lg border dark:border-zinc-700">
+    <table class="w-full text-sm">
+      <thead class="bg-zinc-50 dark:bg-zinc-900 text-left text-xs uppercase tracking-wide text-zinc-500">
+        <tr>
+          <th class="px-4 py-2">Scope</th>
+          <th class="px-4 py-2">{isEs ? 'Qué permite' : 'What it allows'}</th>
+          <th class="px-4 py-2">{isEs ? 'Recomendado para' : 'Recommended for'}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800 text-zinc-700 dark:text-zinc-300">
+        <tr>
+          <td class="px-4 py-2 font-mono text-xs">observe</td>
+          <td class="px-4 py-2">{isEs ? 'Leer y crear observaciones' : 'Read & create observations'}</td>
+          <td class="px-4 py-2">{isEs ? 'Agentes de campo' : 'Field agents'}</td>
+        </tr>
+        <tr>
+          <td class="px-4 py-2 font-mono text-xs">identify</td>
+          <td class="px-4 py-2">{isEs ? 'Cascada de identificación de especies' : 'Species ID cascade'}</td>
+          <td class="px-4 py-2">{isEs ? 'Bots de identificación' : 'ID bots'}</td>
+        </tr>
+        <tr>
+          <td class="px-4 py-2 font-mono text-xs">export</td>
+          <td class="px-4 py-2">{isEs ? 'Exportar Darwin Core CSV' : 'Export Darwin Core CSV'}</td>
+          <td class="px-4 py-2">{isEs ? 'Pipelines de datos' : 'Data pipelines'}</td>
+        </tr>
+        <tr>
+          <td class="px-4 py-2 font-mono text-xs">status</td>
+          <td class="px-4 py-2">{isEs ? 'Métricas públicas de la plataforma' : 'Public platform metrics'}</td>
+          <td class="px-4 py-2">{isEs ? 'Bots de monitoreo' : 'Monitoring bots'}</td>
+        </tr>
+        <tr>
+          <td class="px-4 py-2 font-mono text-xs">admin</td>
+          <td class="px-4 py-2">{isEs ? 'Métricas completas (requiere rol admin)' : 'Full metrics (requires admin role)'}</td>
+          <td class="px-4 py-2">{isEs ? 'Operadores' : 'Operators'}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</article>
+
+<script define:vars={{ MCP_URL, copiedLabel, copyLabel }}>
+  const btn = document.getElementById('copy-url-btn');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      navigator.clipboard.writeText(MCP_URL);
+      btn.textContent = copiedLabel;
+      setTimeout(() => { btn.textContent = copyLabel; }, 1500);
+    });
+  }
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1418,7 +1418,8 @@
       "privacy": "Privacy",
       "terms": "Terms of Use",
       "console": "Console",
-      "sponsorships": "AI Sponsorships"
+      "sponsorships": "AI Sponsorships",
+      "mcp": "MCP Server"
     },
     "descriptions": {
       "vision": "Mission, problem statement, and why Oaxaca is the right place to start.",
@@ -1434,7 +1435,8 @@
       "privacy": "What we collect, where it goes, and your right to delete — in plain language.",
       "terms": "Acceptable use, per-observation licensing, and how we handle account suspensions.",
       "console": "Privileged-actions surface for admin, moderator, and expert roles. Role model, audit log, and per-action runbooks.",
-      "sponsorships": "Share your Anthropic credential with friends, capped per month and audited."
+      "sponsorships": "Share your Anthropic credential with friends, capped per month and audited.",
+      "mcp": "Connect AI agents — Claude Desktop, Cursor, OpenClaw, and any MCP-compatible client — directly to your Rastrum data using the Model Context Protocol."
     },
     "status": {
       "current": "Active",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1418,7 +1418,8 @@
       "privacy": "Privacidad",
       "terms": "Términos de uso",
       "console": "Consola",
-      "sponsorships": "Patrocinios IA"
+      "sponsorships": "Patrocinios IA",
+      "mcp": "Servidor MCP"
     },
     "descriptions": {
       "vision": "Misión, problema y por qué Oaxaca es el lugar correcto para comenzar.",
@@ -1434,7 +1435,8 @@
       "privacy": "Qué recopilamos, a dónde va y tu derecho a eliminar — en lenguaje simple.",
       "terms": "Uso aceptable, licencias por observación y cómo manejamos suspensiones de cuenta.",
       "console": "Superficie de acciones privilegiadas para roles de admin, moderador y experto. Modelo de roles, auditoría y runbooks por acción.",
-      "sponsorships": "Comparte tu credencial Anthropic con amigos, con límite mensual y auditoría."
+      "sponsorships": "Comparte tu credencial Anthropic con amigos, con límite mensual y auditoría.",
+      "mcp": "Conecta agentes de IA — Claude Desktop, Cursor, OpenClaw y cualquier cliente MCP — directamente a tus datos de Rastrum usando el Model Context Protocol."
     },
     "status": {
       "current": "Activo",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -306,6 +306,10 @@ export const docPageMeta = {
     en: "Share your Anthropic credential with friends, capped per month and audited. How sponsorship works for sponsors and beneficiaries.",
     es: "Comparte tu credencial Anthropic con amigos, con límite mensual y auditoría. Cómo funcionan los patrocinios para sponsors y beneficiarios.",
   },
+  mcp: {
+    en: "Connect AI agents to Rastrum via the Model Context Protocol. Setup guide for Claude Desktop, Cursor, OpenClaw, and the Claude Code CLI.",
+    es: "Conecta agentes de IA a Rastrum mediante el Model Context Protocol. Guía de configuración para Claude Desktop, Cursor, OpenClaw y Claude Code CLI.",
+  },
 } as const satisfies Record<DocPage, { en: string; es: string }>;
 
 /**

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -117,7 +117,7 @@ export const routes: Record<string, Record<Locale, string>> = {
 export const docPages = [
   'vision', 'features', 'roadmap', 'tasks', 'market',
   'architecture', 'indigenous', 'funding', 'contribute',
-  'faq', 'privacy', 'terms', 'console', 'sponsorships',
+  'faq', 'privacy', 'terms', 'console', 'sponsorships', 'mcp',
 ] as const;
 
 export type DocPage = (typeof docPages)[number];

--- a/src/pages/en/docs/mcp.astro
+++ b/src/pages/en/docs/mcp.astro
@@ -1,0 +1,13 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import McpView from '../../../components/McpView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+const sections = tr.docs.sections as Record<string, string>;
+---
+
+<DocLayout title={sections.mcp} lang={lang} section="mcp" editPath="src/pages/en/docs/mcp.astro">
+  <McpView lang={lang} />
+</DocLayout>

--- a/src/pages/en/profile/settings/[tab].astro
+++ b/src/pages/en/profile/settings/[tab].astro
@@ -172,6 +172,9 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
           <code class="block rounded bg-zinc-100 dark:bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-800 dark:text-zinc-200 break-all select-all">
             {mcpUrl}
           </code>
+          <a href="/en/docs/mcp/" class="mt-3 inline-block text-xs text-emerald-700 dark:text-emerald-400 hover:underline">
+            Setup guide →
+          </a>
         </section>
 
         <!-- Expert Application -->

--- a/src/pages/es/docs/mcp.astro
+++ b/src/pages/es/docs/mcp.astro
@@ -1,0 +1,13 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import McpView from '../../../components/McpView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+const sections = tr.docs.sections as Record<string, string>;
+---
+
+<DocLayout title={sections.mcp} lang={lang} section="mcp" editPath="src/pages/es/docs/mcp.astro">
+  <McpView lang={lang} />
+</DocLayout>

--- a/src/pages/es/perfil/ajustes/[tab].astro
+++ b/src/pages/es/perfil/ajustes/[tab].astro
@@ -172,6 +172,9 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
           <code class="block rounded bg-zinc-100 dark:bg-zinc-800 px-3 py-2 text-xs font-mono text-zinc-800 dark:text-zinc-200 break-all select-all">
             {mcpUrl}
           </code>
+          <a href="/es/docs/mcp/" class="mt-3 inline-block text-xs text-emerald-700 dark:text-emerald-400 hover:underline">
+            Guía de configuración →
+          </a>
         </section>
 
         <!-- Expert Application -->


### PR DESCRIPTION
## Summary

- **`/en/docs/mcp`** and **`/es/docs/mcp`** — setup guide with server URL, tools table, scopes, and config snippets for OpenClaw, Claude Desktop, Cursor, and Claude Code CLI
- **Settings developer tab** — adds "Setup guide →" link below the MCP Server URL field
- **`docs/runbooks/mcp-proxy.md`** — Cloudflare Worker script + deploy steps for `mcp.rastrum.org` → Supabase proxy (Worker needed because Supabase requires correct Host header for SNI routing; plain CNAME won't work)

The MCP URL in settings/FAQ/features stays as-is (raw Supabase URL) — only the doc page shows `mcp.rastrum.org` since the Worker isn't deployed yet.

Build: ✓ 59 pages, zero errors.