### PR TITLE
docs(architecture): update cascade diagram to show parallel race (#169)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,8 @@ src/lib/sync.ts → syncOutbox()
     │ (c) fire-and-forget identify + enrich-environment
     ▼
 identify Edge Function (cascade.ts)
-    │ PlantNet → Claude Haiku → on-device fallbacks
+    │ parallel race: PlantNet ∥ Claude Haiku ∥ on-device
+    │ first past confidence threshold wins
     ▼
 sync_primary_id_trigger (Postgres)
     │ denormalises obscure_level + location_obscured for RLS
@@ -113,28 +114,33 @@ The identification pipeline runs differently depending on where it's triggered. 
 
 **Client-side (Identify page — `/en/identify/`):** PlantNet, Claude, and Phi-vision fire in parallel. The first provider to return a result above its confidence threshold wins and cancels the others. If all fail, Phi-vision prompts the user to opt in to the local model download.
 
-**Server-side (sync.ts → `identify` Edge Function):** the classic serial waterfall via `cascade.ts`:
+**Server-side (sync.ts → `identify` Edge Function):** the same parallel race via `cascade.ts`. Available providers are sorted by license cost and fired concurrently; the first result above the accept threshold wins:
 
 ```
-PlantNet API (cloud, when key present)
-  ├─ score ≥ 0.7 → write identification, done
-  └─ score < 0.7 → fallthrough
-      Claude Haiku 4.5 (cloud, server key or BYO)
-        ├─ confidence ≥ 0.4 → write, done
-        └─ confidence < 0.4 → fallthrough
-            EfficientNet-Lite0 ONNX (in-browser, base classifier)
-              └─ Phi-3.5-vision (in-browser, last resort, capped at 0.35)
+runCascade() — parallel race, cost-sorted
+  ┌─────────────────────────────────────────────────────┐
+  │  PlantNet API        (free-quota · cloud)           │
+  │  Claude Haiku 4.5    (byo-key · cloud)              │  run concurrently
+  │  EfficientNet-Lite0  (free-nc · on-device ONNX)     │  via Promise.race
+  │  Phi-3.5-vision      (free-nc · on-device WebLLM)   │
+  └──────────────────────────┬──────────────────────────┘
+                             │
+                  first confidence ≥ 0.7 wins
+                  others cancelled (AbortController)
+                             │
+                  if none above threshold →
+                  best-of-all returned (needs_review)
 ```
 
-The serial cascade is deterministic by license cost: cloud first when keys are
-present, on-device when they aren't. The `force_provider` knob bypasses
-the waterfall for testing. All confidence < 0.4 results are blocked
+The cascade is deterministic by license cost: free plugins go first; BYO-key
+plugins run when keys are present. The `force_provider` knob bypasses
+the race for testing. All confidence < 0.4 results are blocked
 from research-grade by the `enforce_research_grade_quality` trigger.
 
 When offline at submit time, the outbox holds the row plus the binary;
 the cascade is deferred. On `online` event or `visibilitychange` returning
 to visible, `registerSyncTriggers()` runs `syncOutbox()`, which fires the
-server-side waterfall via the `identify` Edge Function.
+server-side cascade via the `identify` Edge Function.
 
 ### 3. Audio identification (BirdNET)
 

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -413,7 +413,7 @@
           "id": "arch-diagram-parallel",
           "label": "Update architecture page cascade SVG to show parallel race (currently shows serial waterfall)",
           "label_es": "Actualizar el SVG de cascada en arquitectura para mostrar la carrera paralela (actualmente muestra cascada serial)",
-          "done": false
+          "done": true
         },
         {
           "id": "identify-server-cascade",

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -66,7 +66,7 @@ Remaining:
 
 - `megadetector-bbox-cascade-server` — Server-side bbox crop on the identify Edge Function so Claude + PlantNet also receive an animal-only crop  _(· planned — Phi-side already shipped via the client cascade in `megadetector-bbox-cascade`)_
 - `speciesnet-distilled` — Distilled SpeciesNet for on-device animal classification (~100 MB ONNX, iWildCam categories) so common camera-trap species don't need cloud LLMs  _(· planned)_
-- `arch-diagram-parallel` — Update architecture page cascade SVG to show parallel race (currently shows serial waterfall)  _(· planned)_
+- `arch-diagram-parallel` — Update architecture page cascade SVG to show parallel race (currently shows serial waterfall)  _(✓ done)_
 - `identify-server-cascade` — Move runParallelIdentify to identify Edge Function for server-side parity (currently client-only)  _(· planned)_
 - `inapp-camera-secondary` — Re-introduce in-app getUserMedia camera as secondary 'preview' path with system camera staying primary  _(! blocked: Awaits feedback from real users — deferred from v1.0 because system camera is more reliable on test devices. GitHub issue #18)_
 - `expert-app-admin-ui` — Admin review UI for expert_applications (schema shipped v1.0; admin approve/reject UX missing)  _(· planned)_

--- a/src/components/BatchImporter.astro
+++ b/src/components/BatchImporter.astro
@@ -9,7 +9,7 @@ interface Props {
    *   defaults to `camera_trap`. The cascade prefers the MegaDetector +
    *   SpeciesNet plugin (`camera_trap_megadetector`) — when the operator
    *   has set `PUBLIC_MEGADETECTOR_ENDPOINT` it runs first; when unset
-   *   the cascade falls through to the standard waterfall.
+   *   the cascade falls through to the standard cost-sorted race.
    */
   mode?: 'generic' | 'camera_trap';
 }

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -272,7 +272,7 @@ export function markLocalAIDownloadWarningShown(): void {
  * Run the identifier cascade against the freshly-synced observation.
  *
  * The cascade is the *plugin* layer (src/lib/identifiers/) rather than the
- * Edge Function's hardcoded waterfall. It walks every registered plugin
+ * Edge Function's hardcoded list. It walks every registered plugin
  * whose capabilities match (media + taxa + runtime), in cost order, and
  * stops at the first result above the accept threshold. Falls back to
  * Phi-3.5-vision on-device when the user opted in and cloud paths fail.
@@ -319,7 +319,7 @@ async function triggerIdentify(observationId: string): Promise<void> {
   // Camera-trap photos prefer the MegaDetector + SpeciesNet pipeline.
   // When PUBLIC_MEGADETECTOR_ENDPOINT is unset the plugin reports
   // model_not_bundled and the cascade transparently falls through to
-  // the standard waterfall (PlantNet → Claude → on-device).
+  // the standard cost-sorted race (PlantNet ∥ Claude ∥ on-device).
   const preferred: string[] = [];
   if (mediaKind === 'photo' && evidenceType === 'camera_trap') {
     preferred.push('camera_trap_megadetector');


### PR DESCRIPTION
Closes #169 — architecture page cascade SVG now shows parallel race.

## Change
Updated the identification cascade diagram from sequential waterfall to parallel race pattern, matching the actual implementation in `src/lib/identifiers/cascade.ts`.