### PR TITLE
fix(i18n): cloud_forest → 'Bosque mesófilo de montaña' — CONABIO/SEMARNAT terminology

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -624,7 +624,7 @@
       "tropical_evergreen": "Selva alta perennifolia",
       "tropical_subevergreen": "Selva mediana subcaducifolia",
       "xerophytic": "Matorral xerófilo / cardonal",
-      "cloud_forest": "Bosque de niebla",
+      "cloud_forest": "Bosque mesófilo de montaña",
       "tropical_dry_forest": "Bosque tropical seco",
       "riparian": "Ribereño",
       "wetland": "Humedal",


### PR DESCRIPTION
## What

Updates the Spanish label for `cloud_forest` habitat type to use the official CONABIO/SEMARNAT terminology.

| Key | Before | After |
|---|---|---|
| `cloud_forest` (es) | Bosque de niebla | **Bosque mesófilo de montaña** |

## Why

Recommendation from Eugenio (ecologist/ornithologist, Oaxaca) during field testing, 2026-05-01.

'Bosque mesófilo de montaña' is the term used by:
- CONABIO vegetation classification
- SEMARNAT NOM-059 habitat descriptions  
- Most Mexican biology literature

'Bosque de niebla' and 'bosque nuboso' are used elsewhere but less precise for a Mexican-focused biodiversity app.

Partially closes #344