### PR TITLE
docs(user-pages): add doc pages for v1.2 modules (#220)

### DIFF
--- a/src/components/CameraStationsDocView.astro
+++ b/src/components/CameraStationsDocView.astro
@@ -1,0 +1,51 @@
+---
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+---
+
+<article class="prose prose-zinc dark:prose-invert max-w-none">
+  <h1>{isEs ? 'Estaciones de Cámara' : 'Camera Stations'}</h1>
+  <p class="lead text-lg text-zinc-600 dark:text-zinc-400">
+    {isEs
+      ? 'Registra despliegues de cámaras trampa con periodos activos, calcula noches-trampa y vincula observaciones a estaciones fijas dentro de tus proyectos.'
+      : 'Register camera-trap deployments with active periods, compute trap-nights, and link observations to fixed stations within your projects.'}
+  </p>
+
+  <p>
+    {isEs
+      ? 'Una estación de cámara representa un punto fijo de despliegue con uno o más periodos activos (fecha de inicio y fin). Rastrum calcula automáticamente las noches-trampa y permite derivar índices estándar de vida silvestre como el Índice de Abundancia Relativa (RAI) y la tasa de detección por cada 100 noches-trampa.'
+      : 'A camera station represents a fixed deployment point with one or more active periods (start and end dates). Rastrum automatically computes trap-nights and lets you derive standard wildlife indices like Relative Abundance Index (RAI) and detection rate per 100 trap-nights.'}
+  </p>
+
+  <h2>{isEs ? 'Funcionalidades' : 'Features'}</h2>
+  <ul>
+    <li><strong>{isEs ? 'Estaciones por proyecto' : 'Per-project stations'}:</strong> {isEs
+      ? 'Cada estación pertenece a un proyecto. Crea estaciones desde la UI del proyecto o vía la CLI con --station-key.'
+      : 'Each station belongs to a project. Create stations from the project UI or via the CLI with --station-key.'}</li>
+    <li><strong>{isEs ? 'Periodos activos' : 'Active periods'}:</strong> {isEs
+      ? 'Define múltiples periodos de despliegue por estación. Un periodo sin fecha de fin significa "aún activo".'
+      : 'Define multiple deployment periods per station. A period with no end date means "still active".'}</li>
+    <li><strong>{isEs ? 'Noches-trampa automáticas' : 'Automatic trap-nights'}:</strong> {isEs
+      ? 'Rastrum calcula las noches-trampa sumando los días de todos los periodos activos de la estación.'
+      : 'Rastrum computes trap-nights by summing the days across all active periods for the station.'}</li>
+    <li><strong>{isEs ? 'Vinculación de observaciones' : 'Observation linking'}:</strong> {isEs
+      ? 'Las observaciones se vinculan a estaciones explícitamente — dos estaciones en el mismo polígono necesitan conteos separados.'
+      : 'Observations are linked to stations explicitly — two stations within the same polygon need separate counts.'}</li>
+    <li><strong>{isEs ? 'Integración con CLI' : 'CLI integration'}:</strong> {isEs
+      ? 'El comando rastrum-import acepta --station-key para asignar estación durante la importación masiva de fotos.'
+      : 'The rastrum-import command accepts --station-key to assign a station during batch photo import.'}</li>
+  </ul>
+
+  <h2>{isEs ? 'Índices de vida silvestre' : 'Wildlife indices'}</h2>
+  <p>
+    {isEs
+      ? 'Con las noches-trampa calculadas, puedes derivar métricas estándar de monitoreo de biodiversidad: RAI (detecciones / noches-trampa × 100), tasa de detección por especie, y esfuerzo de muestreo acumulado por proyecto. Estos datos son compatibles con los formatos de reporte de CONANP y CONABIO.'
+      : 'With trap-nights computed, you can derive standard biodiversity monitoring metrics: RAI (detections / trap-nights × 100), per-species detection rate, and cumulative sampling effort per project. This data is compatible with CONANP and CONABIO reporting formats.'}
+  </p>
+
+  <p class="text-sm text-zinc-500 mt-8">
+    {isEs ? 'Spec técnica: ' : 'Technical spec: '}
+    <a href="https://github.com/ArtemioPadilla/rastrum/blob/main/docs/specs/modules/31-camera-stations.md" class="underline">docs/specs/modules/31-camera-stations.md</a>
+  </p>
+</article>

--- a/src/components/CommunityDocView.astro
+++ b/src/components/CommunityDocView.astro
@@ -1,0 +1,51 @@
+---
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+---
+
+<article class="prose prose-zinc dark:prose-invert max-w-none">
+  <h1>{isEs ? 'Descubrimiento de Comunidad' : 'Community Discovery'}</h1>
+  <p class="lead text-lg text-zinc-600 dark:text-zinc-400">
+    {isEs
+      ? 'Encuentra observadores, expertos y naturalistas cerca de ti. Filtra por país, taxón, actividad reciente y más — todo desde una sola página.'
+      : 'Find observers, experts, and naturalists near you. Filter by country, taxon, recent activity, and more — all from a single page.'}
+  </p>
+
+  <p>
+    {isEs
+      ? 'La página de comunidad reúne a todos los observadores de Rastrum en un directorio filtrable. Puedes ordenar por número de especies, actividad reciente o karma, y filtrar por país, grupo taxonómico o rol de experto. Si estás autenticado, el filtro "Cerca de mí" muestra observadores en tu región usando tu centroide aproximado — nunca tu ubicación exacta.'
+      : 'The community page brings together all Rastrum observers in a filterable directory. You can sort by species count, recent activity, or karma, and filter by country, taxon group, or expert role. If you\'re signed in, the "Nearby" filter shows observers in your region using your approximate centroid — never your exact location.'}
+  </p>
+
+  <h2>{isEs ? 'Funcionalidades' : 'Features'}</h2>
+  <ul>
+    <li><strong>{isEs ? 'Directorio de observadores' : 'Observer directory'}:</strong> {isEs
+      ? 'Página paginada con tarjetas de perfil, conteo de especies, racha activa e insignia de experto.'
+      : 'Paginated page with profile cards, species count, active streak, and expert badge.'}</li>
+    <li><strong>{isEs ? 'Filtros combinables' : 'Composable filters'}:</strong> {isEs
+      ? 'Ordenar (especies, actividad 7d/30d, karma), filtrar por país (ISO-3166), solo expertos, y cercanía.'
+      : 'Sort (species, 7d/30d activity, karma), filter by country (ISO-3166), experts only, and nearby.'}</li>
+    <li><strong>{isEs ? 'Filtro de cercanía' : 'Nearby filter'}:</strong> {isEs
+      ? 'Disponible solo para usuarios autenticados. Usa el centroide de tus observaciones — la ubicación precisa nunca se expone.'
+      : 'Available only for signed-in users. Uses the centroid of your observations — precise location is never exposed.'}</li>
+    <li><strong>{isEs ? 'Opt-out de leaderboards' : 'Leaderboard opt-out'}:</strong> {isEs
+      ? 'Cualquier usuario puede ocultarse del directorio desde Perfil → Editar sin afectar su perfil público.'
+      : 'Any user can hide from the directory via Profile → Edit without affecting their public profile.'}</li>
+    <li><strong>{isEs ? 'Estado de URL' : 'URL state'}:</strong> {isEs
+      ? 'Todos los filtros se serializan en la URL para que puedas compartir o guardar búsquedas específicas.'
+      : 'All filters are serialized into the URL so you can share or bookmark specific searches.'}</li>
+  </ul>
+
+  <h2>{isEs ? 'Privacidad' : 'Privacy'}</h2>
+  <p>
+    {isEs
+      ? 'El centroide de cada usuario se calcula a partir de sus observaciones y solo es visible para usuarios autenticados a través de una vista SQL dedicada. Los usuarios anónimos no pueden acceder a datos de ubicación. El opt-out de leaderboards es independiente de la configuración de perfil público.'
+      : 'Each user\'s centroid is computed from their observations and is only visible to authenticated users via a dedicated SQL view. Anonymous users cannot access location data. The leaderboard opt-out is independent of the public profile setting.'}
+  </p>
+
+  <p class="text-sm text-zinc-500 mt-8">
+    {isEs ? 'Spec técnica: ' : 'Technical spec: '}
+    <a href="https://github.com/ArtemioPadilla/rastrum/blob/main/docs/specs/modules/28-community-discovery.md" class="underline">docs/specs/modules/28-community-discovery.md</a>
+  </p>
+</article>

--- a/src/components/ObsDetailDocView.astro
+++ b/src/components/ObsDetailDocView.astro
@@ -1,0 +1,54 @@
+---
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+---
+
+<article class="prose prose-zinc dark:prose-invert max-w-none">
+  <h1>{isEs ? 'Detalle de Observación' : 'Observation Detail'}</h1>
+  <p class="lead text-lg text-zinc-600 dark:text-zinc-400">
+    {isEs
+      ? 'Cada observación tiene una página de detalle pública con galería de fotos, mapa, identificaciones de la comunidad, y herramientas de gestión para el dueño.'
+      : 'Every observation has a public detail page with a photo gallery, map, community identifications, and management tools for the owner.'}
+  </p>
+
+  <p>
+    {isEs
+      ? 'La página de detalle de observación es el punto central para ver, compartir y gestionar una observación individual. Incluye un layout de dos columnas (apilado en móvil) con la galería de fotos y mapa a la izquierda, y metadatos, identificaciones y acciones a la derecha. Los dueños pueden editar la ubicación, eliminar fotos, y gestionar la licencia directamente desde esta vista.'
+      : 'The observation detail page is the central point for viewing, sharing, and managing an individual observation. It features a two-column layout (stacked on mobile) with the photo gallery and map on the left, and metadata, identifications, and actions on the right. Owners can edit the location, delete photos, and manage the license directly from this view.'}
+  </p>
+
+  <h2>{isEs ? 'Funcionalidades' : 'Features'}</h2>
+  <ul>
+    <li><strong>{isEs ? 'Galería de fotos' : 'Photo gallery'}:</strong> {isEs
+      ? 'Lightbox nativo con navegación por teclado, swipe táctil y botón de compartir. Soporte para múltiples fotos por observación.'
+      : 'Native lightbox with keyboard navigation, touch swipe, and share button. Support for multiple photos per observation.'}</li>
+    <li><strong>{isEs ? 'Mapa interactivo' : 'Interactive map'}:</strong> {isEs
+      ? 'MapLibre con el punto de la observación. Las coordenadas se muestran con precisión variable según el nivel de oscurecimiento.'
+      : 'MapLibre with the observation point. Coordinates are shown with variable precision based on the obscure level.'}</li>
+    <li><strong>{isEs ? 'Identificaciones comunitarias' : 'Community identifications'}:</strong> {isEs
+      ? 'Lista de sugerencias de ID de la comunidad con nivel de confianza, nombre del identificador y timestamp.'
+      : 'List of community ID suggestions with confidence level, identifier name, and timestamp.'}</li>
+    <li><strong>{isEs ? 'Gestión del dueño' : 'Owner management'}:</strong> {isEs
+      ? 'Tabs de gestión con edición de ubicación, eliminación atómica de fotos vía Edge Function, y cambio de licencia.'
+      : 'Management tabs with location editing, atomic photo deletion via Edge Function, and license change.'}</li>
+    <li><strong>{isEs ? 'Compartir público' : 'Public sharing'}:</strong> {isEs
+      ? 'URL pública en /share/obs/ con tarjeta OG para redes sociales. Funciona sin autenticación.'
+      : 'Public URL at /share/obs/ with OG card for social media. Works without authentication.'}</li>
+    <li><strong>{isEs ? 'Reacciones y comentarios' : 'Reactions & comments'}:</strong> {isEs
+      ? 'Los usuarios autenticados pueden reaccionar y sugerir identificaciones alternativas.'
+      : 'Authenticated users can react and suggest alternative identifications.'}</li>
+  </ul>
+
+  <h2>{isEs ? 'Privacidad de ubicación' : 'Location privacy'}</h2>
+  <p>
+    {isEs
+      ? 'Las observaciones de especies sensibles (NOM-059 / CITES) usan el nivel de oscurecimiento para reducir la precisión de las coordenadas públicas. Solo el observador o un investigador acreditado puede ver la ubicación exacta. El mapa y las coordenadas mostradas respetan este nivel automáticamente.'
+      : 'Observations of sensitive species (NOM-059 / CITES) use the obscure level to coarsen public coordinates. Only the observer or a credentialed researcher can see the exact location. The map and displayed coordinates respect this level automatically.'}
+  </p>
+
+  <p class="text-sm text-zinc-500 mt-8">
+    {isEs ? 'Página de detalle: ' : 'Detail page: '}
+    <code>/share/obs/&lt;id&gt;</code>
+  </p>
+</article>

--- a/src/components/SponsorPoolsDocView.astro
+++ b/src/components/SponsorPoolsDocView.astro
@@ -1,0 +1,51 @@
+---
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+---
+
+<article class="prose prose-zinc dark:prose-invert max-w-none">
+  <h1>{isEs ? 'Pools de Patrocinio y Multi-Proveedor' : 'Sponsor Pools & Multi-Provider Vision'}</h1>
+  <p class="lead text-lg text-zinc-600 dark:text-zinc-400">
+    {isEs
+      ? 'Rastrum soporta múltiples proveedores de visión AI (Anthropic, Google Vertex, OpenAI) y permite a los sponsors elegir qué modelo usan sus beneficiarios. Los pools de plataforma distribuyen créditos comunitarios.'
+      : 'Rastrum supports multiple AI vision providers (Anthropic, Google Vertex, OpenAI) and lets sponsors choose which model their beneficiaries use. Platform pools distribute community credits.'}
+  </p>
+
+  <p>
+    {isEs
+      ? 'El sistema multi-proveedor extiende los patrocinios de AI (ver la página de Patrocinios IA) con soporte para múltiples backends de visión. Cada credencial de sponsor puede especificar un modelo preferido, y el cascade de identificación respeta esa preferencia. Los pools de plataforma permiten que operadores o instituciones donen créditos que se distribuyen automáticamente entre usuarios sin BYO key.'
+      : 'The multi-provider system extends AI sponsorships (see the AI Sponsorships page) with support for multiple vision backends. Each sponsor credential can specify a preferred model, and the identification cascade respects that preference. Platform pools let operators or institutions donate credits that are automatically distributed among users without a BYO key.'}
+  </p>
+
+  <h2>{isEs ? 'Funcionalidades' : 'Features'}</h2>
+  <ul>
+    <li><strong>{isEs ? 'Múltiples proveedores' : 'Multiple providers'}:</strong> {isEs
+      ? 'Anthropic Claude, Google Vertex AI y OpenAI GPT-4o como backends de visión. El cascade elige por costo, licencia y disponibilidad.'
+      : 'Anthropic Claude, Google Vertex AI, and OpenAI GPT-4o as vision backends. The cascade picks by cost, license, and availability.'}</li>
+    <li><strong>{isEs ? 'Modelo por sponsor' : 'Per-sponsor model'}:</strong> {isEs
+      ? 'Cada sponsor puede fijar un modelo preferido para sus beneficiarios (ej. solo Haiku para controlar costos).'
+      : 'Each sponsor can pin a preferred model for their beneficiaries (e.g. Haiku-only to control costs).'}</li>
+    <li><strong>{isEs ? 'Pools de plataforma' : 'Platform pools'}:</strong> {isEs
+      ? 'Credenciales institucionales que se comparten entre todos los usuarios elegibles. Cuota mensual global con distribución equitativa.'
+      : 'Institutional credentials shared across all eligible users. Global monthly cap with fair distribution.'}</li>
+    <li><strong>{isEs ? 'Auto-rotación' : 'Auto-rotation'}:</strong> {isEs
+      ? 'Cuando un proveedor falla o alcanza su límite, el cascade rota automáticamente al siguiente proveedor disponible.'
+      : 'When a provider fails or hits its limit, the cascade automatically rotates to the next available provider.'}</li>
+    <li><strong>{isEs ? 'Karma por pool' : 'Pool karma'}:</strong> {isEs
+      ? 'Los contribuyentes a pools de plataforma ganan karma proporcional al uso de sus créditos donados.'
+      : 'Platform pool contributors earn karma proportional to the usage of their donated credits.'}</li>
+  </ul>
+
+  <h2>{isEs ? 'Cómo funciona el cascade' : 'How the cascade works'}</h2>
+  <p>
+    {isEs
+      ? 'Cuando un usuario identifica una foto, Rastrum evalúa las credenciales disponibles en orden: (1) BYO key del usuario, (2) credencial de sponsor con modelo preferido, (3) pool de plataforma, (4) PlantNet gratuito, (5) modelo on-device. Si el proveedor preferido falla, el sistema rota al siguiente sin intervención del usuario.'
+      : 'When a user identifies a photo, Rastrum evaluates available credentials in order: (1) user\'s BYO key, (2) sponsor credential with preferred model, (3) platform pool, (4) free PlantNet, (5) on-device model. If the preferred provider fails, the system rotates to the next one without user intervention.'}
+  </p>
+
+  <p class="text-sm text-zinc-500 mt-8">
+    {isEs ? 'Spec técnica: ' : 'Technical spec: '}
+    <a href="https://github.com/ArtemioPadilla/rastrum/blob/main/docs/specs/modules/32-multi-provider-vision.md" class="underline">docs/specs/modules/32-multi-provider-vision.md</a>
+  </p>
+</article>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1433,7 +1433,11 @@
       "console": "Console",
       "sponsorships": "AI Sponsorships",
       "mcp": "MCP Server",
-      "changelog": "Changelog"
+      "changelog": "Changelog",
+      "community": "Community",
+      "camera-stations": "Camera Stations",
+      "sponsor-pools": "Sponsor Pools",
+      "obs-detail": "Observation Detail"
     },
     "descriptions": {
       "vision": "Mission, problem statement, and why Oaxaca is the right place to start.",
@@ -1451,7 +1455,11 @@
       "console": "Privileged-actions surface for admin, moderator, and expert roles. Role model, audit log, and per-action runbooks.",
       "sponsorships": "Share your Anthropic credential with friends, capped per month and audited.",
       "mcp": "Connect AI agents — Claude Desktop, Cursor, OpenClaw, and any MCP-compatible client — directly to your Rastrum data using the Model Context Protocol.",
-      "changelog": "Version history and significant changes in Rastrum."
+      "changelog": "Version history and significant changes in Rastrum.",
+      "community": "Community discovery: find observers, experts, and naturalists near you. Filter by country, taxon, and activity.",
+      "camera-stations": "Camera-trap station management with active periods, trap-night computation, and wildlife detection indices.",
+      "sponsor-pools": "Multi-provider AI vision and platform sponsor pools. Anthropic, Vertex, and OpenAI with community credit distribution.",
+      "obs-detail": "Observation detail page with photo gallery, interactive map, community identifications, and owner management tools."
     },
     "status": {
       "current": "Active",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1433,7 +1433,11 @@
       "console": "Consola",
       "sponsorships": "Patrocinios IA",
       "mcp": "Servidor MCP",
-      "changelog": "Registro de cambios"
+      "changelog": "Registro de cambios",
+      "community": "Comunidad",
+      "camera-stations": "Estaciones de Cámara",
+      "sponsor-pools": "Pools de Patrocinio",
+      "obs-detail": "Detalle de Observación"
     },
     "descriptions": {
       "vision": "Misión, problema y por qué Oaxaca es el lugar correcto para comenzar.",
@@ -1451,7 +1455,11 @@
       "console": "Superficie de acciones privilegiadas para roles de admin, moderador y experto. Modelo de roles, auditoría y runbooks por acción.",
       "sponsorships": "Comparte tu credencial Anthropic con amigos, con límite mensual y auditoría.",
       "mcp": "Conecta agentes de IA — Claude Desktop, Cursor, OpenClaw y cualquier cliente MCP — directamente a tus datos de Rastrum usando el Model Context Protocol.",
-      "changelog": "Historial de versiones y cambios significativos en Rastrum."
+      "changelog": "Historial de versiones y cambios significativos en Rastrum.",
+      "community": "Descubrimiento de comunidad: encuentra observadores, expertos y naturalistas cerca de ti. Filtra por país, taxón y actividad.",
+      "camera-stations": "Gestión de estaciones de cámara trampa con periodos activos, cálculo de noches-trampa e índices de detección de vida silvestre.",
+      "sponsor-pools": "Visión AI multi-proveedor y pools de patrocinio de plataforma. Anthropic, Vertex y OpenAI con distribución de créditos comunitarios.",
+      "obs-detail": "Página de detalle de observación con galería de fotos, mapa interactivo, identificaciones comunitarias y herramientas de gestión."
     },
     "status": {
       "current": "Activo",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -119,7 +119,8 @@ export const docPages = [
   'vision', 'features', 'roadmap', 'tasks', 'market',
   'architecture', 'indigenous', 'funding', 'contribute',
   'faq', 'privacy', 'terms', 'console', 'sponsorships', 'mcp',
-  'changelog',
+  'changelog', 'community', 'camera-stations', 'sponsor-pools',
+  'obs-detail',
 ] as const;
 
 export type DocPage = (typeof docPages)[number];
@@ -316,6 +317,22 @@ export const docPageMeta = {
   changelog: {
     en: "Version history and significant changes in Rastrum. What shipped per version, with PR links and summaries.",
     es: "Historial de versiones y cambios significativos en Rastrum. Lo que se entregó por versión, con enlaces a PRs y resúmenes.",
+  },
+  community: {
+    en: "Community discovery: find observers, experts, and naturalists. Filter by country, taxon, activity, and nearby — with privacy-first centroid gating.",
+    es: "Descubrimiento de comunidad: encuentra observadores, expertos y naturalistas. Filtra por país, taxón, actividad y cercanía — con centroide protegido.",
+  },
+  'camera-stations': {
+    en: "Camera-trap station management: active periods, trap-night computation, RAI and detection-rate indices for biodiversity monitoring projects.",
+    es: "Gestión de estaciones de cámara trampa: periodos activos, cálculo de noches-trampa, índices RAI y tasa de detección para proyectos de monitoreo.",
+  },
+  'sponsor-pools': {
+    en: "Multi-provider vision and platform sponsor pools. Anthropic, Vertex, OpenAI backends with per-sponsor model pinning and community credit distribution.",
+    es: "Visión multi-proveedor y pools de patrocinio de plataforma. Backends Anthropic, Vertex, OpenAI con modelo por sponsor y distribución de créditos comunitarios.",
+  },
+  'obs-detail': {
+    en: "Observation detail page: photo gallery, interactive map, community identifications, owner management tools, and public sharing with OG cards.",
+    es: "Página de detalle de observación: galería de fotos, mapa interactivo, identificaciones comunitarias, herramientas de gestión y compartir público con tarjetas OG.",
   },
 } as const satisfies Record<DocPage, { en: string; es: string }>;
 

--- a/src/pages/en/docs/camera-stations.astro
+++ b/src/pages/en/docs/camera-stations.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import CameraStationsDocView from '../../../components/CameraStationsDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+---
+
+<DocLayout title={tr.docs.sections['camera-stations']} lang={lang} section="camera-stations" editPath="src/pages/en/docs/camera-stations.astro">
+  <CameraStationsDocView lang={lang} />
+</DocLayout>

--- a/src/pages/en/docs/community.astro
+++ b/src/pages/en/docs/community.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import CommunityDocView from '../../../components/CommunityDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+---
+
+<DocLayout title={tr.docs.sections.community} lang={lang} section="community" editPath="src/pages/en/docs/community.astro">
+  <CommunityDocView lang={lang} />
+</DocLayout>

--- a/src/pages/en/docs/obs-detail.astro
+++ b/src/pages/en/docs/obs-detail.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import ObsDetailDocView from '../../../components/ObsDetailDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+---
+
+<DocLayout title={tr.docs.sections['obs-detail']} lang={lang} section="obs-detail" editPath="src/pages/en/docs/obs-detail.astro">
+  <ObsDetailDocView lang={lang} />
+</DocLayout>

--- a/src/pages/en/docs/sponsor-pools.astro
+++ b/src/pages/en/docs/sponsor-pools.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import SponsorPoolsDocView from '../../../components/SponsorPoolsDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+---
+
+<DocLayout title={tr.docs.sections['sponsor-pools']} lang={lang} section="sponsor-pools" editPath="src/pages/en/docs/sponsor-pools.astro">
+  <SponsorPoolsDocView lang={lang} />
+</DocLayout>

--- a/src/pages/es/docs/camera-stations.astro
+++ b/src/pages/es/docs/camera-stations.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import CameraStationsDocView from '../../../components/CameraStationsDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+---
+
+<DocLayout title={tr.docs.sections['camera-stations']} lang={lang} section="camera-stations" editPath="src/pages/es/docs/camera-stations.astro">
+  <CameraStationsDocView lang={lang} />
+</DocLayout>

--- a/src/pages/es/docs/community.astro
+++ b/src/pages/es/docs/community.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import CommunityDocView from '../../../components/CommunityDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+---
+
+<DocLayout title={tr.docs.sections.community} lang={lang} section="community" editPath="src/pages/es/docs/community.astro">
+  <CommunityDocView lang={lang} />
+</DocLayout>

--- a/src/pages/es/docs/obs-detail.astro
+++ b/src/pages/es/docs/obs-detail.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import ObsDetailDocView from '../../../components/ObsDetailDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+---
+
+<DocLayout title={tr.docs.sections['obs-detail']} lang={lang} section="obs-detail" editPath="src/pages/es/docs/obs-detail.astro">
+  <ObsDetailDocView lang={lang} />
+</DocLayout>

--- a/src/pages/es/docs/sponsor-pools.astro
+++ b/src/pages/es/docs/sponsor-pools.astro
@@ -1,0 +1,12 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import SponsorPoolsDocView from '../../../components/SponsorPoolsDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+---
+
+<DocLayout title={tr.docs.sections['sponsor-pools']} lang={lang} section="sponsor-pools" editPath="src/pages/es/docs/sponsor-pools.astro">
+  <SponsorPoolsDocView lang={lang} />
+</DocLayout>

--- a/tests/e2e/community.spec.ts
+++ b/tests/e2e/community.spec.ts
@@ -73,6 +73,6 @@ test.describe('community/observers — mobile', () => {
     await page.locator('#mobile-menu-toggle').click();
     const drawer = page.locator('#mobile-drawer');
     await expect(drawer).toBeVisible();
-    await expect(drawer.getByText('Community', { exact: true })).toBeVisible();
+    await expect(drawer.locator('p').filter({ hasText: /^Community$/ })).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes #220

Adds user-facing doc pages for 4 v1.2 modules that were missing them:

- **Community** — community discovery, observer directory, composable filters, nearby, leaderboard opt-out
- **Camera Stations** — camera-trap station management, active periods, trap-nights, wildlife indices
- **Sponsor Pools** — multi-provider AI vision, per-sponsor model pinning, platform pool credit distribution
- **Observation Detail** — photo gallery, interactive map, community IDs, owner management, public sharing

Each module follows the established pattern:
- Shared `*DocView.astro` component with bilingual EN/ES content
- Paired `src/pages/{en,es}/docs/<slug>.astro` pages
- `docPages` entry in `src/i18n/utils.ts`
- `docPageMeta` entry with SEO descriptions
- `sections` + `descriptions` keys in both `en.json` and `es.json`

Verified: `tsc --noEmit` ✓ | `npm run build` (217 pages) ✓ | `vitest run` (734 tests) ✓