### PR TITLE
docs(tasks): close WIP — AI-mode-selector + expert-applications (#328)

### DIFF
--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-04-28",
+  "updated": "2026-04-30",
   "schema_version": 1,
   "notes_en": "Per-item task breakdown. Each entry mirrors docs/tasks.md. Subtasks: 'done'|'in_progress'|'blocked'|'planned'. The page at /{lang}/docs/tasks/ renders this with progress bars + commit/spec links.",
   "notes_es": "Desglose por ítem. Cada entrada refleja docs/tasks.md. Subtareas: 'done'|'in_progress'|'blocked'|'planned'. La página /{lang}/docs/tasks/ la renderiza con barras de progreso y enlaces a commits y specs.",
@@ -3068,6 +3068,13 @@
       "modules": [],
       "subtasks": [
         {
+          "label_en": "Expert-applications console tab in admin sidebar (ExpertApplicationsBrowser.astro + console-tabs.ts entry + EN/ES routes)",
+          "label_es": "Tab de consola expert-applications en sidebar admin (ExpertApplicationsBrowser.astro + entrada en console-tabs.ts + rutas EN/ES)",
+          "status": "done",
+          "ref_en": "Shipped in admin-console series; closes #328",
+          "ref_es": "Entregado en la serie admin-console; cierra #328"
+        },
+        {
           "label_en": "Build /en/profile/admin/experts/ page with pending application list",
           "label_es": "Construir pagina /en/profile/admin/experts/ con lista de solicitudes pendientes",
           "status": "planned"
@@ -3677,6 +3684,13 @@
           "label_en": "Onboarding tour + replay",
           "label_es": "Tour de bienvenida + replay",
           "status": "done"
+        },
+        {
+          "label_en": "AI mode selector in ObserveView2 (Sponsored / Own key / Local toggle with localStorage persistence)",
+          "label_es": "Selector de modo IA en ObserveView2 (toggle Patrocinado / Llave propia / Local con persistencia en localStorage)",
+          "status": "done",
+          "ref_en": "Shipped in ObserveView2; closes #328",
+          "ref_es": "Entregado en ObserveView2; cierra #328"
         },
         {
           "label_en": "Optional: delete ANTHROPIC_API_KEY env",

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -69,7 +69,7 @@ Remaining:
 - `arch-diagram-parallel` — Update architecture page cascade SVG to show parallel race (currently shows serial waterfall)  _(· planned)_
 - `identify-server-cascade` — Move runParallelIdentify to identify Edge Function for server-side parity (currently client-only)  _(· planned)_
 - `inapp-camera-secondary` — Re-introduce in-app getUserMedia camera as secondary 'preview' path with system camera staying primary  _(! blocked: Awaits feedback from real users — deferred from v1.0 because system camera is more reliable on test devices. GitHub issue #18)_
-- `expert-app-admin-ui` — Admin review UI for expert_applications (schema shipped v1.0; admin approve/reject UX missing)  _(· planned)_
+- `expert-app-admin-ui` — Admin review UI for expert_applications (schema shipped v1.0; admin approve/reject UX missing; **console tab shipped** — `ExpertApplicationsBrowser.astro` + `console-tabs.ts` entry live since admin-console series; closes #328)  _(· planned — remaining: approve/reject actions + email notification)_
 - `bioblitz-events-ui-poll` — Bioblitz event detail UI — build when first community organizer requests one  _(! blocked: Speculative without a pilot event. Reshelved here from v1.0 alongside its schema sibling.)_
 - `plantnet-quota-monitor` — Alerting / dashboard for PlantNet daily-quota usage (500/day shared); fall through gracefully when exhausted  _(· planned)_
 - `oauth-logo-google` — Upload Rastrum logo + privacy/terms URLs at Google Cloud Console OAuth consent screen  _(! blocked: Manual operator action — see GitHub issue #3)_
@@ -226,3 +226,16 @@ A second wave landed the same day, focused on the CONANP-Oaxaca / DRFSIPS / PROR
   expiry-monitor crons (PR #207), nightly per-provider smoke probe
   (PR #210). _(✓ shipped — pool dashboard with top-taxa, cost-per-100
   picker, pool karma incentives tracked as #226/#227/#228)_
+
+---
+
+## Resolved issues
+
+### #328 — AI-mode-selector + expert-applications console tab (closed)
+
+Both features were shipped in prior PRs and are live in the codebase:
+
+- **Expert-applications console tab:** `ExpertApplicationsBrowser.astro` + `console-tabs.ts` entry + EN/ES route pages. Shipped as part of the admin-console series (PR1–PR16). The remaining `expert-app-admin-ui` subtasks (approve/reject actions + email notification) are separate planned work.
+- **AI mode selector in ObserveView2:** Three-way toggle (Sponsored / Own key / Local) with `localStorage` persistence under `rastrum.obs2.aiMode`. Shipped as part of the ObserveView2 + ai-sponsorships work.
+
+No code changes needed — this is a docs-only update to reflect completion.


### PR DESCRIPTION
Closes #328 — both features already shipped.

## What changed

Docs-only update to `tasks.json` and `tasks.md`:

- **Expert-applications console tab**: Added a `done` subtask to `expert-app-admin-ui` recording that `ExpertApplicationsBrowser.astro` + `console-tabs.ts` entry + EN/ES routes shipped in the admin-console series (PR1–PR16). Remaining admin review actions (approve/reject + email) stay planned.
- **AI mode selector in ObserveView2**: Added a `done` subtask to `ai-sponsorships` recording the three-way toggle (Sponsored / Own key / Local) with localStorage persistence shipped in ObserveView2.
- **tasks.md**: Added a `Resolved issues` section noting #328 is closed.

## Verification

- `npx tsc --noEmit` — zero errors
- `npm run test` — 734 tests pass
- JSON validated