### PR TITLE
feat(analytics): extend PostHog tracking to 5 more components

### DIFF
--- a/src/components/InstallPwaButton.astro
+++ b/src/components/InstallPwaButton.astro
@@ -134,6 +134,7 @@ const tr = t(lang);
     try {
       await saved.prompt();
       const choice = await saved.userChoice;
+      window.posthog?.capture('pwa_install_prompted', { outcome: choice.outcome });
       if (choice.outcome === 'accepted' || choice.outcome === 'dismissed') {
         // The contract is that the prompt is single-use.
         saved = null;
@@ -145,6 +146,7 @@ const tr = t(lang);
   });
 
   window.addEventListener('appinstalled', () => {
+    window.posthog?.capture('pwa_installed');
     saved = null;
     hideAndroidBtn();
     iosHint?.classList.add('hidden');

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -2462,6 +2462,7 @@ const idAgainFailedLabel   = observeStrings.id_again_failed         ?? (isEs ? '
     if (!obsDraft) return;
     const savedObs = await saveObservationToOutbox(obsDraft);
     lastSavedObservationId = savedObs.id;
+    window.posthog?.capture('observation_saved', { observation_id: savedObs.id });
     form.dispatchEvent(new CustomEvent('rastrum:form-saved'));
 
     // Attempt immediate sync if online; otherwise it'll flush on next online event.

--- a/src/components/ProjectNewView.astro
+++ b/src/components/ProjectNewView.astro
@@ -229,6 +229,7 @@ const projectsBase = routes.projects[lang];
       submit?.setAttribute('disabled', 'true');
       try {
         await upsertProject({ slug, name, name_es, description, description_es, visibility, polygon });
+        window.posthog?.capture('project_created', { slug, visibility });
         window.location.assign(`/${lang}${projectsBase}/detail/?slug=${encodeURIComponent(slug)}`);
       } catch (err) {
         const code = (err instanceof Error) ? err.message : 'unknown';

--- a/src/components/ReportDialog.astro
+++ b/src/components/ReportDialog.astro
@@ -196,6 +196,7 @@ const reportTr = tr.socialgraph.report;
       errorEl?.classList.add('hidden');
       try {
         await reportTarget({ target, target_id: targetId, reason, note });
+        window.posthog?.capture('content_reported', { target, reason });
         thanksEl?.classList.remove('hidden');
         setTimeout(close, 1400);
       } catch (err) {

--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -451,6 +451,7 @@ const i18nBag = {
     if (!label || !secret) return;
     try {
       await createCredential({ label, secret, kind, preferred_model, endpoint });
+      window.posthog?.capture('sponsorship_credential_added', { kind });
       (document.getElementById('cred-secret-input') as HTMLInputElement).value = '';
       (document.getElementById('cred-model-input') as HTMLInputElement).value = '';
       (document.getElementById('cred-endpoint-input') as HTMLInputElement).value = '';


### PR DESCRIPTION
## Summary

Extends the PostHog instrumentation from #6a27abd to cover the 5 highest-value user actions that were missing.

## New events

| Component | Event | Properties |
|---|---|---|
| `ObservationForm` | `observation_saved` | `observation_id` |
| `InstallPwaButton` | `pwa_install_prompted` | `outcome` (accepted/dismissed) |
| `InstallPwaButton` | `pwa_installed` | — |
| `ReportDialog` | `content_reported` | `target`, `reason` |
| `ProjectNewView` | `project_created` | `slug`, `visibility` |
| `SponsoringView` | `sponsorship_credential_added` | `kind` (provider type) |

## Safety notes

- All calls use `window.posthog?.capture` — no-op when env vars are unset
- No PII: UUIDs only, no emails/names/coords
- `content_reported` sends `reason` (enum) and `target` type, not the note text
- `sponsorship_credential_added` sends provider `kind`, never the secret

## Tested

- `npm run typecheck` — zero errors
- `npm run build` — 201 pages, complete