### PR TITLE
feat(observe): add content sensitivity flag for graphic photos (#349)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -241,6 +241,9 @@ CREATE TABLE IF NOT EXISTS public.observations (
                         CHECK (evidence_type IN
                           ('direct_sighting','track','scat','burrow','nest','feather','bone','sound','camera_trap')),
 
+  -- Content sensitivity (v1.1+): blur/gate graphic photos (dead animals, predation, wounds)
+  content_sensitive  boolean NOT NULL DEFAULT false,
+
   -- Environmental enrichment (auto-filled)
   moon_phase            text,
   moon_illumination     numeric CHECK (moon_illumination BETWEEN 0 AND 1),
@@ -280,6 +283,9 @@ CREATE INDEX IF NOT EXISTS idx_obs_sync ON observations(sync_status) WHERE sync_
 CREATE INDEX IF NOT EXISTS idx_obs_primary_taxon ON observations(primary_taxon_id);
 CREATE INDEX IF NOT EXISTS idx_obs_public ON observations(sync_status, obscure_level)
   WHERE sync_status = 'synced';
+
+-- Idempotent column add for existing databases (v1.1+)
+ALTER TABLE public.observations ADD COLUMN IF NOT EXISTS content_sensitive boolean NOT NULL DEFAULT false;
 
 -- ============================================================
 -- IDENTIFICATIONS

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -201,6 +201,18 @@ const weathers = WEATHERS;
             {weathers.map(w => <option value={w}>{w}</option>)}
           </select>
         </div>
+        <!-- Content sensitivity -->
+        <div class="flex items-start gap-3">
+          <input id="obs2-sensitive" type="checkbox" class="mt-1 rounded border-zinc-300 dark:border-zinc-700 text-emerald-600 focus:ring-emerald-500" />
+          <div>
+            <label for="obs2-sensitive" class="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              {observeStr.content_sensitive_label ?? (isEs ? "Contiene contenido gráfico" : "Contains graphic content")}
+            </label>
+            <p class="text-xs text-zinc-400 dark:text-zinc-500">
+              {observeStr.content_sensitive_hint ?? (isEs ? "Fotos se difuminarán para otros usuarios" : "Photos will be blurred for other users")}
+            </p>
+          </div>
+        </div>
       </div>
     </details>
 
@@ -803,6 +815,7 @@ postForm?.addEventListener('submit', async (e) => {
     const notes = (document.getElementById('obs2-notes') as HTMLTextAreaElement | null)?.value.trim() || null;
     const habitatVal = (document.getElementById('obs2-habitat') as HTMLSelectElement | null)?.value || null;
     const weatherVal = (document.getElementById('obs2-weather') as HTMLSelectElement | null)?.value || null;
+    const sensitiveVal = (document.getElementById('obs2-sensitive') as HTMLInputElement | null)?.checked ?? false;
     const taxonInput = (document.getElementById('obs2-taxon-input') as HTMLInputElement | null)?.value.trim();
 
     // MediaRecorder-produced Blobs sometimes have an empty `type` (notably
@@ -839,6 +852,7 @@ postForm?.addEventListener('submit', async (e) => {
       habitat: habitatVal as never,
       weather: weatherVal as never,
       notes,
+      contentSensitive: sensitiveVal,
     });
 
     await syncOutbox().catch(() => {});

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -645,6 +645,8 @@
     "crop_rotate_right": "Rotate right",
     "crop_reset": "Reset",
     "crop_drag_hint": "Drag the corners to resize. Drag inside to move.",
+    "content_sensitive_label": "Contains graphic content",
+    "content_sensitive_hint": "Check if this observation shows dead animals, predation, wounds, or other potentially disturbing content. Photos will be blurred by default for other users.",
     "ban_banner_message": "Your account is suspended until {date}. Reason: {reason}.",
     "ban_banner_message_permanent": "Your account is permanently suspended. Reason: {reason}.",
     "ban_banner_appeal": "Appeal",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -645,6 +645,8 @@
     "crop_rotate_right": "Rotar a la derecha",
     "crop_reset": "Restablecer",
     "crop_drag_hint": "Arrastra las esquinas para redimensionar. Arrastra dentro para mover.",
+    "content_sensitive_label": "Contiene contenido gráfico",
+    "content_sensitive_hint": "Marca si esta observación muestra animales muertos, depredación, heridas u otro contenido potencialmente perturbador. Las fotos se difuminarán por defecto para otros usuarios.",
     "ban_banner_message": "Tu cuenta está suspendida hasta {date}. Razón: {reason}.",
     "ban_banner_message_permanent": "Tu cuenta está suspendida indefinidamente. Razón: {reason}.",
     "ban_banner_appeal": "Apelar",

--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -44,6 +44,7 @@ export interface ObservationDraft {
   weather?: WeatherTag | null;
   evidenceType?: EvidenceType;
   notes?: string | null;
+  contentSensitive?: boolean;
   appVersion?: string;
   deviceOs?: string | null;
   /**
@@ -85,6 +86,7 @@ export function buildObservation(draft: ObservationDraft): Observation {
     habitat:       draft.habitat       ?? null,
     weather:       draft.weather       ?? null,
     evidenceType:  draft.evidenceType  ?? 'direct_sighting',
+    contentSensitive: draft.contentSensitive ?? false,
     notes:         draft.notes         ?? null,
     moonPhase: null,
     moonIllumination: null,

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -107,6 +107,7 @@ async function syncOne(record: ObservationRecord): Promise<void> {
     habitat:         obs.habitat,
     weather:         obs.weather,
     evidence_type:   obs.evidenceType ?? 'direct_sighting',
+    content_sensitive: obs.contentSensitive ?? false,
     notes:           obs.notes,
     sync_status:     'synced' as const,
     app_version:     obs.appVersion,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,6 +91,7 @@ export interface Observation {
   habitat: HabitatType | null;
   weather: WeatherTag | null;
   evidenceType: EvidenceType;
+  contentSensitive: boolean;
   notes: string | null;
 
   // Env enrichment, filled post-submission (v1.0+)


### PR DESCRIPTION
Closes #349 — content sensitivity flag for blurring/gating graphic photos.

## Changes
- **Schema**: `content_sensitive` boolean column on `observations` (idempotent, defaults false)
- **Types**: `contentSensitive` field on `Observation` interface
- **Sync**: forwards the flag to the server row during sync
- **Form**: checkbox in ObserveView2 advanced fields (EN/ES)
- **i18n**: bilingual labels and hints

The blur/gate rendering in observation display components is a follow-up — this PR adds the data layer and input UI.

## Testing
- `npm run typecheck` — zero errors
- `npm run test` — all tests pass
- `npm run build` — builds successfully