### PR TITLE
fix(map): attempt geolocation when map picker opens without coordinates (#341)

### DIFF
--- a/src/components/MapPicker.astro
+++ b/src/components/MapPicker.astro
@@ -258,6 +258,23 @@ const initialLng  = initialCoords?.lng ?? '';
             state.satToggle.classList.toggle('border-emerald-500', state.isSatellite);
           }
         });
+
+        // If no initial coordinates were provided, attempt geolocation to center
+        // the map on the user's actual position instead of the CDMX default.
+        if (!haveInitial && navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(
+            (pos) => {
+              const { latitude: lat, longitude: lng } = pos.coords;
+              if (state.map && isValidLatLng(lat, lng)) {
+                state.map.flyTo({ center: [lng, lat], zoom: 13 });
+                state.marker?.setLngLat([lng, lat]);
+                setSelected(state, lat, lng);
+              }
+            },
+            () => { /* geolocation denied or timed out — keep the default view */ },
+            { enableHighAccuracy: true, timeout: 8000 },
+          );
+        }
       } catch {
         setStatus(state, state.isEs
           ? 'No se pudo cargar el mapa. Usa la entrada manual.'

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -731,8 +731,11 @@ function startGPS() {
         if (locNode) setNodeState(pipelineState, locNode.id, 'done');
       }
     },
-    () => {
-      if (gpsStatus) gpsStatus.textContent = isEs ? 'No se pudo obtener ubicación' : 'Could not get location';
+    (err) => {
+      const msg = err.code === 1
+        ? (isEs ? 'Permiso de ubicación denegado' : 'Location permission denied')
+        : (isEs ? 'No se pudo obtener ubicación — usa el mapa para elegir' : 'Could not get location — use the map to pick one');
+      if (gpsStatus) gpsStatus.textContent = msg;
     },
     { enableHighAccuracy: true, timeout: 20000 },
   );


### PR DESCRIPTION
Fixes #341 — default location shows CDMX instead of current GPS position.

## Root cause
The MapPicker used `MEXICO_DEFAULT_CENTER` (CDMX: 19.4, -99.1) as fallback when no initial coordinates were provided, without attempting geolocation. Observations from Oaxaca were being recorded with CDMX coordinates.

## Fix
- MapPicker now calls `navigator.geolocation.getCurrentPosition()` when opening without initial coords, flying to the user's position if available
- ObserveView2's GPS error callback now distinguishes permission denial from timeout and nudges the user to pick manually

## Testing
- `npm run typecheck` — zero errors
- `npm run test` — all tests pass