### PR TITLE
fix(mcp): return 202 Accepted for notifications/initialized

### DIFF
--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -455,8 +455,10 @@ Deno.serve(async (req: Request) => {
   }
 
   // ── notifications/initialized ─────────────────────────────────────
+  // Streamable HTTP (2025-03-26) expects 202 Accepted for notifications.
+  // Legacy SSE transport also sends this; both are fine with 202.
   if (body.method === 'notifications/initialized') {
-    return new Response('', { status: 204, headers: corsHeaders });
+    return new Response(null, { status: 202, headers: corsHeaders });
   }
 
   // Everything below requires auth.


### PR DESCRIPTION
**Problema:** `new Response('', { status: 204 })` con body de string vacío hace que Supabase Edge Runtime lance un `500 Internal Server Error`.

**Fix:** Cambiar a `new Response(null, { status: 202 })`:
- `null` body es el correcto para respuestas sin body en Deno/Supabase
- `202 Accepted` es lo que espera el Streamable HTTP transport (MCP spec 2025-03-26)

Esto desbloquea a OpenClaw usando `transport: streamable-http` — que es más confiable que SSE porque no depende del cold start de Deno.