### PR TITLE
fix(obs-detail): location save no longer hangs silently — timeout + diagnostics

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -500,11 +500,31 @@ export async function wireManagePanelLocation(
     savingEl?.classList.remove('hidden');
     try {
       const literal = pointGeographyLiteral(e.detail.coords.lat, e.detail.coords.lng);
-      const { error } = await supabase
+      // Hard 15 s timeout — if PostgREST never returns (RLS recursion regressed,
+      // CORS preflight stalled, auth refresh deadlock, etc.) the user gets a
+      // visible error instead of a button stuck on "saving…" forever.
+      // Returning the explicit `select()` makes PostgREST send back the updated
+      // row, which forces the round-trip to complete instead of fire-and-forget.
+      const updatePromise = supabase
         .from('observations')
         .update({ location: literal, updated_at: new Date().toISOString() })
-        .eq('id', obsId);
-      if (error) throw error;
+        .eq('id', obsId)
+        .select('id, location')
+        .maybeSingle();
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('save_timeout')), 15_000),
+      );
+      const result = await Promise.race([updatePromise, timeout]) as { data: unknown; error: { message?: string; code?: string } | null };
+      if (result.error) {
+        console.error('[manage-panel] location update failed', { obsId, err: result.error });
+        throw new Error(result.error.message || result.error.code || 'update_failed');
+      }
+      if (!result.data) {
+        // Empty body = RLS filtered the UPDATE (no rows matched observer_id).
+        // Don't claim success — the row didn't change.
+        console.warn('[manage-panel] location update returned 0 rows (RLS filtered)', { obsId });
+        throw new Error('rls_filtered');
+      }
 
       window.dispatchEvent(new CustomEvent('rastrum:mappicker-set', {
         detail: { id: 'obs-detail-loc-view', coords: e.detail.coords },
@@ -517,8 +537,21 @@ export async function wireManagePanelLocation(
       savedEl?.classList.remove('hidden');
     } catch (err) {
       const code = err instanceof Error ? err.message : String(err);
+      console.error('[manage-panel] location save error', { obsId, code, err });
       if (errEl) {
-        errEl.textContent = code === 'coords_invalid' ? errCopy.invalidCoords : errCopy.saveFailed;
+        if (code === 'coords_invalid') {
+          errEl.textContent = errCopy.invalidCoords;
+        } else if (code === 'save_timeout') {
+          errEl.textContent = isEs
+            ? 'Tiempo de espera agotado. Revisa tu conexión o intenta de nuevo.'
+            : 'Save timed out. Check your connection and try again.';
+        } else if (code === 'rls_filtered') {
+          errEl.textContent = isEs
+            ? 'No tienes permiso para editar esta observación.'
+            : 'You do not have permission to edit this observation.';
+        } else {
+          errEl.textContent = `${errCopy.saveFailed} (${code})`;
+        }
         errEl.classList.remove('hidden');
       }
     } finally {


### PR DESCRIPTION
## Summary

Defense-in-depth for the location-save flow on \`/share/obs/?id=…\`. Reported by user 2026-05-01: clicking Save on Edit location stayed at \"saving…\" forever with no Network request visible, even after a hard refresh. Root cause is still unconfirmed in prod (could be RLS-filtered fire-and-forget UPDATE, hung fetch, auth refresh deadlock), so this PR makes the symptom impossible to silence.

## Changes (all in \`src/lib/manage-panel.ts\`, \`wireManagePanelLocation\` listener)

1. **Append \`.select('id, location').maybeSingle()\` to the UPDATE.** PostgREST now returns the updated row, so the await can't fire-and-forget. If RLS filtered the UPDATE to 0 rows, \`data === null\` and we throw \`rls_filtered\` — no more false \"Saved!\" toast on a row that didn't change.
2. **15 s timeout via \`Promise.race\`.** Frozen \"saving…\" button becomes a clean \"Save timed out\" message after 15 s, and the saving indicator clears via the existing \`finally\` block.
3. **Structured \`console.error\`** on every error path (\`obsId\`, \`code\`, raw \`err\`) so prod-only repros can be diagnosed from the user's DevTools.
4. **Error copy** in EN + ES for the two new failure modes (\`save_timeout\`, \`rls_filtered\`).

## Non-changes
- No SQL / RLS / schema changes.
- No public API or i18n key churn.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npx vitest run src/lib/manage-panel.test.ts\` — 14/14 (existing tests cover \`pointGeographyLiteral\` only; the listener is integration-tested via the e2e flow)
- [ ] In prod after merge: edit obs coordinates on \`/share/obs/?id=<uuid>\`, observe either a clean save OR a specific error message in <15 s. If error fires, capture \`[manage-panel] location save error\` from DevTools Console for next-step root-cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)