### PR TITLE
fix(settings): expose Security + AI tabs in nav (PR #303 follow-up)

### DIFF
--- a/src/components/SettingsShell.astro
+++ b/src/components/SettingsShell.astro
@@ -22,6 +22,8 @@ const profileHubPath   = getLocalizedPath(lang, routes.profile[locale] + '/');
 
 const tabs = [
   { key: 'profile',     label: settings.tabs.profile,     href: profilePath },
+  { key: 'security',    label: settings.tabs.security,    href: securityPath },
+  { key: 'ai',          label: settings.tabs.ai,          href: aiPath },
   { key: 'preferences', label: settings.tabs.preferences, href: preferencesPath },
   { key: 'data',        label: settings.tabs.data,        href: dataPath },
   { key: 'developer',   label: settings.tabs.developer,   href: developerPath },


### PR DESCRIPTION
## Summary
PR #303 (\`feat(settings): split profile tab → Profile / Security / AI tabs\`) added the \`security\` and \`ai\` routes plus the rendering blocks in \`[tab].astro\`, but **never wired the new tabs into \`SettingsShell.astro\`'s nav array**. Users had no way to click into them.

i18n keys (\`settings.tabs.security\`, \`settings.tabs.ai\`) were already present in EN and ES.

## Test plan
- [ ] \`npm run build\` produces \`dist/en/profile/settings/{security,ai}\` and \`dist/es/perfil/ajustes/{security,ai}\` (verified locally)
- [ ] \`/en/profile/settings/profile/\` shows the new Security and AI tabs in the horizontal tab bar
- [ ] Clicking each tab navigates and renders the right \`<ProfileEditForm section="…">\` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)