### PR TITLE
fix(obs-detail): location save no longer hangs silently — timeout + diagnostics

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -500,11 +500,31 @@ export async function wireManagePanelLocation(
     savingEl?.classList.remove('hidden');
     try {
       const literal = pointGeographyLiteral(e.detail.coords.lat, e.detail.coords.lng);
-      const { error } = await supabase
+      // Hard 15 s timeout — if PostgREST never returns (RLS recursion regressed,
+      // CORS preflight stalled, auth refresh deadlock, etc.) the user gets a
+      // visible error instead of a button stuck on "saving…" forever.
+      // Returning the explicit `select()` makes PostgREST send back the updated
+      // row, which forces the round-trip to complete instead of fire-and-forget.
+      const updatePromise = supabase
         .from('observations')
         .update({ location: literal, updated_at: new Date().toISOString() })
-        .eq('id', obsId);
-      if (error) throw error;
+        .eq('id', obsId)
+        .select('id, location')
+        .maybeSingle();
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('save_timeout')), 15_000),
+      );
+      const result = await Promise.race([updatePromise, timeout]) as { data: unknown; error: { message?: string; code?: string } | null };
+      if (result.error) {
+        console.error('[manage-panel] location update failed', { obsId, err: result.error });
+        throw new Error(result.error.message || result.error.code || 'update_failed');
+      }
+      if (!result.data) {
+        // Empty body = RLS filtered the UPDATE (no rows matched observer_id).
+        // Don't claim success — the row didn't change.
+        console.warn('[manage-panel] location update returned 0 rows (RLS filtered)', { obsId });
+        throw new Error('rls_filtered');
+      }
 
       window.dispatchEvent(new CustomEvent('rastrum:mappicker-set', {
         detail: { id: 'obs-detail-loc-view', coords: e.detail.coords },
@@ -517,8 +537,21 @@ export async function wireManagePanelLocation(
       savedEl?.classList.remove('hidden');
     } catch (err) {
       const code = err instanceof Error ? err.message : String(err);
+      console.error('[manage-panel] location save error', { obsId, code, err });
       if (errEl) {
-        errEl.textContent = code === 'coords_invalid' ? errCopy.invalidCoords : errCopy.saveFailed;
+        if (code === 'coords_invalid') {
+          errEl.textContent = errCopy.invalidCoords;
+        } else if (code === 'save_timeout') {
+          errEl.textContent = isEs
+            ? 'Tiempo de espera agotado. Revisa tu conexión o intenta de nuevo.'
+            : 'Save timed out. Check your connection and try again.';
+        } else if (code === 'rls_filtered') {
+          errEl.textContent = isEs
+            ? 'No tienes permiso para editar esta observación.'
+            : 'You do not have permission to edit this observation.';
+        } else {
+          errEl.textContent = `${errCopy.saveFailed} (${code})`;
+        }
         errEl.classList.remove('hidden');
       }
     } finally {


### PR DESCRIPTION
## Summary
- Append `.select('id, location').maybeSingle()` to the location UPDATE so PostgREST waits for the row — RLS-filtered 0-row updates now throw `rls_filtered` instead of falsely showing "Saved!".
- 15 s `Promise.race` timeout: a hung fetch surfaces a "Save timed out" error instead of an indefinitely frozen button. Saving indicator always clears in `finally`.
- Structured `console.error` on every error path (`obsId`, `code`, raw `err`) so prod failures can be root-caused from DevTools.
- New EN + ES copy for the timeout + rls_filtered failure modes.

Reported 2026-05-01: clicking Save on Edit location stayed at "saving…" indefinitely with no Network request visible. Root cause unconfirmed — this PR is defense-in-depth so the symptom can never be silent again.

No schema or RLS change.

## Test plan
- [ ] Edit a location and Save — happy path still shows "Saved!" and updates the marker
- [ ] Sign in as a non-owner, attempt to PATCH the same observation via DevTools — UI now surfaces `rls_filtered` instead of silent success
- [ ] Throttle Network to "Offline" mid-save — UI surfaces "Save timed out" within 15 s and the saving indicator clears
- [ ] DevTools Console shows structured `obs.update_location.<code>` log on every failure with `obsId` + raw `err`
- [ ] EN + ES copy renders for both new error modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)