### PR TITLE
fix(identifiers): read source from Edge Function response (#332)

### DIFF
--- a/src/lib/identifiers/claude.ts
+++ b/src/lib/identifiers/claude.ts
@@ -93,7 +93,7 @@ export const claudeIdentifier: Identifier = {
       family: r.family ?? null,
       kingdom: (r.kingdom as IDResult['kingdom']) ?? 'Unknown',
       confidence: r.confidence ?? 0,
-      source: 'claude_haiku',
+      source: (r.source as IDResult['source']) ?? PLUGIN_ID,
       raw: r.raw,
     };
   },


### PR DESCRIPTION
Fixes #332 — AnthropicProvider hardcodes source as claude_haiku regardless of model.

## Change
The `identify()` return in `claude.ts` now reads `r.source` from the Edge Function response instead of hardcoding `'claude_haiku'`. Falls back to `PLUGIN_ID` when the server doesn't return a source field.

This means if the server-side identify function uses claude_sonnet or another model, the identification record correctly reflects which model produced the result.

## Testing
- `npm run typecheck` — zero errors
- `npm run test` — all tests pass