### PR TITLE
feat(chrome): surface /docs/sponsorships/ in Docs MegaMenu (#221)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -117,9 +117,10 @@ const docColumns = [
   {
     heading: tr.nav.docs_groups.community,
     items: [
-      { key: 'indigenous', label: tr.nav.docs_groups.community_items.indigenous },
-      { key: 'funding',    label: tr.nav.docs_groups.community_items.funding },
-      { key: 'contribute', label: tr.nav.docs_groups.community_items.contribute },
+      { key: 'indigenous',    label: tr.nav.docs_groups.community_items.indigenous },
+      { key: 'funding',       label: tr.nav.docs_groups.community_items.funding },
+      { key: 'contribute',    label: tr.nav.docs_groups.community_items.contribute },
+      { key: 'sponsorships',  label: tr.nav.docs_groups.community_items.sponsorships },
     ],
   },
 ];

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -48,7 +48,8 @@
       "community_items": {
         "indigenous": "Indigenous",
         "funding": "Funding",
-        "contribute": "Contribute"
+        "contribute": "Contribute",
+        "sponsorships": "Sponsorships"
       }
     },
     "drawer": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -48,7 +48,8 @@
       "community_items": {
         "indigenous": "Lenguas indígenas",
         "funding": "Financiamiento",
-        "contribute": "Contribuir"
+        "contribute": "Contribuir",
+        "sponsorships": "Patrocinios"
       }
     },
     "drawer": {


### PR DESCRIPTION
Closes #221 — adds sponsorships link to the desktop Docs dropdown menu.