### PR TITLE
feat(console): add shared bulk-selection helpers for entity browsers (#248)

### DIFF
--- a/src/lib/console-bulk.ts
+++ b/src/lib/console-bulk.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared bulk-selection helpers for console entity browsers.
+ * Each browser instantiates its own BulkState; the helpers manage
+ * the checkbox UI and provide the selected IDs for bulk actions.
+ */
+
+export interface BulkState {
+  selected: Set<string>;
+  allIds: string[];
+}
+
+export function createBulkState(): BulkState {
+  return { selected: new Set(), allIds: [] };
+}
+
+export function toggleOne(state: BulkState, id: string): void {
+  if (state.selected.has(id)) state.selected.delete(id);
+  else state.selected.add(id);
+}
+
+export function toggleAll(state: BulkState): void {
+  if (state.selected.size === state.allIds.length) {
+    state.selected.clear();
+  } else {
+    state.allIds.forEach(id => state.selected.add(id));
+  }
+}
+
+export function isAllSelected(state: BulkState): boolean {
+  return state.allIds.length > 0 && state.selected.size === state.allIds.length;
+}
+
+export function selectedCount(state: BulkState): number {
+  return state.selected.size;
+}
+
+export function getSelectedIds(state: BulkState): string[] {
+  return [...state.selected];
+}
+
+export function clearSelection(state: BulkState): void {
+  state.selected.clear();
+}
+
+export function updateAllIds(state: BulkState, ids: string[]): void {
+  state.allIds = ids;
+  // Remove any selected IDs that are no longer in the list
+  for (const id of state.selected) {
+    if (!ids.includes(id)) state.selected.delete(id);
+  }
+}

--- a/tests/lib/console-bulk.test.ts
+++ b/tests/lib/console-bulk.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createBulkState, toggleOne, toggleAll, isAllSelected,
+  selectedCount, getSelectedIds, clearSelection, updateAllIds,
+} from '../../src/lib/console-bulk';
+
+describe('console-bulk', () => {
+  it('toggleOne adds and removes IDs', () => {
+    const state = createBulkState();
+    state.allIds = ['a', 'b', 'c'];
+    toggleOne(state, 'a');
+    expect(selectedCount(state)).toBe(1);
+    toggleOne(state, 'a');
+    expect(selectedCount(state)).toBe(0);
+  });
+
+  it('toggleAll selects all then deselects all', () => {
+    const state = createBulkState();
+    state.allIds = ['a', 'b', 'c'];
+    toggleAll(state);
+    expect(isAllSelected(state)).toBe(true);
+    expect(getSelectedIds(state).sort()).toEqual(['a', 'b', 'c']);
+    toggleAll(state);
+    expect(selectedCount(state)).toBe(0);
+  });
+
+  it('updateAllIds prunes stale selections', () => {
+    const state = createBulkState();
+    state.allIds = ['a', 'b', 'c'];
+    toggleAll(state);
+    updateAllIds(state, ['b', 'c', 'd']);
+    expect(getSelectedIds(state).sort()).toEqual(['b', 'c']);
+  });
+
+  it('clearSelection empties the set', () => {
+    const state = createBulkState();
+    state.allIds = ['a', 'b'];
+    toggleAll(state);
+    clearSelection(state);
+    expect(selectedCount(state)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #248 — bulk operations across entity browsers.

## Changes
New `src/lib/console-bulk.ts` with shared bulk-selection state management. Entity browsers can import `createBulkState()`, `toggleOne()`, `toggleAll()`, etc. to add select-all checkboxes and bulk action buttons.

Includes unit tests.

## Testing
- `npm run typecheck` — zero errors
- `npm run test` — all tests pass