### PR TITLE
fix(birdnet+audio): sigmoid confidence, persist client ID, audio MIME, M32 source enum

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -291,7 +291,10 @@ CREATE TABLE IF NOT EXISTS public.identifications (
   scientific_name text,                    -- denormalized, stored at ID time
   confidence      numeric CHECK (confidence BETWEEN 0 AND 1),
   source          text NOT NULL
-                  CHECK (source IN ('plantnet','claude_haiku','claude_sonnet','onnx_offline','human')),
+                  CHECK (source IN (
+                    'plantnet','claude_haiku','claude_sonnet','onnx_offline','human',
+                    'birdnet_lite','onnx_efficientnet_lite0','camera_trap_megadetector','phi_vision'
+                  )),
   raw_response    jsonb,                   -- full API response
   is_primary      boolean NOT NULL DEFAULT true,
   is_research_grade boolean DEFAULT false,
@@ -6636,3 +6639,19 @@ END;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.merge_user_accounts(uuid, uuid, uuid, text) TO service_role;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Migration: extend identifications.source CHECK to cover client-side
+-- identifiers (BirdNET-Lite audio, EfficientNet-Lite0 images, MegaDetector
+-- camera-trap, Phi-3.5-vision). Without this, the sync layer's direct
+-- insert of a client identification (added 2026-05-01 to fix audio
+-- observations landing as "Unknown species") fails the CHECK constraint.
+-- ═══════════════════════════════════════════════════════════════════════════
+ALTER TABLE public.identifications
+  DROP CONSTRAINT IF EXISTS identifications_source_check;
+ALTER TABLE public.identifications
+  ADD CONSTRAINT identifications_source_check
+  CHECK (source IN (
+    'plantnet','claude_haiku','claude_sonnet','onnx_offline','human',
+    'birdnet_lite','onnx_efficientnet_lite0','camera_trap_megadetector','phi_vision'
+  ));

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -292,8 +292,12 @@ CREATE TABLE IF NOT EXISTS public.identifications (
   confidence      numeric CHECK (confidence BETWEEN 0 AND 1),
   source          text NOT NULL
                   CHECK (source IN (
+                    -- Server-side cascade
                     'plantnet','claude_haiku','claude_sonnet','onnx_offline','human',
-                    'birdnet_lite','onnx_efficientnet_lite0','camera_trap_megadetector','phi_vision'
+                    -- Client-side identifiers
+                    'birdnet_lite','onnx_efficientnet_lite0','camera_trap_megadetector','phi_vision',
+                    -- M32 multi-provider vision (each provider tags its result with its kind)
+                    'bedrock','openai','azure_openai','gemini','vertex_ai'
                   )),
   raw_response    jsonb,                   -- full API response
   is_primary      boolean NOT NULL DEFAULT true,
@@ -6652,6 +6656,10 @@ ALTER TABLE public.identifications
 ALTER TABLE public.identifications
   ADD CONSTRAINT identifications_source_check
   CHECK (source IN (
+    -- Server-side cascade
     'plantnet','claude_haiku','claude_sonnet','onnx_offline','human',
-    'birdnet_lite','onnx_efficientnet_lite0','camera_trap_megadetector','phi_vision'
+    -- Client-side identifiers (M03 + M31)
+    'birdnet_lite','onnx_efficientnet_lite0','camera_trap_megadetector','phi_vision',
+    -- M32 multi-provider vision (each provider tags its result with its kind)
+    'bedrock','openai','azure_openai','gemini','vertex_ai'
   ));

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -762,10 +762,21 @@ postForm?.addEventListener('submit', async (e) => {
     const weatherVal = (document.getElementById('obs2-weather') as HTMLSelectElement | null)?.value || null;
     const taxonInput = (document.getElementById('obs2-taxon-input') as HTMLInputElement | null)?.value.trim();
 
+    // MediaRecorder-produced Blobs sometimes have an empty `type` (notably
+    // iOS Safari and certain Android Chrome paths). Falling back to
+    // application/octet-stream causes sync.ts's MIME-prefix chain to mis-classify
+    // the file as `media_type='photo'`, which then breaks the share/obs page
+    // (broken-image card + audio player never mounts). Backfill a sensible
+    // MIME from the triaged kind so the type carries through.
     const mediaInputs = pipelineState.files.map(pf => ({
       blob: pf.file,
       blobId: pf.id,
-      mimeType: pf.file.type || 'application/octet-stream',
+      mimeType: pf.file.type || (
+        pf.kind === 'audio' ? 'audio/webm' :
+        pf.kind === 'video' ? 'video/webm' :
+        pf.kind === 'photo' ? 'image/jpeg' :
+        'application/octet-stream'
+      ),
       sizeBytes: pf.file.size,
       mediaType: pf.kind === 'audio' ? 'audio' as const : pf.kind === 'video' ? 'video' as const : 'photo' as const,
     }));

--- a/src/lib/identifiers/birdnet.ts
+++ b/src/lib/identifiers/birdnet.ts
@@ -197,13 +197,18 @@ export const birdnetIdentifier: Identifier = {
 
     onProgress({ progress: 1, text: 'Done' });
 
+    // BirdNET-Lite v2.4 emits raw logits (no activation). Apply sigmoid
+    // to map into [0,1] so the value satisfies the `identifications.confidence
+    // CHECK BETWEEN 0 AND 1` constraint and renders sensibly as a percentage.
+    const sigmoid = (x: number) => 1 / (1 + Math.exp(-x));
+
     return {
       scientific_name: parsed.scientific_name,
       common_name_en: parsed.common_name_en,
       common_name_es: null,
       family: null,
       kingdom: 'Animalia',
-      confidence: best.score,
+      confidence: sigmoid(best.score),
       source: PLUGIN_ID,
       raw: {
         // Legacy field kept for backward compat

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -167,11 +167,37 @@ async function syncOne(record: ObservationRecord): Promise<void> {
     console.warn('[rastrum] OG card render failed (non-fatal)', err);
   }
 
-  // 4. Mark synced in Dexie + enqueue ID request if not already
+  // 4. Mark synced in Dexie
   await db.observations.update(record.id, {
     sync_status: 'synced',
     updated_at: new Date().toISOString(),
   });
+
+  // 4.5. If the client already identified the species (e.g. BirdNET on audio,
+  //      EfficientNet on image), persist that identification directly. Audio
+  //      has no server-side identifier in the cascade, so without this step
+  //      the observation lands as "Unknown species" forever.
+  const clientId = obs.identification;
+  if (clientId.scientificName && clientId.status === 'accepted') {
+    const supabase = getSupabase();
+    const { error: clientIdErr } = await supabase.from('identifications').insert({
+      observation_id: record.id,
+      scientific_name: clientId.scientificName,
+      confidence: Math.max(0, Math.min(1, clientId.confidence ?? 0)),
+      source: clientId.source ?? 'human',
+      is_primary: true,
+    });
+    if (clientIdErr) {
+      console.warn('[rastrum] client identification persist failed', clientIdErr);
+      // Fall through to server cascade as a backstop.
+    } else {
+      // Identification persisted; skip the server cascade for this observation.
+      triggerEnvEnrichment(record.id).catch(err => console.warn('[rastrum] enrich failed', err));
+      return;
+    }
+  }
+
+  // 5. No client identification (or persistence failed) — queue the server cascade.
   const existingQueue = await db.idQueue.get(record.id);
   if (!existingQueue) {
     await db.idQueue.put({
@@ -181,8 +207,8 @@ async function syncOne(record: ObservationRecord): Promise<void> {
     });
   }
 
-  // 5. Trigger the identify Edge Function async (fire-and-forget; the queue
-  //    catches retries). The function does its own DB writes.
+  // 5b. Trigger the identify Edge Function async (fire-and-forget; the queue
+  //     catches retries). The function does its own DB writes.
   triggerIdentify(record.id).catch(err => console.warn('[rastrum] identify failed', err));
 
   // 6. Trigger environmental enrichment (lunar / weather). Also fire-and-forget.


### PR DESCRIPTION
## Summary
Fixes the BirdNET / audio-observation bugs the user surfaced:

### 1. Confidence card showed >100% (e.g. \"189%\")
BirdNET-Lite v2.4 emits raw logits, not probabilities. Apply \`sigmoid()\` before returning so the value lands in \`[0,1]\`. Also satisfies the \`identifications.confidence CHECK BETWEEN 0 AND 1\` schema constraint that would have rejected fix #2's insert.

### 2. Saved observations rendered as \"Unknown species\"
\`syncOne()\` was discarding the client's accepted identification and queueing the server-side cascade — but the cascade has no audio identifier (BirdNET is client-only), so \`public.identifications\` stayed empty forever. Now: when a client identification is present and accepted, persist it directly to \`public.identifications\` (\`is_primary: true\`) and skip the cascade. Server cascade still runs as backstop on persist failure.

### 3. Share page showed broken-image card instead of audio player
When \`MediaRecorder\` produces a Blob with empty \`type\` (notably iOS Safari), the save code's \`pf.file.type || 'application/octet-stream'\` yielded the generic MIME, and \`sync.ts\`'s prefix chain defaulted \`media_files.media_type\` to \`'photo'\`. The share page then rendered the audio URL as \`<img src>\` (broken icon) and the audio player div stayed hidden. Backfill MIME from \`pf.kind\` when \`pf.file.type\` is empty.

### 4. Schema source enum was missing 9 sources
Extends \`identifications.source\` CHECK from the original 5 server-cascade values to cover all real producers:
- **Server cascade** (kept): \`plantnet\`, \`claude_haiku\`, \`claude_sonnet\`, \`onnx_offline\`, \`human\`
- **Client-side identifiers**: \`birdnet_lite\`, \`onnx_efficientnet_lite0\`, \`camera_trap_megadetector\`, \`phi_vision\`
- **M32 multi-provider vision**: \`bedrock\`, \`openai\`, \`azure_openai\`, \`gemini\`, \`vertex_ai\` (matches the literals hardcoded in \`vision-provider.ts\`)

Idempotent \`DROP CONSTRAINT IF EXISTS\` + \`ADD CONSTRAINT\` migration appended to \`schema.sql\`.

## Known follow-ups (not in this PR)
- Existing rows mis-classified as \`media_type='photo'\` need manual fix or re-upload — code change only prevents new occurrences
- \`AnthropicProvider\` in \`vision-provider.ts\` hardcodes \`'claude_haiku'\` as source regardless of model; should switch on \`this.cred.model\`. Worth a follow-up issue
- Per-media-file BirdNET segments (currently only one identification per observation)

## Test plan
- [x] All 730 unit tests pass + typecheck clean
- [ ] \`make db-apply\` succeeds against an existing DB (idempotent DROP+ADD)
- [ ] After deploy: record bird call → BirdNET shows confidence ≤ 100%
- [ ] After deploy: save audio observation → \`/share/obs/?id=…\` shows audio player + spectrogram, identified species (not \"Unknown\"), reachable BirdNET segments overlay
- [ ] M32 multi-provider identifications (Bedrock / OpenAI / Vertex etc.) successfully persist instead of failing the CHECK constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)