### PR TITLE
fix(local-ai): gate Phi Vision on device memory to prevent mobile crash (#338)

### DIFF
--- a/src/lib/identifiers/phi-vision.ts
+++ b/src/lib/identifiers/phi-vision.ts
@@ -25,8 +25,13 @@ export const phiVisionIdentifier: Identifier = {
     cost_per_id_usd: 0,
   },
   async isAvailable() {
-    if (typeof navigator === 'undefined' || !('gpu' in navigator)) {
-      return { ready: false, reason: 'unsupported', message: 'WebGPU not available.' };
+    const { localAISupported } = await import('../local-ai');
+    if (!localAISupported()) {
+      const mem = typeof navigator !== 'undefined' ? (navigator as Navigator & { deviceMemory?: number }).deviceMemory : undefined;
+      if (typeof mem === 'number' && mem <= 4) {
+        return { ready: false, reason: 'insufficient_memory', message: `Device has ~${mem} GB RAM — Phi Vision needs ≥6 GB` };
+      }
+      return { ready: false, reason: 'unsupported', message: 'WebGPU not available' };
     }
     const { getModelCacheStatus, VISION_MODEL_ID } = await import('../local-ai');
     const status = await getModelCacheStatus(VISION_MODEL_ID);

--- a/src/lib/identifiers/types.ts
+++ b/src/lib/identifiers/types.ts
@@ -91,7 +91,7 @@ export interface IdentifierCapabilities {
 /** Per-plugin status surfaced to the UI. */
 export type IdentifierAvailability =
   | { ready: true }
-  | { ready: false; reason: 'needs_key' | 'needs_download' | 'unsupported' | 'model_not_bundled' | 'disabled'; message?: string };
+  | { ready: false; reason: 'needs_key' | 'needs_download' | 'unsupported' | 'insufficient_memory' | 'model_not_bundled' | 'disabled'; message?: string };
 
 /** Context passed to identify(). All fields optional. */
 export interface IdentifyInput {

--- a/src/lib/local-ai.ts
+++ b/src/lib/local-ai.ts
@@ -45,12 +45,21 @@ let createEngine: typeof CreateMLCEngineFn | null = null;
 
 /**
  * Returns true when WebLLM can probably run on this device.
- * Hard requirement: WebGPU. Soft requirement: ≥4 GB RAM (we can't reliably
- * detect free VRAM, so we rely on the user to opt in informedly).
+ * Hard requirement: WebGPU. Soft requirement: ≥6 GB device memory.
+ * Mobile devices with ≤4 GB RAM will crash when loading the ~4 GB
+ * Phi-3.5-vision model, so we gate on navigator.deviceMemory when
+ * available (Chrome/Edge expose it; Safari/Firefox don't — for those
+ * we fall through and rely on the download warning).
  */
 export function localAISupported(): boolean {
   if (typeof navigator === 'undefined') return false;
-  return 'gpu' in navigator && typeof (navigator as Navigator & { gpu?: unknown }).gpu !== 'undefined';
+  const hasGpu = 'gpu' in navigator && typeof (navigator as Navigator & { gpu?: unknown }).gpu !== 'undefined';
+  if (!hasGpu) return false;
+  // navigator.deviceMemory is approximate (0.25, 0.5, 1, 2, 4, 8 GiB).
+  // Phi-3.5-vision needs ~4 GB VRAM + overhead; reject devices reporting ≤4 GB.
+  const mem = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+  if (typeof mem === 'number' && mem <= 4) return false;
+  return true;
 }
 
 async function ensureCreator() {


### PR DESCRIPTION
Fixes #338 — local Phi Vision model crashes browser/device on mobile.

## Root cause
`localAISupported()` only checked for WebGPU presence, not device memory. Mobile devices with WebGPU support but ≤4 GB RAM would attempt to load the ~4 GB Phi-3.5-vision model, exhausting memory and crashing the browser.

## Fix
- `localAISupported()` now checks `navigator.deviceMemory` and rejects devices with ≤4 GB RAM
- `phi-vision.ts` `isAvailable()` returns a specific `insufficient_memory` reason with detected RAM
- Added `'insufficient_memory'` to the `IdentifierAvailability` reason union in `types.ts`
- Browsers that don't expose `deviceMemory` (Safari, Firefox) fall through to the existing download warning

## Testing
- `npm run typecheck` — zero errors
- `npm run test` — all 730 tests pass