### PR TITLE
fix(sync): persist client identifications with needs_review status (#343)

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -177,8 +177,13 @@ async function syncOne(record: ObservationRecord): Promise<void> {
   //      EfficientNet on image), persist that identification directly. Audio
   //      has no server-side identifier in the cascade, so without this step
   //      the observation lands as "Unknown species" forever.
+  //
+  //      Fix #343: also persist identifications with status 'needs_review',
+  //      and accept pipeline results that have confidence > 0 even when
+  //      scientificName is still empty (partial results with common names).
   const clientId = obs.identification;
-  if (clientId.scientificName && clientId.status === 'accepted') {
+  const hasIdentification = clientId.scientificName || (clientId.confidence > 0 && clientId.source !== 'human');
+  if (hasIdentification && (clientId.status === 'accepted' || clientId.status === 'needs_review')) {
     const supabase = getSupabase();
     const { error: clientIdErr } = await supabase.from('identifications').insert({
       observation_id: record.id,
@@ -186,6 +191,11 @@ async function syncOne(record: ObservationRecord): Promise<void> {
       confidence: Math.max(0, Math.min(1, clientId.confidence ?? 0)),
       source: clientId.source ?? 'human',
       is_primary: true,
+      raw_response: {
+        common_name_en: clientId.commonNameEn,
+        common_name_es: clientId.commonNameEs,
+        client_persisted: true,
+      },
     });
     if (clientIdErr) {
       console.warn('[rastrum] client identification persist failed', clientIdErr);


### PR DESCRIPTION
Fixes #343 — AI identification and manual species name lost on sync.

## Root cause
The sync engine (step 4.5 in syncOne) only persisted client-side identifications when `clientId.scientificName && clientId.status === 'accepted'`. This dropped:
- Pipeline results marked `needs_review` (confidence below threshold)
- Identifications with confidence > 0 but empty scientificName (partial results)

## Fix
Broadened the persistence guard to accept identifications with either a scientific name or meaningful confidence data, with status `accepted` or `needs_review`. Common names are now included in `raw_response` for traceability.

## Testing
- `npm run typecheck` — zero errors
- `npm run test` — all tests pass