### PR TITLE
fix(mcp): use canonical public URL for SSE endpoint event

### DIFF
--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -384,9 +384,12 @@ Deno.serve(async (req: Request) => {
   // Clients that support Streamable HTTP (Claude Desktop, Cursor, Copilot)
   // never issue a GET, so this branch is invisible to them.
   if (req.method === 'GET') {
-    // Supabase Edge Runtime may forward the request as http:// internally;
-    // force https:// so the MCP SDK origin-check passes.
-    const selfUrl = new URL(req.url).href.split('?')[0].replace(/^http:/, 'https:');
+    // Supabase Edge Runtime strips /functions/v1/ from req.url internally and
+    // may also forward the request as http://. Build the canonical public URL
+    // from the known project ref + function name instead of trusting req.url.
+    const projectRef = Deno.env.get('SUPABASE_URL')?.match(/https:\/\/([^.]+)/)?.[1]
+      ?? new URL(req.url).hostname.split('.')[0];
+    const selfUrl = `https://${projectRef}.supabase.co/functions/v1/mcp`;
     const sseHeaders = {
       ...corsHeaders,
       'Content-Type': 'text/event-stream',


### PR DESCRIPTION
**Problema:** Supabase Edge Runtime expone `req.url` como el path interno (`/mcp`) sin el prefijo `/functions/v1/`, causando que el SDK de MCP haga POST a una URL inválida:

```
Error POSTing to endpoint (HTTP 404): {"error":"requested path is invalid"}
```

**Fix:** Construir la URL del endpoint desde `SUPABASE_URL` (que siempre tiene el project ref y hostname correcto) en lugar de confiar en `req.url`.

Resultado: `https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp` ✅