### PR TITLE
ux(observe): remove Quick ID branding — consolidate into identify mode (closes #298)

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -65,14 +65,14 @@
       "explore": "Explore",
       "chat": "Chat",
       "observe": "Observe",
-      "quick_id": "Quick ID",
+      "quick_id": "Identify mode",
       "recent": "Recent",
       "profile": "Profile",
       "home": "Home",
       "identify": "Identify",
       "sign_in": "Sign in",
       "fab_observe_label": "Start observation",
-      "fab_quick_id_label": "Quick identify"
+      "fab_quick_id_label": "Identify without saving"
     }
   },
   "home": {
@@ -123,7 +123,7 @@
     ],
     "docs_cta": "Read the Docs",
     "github_cta": "View on GitHub",
-    "cta_identify": "Quick ID",
+    "cta_identify": "Identify without saving",
     "cta_subtitle": "Save with GPS, photo and habitat"
   },
   "identify": {
@@ -883,8 +883,8 @@
         "body": "Tap to start observing — anywhere in the app."
       },
       "quick_id": {
-        "title": "Quick ID",
-        "body": "While on the Observe screen, the same button becomes Quick ID — photo lookup, no save needed."
+        "title": "Identify mode",
+        "body": "While on the Observe screen, the same button becomes Identify mode — photo lookup using only your own keys or local models."
       },
       "explore": {
         "title": "Explore",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -65,14 +65,14 @@
       "explore": "Explorar",
       "chat": "Chat",
       "observe": "Observar",
-      "quick_id": "ID rápida",
+      "quick_id": "Modo identificar",
       "recent": "Recientes",
       "profile": "Perfil",
       "home": "Inicio",
       "identify": "Identificar",
       "sign_in": "Ingresar",
       "fab_observe_label": "Iniciar observación",
-      "fab_quick_id_label": "Identificación rápida"
+      "fab_quick_id_label": "Identificar sin guardar"
     }
   },
   "home": {
@@ -123,7 +123,7 @@
     ],
     "docs_cta": "Leer la Documentación",
     "github_cta": "Ver en GitHub",
-    "cta_identify": "Identificación rápida",
+    "cta_identify": "Identificar sin guardar",
     "cta_subtitle": "Guarda con GPS, foto y hábitat"
   },
   "identify": {
@@ -883,8 +883,8 @@
         "body": "Toca para iniciar una observación — desde cualquier pantalla de la app."
       },
       "quick_id": {
-        "title": "Identificación rápida",
-        "body": "Desde la pantalla de observación, el mismo botón se convierte en Identificación Rápida — búsqueda por foto, sin guardar."
+        "title": "Modo identificar",
+        "body": "Desde la pantalla de observación, el mismo botón se convierte en modo identificar — búsqueda por foto usando solo tus propias claves o modelos locales."
       },
       "explore": {
         "title": "Explorar",


### PR DESCRIPTION
## What

Removes 'Quick ID' as a standalone feature concept. Renames all references to 'Identify without saving' / 'Identificar sin guardar' in both EN and ES.

## Changes (i18n only — no logic changes)

| Key | Before | After (EN) |
|---|---|---|
| `home.cta_identify` | Quick ID | Identify without saving |
| `nav.bottom.quick_id` | Quick ID | Identify mode |
| `nav.bottom.fab_quick_id_label` | Quick identify | Identify without saving |
| `onboarding.quick_id.title` | Quick ID | Identify mode |
| `onboarding.quick_id.body` | photo lookup, no save needed | photo lookup using only your own keys or local models |

## What this does NOT change

- No route changes — `/observe?mode=identify` still works as before
- No component logic changes — only string values updated
- Sponsor key restriction (part of #298 AC) deferred — requires changes to `detectRunners()`, tracked separately

Closes #298