### PR TITLE
chore(edge): pin @supabase/supabase-js in recompute-user-stats

### DIFF
--- a/supabase/functions/recompute-user-stats/index.ts
+++ b/supabase/functions/recompute-user-stats/index.ts
@@ -15,7 +15,7 @@
  * Cron-only; deployed --no-verify-jwt like recompute-streaks/award-badges.
  */
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
 import { requireCronSecret } from '../_shared/cron-auth.ts';
 
 serve(async (req) => {


### PR DESCRIPTION
## Summary
- Pins the `@supabase/supabase-js` import in `recompute-user-stats/index.ts` from `@2` to `@2.39.7`, aligning with every other Edge Function in the repo (award-badges, streak-push, identify, admin, follow, stripe-webhook, …).
- Loose end from `ci/pin-esm-imports` (squash-merged); this single file slipped through.

## Test plan
- [ ] CI green (typecheck + tests)
- [ ] Edge Function deploy on merge succeeds for `recompute-user-stats`
- [ ] Nightly cron `recompute-user-stats` continues to fire successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)