### PR TITLE
feat(docs): add /docs/changelog/ page with version history (#253)

### DIFF
--- a/src/components/ChangelogView.astro
+++ b/src/components/ChangelogView.astro
@@ -1,0 +1,120 @@
+---
+import { t } from '../i18n/utils';
+
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+
+interface ChangelogEntry {
+  version: string;
+  date: string;
+  highlights: string[];
+  prs: Array<{ number: number; title: string }>;
+}
+
+const changelog: ChangelogEntry[] = [
+  {
+    version: '1.0.1',
+    date: '2026-05-01',
+    highlights: isEs
+      ? [
+          'Fix: magic link loop en PWA resuelto (PKCE + guard de ejecución)',
+          'Fix: sync ahora persiste identificaciones con status needs_review',
+          'Fix: detección de tipo de media mejorada para MIME vacíos',
+          'Fix: override de especie funciona offline (guarda en Dexie)',
+          'Fix: mapa intenta geolocalización al abrir sin coordenadas',
+          'Fix: Phi Vision bloqueado en dispositivos con ≤4 GB RAM',
+          'Fix: Claude plugin lee source del Edge Function',
+          'Nuevo: capa de sinónimos taxonómicos (Aratinga → Psittacara)',
+          'Nuevo: flag de sensibilidad de contenido para fotos gráficas',
+          'Docs: referencias taxonómicas oficiales para México',
+        ]
+      : [
+          'Fix: magic link loop on PWA resolved (PKCE + execution guard)',
+          'Fix: sync now persists identifications with needs_review status',
+          'Fix: improved media type detection for empty MIME types',
+          'Fix: species override works offline (saves to Dexie)',
+          'Fix: map attempts geolocation when opening without coordinates',
+          'Fix: Phi Vision blocked on devices with ≤4 GB RAM',
+          'Fix: Claude plugin reads source from Edge Function',
+          'New: taxonomy synonym correction layer (Aratinga → Psittacara)',
+          'New: content sensitivity flag for graphic photos',
+          'Docs: official taxonomy references for Mexico',
+        ],
+    prs: [
+      { number: 350, title: 'fix(auth): resolve magic link loop on PWA callback' },
+      { number: 353, title: 'fix(sync): persist client identifications with needs_review status' },
+      { number: 357, title: 'fix(sync): improve media type detection for empty MIME types' },
+      { number: 361, title: 'fix(manage-panel): save species override to Dexie when offline' },
+      { number: 355, title: 'fix(map): attempt geolocation when map picker opens' },
+      { number: 354, title: 'fix(local-ai): gate Phi Vision on device memory' },
+      { number: 352, title: 'fix(identifiers): read source from Edge Function response' },
+      { number: 358, title: 'fix(taxonomy): add synonym correction for outdated species names' },
+      { number: 359, title: 'feat(observe): add content sensitivity flag' },
+      { number: 360, title: 'docs(taxonomy): establish official taxonomy references' },
+    ],
+  },
+  {
+    version: '1.0.0',
+    date: '2026-04-26',
+    highlights: isEs
+      ? [
+          'Lanzamiento público de Rastrum',
+          'PWA offline-first con identificación de especies por IA',
+          'Soporte bilingüe EN/ES completo',
+          'Integración con PlantNet, Claude, BirdNET, Phi Vision',
+          'Exportación Darwin Core para GBIF',
+          'Consola de administración con 28 tabs',
+        ]
+      : [
+          'Public launch of Rastrum',
+          'Offline-first PWA with AI species identification',
+          'Full bilingual EN/ES support',
+          'Integration with PlantNet, Claude, BirdNET, Phi Vision',
+          'Darwin Core export for GBIF',
+          'Admin console with 28 tabs',
+        ],
+    prs: [],
+  },
+];
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h1>{isEs ? 'Registro de cambios' : 'Changelog'}</h1>
+  <p class="text-zinc-600 dark:text-zinc-400">
+    {isEs
+      ? 'Historial de versiones y cambios significativos en Rastrum.'
+      : 'Version history and significant changes in Rastrum.'}
+  </p>
+
+  {changelog.map(entry => (
+    <section class="mt-8">
+      <h2 class="flex items-center gap-3">
+        <span class="text-emerald-700 dark:text-emerald-400">v{entry.version}</span>
+        <span class="text-sm font-normal text-zinc-500">{entry.date}</span>
+      </h2>
+      <ul>
+        {entry.highlights.map(h => <li>{h}</li>)}
+      </ul>
+      {entry.prs.length > 0 && (
+        <details class="mt-2">
+          <summary class="text-sm text-zinc-500 cursor-pointer">
+            {isEs ? `${entry.prs.length} pull requests` : `${entry.prs.length} pull requests`}
+          </summary>
+          <ul class="text-sm mt-1">
+            {entry.prs.map(pr => (
+              <li>
+                <a href={`https://github.com/ArtemioPadilla/rastrum/pull/${pr.number}`}
+                   class="text-emerald-700 dark:text-emerald-400 no-underline hover:underline"
+                   target="_blank" rel="noopener">
+                  #{pr.number}
+                </a>
+                {' '}{pr.title}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </section>
+  ))}
+</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1432,7 +1432,8 @@
       "terms": "Terms of Use",
       "console": "Console",
       "sponsorships": "AI Sponsorships",
-      "mcp": "MCP Server"
+      "mcp": "MCP Server",
+      "changelog": "Changelog"
     },
     "descriptions": {
       "vision": "Mission, problem statement, and why Oaxaca is the right place to start.",
@@ -1449,7 +1450,8 @@
       "terms": "Acceptable use, per-observation licensing, and how we handle account suspensions.",
       "console": "Privileged-actions surface for admin, moderator, and expert roles. Role model, audit log, and per-action runbooks.",
       "sponsorships": "Share your Anthropic credential with friends, capped per month and audited.",
-      "mcp": "Connect AI agents — Claude Desktop, Cursor, OpenClaw, and any MCP-compatible client — directly to your Rastrum data using the Model Context Protocol."
+      "mcp": "Connect AI agents — Claude Desktop, Cursor, OpenClaw, and any MCP-compatible client — directly to your Rastrum data using the Model Context Protocol.",
+      "changelog": "Version history and significant changes in Rastrum."
     },
     "status": {
       "current": "Active",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1432,7 +1432,8 @@
       "terms": "Términos de uso",
       "console": "Consola",
       "sponsorships": "Patrocinios IA",
-      "mcp": "Servidor MCP"
+      "mcp": "Servidor MCP",
+      "changelog": "Registro de cambios"
     },
     "descriptions": {
       "vision": "Misión, problema y por qué Oaxaca es el lugar correcto para comenzar.",
@@ -1449,7 +1450,8 @@
       "terms": "Uso aceptable, licencias por observación y cómo manejamos suspensiones de cuenta.",
       "console": "Superficie de acciones privilegiadas para roles de admin, moderador y experto. Modelo de roles, auditoría y runbooks por acción.",
       "sponsorships": "Comparte tu credencial Anthropic con amigos, con límite mensual y auditoría.",
-      "mcp": "Conecta agentes de IA — Claude Desktop, Cursor, OpenClaw y cualquier cliente MCP — directamente a tus datos de Rastrum usando el Model Context Protocol."
+      "mcp": "Conecta agentes de IA — Claude Desktop, Cursor, OpenClaw y cualquier cliente MCP — directamente a tus datos de Rastrum usando el Model Context Protocol.",
+      "changelog": "Historial de versiones y cambios significativos en Rastrum."
     },
     "status": {
       "current": "Activo",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -119,6 +119,7 @@ export const docPages = [
   'vision', 'features', 'roadmap', 'tasks', 'market',
   'architecture', 'indigenous', 'funding', 'contribute',
   'faq', 'privacy', 'terms', 'console', 'sponsorships', 'mcp',
+  'changelog',
 ] as const;
 
 export type DocPage = (typeof docPages)[number];
@@ -311,6 +312,10 @@ export const docPageMeta = {
   mcp: {
     en: "Connect AI agents to Rastrum via the Model Context Protocol. Setup guide for Claude Desktop, Cursor, OpenClaw, and the Claude Code CLI.",
     es: "Conecta agentes de IA a Rastrum mediante el Model Context Protocol. Guía de configuración para Claude Desktop, Cursor, OpenClaw y Claude Code CLI.",
+  },
+  changelog: {
+    en: "Version history and significant changes in Rastrum. What shipped per version, with PR links and summaries.",
+    es: "Historial de versiones y cambios significativos en Rastrum. Lo que se entregó por versión, con enlaces a PRs y resúmenes.",
   },
 } as const satisfies Record<DocPage, { en: string; es: string }>;
 

--- a/src/pages/en/docs/changelog.astro
+++ b/src/pages/en/docs/changelog.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import ChangelogView from '../../../components/ChangelogView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+---
+
+<DocLayout title="Changelog" lang={lang} section="changelog" editPath="src/pages/en/docs/changelog.astro">
+  <ChangelogView lang={lang} />
+</DocLayout>

--- a/src/pages/es/docs/changelog.astro
+++ b/src/pages/es/docs/changelog.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import ChangelogView from '../../../components/ChangelogView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+---
+
+<DocLayout title="Registro de cambios" lang={lang} section="changelog" editPath="src/pages/es/docs/changelog.astro">
+  <ChangelogView lang={lang} />
+</DocLayout>


### PR DESCRIPTION
Closes #253 — /docs/changelog/ page with PR links and summaries.

## Changes
- New `ChangelogView.astro` component with bilingual changelog data
- Paired EN/ES pages at `/en/docs/changelog/` and `/es/docs/changelog/`
- Added to `docPages` in `utils.ts` and i18n keys in both language files

## Testing
- `npm run typecheck` — zero errors
- `npm run build` — both pages render
- `npm run test` — all tests pass