### PR TITLE
feat(byo-keys): add multi-provider key management helpers (#331)

### DIFF
--- a/src/lib/byo-keys.ts
+++ b/src/lib/byo-keys.ts
@@ -99,3 +99,48 @@ export function clearAllKeys(): void {
 export function hasKeysForPlugin(pluginId: string): boolean {
   return Object.keys(getAllKeysForPlugin(pluginId)).length > 0;
 }
+
+/** List all plugin IDs that have at least one key configured. */
+export function listConfiguredPluginIds(): string[] {
+  const m = readMap();
+  const pluginIds = new Set<string>();
+  for (const key of Object.keys(m)) {
+    const dot = key.indexOf('.');
+    if (dot > 0 && m[key]?.trim()) pluginIds.add(key.slice(0, dot));
+  }
+  return [...pluginIds];
+}
+
+/**
+ * Summary of all configured BYO keys for the profile AI settings page.
+ * Returns an array of { pluginId, keyCount, keyNames } for each plugin
+ * that has at least one key set.
+ */
+export function getKeysSummary(): Array<{ pluginId: string; keyCount: number; keyNames: string[] }> {
+  const m = readMap();
+  const byPlugin = new Map<string, string[]>();
+  for (const [fullKey, value] of Object.entries(m)) {
+    if (!value?.trim()) continue;
+    const dot = fullKey.indexOf('.');
+    if (dot <= 0) continue;
+    const pluginId = fullKey.slice(0, dot);
+    const keyName = fullKey.slice(dot + 1);
+    if (!byPlugin.has(pluginId)) byPlugin.set(pluginId, []);
+    byPlugin.get(pluginId)!.push(keyName);
+  }
+  return [...byPlugin.entries()].map(([pluginId, keyNames]) => ({
+    pluginId,
+    keyCount: keyNames.length,
+    keyNames,
+  }));
+}
+
+/** Remove all keys for a specific plugin. */
+export function clearAllKeysForPlugin(pluginId: string): void {
+  const m = readMap();
+  const prefix = pluginId + '.';
+  for (const key of Object.keys(m)) {
+    if (key.startsWith(prefix)) delete m[key];
+  }
+  writeMap(m);
+}

--- a/tests/lib/byo-keys-multi.test.ts
+++ b/tests/lib/byo-keys-multi.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Map-backed localStorage shim for Node (vitest runs in Node, not browser)
+const store = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+    get length() { return store.size; },
+    key: (i: number) => [...store.keys()][i] ?? null,
+  },
+  writable: true,
+  configurable: true,
+});
+
+import {
+  setKey, getKey, clearKey,
+  listConfiguredPluginIds, getKeysSummary, clearAllKeysForPlugin,
+} from '../../src/lib/byo-keys';
+
+describe('byo-keys multi-provider helpers', () => {
+  beforeEach(() => store.clear());
+
+  it('listConfiguredPluginIds returns unique plugin IDs', () => {
+    setKey('claude_haiku', 'anthropic', 'sk-ant-test');
+    setKey('plantnet', 'plantnet', '2b10-test');
+    expect(listConfiguredPluginIds().sort()).toEqual(['claude_haiku', 'plantnet']);
+  });
+
+  it('getKeysSummary returns per-plugin breakdown', () => {
+    setKey('claude_haiku', 'anthropic', 'sk-ant-test');
+    setKey('plantnet', 'plantnet', '2b10-test');
+    const summary = getKeysSummary();
+    expect(summary).toHaveLength(2);
+    const claude = summary.find(s => s.pluginId === 'claude_haiku');
+    expect(claude?.keyCount).toBe(1);
+    expect(claude?.keyNames).toEqual(['anthropic']);
+  });
+
+  it('clearAllKeysForPlugin removes all keys for a plugin', () => {
+    setKey('claude_haiku', 'anthropic', 'sk-ant-test');
+    setKey('plantnet', 'plantnet', '2b10-test');
+    clearAllKeysForPlugin('claude_haiku');
+    expect(getKey('claude_haiku', 'anthropic')).toBeUndefined();
+    expect(getKey('plantnet', 'plantnet')).toBe('2b10-test');
+  });
+
+  it('listConfiguredPluginIds ignores empty values', () => {
+    setKey('claude_haiku', 'anthropic', 'sk-ant-test');
+    setKey('claude_haiku', 'anthropic', '');
+    expect(listConfiguredPluginIds()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #331 — personal multi-provider keys parity with Sponsors UI.

## Changes
New helpers in `byo-keys.ts`:
- `listConfiguredPluginIds()`: returns all plugin IDs with at least one key set
- `getKeysSummary()`: per-plugin breakdown (pluginId, keyCount, keyNames)
- `clearAllKeysForPlugin()`: remove all keys for a specific plugin

## Testing
- New test file: `tests/lib/byo-keys-multi.test.ts`
- `npm run typecheck` — zero errors
- `npm run test` — all tests pass