### PR TITLE
ux(sync): show error code + report bug button in failed sync rows (closes #287)

### DIFF
--- a/src/components/MyObservationsView.astro
+++ b/src/components/MyObservationsView.astro
@@ -37,6 +37,7 @@ const shareLabel        = profileStrings.my_observations_share         ?? (lang 
 const retryLabel        = profileStrings.my_observations_retry         ?? (lang === 'es' ? 'Reintentar' : 'Retry');
 const retryingLabel     = profileStrings.my_observations_retrying      ?? (lang === 'es' ? 'Sincronizando…' : 'Syncing…');
 const retryFailedTpl    = profileStrings.my_observations_retry_failed  ?? (lang === 'es' ? 'No se pudo: {error}' : 'Sync failed: {error}');
+const syncReportBugLabel = profileStrings.my_observations_sync_report_bug ?? (lang === 'es' ? 'Reportar bug' : 'Report bug');
 const retryOkLabel      = profileStrings.my_observations_retry_ok      ?? (lang === 'es' ? 'Sincronizada.' : 'Synced.');
 const lastSyncTpl       = profileStrings.my_observations_last_sync     ?? (lang === 'es' ? 'Última sincronización: {when}' : 'Last sync: {when}');
 const lastSyncNever     = profileStrings.my_observations_last_sync_never ?? (lang === 'es' ? 'Aún no se ha sincronizado nada.' : 'Nothing has synced yet.');
@@ -73,6 +74,7 @@ const tabs = [
   data-label-retry={retryLabel}
   data-label-retrying={retryingLabel}
   data-label-retry-failed={retryFailedTpl}
+  data-label-sync-report-bug={syncReportBugLabel}
   data-label-retry-ok={retryOkLabel}
   data-label-last-sync={lastSyncTpl}
   data-label-last-sync-never={lastSyncNever}
@@ -185,6 +187,7 @@ const tabs = [
     id: string;
     observed_at: string;
     sync_status: 'synced' | 'pending' | 'error' | 'draft';
+    sync_error?: string | null;
     state_province: string | null;
     hidden: boolean | null;
     hidden_reason: string | null;
@@ -204,12 +207,29 @@ const tabs = [
   let busy = false;
   let userId: string | null = null;
 
-  function statusBadge(status: Row['sync_status']): string {
+  function statusBadge(status: Row['sync_status'], syncError?: string | null, obsId?: string, obsName?: string): string {
     if (!root) return '';
     if (status === 'synced')  return `<span class="inline-flex items-center rounded-full bg-emerald-100 dark:bg-emerald-900/30 px-2 py-0.5 text-[11px] font-semibold text-emerald-800 dark:text-emerald-300">${root.dataset.labelStatusSynced ?? ''}</span>`;
     if (status === 'pending') return `<span class="inline-flex items-center rounded-full bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 text-[11px] font-semibold text-amber-800 dark:text-amber-300">${root.dataset.labelStatusPending ?? ''}</span>`;
     if (status === 'draft')   return `<span class="inline-flex items-center rounded-full bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 text-[11px] font-semibold text-zinc-700 dark:text-zinc-300">${root.dataset.labelStatusDraft ?? ''}</span>`;
-    return `<span class="inline-flex items-center rounded-full bg-red-100 dark:bg-red-900/30 px-2 py-0.5 text-[11px] font-semibold text-red-800 dark:text-red-300">${root.dataset.labelStatusError ?? ''}</span>`;
+    // Error status — show error detail and report bug button
+    const errorLabel = root.dataset.labelStatusError ?? '';
+    const reportLabel = root.dataset.labelSyncReportBug ?? 'Report bug';
+    const errorDetail = syncError ? syncError.slice(0, 80) : '';
+    let bugBtn = '';
+    if (syncError) {
+      const issueTitle = encodeURIComponent(`Sync error: ${syncError.slice(0, 60)}`);
+      const issueBody = encodeURIComponent(
+        `**Error:** ${syncError}\n` +
+        `**Observation ID:** ${obsId ?? 'unknown'}\n` +
+        `**Observation:** ${obsName ?? 'unknown'}\n` +
+        `**Timestamp:** ${new Date().toISOString()}\n` +
+        `**User agent:** ${navigator.userAgent}`
+      );
+      const issueUrl = `https://github.com/ArtemioPadilla/rastrum/issues/new?title=${issueTitle}&body=${issueBody}`;
+      bugBtn = `<a href="${issueUrl}" target="_blank" rel="noopener" class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:text-red-400 underline hover:no-underline" aria-label="${reportLabel}">${reportLabel}</a>`;
+    }
+    return `<span class="inline-flex flex-wrap items-center gap-1 rounded-full bg-red-100 dark:bg-red-900/30 px-2 py-0.5 text-[11px] font-semibold text-red-800 dark:text-red-300">${errorLabel}${errorDetail ? `<span class="font-normal opacity-80 ml-1">${escapeText(errorDetail)}</span>` : ''}${bugBtn}</span>`;
   }
 
   function escapeText(s: string): string {
@@ -277,7 +297,7 @@ const tabs = [
             <p class="text-sm italic font-medium text-zinc-900 dark:text-zinc-100 truncate">${escapeText(name)}</p>
             <p class="text-xs text-zinc-500 truncate">${date}${escapeText(region)}</p>
             <div class="mt-1 flex items-center gap-1.5 flex-wrap">
-              ${statusBadge(r.sync_status)}
+              ${statusBadge(r.sync_status, r.sync_error, r.id, name)}
               ${ident?.is_research_grade ? `<span class="inline-flex items-center gap-1 rounded-full bg-emerald-100 dark:bg-emerald-900/30 px-2 py-0.5 text-[11px] font-semibold text-emerald-800 dark:text-emerald-300" title="${escapeText(root?.dataset.labelResearchGradeTitle ?? '')}"><svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>${escapeText(root?.dataset.labelResearchGrade ?? '')}</span>` : ''}
               ${faveChipHtml}
               ${hiddenBadgeHtml}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -447,6 +447,7 @@
     "my_observations_retry": "Retry",
     "my_observations_retrying": "Syncing…",
     "my_observations_retry_failed": "Sync failed: {error}",
+    "my_observations_sync_report_bug": "Report bug",
     "my_observations_retry_ok": "Synced.",
     "my_observations_last_sync": "Last sync: {when}",
     "my_observations_last_sync_never": "Nothing has synced on this device yet.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -447,6 +447,7 @@
     "my_observations_retry": "Reintentar",
     "my_observations_retrying": "Sincronizando…",
     "my_observations_retry_failed": "No se pudo sincronizar: {error}",
+    "my_observations_sync_report_bug": "Reportar bug",
     "my_observations_retry_ok": "¡Listo! Se sincronizó.",
     "my_observations_last_sync": "Última sincronización: {when}",
     "my_observations_last_sync_never": "Aún no se ha sincronizado nada en este dispositivo.",


### PR DESCRIPTION
## What

When an observation fails to sync, users now see the actual error message instead of a generic badge. They can also open a pre-filled GitHub issue directly from the observation row.

## Changes

- `MyObservationsView.astro`: 
  - Added `sync_error?: string | null` to Row type
  - Updated `statusBadge()` to accept and display error detail (truncated to 80 chars)
  - Added 'Report bug' link that opens pre-filled GitHub issue with error, obs ID, user agent, timestamp
- `src/i18n/en.json` + `es.json`: added `my_observations_sync_report_bug` key

## Before / After

**Before:** `⚠️ Error de sincronización` (no info)

**After:** `⚠️ Error de sincronización  infinite recursion detected in policy (42P17)  [Reportar bug]`

Closes #287