### PR TITLE
fix(docs): render /docs/console + /docs/contribute with proper HTML (EN+ES)

### DIFF
--- a/src/pages/en/docs/console.astro
+++ b/src/pages/en/docs/console.astro
@@ -1,21 +1,142 @@
 ---
 import DocLayout from '../../../layouts/DocLayout.astro';
+import { t } from '../../../i18n/utils';
+
 const lang = 'en';
+const tr = t(lang);
+
+const githubBase = 'https://github.com/ArtemioPadilla/rastrum/blob/main';
 ---
-<DocLayout title="Console" lang={lang} section="console">
 
-# Console
+<DocLayout title={tr.docs.sections.console} lang={lang} section="console" editPath="src/pages/en/docs/console.astro">
+  <article class="space-y-8">
+    <div>
+      <h1 class="text-3xl font-bold tracking-tight mb-4">{tr.docs.sections.console}</h1>
+      <p class="text-lg text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.console}</p>
+      <p class="mt-4 text-sm text-zinc-500 dark:text-zinc-500">
+        If you don't see a <span class="font-mono px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800/40 text-slate-600 dark:text-slate-300">Console</span> pill in the header, this page doesn't apply to you yet — every privileged surface is gated by an explicit role grant.
+      </p>
+    </div>
 
-The **Console** is a privileged-actions surface for users who hold an admin, moderator, or expert role. If you don't see a "Console" pill in the header, this page doesn't apply to you.
+    <!-- Who it's for -->
+    <section>
+      <h2 id="roles" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#roles" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Who it's for
+      </h2>
+      <div class="grid sm:grid-cols-3 gap-4 not-prose">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Admins</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Manage user roles, review researcher credentials, watch sync failures and API quotas, and audit every privileged action.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Moderators</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Triage flagged content, run the appeals queue, and apply soft-bans with audit trails.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Experts</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Review the validation queue scoped to your taxa and watch your per-taxon expertise score.</p>
+        </div>
+      </div>
+    </section>
 
-## What it's for
+    <!-- What's inside -->
+    <section>
+      <h2 id="surface" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#surface" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> What's inside
+      </h2>
+      <p class="text-zinc-700 dark:text-zinc-300 mb-4">
+        The console lives at <span class="font-mono text-sm">/console/</span> and bundles 36+ tabs grouped by role. The sidebar and role pills are projections of a single <span class="font-mono text-sm">console-tabs.ts</span> source — adding a new surface is one entry, not a hand-rolled route.
+      </p>
+      <div class="space-y-3 not-prose">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Admin tabs</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Overview, Users, Roles, Credentials, Audit log, API quotas, Sync failures, Cron runs, Feature flags, Bans, Karma, Anomalies, Forensics, Errors, Health, Webhooks, Proposals, plus seven read-only entity browsers (Identifications, Notifications, Media, Follows, Watchlists, Projects, Taxon changes).</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Moderator tabs</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Overview, Flag queue, Comments triage, Appeals.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Expert tabs</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Overview, Expertise score, Validation queue, Apply for an expert badge.</p>
+        </div>
+      </div>
+    </section>
 
-- **Admins** manage user roles, review researcher credentials, watch sync failures and API quotas, audit every privileged action.
-- **Moderators** triage flagged content and manage soft-bans (PR3).
-- **Experts** review the validation queue scoped to their taxa and watch their per-taxon expertise score (PR2).
+    <!-- How privileges work -->
+    <section>
+      <h2 id="privileges" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#privileges" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> How privileges work
+      </h2>
+      <div class="space-y-3 text-zinc-700 dark:text-zinc-300">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Server-side dispatcher</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Every privileged write goes through the <span class="font-mono">supabase/functions/admin/</span> Edge Function. The dispatcher re-verifies the JWT, enforces the action's required role, runs the handler, and inserts an <span class="font-mono">admin_audit</span> row in the same transaction. Browsers never write directly to privileged tables.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-1">RLS predicate: <span class="font-mono">has_role(uid, role)</span></p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">All privilege-gated rows use <span class="font-mono">has_role()</span>, not denormalised flags like <span class="font-mono">users.is_expert</span>. Roles can also be time-bounded (<span class="font-mono">expires_at</span>) and auto-revoked nightly.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Two-person rule</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Irreversible actions can require a second admin's approval through <span class="font-mono">admin_action_proposals</span>. The dispatcher enforces the gate when the feature flag is on; pending proposals expire hourly.</p>
+        </div>
+      </div>
+    </section>
 
-## How it's built
+    <!-- Observability -->
+    <section>
+      <h2 id="observability" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#observability" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Observability &amp; forensics
+      </h2>
+      <div class="grid sm:grid-cols-2 gap-4 not-prose">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Anomalies</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Hourly <span class="font-mono">detect_admin_anomalies()</span> cron flags off-hours actions (per-admin timezone), bulk grants, and unusual write patterns.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Health digest</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Weekly <span class="font-mono">compute_admin_health_digest()</span> snapshot drives the hero card on <span class="font-mono">/console/health/</span> with directional Δ pills and 12-week sparklines.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Function errors</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">A structured <span class="font-mono">function_errors</span> sink wired into the dispatcher. <span class="font-mono">/console/errors/</span> offers severity-coloured pills, URL-driven filters, single + bulk acknowledge.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Webhooks</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">HMAC-SHA256 outbound signing, per-webhook deliveries drilldown, click-to-replay, and nonce-based replay protection.</p>
+        </div>
+      </div>
+    </section>
 
-See [Module 24](https://github.com/ArtemioPadilla/rastrum/blob/main/docs/specs/modules/24-admin-console.md) for the implementation reference, and the [design doc](https://github.com/ArtemioPadilla/rastrum/blob/main/docs/superpowers/specs/2026-04-27-admin-console-design.md) for rationale.
-
+    <!-- References -->
+    <section>
+      <h2 id="references" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#references" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> References
+      </h2>
+      <div class="space-y-2 not-prose">
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/specs/modules/24-admin-console.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Module 24 — Admin Console</a> <span class="text-zinc-500 dark:text-zinc-500">— implementation reference</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/admin-bootstrap.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Admin bootstrap</a> <span class="text-zinc-500 dark:text-zinc-500">— first admin / role grants</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/role-model.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Role model</a> <span class="text-zinc-500 dark:text-zinc-500">— admin / moderator / expert grants</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/admin-audit.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Audit log</a> <span class="text-zinc-500 dark:text-zinc-500">— querying admin_audit</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/admin-ops.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Per-action ops</a> <span class="text-zinc-500 dark:text-zinc-500">— what each tab does day-to-day</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/admin-entity-browsers.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Entity browsers</a> <span class="text-zinc-500 dark:text-zinc-500">— shared paginated template</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/superpowers/specs/2026-04-27-admin-console-design.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Design doc — Admin console</a> <span class="text-zinc-500 dark:text-zinc-500">— rationale and history</span></p>
+        </div>
+      </div>
+    </section>
+  </article>
 </DocLayout>

--- a/src/pages/en/docs/contribute.astro
+++ b/src/pages/en/docs/contribute.astro
@@ -1,114 +1,191 @@
 ---
 import DocLayout from '../../../layouts/DocLayout.astro';
+import { t } from '../../../i18n/utils';
+
 const lang = 'en';
----
-<DocLayout title="Contributing" lang={lang} section="contribute">
-
-# 🤝 Contributing
-
-Rastrum is open source and community-driven. There are many ways to contribute beyond code.
-
-## Ways to Contribute
-
-### 🌿 Code
-- **Frontend (SvelteKit 2):** UI components, offline sync, map interactions
-- **Backend (Supabase Edge Functions):** AI pipeline routing, export pipelines
-- **On-device ML (ONNX):** Model quantization, regional species packs
-- **PWA/Capacitor:** iOS/Android wrapper improvements
-
-### 📸 Data & Species Curation
-- Submit field observations from Mexico / LATAM
-- Validate AI identifications as an expert
-- Contribute regional species checklists (Darwin Core format)
-- Add morphometric fields for ecological evidence (tracks, scat)
-
-### 🌐 Translations
-- Spanish ↔ English (core UI)
-- Zapoteco, Mixteco, Náhuatl, Maya, Tsotsil/Tseltal (priority)
-- Partner with INALI, UNAM linguistics, or CIESAS for Indigenous languages
-
-### 🔬 Expert Validation
-- Apply for an expert badge in your taxonomic group (ornithology, botany, mycology, herpetology, entomology...)
-- Review the expert identification queue
-- Contribute regional species keys and disambiguation guides
-
-### 📍 PITs & Trails
-- Install QR anchors in your local trails or protected areas
-- Create biodiversity trail routes with waypoints
-- Document local species checklists per trail segment
-
+const tr = t(lang);
 ---
 
-## Development Setup
+<DocLayout title={tr.docs.sections.contribute} lang={lang} section="contribute" editPath="src/pages/en/docs/contribute.astro">
+  <article class="space-y-8">
+    <div>
+      <h1 class="text-3xl font-bold tracking-tight mb-4">{tr.docs.sections.contribute}</h1>
+      <p class="text-lg text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.contribute}</p>
+      <p class="mt-4 text-sm text-zinc-500 dark:text-zinc-500">
+        Rastrum is solo-developed but open-source and community-driven. Code, observations, expert validation, translations, and docs are all welcome — pick the lane that fits.
+      </p>
+    </div>
 
-```bash
-git clone https://github.com/ArtemioPadilla/rastrum.git
+    <!-- Ways to contribute -->
+    <section>
+      <h2 id="ways" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#ways" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Ways to contribute
+      </h2>
+      <div class="space-y-4 not-prose">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Code</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">Frontend (Astro + Tailwind):</span> components, identifier UX, offline outbox, MapLibre interactions</li>
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">Backend (Supabase Edge Functions, Deno):</span> identifier cascade, enrichment, exports, MCP server, admin dispatcher</li>
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">On-device ML:</span> WebLLM tuning, ONNX model packaging, regional species packs</li>
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">CLI batch import (Node 20+):</span> camera-trap memory cards, EXIF parity with the PWA</li>
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">PWA / Capacitor:</span> service worker, install flow, iOS/Android shell improvements</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Data &amp; species curation</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li>Submit field observations from Mexico / LATAM</li>
+            <li>Validate AI identifications as a community member or expert</li>
+            <li>Contribute regional species checklists (Darwin Core / SNIB / CONANP presets)</li>
+            <li>Add morphometric fields for ecological evidence (tracks, scat, nests, calls)</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Translations</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li>Spanish ↔ English parity in <span class="font-mono">{'src/i18n/{en,es}.json'}</span></li>
+            <li>Zapoteco, Mixteco, Náhuatl, Maya, Tsotsil/Tseltal (priority — pilot pending)</li>
+            <li>Partner with INALI, UNAM linguistics, or CIESAS for Indigenous languages</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Expert validation</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li>Apply for an expert badge in your taxonomic group (ornithology, botany, mycology, herpetology, entomology…)</li>
+            <li>Review the validation queue scoped to your taxa</li>
+            <li>Contribute regional disambiguation guides and identification keys</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Docs &amp; runbooks</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li>Module specs under <span class="font-mono">docs/specs/modules/</span></li>
+            <li>Operator runbooks under <span class="font-mono">docs/runbooks/</span></li>
+            <li>Doc pages under <span class="font-mono">{'src/pages/{en,es}/docs/'}</span> — must stay paired EN/ES</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Development setup -->
+    <section>
+      <h2 id="setup" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#setup" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Development setup
+      </h2>
+      <p class="text-zinc-700 dark:text-zinc-300 mb-3">
+        The repo is solo-developed on macOS but the toolchain runs anywhere with Node 20+ and a Postgres-capable Supabase project. <span class="font-mono">make help</span> lists every workflow.
+      </p>
+      <pre class="not-prose p-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-sm overflow-x-auto"><code class="font-mono text-zinc-800 dark:text-zinc-200">git clone https://github.com/ArtemioPadilla/rastrum.git
 cd rastrum
-npm install
-npm run dev        # Astro dev server (current content site)
-```
-
-Environment variables needed (copy `.env.example`):
-```
-PUBLIC_SUPABASE_URL=
+make install        <span class="text-zinc-500"># npm ci</span>
+make dev            <span class="text-zinc-500"># astro dev — http://localhost:4321</span>
+make test           <span class="text-zinc-500"># vitest run</span>
+make typecheck      <span class="text-zinc-500"># tsc --noEmit</span>
+make build          <span class="text-zinc-500"># static build into dist/</span></code></pre>
+      <p class="text-zinc-700 dark:text-zinc-300 mt-4 mb-3">Copy <span class="font-mono">.env.example</span> to <span class="font-mono">.env.local</span> and fill the keys you need:</p>
+      <pre class="not-prose p-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-sm overflow-x-auto"><code class="font-mono text-zinc-800 dark:text-zinc-200">PUBLIC_SUPABASE_URL=
 PUBLIC_SUPABASE_ANON_KEY=
-PLANTNET_API_KEY=
-```
+PLANTNET_API_KEY=        <span class="text-zinc-500"># optional, for the PlantNet identifier</span></code></pre>
+    </section>
 
----
+    <!-- Process -->
+    <section>
+      <h2 id="process" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#process" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Contribution process
+      </h2>
+      <ol class="space-y-3 not-prose">
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">1</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Fork &amp; branch</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Branch off <span class="font-mono">main</span>; one logical change per PR.</p>
+          </div>
+        </li>
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">2</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Sign your commits (DCO)</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Use <span class="font-mono">git commit -s</span>. We use the Developer Certificate of Origin, not a CLA — no paperwork.</p>
+          </div>
+        </li>
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">3</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Pre-PR checks pass</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400"><span class="font-mono">make typecheck</span> &amp; <span class="font-mono">make test</span> &amp; <span class="font-mono">make build</span> — all green, EN/ES pages paired.</p>
+          </div>
+        </li>
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">4</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Open the PR</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Clear description, linked issue (if any), screenshots for UI work. CI must be green before review.</p>
+          </div>
+        </li>
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">5</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Review</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Aim for a maintainer reply within 7 days. Schema changes hit an extra pre-merge gate that applies the schema twice in a Postgres+PostGIS service container.</p>
+          </div>
+        </li>
+      </ol>
+      <div class="mt-4 p-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-900/30 not-prose">
+        <p class="text-sm font-medium text-zinc-900 dark:text-zinc-100 mb-1">DCO sign-off</p>
+        <p class="text-sm text-zinc-600 dark:text-zinc-400">Append <span class="font-mono">Signed-off-by: Your Name &lt;your_email&gt;</span> to every commit message (<span class="font-mono">git commit -s</span> does this for you). By signing, you certify you wrote the code or have the right to submit it under the project's license.</p>
+      </div>
+    </section>
 
-## Contribution Process
+    <!-- License -->
+    <section>
+      <h2 id="license" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#license" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> License
+      </h2>
+      <div class="not-prose overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-zinc-200 dark:border-zinc-800">
+              <th class="text-left py-2 px-3 text-zinc-500 dark:text-zinc-400 font-medium">Component</th>
+              <th class="text-left py-2 px-3 text-zinc-500 dark:text-zinc-400 font-medium">License</th>
+            </tr>
+          </thead>
+          <tbody class="text-zinc-700 dark:text-zinc-300">
+            <tr class="border-b border-zinc-100 dark:border-zinc-900 bg-zinc-50/50 dark:bg-zinc-950/50">
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Client code (PWA, CLI, components)</td>
+              <td class="py-2 px-3 font-mono">MIT</td>
+            </tr>
+            <tr class="border-b border-zinc-100 dark:border-zinc-900">
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Server / Edge Functions</td>
+              <td class="py-2 px-3 font-mono">AGPL-3.0</td>
+            </tr>
+            <tr class="border-b border-zinc-100 dark:border-zinc-900 bg-zinc-50/50 dark:bg-zinc-950/50">
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Documentation</td>
+              <td class="py-2 px-3 font-mono">CC BY 4.0</td>
+            </tr>
+            <tr class="border-b border-zinc-100 dark:border-zinc-900">
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Per-observation</td>
+              <td class="py-2 px-3 font-mono">CC BY / CC BY-NC / CC0 (chosen by observer)</td>
+            </tr>
+            <tr>
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Taxonomic data</td>
+              <td class="py-2 px-3 font-mono">CC0</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-1. **Fork** the repo and create a feature branch
-2. **Sign** your commits with DCO (`git commit -s`)  
-   *We use DCO (Developer Certificate of Origin), not CLA — no paperwork, no anxiety*
-3. **Open a PR** with a clear description and linked issue
-4. **Tests** must pass: `npm run build`
-5. **Review** from a maintainer within 7 days
-
----
-
-## DCO Sign-off
-
-Add to every commit:
-```
-Signed-off-by: Your Name &lt;your_email&gt;
-```
-
-Or use `git commit -s` to add automatically. By signing, you certify:
-
-> "I wrote this code, or have the right to submit it under the open source license applicable to this project."
-
----
-
-## License
-
-| Component | License |
-|-----------|---------|
-| Server / backend | AGPL-3.0 |
-| Client SDKs | Apache 2.0 |
-| Documentation | CC BY 4.0 |
-| Taxonomic data | CC0 |
-| ML models (small) | Apache 2.0 |
-
----
-
-## Community Channels
-
-- **GitHub Discussions:** Feature proposals, architectural decisions
-- **GitHub Issues:** Bug reports, feature requests
-- **Spec:** docs/specs/rastrum-v1.md (on GitHub)
-
----
-
-## Priorities for Early Contributors
-
-The highest-impact contributions right now:
-
-1. **Zapoteco UI translation** — first Indigenous language pilot
-2. **SvelteKit migration** — the Astro site needs to move to SvelteKit for the app shell
-3. **Dexie offline queue** — IndexedDB observation outbox + Supabase sync
-4. **EfficientNet-Lite0 ONNX** — quantized model bundle for offline ID
-5. **Darwin Core export** — occurrence CSV + DwC Archive generator
-
+    <!-- Channels -->
+    <section>
+      <h2 id="channels" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#channels" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Where to ask
+      </h2>
+      <ul class="space-y-2 not-prose">
+        <li class="text-sm text-zinc-700 dark:text-zinc-300"><span class="font-medium">GitHub Discussions:</span> feature proposals, architectural decisions, "is this in scope?"</li>
+        <li class="text-sm text-zinc-700 dark:text-zinc-300"><span class="font-medium">GitHub Issues:</span> bug reports, concrete feature requests, regressions</li>
+        <li class="text-sm text-zinc-700 dark:text-zinc-300"><span class="font-medium">Module specs:</span> <span class="font-mono">docs/specs/modules/00-index.md</span> on GitHub catalogues the ~34 implementation specs</li>
+      </ul>
+    </section>
+  </article>
 </DocLayout>

--- a/src/pages/es/docs/console.astro
+++ b/src/pages/es/docs/console.astro
@@ -1,21 +1,142 @@
 ---
 import DocLayout from '../../../layouts/DocLayout.astro';
+import { t } from '../../../i18n/utils';
+
 const lang = 'es';
+const tr = t(lang);
+
+const githubBase = 'https://github.com/ArtemioPadilla/rastrum/blob/main';
 ---
-<DocLayout title="Consola" lang={lang} section="console">
 
-# Consola
+<DocLayout title={tr.docs.sections.console} lang={lang} section="console" editPath="src/pages/es/docs/console.astro">
+  <article class="space-y-8">
+    <div>
+      <h1 class="text-3xl font-bold tracking-tight mb-4">{tr.docs.sections.console}</h1>
+      <p class="text-lg text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.console}</p>
+      <p class="mt-4 text-sm text-zinc-500 dark:text-zinc-500">
+        Si no ves la píldora <span class="font-mono px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800/40 text-slate-600 dark:text-slate-300">Consola</span> en el encabezado, esta página todavía no aplica para ti — cada superficie privilegiada está protegida por una concesión de rol explícita.
+      </p>
+    </div>
 
-La **Consola** es una superficie de acciones privilegiadas para usuarios con rol de admin, moderador o experto. Si no ves la píldora "Consola" en el encabezado, esta página no aplica para ti.
+    <!-- Who it's for -->
+    <section>
+      <h2 id="roles" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#roles" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Para quién es
+      </h2>
+      <div class="grid sm:grid-cols-3 gap-4 not-prose">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Admins</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Gestionan roles de usuario, revisan credenciales de investigador, monitorean fallos de sincronización y cuotas de API, y auditan cada acción privilegiada.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Moderadores</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Atienden contenido reportado, gestionan la cola de apelaciones y aplican suspensiones suaves con bitácora auditable.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Expertos</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Revisan la cola de validación filtrada por sus taxa y monitorean su puntaje de experiencia por taxón.</p>
+        </div>
+      </div>
+    </section>
 
-## Para qué sirve
+    <!-- What's inside -->
+    <section>
+      <h2 id="surface" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#surface" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Qué incluye
+      </h2>
+      <p class="text-zinc-700 dark:text-zinc-300 mb-4">
+        La consola vive en <span class="font-mono text-sm">/consola/</span> y agrupa 36+ pestañas por rol. La barra lateral y las píldoras son proyecciones de una sola fuente <span class="font-mono text-sm">console-tabs.ts</span>: agregar una nueva superficie es una entrada, no una ruta hecha a mano.
+      </p>
+      <div class="space-y-3 not-prose">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Pestañas de admin</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Resumen, Usuarios, Roles, Credenciales, Bitácora, Cuotas de API, Fallos de sync, Ejecuciones de cron, Feature flags, Bans, Karma, Anomalías, Forense, Errores, Salud, Webhooks, Propuestas, más siete navegadores de entidades de solo lectura (Identificaciones, Notificaciones, Medios, Seguimientos, Listas, Proyectos, Cambios de taxón).</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Pestañas de moderador</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Resumen, Cola de reportes, Triaje de comentarios, Apelaciones.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Pestañas de experto</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Resumen, Puntaje de experiencia, Cola de validación, Solicitar insignia de experto.</p>
+        </div>
+      </div>
+    </section>
 
-- **Admins** gestionan roles de usuario, revisan credenciales de investigador, monitorean fallos de sync y cuotas de API, y auditan cada acción privilegiada.
-- **Moderadores** atienden contenido reportado y gestionan suspensiones (PR3).
-- **Expertos** revisan la cola de validación filtrada por sus taxa y miran su puntaje de experiencia por taxón (PR2).
+    <!-- How privileges work -->
+    <section>
+      <h2 id="privileges" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#privileges" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Cómo funcionan los privilegios
+      </h2>
+      <div class="space-y-3 text-zinc-700 dark:text-zinc-300">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Despachador del lado del servidor</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Cada escritura privilegiada pasa por la Edge Function <span class="font-mono">supabase/functions/admin/</span>. El despachador reverifica el JWT, exige el rol requerido, ejecuta el handler e inserta un registro <span class="font-mono">admin_audit</span> en la misma transacción. Los navegadores nunca escriben directo a las tablas privilegiadas.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Predicado RLS: <span class="font-mono">has_role(uid, role)</span></p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Todas las filas con privilegio usan <span class="font-mono">has_role()</span>, no flags desnormalizados como <span class="font-mono">users.is_expert</span>. Los roles también pueden tener vencimiento (<span class="font-mono">expires_at</span>) y revocarse automáticamente cada noche.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-1">Regla de dos personas</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Las acciones irreversibles pueden requerir aprobación de un segundo admin a través de <span class="font-mono">admin_action_proposals</span>. El despachador hace cumplir la regla cuando el feature flag está activo; las propuestas pendientes vencen cada hora.</p>
+        </div>
+      </div>
+    </section>
 
-## Cómo está construida
+    <!-- Observability -->
+    <section>
+      <h2 id="observability" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#observability" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Observabilidad y forense
+      </h2>
+      <div class="grid sm:grid-cols-2 gap-4 not-prose">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Anomalías</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">El cron horario <span class="font-mono">detect_admin_anomalies()</span> marca acciones fuera de horario (zona horaria por admin), concesiones masivas y patrones inusuales de escritura.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Resumen de salud</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">El snapshot semanal <span class="font-mono">compute_admin_health_digest()</span> alimenta la tarjeta principal en <span class="font-mono">/consola/health/</span> con píldoras direccionales Δ y sparklines de 12 semanas.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Errores de funciones</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Sumidero estructurado <span class="font-mono">function_errors</span> conectado al despachador. <span class="font-mono">/consola/errors/</span> ofrece píldoras coloreadas por severidad, filtros por URL y reconocimiento individual o en lote.</p>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Webhooks</p>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400">Firmado HMAC-SHA256 saliente, vista detallada de entregas por webhook, replay con un clic y protección contra reenvío basada en nonce.</p>
+        </div>
+      </div>
+    </section>
 
-Consulta [Módulo 24](https://github.com/ArtemioPadilla/rastrum/blob/main/docs/specs/modules/24-admin-console.md) para la referencia de implementación, y el [doc de diseño](https://github.com/ArtemioPadilla/rastrum/blob/main/docs/superpowers/specs/2026-04-27-admin-console-design.md) para el rationale.
-
+    <!-- References -->
+    <section>
+      <h2 id="references" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#references" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Referencias
+      </h2>
+      <div class="space-y-2 not-prose">
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/specs/modules/24-admin-console.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Módulo 24 — Consola admin</a> <span class="text-zinc-500 dark:text-zinc-500">— referencia de implementación</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/admin-bootstrap.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Bootstrap de admin</a> <span class="text-zinc-500 dark:text-zinc-500">— primer admin / concesiones de rol</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/role-model.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Modelo de roles</a> <span class="text-zinc-500 dark:text-zinc-500">— concesiones admin / moderador / experto</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/admin-audit.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Bitácora de auditoría</a> <span class="text-zinc-500 dark:text-zinc-500">— consultando admin_audit</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/admin-ops.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Operación por acción</a> <span class="text-zinc-500 dark:text-zinc-500">— qué hace cada pestaña en el día a día</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/runbooks/admin-entity-browsers.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Runbook — Navegadores de entidades</a> <span class="text-zinc-500 dark:text-zinc-500">— plantilla paginada compartida</span></p>
+        </div>
+        <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="text-sm"><a href={`${githubBase}/docs/superpowers/specs/2026-04-27-admin-console-design.md`} target="_blank" rel="noopener" class="font-medium text-emerald-600 dark:text-emerald-400 hover:underline">Doc de diseño — Consola admin</a> <span class="text-zinc-500 dark:text-zinc-500">— racional e historia</span></p>
+        </div>
+      </div>
+    </section>
+  </article>
 </DocLayout>

--- a/src/pages/es/docs/contribute.astro
+++ b/src/pages/es/docs/contribute.astro
@@ -1,114 +1,191 @@
 ---
 import DocLayout from '../../../layouts/DocLayout.astro';
+import { t } from '../../../i18n/utils';
+
 const lang = 'es';
----
-<DocLayout title="Contribuir" lang={lang} section="contribute" editPath="src/pages/es/docs/contribute.astro">
-
-# 🤝 Contribuir
-
-Rastrum es de código abierto e impulsado por la comunidad. Hay muchas formas de contribuir más allá del código.
-
-## Formas de Contribuir
-
-### 🌿 Código
-- **Frontend (SvelteKit 2):** Componentes UI, sincronización offline, interacciones de mapa
-- **Backend (Supabase Edge Functions):** Enrutamiento del pipeline IA, pipelines de exportación
-- **ML en dispositivo (ONNX):** Cuantización de modelos, paquetes regionales de especies
-- **PWA/Capacitor:** Mejoras del wrapper iOS/Android
-
-### 📸 Datos y Curación de Especies
-- Enviar observaciones de campo desde México / LATAM
-- Validar identificaciones de IA como experto
-- Contribuir listas de verificación regionales de especies (formato Darwin Core)
-- Agregar campos morfométricos para evidencia ecológica (huellas, excrementos)
-
-### 🌐 Traducciones
-- Español ↔ Inglés (UI principal)
-- Zapoteco, Mixteco, Náhuatl, Maya, Tsotsil/Tseltal (prioridad)
-- Alianza con INALI, lingüística UNAM o CIESAS para lenguas indígenas
-
-### 🔬 Validación Experta
-- Solicitar una insignia de experto en tu grupo taxonómico (ornitología, botánica, micología, herpetología, entomología...)
-- Revisar la cola de identificación experta
-- Contribuir claves regionales de especies y guías de desambiguación
-
-### 📍 PITs y Senderos
-- Instalar anclajes QR en tus senderos locales o áreas protegidas
-- Crear rutas de senderos de biodiversidad con puntos de ruta
-- Documentar listas de verificación de especies locales por segmento de sendero
-
+const tr = t(lang);
 ---
 
-## Configuración de Desarrollo
+<DocLayout title={tr.docs.sections.contribute} lang={lang} section="contribute" editPath="src/pages/es/docs/contribute.astro">
+  <article class="space-y-8">
+    <div>
+      <h1 class="text-3xl font-bold tracking-tight mb-4">{tr.docs.sections.contribute}</h1>
+      <p class="text-lg text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.contribute}</p>
+      <p class="mt-4 text-sm text-zinc-500 dark:text-zinc-500">
+        Rastrum es desarrollado por una sola persona pero es código abierto e impulsado por la comunidad. Código, observaciones, validación experta, traducciones y docs son bienvenidos — escoge el carril que más te acomode.
+      </p>
+    </div>
 
-```bash
-git clone https://github.com/ArtemioPadilla/rastrum.git
+    <!-- Ways to contribute -->
+    <section>
+      <h2 id="ways" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#ways" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Formas de contribuir
+      </h2>
+      <div class="space-y-4 not-prose">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Código</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">Frontend (Astro + Tailwind):</span> componentes, UX de identificadores, bandeja offline, interacciones MapLibre</li>
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">Backend (Supabase Edge Functions, Deno):</span> cascada de identificación, enriquecimiento, exportaciones, servidor MCP, despachador admin</li>
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">ML en dispositivo:</span> ajuste de WebLLM, empaquetado de modelos ONNX, paquetes regionales de especies</li>
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">CLI de importación batch (Node 20+):</span> tarjetas SD de cámara-trampa, paridad EXIF con la PWA</li>
+            <li><span class="font-medium text-zinc-700 dark:text-zinc-300">PWA / Capacitor:</span> service worker, flujo de instalación, mejoras del shell iOS/Android</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Datos y curación de especies</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li>Enviar observaciones de campo desde México / LATAM</li>
+            <li>Validar identificaciones de IA como miembro de la comunidad o experto</li>
+            <li>Contribuir listas regionales de especies (Darwin Core / presets SNIB / CONANP)</li>
+            <li>Agregar campos morfométricos para evidencia ecológica (huellas, excrementos, nidos, cantos)</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Traducciones</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li>Paridad español ↔ inglés en <span class="font-mono">{'src/i18n/{en,es}.json'}</span></li>
+            <li>Zapoteco, Mixteco, Náhuatl, Maya, Tsotsil/Tseltal (prioridad — piloto pendiente)</li>
+            <li>Alianza con INALI, lingüística UNAM o CIESAS para lenguas indígenas</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Validación experta</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li>Solicitar insignia de experto en tu grupo taxonómico (ornitología, botánica, micología, herpetología, entomología…)</li>
+            <li>Revisar la cola de validación filtrada por tus taxa</li>
+            <li>Contribuir guías regionales de desambiguación y claves de identificación</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Docs y runbooks</p>
+          <ul class="text-sm text-zinc-600 dark:text-zinc-400 space-y-1 list-disc pl-5">
+            <li>Specs de módulo en <span class="font-mono">docs/specs/modules/</span></li>
+            <li>Runbooks de operador en <span class="font-mono">docs/runbooks/</span></li>
+            <li>Páginas de docs en <span class="font-mono">{'src/pages/{en,es}/docs/'}</span> — deben mantener paridad EN/ES</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Development setup -->
+    <section>
+      <h2 id="setup" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#setup" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Configuración de desarrollo
+      </h2>
+      <p class="text-zinc-700 dark:text-zinc-300 mb-3">
+        El repo se desarrolla en macOS pero el toolchain corre en cualquier sistema con Node 20+ y un proyecto Supabase con Postgres. <span class="font-mono">make help</span> lista todos los workflows.
+      </p>
+      <pre class="not-prose p-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-sm overflow-x-auto"><code class="font-mono text-zinc-800 dark:text-zinc-200">git clone https://github.com/ArtemioPadilla/rastrum.git
 cd rastrum
-npm install
-npm run dev        # Servidor de desarrollo Astro (sitio de contenido actual)
-```
-
-Variables de entorno necesarias (copiar `.env.example`):
-```
-PUBLIC_SUPABASE_URL=
+make install        <span class="text-zinc-500"># npm ci</span>
+make dev            <span class="text-zinc-500"># astro dev — http://localhost:4321</span>
+make test           <span class="text-zinc-500"># vitest run</span>
+make typecheck      <span class="text-zinc-500"># tsc --noEmit</span>
+make build          <span class="text-zinc-500"># build estático en dist/</span></code></pre>
+      <p class="text-zinc-700 dark:text-zinc-300 mt-4 mb-3">Copia <span class="font-mono">.env.example</span> a <span class="font-mono">.env.local</span> y rellena las llaves que necesites:</p>
+      <pre class="not-prose p-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 text-sm overflow-x-auto"><code class="font-mono text-zinc-800 dark:text-zinc-200">PUBLIC_SUPABASE_URL=
 PUBLIC_SUPABASE_ANON_KEY=
-PLANTNET_API_KEY=
-```
+PLANTNET_API_KEY=        <span class="text-zinc-500"># opcional, para el identificador PlantNet</span></code></pre>
+    </section>
 
----
+    <!-- Process -->
+    <section>
+      <h2 id="process" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#process" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Proceso de contribución
+      </h2>
+      <ol class="space-y-3 not-prose">
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">1</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Fork y rama</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Crea una rama desde <span class="font-mono">main</span>; un cambio lógico por PR.</p>
+          </div>
+        </li>
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">2</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Firma tus commits (DCO)</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Usa <span class="font-mono">git commit -s</span>. Usamos el Developer Certificate of Origin, no un CLA — sin papeleo.</p>
+          </div>
+        </li>
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">3</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Verificaciones pre-PR</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400"><span class="font-mono">make typecheck</span> &amp; <span class="font-mono">make test</span> &amp; <span class="font-mono">make build</span> — todo verde, páginas EN/ES emparejadas.</p>
+          </div>
+        </li>
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">4</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Abre el PR</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Descripción clara, issue vinculado (si aplica), capturas para cambios de UI. CI debe estar verde antes de revisar.</p>
+          </div>
+        </li>
+        <li class="flex items-start gap-3">
+          <span class="shrink-0 mt-0.5 w-6 h-6 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 text-xs font-semibold flex items-center justify-center">5</span>
+          <div>
+            <p class="font-medium text-zinc-900 dark:text-zinc-100">Revisión</p>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">Esperamos una respuesta de maintainer en 7 días. Cambios de schema pasan un gate adicional pre-merge que aplica el schema dos veces en un contenedor Postgres+PostGIS.</p>
+          </div>
+        </li>
+      </ol>
+      <div class="mt-4 p-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-900/30 not-prose">
+        <p class="text-sm font-medium text-zinc-900 dark:text-zinc-100 mb-1">Firma DCO</p>
+        <p class="text-sm text-zinc-600 dark:text-zinc-400">Agrega <span class="font-mono">Signed-off-by: Tu Nombre &lt;tu_email&gt;</span> a cada mensaje de commit (<span class="font-mono">git commit -s</span> lo hace por ti). Al firmar, certificas que escribiste el código o que tienes derecho a enviarlo bajo la licencia del proyecto.</p>
+      </div>
+    </section>
 
-## Proceso de Contribución
+    <!-- License -->
+    <section>
+      <h2 id="license" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#license" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Licencia
+      </h2>
+      <div class="not-prose overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-zinc-200 dark:border-zinc-800">
+              <th class="text-left py-2 px-3 text-zinc-500 dark:text-zinc-400 font-medium">Componente</th>
+              <th class="text-left py-2 px-3 text-zinc-500 dark:text-zinc-400 font-medium">Licencia</th>
+            </tr>
+          </thead>
+          <tbody class="text-zinc-700 dark:text-zinc-300">
+            <tr class="border-b border-zinc-100 dark:border-zinc-900 bg-zinc-50/50 dark:bg-zinc-950/50">
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Código cliente (PWA, CLI, componentes)</td>
+              <td class="py-2 px-3 font-mono">MIT</td>
+            </tr>
+            <tr class="border-b border-zinc-100 dark:border-zinc-900">
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Servidor / Edge Functions</td>
+              <td class="py-2 px-3 font-mono">AGPL-3.0</td>
+            </tr>
+            <tr class="border-b border-zinc-100 dark:border-zinc-900 bg-zinc-50/50 dark:bg-zinc-950/50">
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Documentación</td>
+              <td class="py-2 px-3 font-mono">CC BY 4.0</td>
+            </tr>
+            <tr class="border-b border-zinc-100 dark:border-zinc-900">
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Por observación</td>
+              <td class="py-2 px-3 font-mono">CC BY / CC BY-NC / CC0 (lo elige el observador)</td>
+            </tr>
+            <tr>
+              <td class="py-2 px-3 font-medium text-zinc-900 dark:text-zinc-100">Datos taxonómicos</td>
+              <td class="py-2 px-3 font-mono">CC0</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-1. **Fork** del repositorio y crear una rama de funcionalidad
-2. **Firmar** tus commits con DCO (`git commit -s`)
-   *Usamos DCO (Developer Certificate of Origin), no CLA — sin papeleo, sin ansiedad*
-3. **Abrir un PR** con descripción clara e issue vinculado
-4. **Pruebas** deben pasar: `npm run build`
-5. **Revisión** de un maintainer en un máximo de 7 días
-
----
-
-## Firma DCO
-
-Agregar a cada commit:
-```
-Signed-off-by: Tu Nombre &lt;tu_email&gt;
-```
-
-O usar `git commit -s` para agregar automáticamente. Al firmar, certificas:
-
-> "Yo escribí este código, o tengo el derecho de enviarlo bajo la licencia de código abierto aplicable a este proyecto."
-
----
-
-## Licencia
-
-| Componente | Licencia |
-|------------|----------|
-| Servidor / backend | AGPL-3.0 |
-| SDKs cliente | Apache 2.0 |
-| Documentación | CC BY 4.0 |
-| Datos taxonómicos | CC0 |
-| Modelos ML (pequeños) | Apache 2.0 |
-
----
-
-## Canales de Comunidad
-
-- **GitHub Discussions:** Propuestas de funcionalidades, decisiones arquitectónicas
-- **GitHub Issues:** Reportes de bugs, solicitudes de funcionalidades
-- **Especificación:** docs/specs/rastrum-v1.md (en GitHub)
-
----
-
-## Prioridades para Contribuidores Iniciales
-
-Las contribuciones de mayor impacto ahora mismo:
-
-1. **Traducción UI Zapoteco** — primer piloto de lengua indígena
-2. **Migración a SvelteKit** — el sitio Astro necesita moverse a SvelteKit para el shell de app
-3. **Cola offline Dexie** — bandeja de salida IndexedDB de observaciones + sincronización Supabase
-4. **EfficientNet-Lite0 ONNX** — paquete de modelo cuantizado para ID offline
-5. **Exportación Darwin Core** — generador de CSV de ocurrencias + Darwin Core Archive
-
+    <!-- Channels -->
+    <section>
+      <h2 id="channels" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+        <a href="#channels" class="text-zinc-600 dark:text-zinc-400 hover:text-emerald-500 transition-colors">#</a> Dónde preguntar
+      </h2>
+      <ul class="space-y-2 not-prose">
+        <li class="text-sm text-zinc-700 dark:text-zinc-300"><span class="font-medium">GitHub Discussions:</span> propuestas de funcionalidad, decisiones arquitectónicas, "¿esto está en alcance?"</li>
+        <li class="text-sm text-zinc-700 dark:text-zinc-300"><span class="font-medium">GitHub Issues:</span> reportes de bugs, solicitudes concretas, regresiones</li>
+        <li class="text-sm text-zinc-700 dark:text-zinc-300"><span class="font-medium">Specs de módulo:</span> <span class="font-mono">docs/specs/modules/00-index.md</span> en GitHub cataloga las ~34 specs de implementación</li>
+      </ul>
+    </section>
+  </article>
 </DocLayout>


### PR DESCRIPTION
## Summary

- `/{en,es}/docs/console/` and `/{en,es}/docs/contribute/` were authored as raw markdown inside `.astro` files. Astro doesn't process markdown in `.astro`, and the repo doesn't pull in `@tailwindcss/typography`, so the browser rendered headings/lists/code as unformatted plain text (see screenshots in the issue thread).
- Rewrote all four pages with the same structured Astro+Tailwind pattern used by `vision.astro` / `funding.astro` — i18n-driven hero, role/feature cards, anchored sections, reference links.
- Also refreshed `contribute.astro` content: removed stale "SvelteKit 2" / "current content site" claims, lined the dev setup up with the `make`-driven workflow, and updated the license matrix to match `CLAUDE.md` (MIT client / AGPL server / CC docs / per-observation CC).
- Escaped `{en,es}` in JSX expression positions to avoid the `en is not defined` build trap.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` — 201 pages, no errors
- [x] `npm run test` — 718 / 718 passing
- [x] Verified rendered HTML: 1 `<h1>`, real `<h2>` anchors, Tailwind cards on all four output pages, no literal `# Heading` text
- [x] Audited remaining `pages/{en,es}/docs/*.astro` — only these four had the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)