### PR TITLE
fix(mcp): force https:// in SSE endpoint event URL

### DIFF
--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -384,7 +384,9 @@ Deno.serve(async (req: Request) => {
   // Clients that support Streamable HTTP (Claude Desktop, Cursor, Copilot)
   // never issue a GET, so this branch is invisible to them.
   if (req.method === 'GET') {
-    const selfUrl = new URL(req.url).href.split('?')[0]; // strip any query params
+    // Supabase Edge Runtime may forward the request as http:// internally;
+    // force https:// so the MCP SDK origin-check passes.
+    const selfUrl = new URL(req.url).href.split('?')[0].replace(/^http:/, 'https:');
     const sseHeaders = {
       ...corsHeaders,
       'Content-Type': 'text/event-stream',


### PR DESCRIPTION
El PR #319 ya está mergeado pero este commit quedó fuera porque fue pusheado después del merge.

**Problema:** Supabase Edge Runtime recibe las requests internamente como `http://`, pero el SDK de MCP hace un origin-check y rechaza cualquier URL de endpoint cuyo origin no coincida con el de la conexión (`https://`).

Error que produce:
```
Endpoint origin does not match connection origin: http://reppvlqejgoqvitturxp.supabase.co
```

**Fix:** Reemplazar `http://` con `https://` al construir la URL del endpoint event.