### PR TITLE
feat(audio): radial visualizer v4 + fix audio player + card placeholders

### DIFF
--- a/src/components/AudioPlayer.astro
+++ b/src/components/AudioPlayer.astro
@@ -1,29 +1,16 @@
 ---
 /**
- * AudioPlayer — waveform + spectrogram player for audio observations.
+ * AudioPlayer — waveform + spectrogram + radial visualizer for audio observations.
  *
  * Uses wavesurfer.js (v7) with the Spectrogram plugin.
  * Renders client-side only (the `<script>` block). The HTML shell is
  * lightweight and accessible without JS (falls back to a native <audio> tag).
  *
- * Props:
- *   audioUrl   — R2 URL to the audio file
- *   mimeType   — MIME type hint (e.g. 'audio/mpeg', 'audio/ogg')
- *   lang       — 'en' | 'es'
- *   obsId      — Observation ID, used to scope DOM IDs so multiple players
- *                can coexist on the same page (future-proofing)
- *   label      — Optional accessible label (e.g. species name)
- *   showSpectrogram — Whether to render the spectrogram (default: true).
- *                     Pass false to show waveform-only (faster, lower memory).
- *
- * Spectrogram notes:
- *   - Color map: inferno (perceptually uniform, bioacoustics standard)
- *   - Frequency range: 0–12 kHz (covers most bird vocalizations)
- *   - FFT window: 512 (good freq resolution for tonal bird songs)
- *   - Lazy: spectrogram is only computed when the user clicks "Show spectrogram"
- *     to avoid blocking the UI on low-end phones
- *   - BirdNET detection windows (if provided) are drawn as overlays on the
- *     spectrogram canvas (future: pass detections as JSON prop)
+ * Visualization versions:
+ *   v1: waveform + lazy spectrogram (inferno colormap)
+ *   v2: BirdNET detection overlay on spectrogram with interactive tooltips
+ *   v3: frequency zoom, export spectrogram as PNG
+ *   v4: real-time radial frequency visualizer with BirdNET species coloring
  */
 
 interface Props {
@@ -53,12 +40,8 @@ const loadingLabel = isEs ? 'Cargando audio…' : 'Loading audio…';
 const errorLabel   = isEs ? 'No se pudo cargar el audio.' : 'Could not load audio.';
 const freqLabel    = isEs ? 'Frecuencia (kHz)' : 'Frequency (kHz)';
 const timeLabel    = isEs ? 'Tiempo (s)' : 'Time (s)';
-
-const waveId    = `ws-wave-${obsId}`;
-const spectroId = `ws-spec-${obsId}`;
-const playBtnId = `ws-play-${obsId}`;
-const toggleId  = `ws-toggle-spec-${obsId}`;
-const timerId   = `ws-time-${obsId}`;
+const radialLabel  = isEs ? 'Visualizar' : 'Visualize';
+const radialHide   = isEs ? 'Ocultar' : 'Hide';
 ---
 
 <div
@@ -74,67 +57,60 @@ const timerId   = `ws-time-${obsId}`;
   data-label-spectro-hide={spectroHide}
   data-label-freq={freqLabel}
   data-label-time={timeLabel}
+  data-label-radial={radialLabel}
+  data-label-radial-hide={radialHide}
 >
   <!-- Waveform container -->
   <div class="px-3 pt-3">
-    <div id={waveId} class="w-full" style="min-height: 60px;"></div>
+    <div id={`ws-wave-${obsId}`} class="w-full" style="min-height: 60px;"></div>
   </div>
 
   <!-- Controls bar -->
   <div class="flex items-center gap-3 px-3 py-2">
-    <!-- Play/Pause -->
     <button
-      id={playBtnId}
+      id={`ws-play-${obsId}`}
       type="button"
       aria-label={playLabel}
       class="w-9 h-9 rounded-full bg-emerald-600 hover:bg-emerald-700 active:bg-emerald-800 text-white flex items-center justify-center shrink-0 transition-colors disabled:opacity-40"
       disabled
     >
-      <!-- Play icon (default) -->
-      <svg class="play-icon w-4 h-4 ml-0.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M8 5v14l11-7z"/>
-      </svg>
-      <!-- Pause icon (hidden until playing) -->
-      <svg class="pause-icon hidden w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/>
-      </svg>
+      <svg class="play-icon w-4 h-4 ml-0.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
+      <svg class="pause-icon hidden w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>
     </button>
-
-    <!-- Time readout -->
-    <span id={timerId} class="text-xs font-mono text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">0:00</span>
-
-    <!-- Loading / error state -->
+    <span id={`ws-time-${obsId}`} class="text-xs font-mono text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">0:00</span>
     <span class="loading-label text-xs text-zinc-400 dark:text-zinc-500">{loadingLabel}</span>
     <span class="error-label hidden text-xs text-red-500">{errorLabel}</span>
-
     <div class="flex-1"></div>
-
-    <!-- Toggle spectrogram (only shown when showSpectrogram=true) -->
     {showSpectrogram && (
-      <button
-        id={toggleId}
-        type="button"
-        aria-expanded="false"
-        class="text-xs text-emerald-700 dark:text-emerald-400 underline underline-offset-2 hover:no-underline transition-all shrink-0"
-      >
-        {spectroLabel}
-      </button>
+      <button id={`ws-toggle-radial-${obsId}`} type="button" aria-expanded="false"
+        class="text-xs text-sky-600 dark:text-sky-400 underline underline-offset-2 hover:no-underline transition-all shrink-0">{radialLabel}</button>
+    )}
+    {showSpectrogram && (
+      <button id={`ws-toggle-spec-${obsId}`} type="button" aria-expanded="false"
+        class="text-xs text-emerald-700 dark:text-emerald-400 underline underline-offset-2 hover:no-underline transition-all shrink-0">{spectroLabel}</button>
     )}
   </div>
 
+  <!-- v4: Radial visualizer panel -->
+  {showSpectrogram && (
+    <div id={`ws-radial-${obsId}`} class="hidden px-3 pb-3">
+      <div class="relative flex items-center justify-center rounded-xl bg-zinc-950 overflow-hidden" style="height: 280px;">
+        <canvas id={`ws-radial-canvas-${obsId}`} class="w-full h-full" aria-hidden="true"></canvas>
+        <div id={`ws-radial-label-${obsId}`} class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none select-none">
+          <span id={`ws-radial-species-${obsId}`} class="text-sm font-semibold italic text-white/80 drop-shadow-lg transition-all duration-300"></span>
+          <span id={`ws-radial-common-${obsId}`} class="text-[11px] text-white/50 mt-0.5 transition-all duration-300"></span>
+        </div>
+      </div>
+    </div>
+  )}
+
   <!-- Spectrogram panel (lazy, collapsed by default) -->
   {showSpectrogram && (
-    <div id={spectroId} class="hidden px-3 pb-2">
-      <!-- Spectrogram toolbar: freq zoom + export -->
+    <div id={`ws-spec-${obsId}`} class="hidden px-3 pb-2">
       <div class="flex items-center gap-2 mb-2 flex-wrap">
-        <!-- Frequency range selector -->
         <div class="flex items-center gap-1 text-[10px] text-zinc-500 dark:text-zinc-400">
           <span>{isEs ? 'Rango:' : 'Range:'}</span>
-          <select
-            id={`ws-freq-range-${obsId}`}
-            class="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-[10px] px-1 py-0.5"
-            aria-label={isEs ? 'Rango de frecuencias' : 'Frequency range'}
-          >
+          <select id={`ws-freq-range-${obsId}`} class="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-[10px] px-1 py-0.5" aria-label={isEs ? 'Rango de frecuencias' : 'Frequency range'}>
             <option value="12000">0 – 12 kHz</option>
             <option value="8000">0 – 8 kHz</option>
             <option value="4000">0 – 4 kHz</option>
@@ -142,104 +118,48 @@ const timerId   = `ws-time-${obsId}`;
           </select>
         </div>
         <div class="flex-1"></div>
-        <!-- Export PNG -->
-        <button
-          id={`ws-export-${obsId}`}
-          type="button"
-          class="flex items-center gap-1 text-[10px] text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
-          title={isEs ? 'Descargar espectrograma como imagen' : 'Download spectrogram as image'}
-        >
-          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
-          </svg>
+        <button id={`ws-export-${obsId}`} type="button" class="flex items-center gap-1 text-[10px] text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors" title={isEs ? 'Descargar espectrograma como imagen' : 'Download spectrogram as image'}>
+          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
           {isEs ? 'Exportar PNG' : 'Export PNG'}
         </button>
-        <!-- Info tooltip toggle -->
-        <button
-          id={`ws-info-btn-${obsId}`}
-          type="button"
-          class="w-5 h-5 rounded-full border border-zinc-300 dark:border-zinc-700 text-[10px] text-zinc-500 dark:text-zinc-400 hover:border-emerald-500 hover:text-emerald-500 transition-colors flex items-center justify-center font-bold"
-          aria-label={isEs ? '¿Qué estoy viendo?' : 'What am I looking at?'}
-          title={isEs ? '¿Qué estoy viendo?' : 'What am I looking at?'}
-        >?</button>
+        <button id={`ws-info-btn-${obsId}`} type="button" class="w-5 h-5 rounded-full border border-zinc-300 dark:border-zinc-700 text-[10px] text-zinc-500 dark:text-zinc-400 hover:border-emerald-500 hover:text-emerald-500 transition-colors flex items-center justify-center font-bold" aria-label={isEs ? '¿Qué estoy viendo?' : 'What am I looking at?'} title={isEs ? '¿Qué estoy viendo?' : 'What am I looking at?'}>?</button>
       </div>
-
-      <!-- Educational info panel (collapsed by default) -->
       <div id={`ws-info-panel-${obsId}`} class="hidden mb-2 rounded-lg border border-emerald-200 dark:border-emerald-900/40 bg-emerald-50 dark:bg-emerald-950/30 p-3 text-xs text-zinc-700 dark:text-zinc-300 space-y-1.5">
         <p class="font-semibold text-emerald-800 dark:text-emerald-300">{isEs ? '¿Qué es un espectrograma?' : 'What is a spectrogram?'}</p>
-        <p>{isEs
-          ? 'Muestra cómo cambian las frecuencias del sonido a lo largo del tiempo. El eje horizontal es el tiempo, el vertical es la frecuencia (tono), y el color indica la intensidad (más brillante = más fuerte).'
-          : 'Shows how the frequencies in a sound change over time. The horizontal axis is time, the vertical axis is frequency (pitch), and the color shows intensity — brighter = louder.'}
-        </p>
-        <p>{isEs
-          ? '🌈 Colormap inferno: negro = silencio, morado/azul = débil, naranja = moderado, amarillo/blanco = muy fuerte.'
-          : '🌈 Inferno colormap: black = silence, purple/blue = faint, orange = moderate, yellow/white = very loud.'}
-        </p>
-        <p>{isEs
-          ? '🐦 Los cantos de aves suelen aparecer entre 1–8 kHz. Patrones horizontales = tonos sostenidos; patrones verticales = clics o golpes.'
-          : '🐦 Bird songs typically appear between 1–8 kHz. Horizontal streaks = sustained tones; vertical streaks = clicks or percussive sounds.'}
-        </p>
-        <p id={`ws-birdnet-info-${obsId}`} class="hidden font-medium text-emerald-700 dark:text-emerald-400">{isEs
-          ? '✅ Las bandas verdes/coloreadas muestran segmentos donde BirdNET detectó una especie. Toca una banda para ver detalles.'
-          : '✅ Colored bands show segments where BirdNET detected a species. Tap a band for details.'}
-        </p>
+        <p>{isEs ? 'Muestra cómo cambian las frecuencias del sonido a lo largo del tiempo. El eje horizontal es el tiempo, el vertical es la frecuencia (tono), y el color indica la intensidad (más brillante = más fuerte).' : 'Shows how the frequencies in a sound change over time. The horizontal axis is time, the vertical axis is frequency (pitch), and the color shows intensity — brighter = louder.'}</p>
+        <p>{isEs ? '🌈 Colormap inferno: negro = silencio, morado/azul = débil, naranja = moderado, amarillo/blanco = muy fuerte.' : '🌈 Inferno colormap: black = silence, purple/blue = faint, orange = moderate, yellow/white = very loud.'}</p>
+        <p>{isEs ? '🐦 Los cantos de aves suelen aparecer entre 1–8 kHz. Patrones horizontales = tonos sostenidos; patrones verticales = clics o golpes.' : '🐦 Bird songs typically appear between 1–8 kHz. Horizontal streaks = sustained tones; vertical streaks = clicks or percussive sounds.'}</p>
+        <p id={`ws-birdnet-info-${obsId}`} class="hidden font-medium text-emerald-700 dark:text-emerald-400">{isEs ? '✅ Las bandas verdes/coloreadas muestran segmentos donde BirdNET detectó una especie. Toca una banda para ver detalles.' : '✅ Colored bands show segments where BirdNET detected a species. Tap a band for details.'}</p>
       </div>
-
-      <!-- Frequency axis top label -->
       <div class="flex items-end justify-between mb-1 text-[10px] text-zinc-400 dark:text-zinc-500 select-none">
         <span id={`ws-freq-top-${obsId}`}>12 kHz</span>
         <span class="italic">{freqLabel}</span>
         <span>0 Hz</span>
       </div>
-
-      <!-- Spectrogram host + BirdNET overlay container -->
       <div class="relative">
-        <!-- Spectrogram canvas renders here (wavesurfer appends it) -->
-        <div
-          id={`ws-spec-host-${obsId}`}
-          class="ws-spectrogram-host w-full rounded overflow-hidden bg-zinc-950"
-          style="height: 140px;"
-          aria-hidden="true"
-        ></div>
-        <!-- BirdNET detection overlays (injected by JS) -->
+        <div id={`ws-spec-host-${obsId}`} class="ws-spectrogram-host w-full rounded overflow-hidden bg-zinc-950" style="height: 140px;" aria-hidden="true"></div>
         <div id={`ws-detections-${obsId}`} class="absolute inset-0 pointer-events-none" aria-hidden="true"></div>
-        <!-- Interactive tooltip -->
-        <div
-          id={`ws-tooltip-${obsId}`}
-          class="hidden absolute z-10 rounded-lg border border-emerald-300 dark:border-emerald-700 bg-white/95 dark:bg-zinc-900/95 shadow-lg p-2.5 text-xs max-w-[200px] pointer-events-none"
-          role="tooltip"
-        ></div>
+        <div id={`ws-tooltip-${obsId}`} class="hidden absolute z-10 rounded-lg border border-emerald-300 dark:border-emerald-700 bg-white/95 dark:bg-zinc-900/95 shadow-lg p-2.5 text-xs max-w-[200px] pointer-events-none" role="tooltip"></div>
       </div>
-
-      <!-- Time axis label -->
-      <div class="mt-1 text-[10px] text-zinc-400 dark:text-zinc-500 text-right select-none italic">
-        {timeLabel}
-      </div>
-
-      <!-- BirdNET species legend (populated by JS) -->
+      <div class="mt-1 text-[10px] text-zinc-400 dark:text-zinc-500 text-right select-none italic">{timeLabel}</div>
       <div id={`ws-legend-${obsId}`} class="hidden mt-2 space-y-1"></div>
     </div>
   )}
 
-  <!-- Fallback for no-JS: native audio element -->
   <noscript>
     <div class="px-3 pb-3">
-      <audio controls src={audioUrl} class="w-full">
-        <track kind="captions" />
-      </audio>
+      <audio controls src={audioUrl} class="w-full"><track kind="captions" /></audio>
     </div>
   </noscript>
 </div>
 
 <script>
 /**
- * AudioPlayer client-side init — v2+v3.
+ * AudioPlayer client-side init — v1 through v4.
+ * v1: waveform + lazy spectrogram (inferno colormap)
  * v2: BirdNET detection overlay on spectrogram with interactive tooltips
  * v3: frequency zoom, export spectrogram as PNG
- *
- * Each `.rastrum-audio-player` element is independent (separate WaveSurfer
- * instance). Data flows from the page via data-* attributes and the
- * `rastrum:audio-birdnet-ready` custom event.
+ * v4: real-time radial frequency visualizer with BirdNET species coloring
  */
 (function () {
   if (document.readyState === 'loading') {
@@ -264,39 +184,39 @@ const timerId   = `ws-time-${obsId}`;
     });
   });
 
-  // Listen for BirdNET results injected after the player is already live
   document.addEventListener('rastrum:audio-birdnet-ready', (e: Event) => {
     const ev = e as CustomEvent<{ obsId: string; segments: BirdNetSegment[]; durationSec: number }>;
     const { obsId, segments, durationSec } = ev.detail;
     const container = document.querySelector<HTMLElement>(`[data-obs-id="${obsId}"]`);
     if (!container) return;
     renderDetectionOverlay(container, obsId, segments, durationSec);
+    // Store segments on the container for the radial visualizer to pick up
+    (container as HTMLElement & { __birdnetSegments?: BirdNetSegment[]; __birdnetDuration?: number }).__birdnetSegments = segments;
+    (container as HTMLElement & { __birdnetDuration?: number }).__birdnetDuration = durationSec;
   });
 
   // ── Types ──────────────────────────────────────────────────────────────
-  interface BirdNetCandidate {
-    scientific_name: string;
-    common_name_en: string | null;
-    score: number;
-  }
-  interface BirdNetSegment {
-    startSec: number;
-    endSec: number;
-    top: BirdNetCandidate[];
-  }
+  interface BirdNetCandidate { scientific_name: string; common_name_en: string | null; score: number; }
+  interface BirdNetSegment { startSec: number; endSec: number; top: BirdNetCandidate[]; }
+
+  // ── Species color palette (shared v2 + v4) ────────────────────────────
+  const SPECIES_COLORS = [
+    { bg: 'rgba(16,185,129,0.25)',  border: '#10b981', text: '#6ee7b7', rgb: [16,185,129] },
+    { bg: 'rgba(251,191,36,0.25)',  border: '#fbbf24', text: '#fde68a', rgb: [251,191,36] },
+    { bg: 'rgba(167,139,250,0.25)', border: '#a78bfa', text: '#c4b5fd', rgb: [167,139,250] },
+    { bg: 'rgba(251,113,133,0.25)', border: '#fb7185', text: '#fda4af', rgb: [251,113,133] },
+    { bg: 'rgba(56,189,248,0.25)',  border: '#38bdf8', text: '#7dd3fc', rgb: [56,189,248] },
+    { bg: 'rgba(52,211,153,0.25)',  border: '#34d399', text: '#6ee7b7', rgb: [52,211,153] },
+    { bg: 'rgba(249,115,22,0.25)',  border: '#f97316', text: '#fdba74', rgb: [249,115,22] },
+    { bg: 'rgba(232,121,249,0.25)', border: '#e879f9', text: '#f0abfc', rgb: [232,121,249] },
+  ];
+  const DEFAULT_COLOR_RGB = [16, 185, 129]; // emerald when no BirdNET data
 
   // ── Inferno colormap (256 RGBA entries) ───────────────────────────────
   function buildInfernoColormap(): [number, number, number, number][] {
     const stops: [number, [number, number, number]][] = [
-      [0,    [0,   0,   4]],
-      [0.13, [31,  12,  72]],
-      [0.25, [85,  15,  109]],
-      [0.38, [139, 34,  82]],
-      [0.50, [188, 55,  84]],
-      [0.63, [229, 107, 54]],
-      [0.75, [246, 163, 10]],
-      [0.88, [250, 213, 43]],
-      [1.0,  [252, 255, 164]],
+      [0, [0,0,4]], [0.13, [31,12,72]], [0.25, [85,15,109]], [0.38, [139,34,82]],
+      [0.50, [188,55,84]], [0.63, [229,107,54]], [0.75, [246,163,10]], [0.88, [250,213,43]], [1.0, [252,255,164]],
     ];
     const out: [number, number, number, number][] = [];
     for (let i = 0; i < 256; i++) {
@@ -307,33 +227,17 @@ const timerId   = `ws-time-${obsId}`;
       }
       const span = hi[0] - lo[0];
       const f = span > 0 ? (t - lo[0]) / span : 0;
-      const r = Math.round(lo[1][0] + f * (hi[1][0] - lo[1][0]));
-      const g = Math.round(lo[1][1] + f * (hi[1][1] - lo[1][1]));
-      const b = Math.round(lo[1][2] + f * (hi[1][2] - lo[1][2]));
-      out.push([r / 255, g / 255, b / 255, 1]);
+      out.push([
+        Math.round(lo[1][0] + f * (hi[1][0] - lo[1][0])) / 255,
+        Math.round(lo[1][1] + f * (hi[1][1] - lo[1][1])) / 255,
+        Math.round(lo[1][2] + f * (hi[1][2] - lo[1][2])) / 255, 1,
+      ]);
     }
     return out;
   }
 
   // ── Detection overlay (v2) ─────────────────────────────────────────────
-  // Species color palette: up to 8 distinct colors for different species
-  const SPECIES_COLORS = [
-    { bg: 'rgba(16,185,129,0.25)',  border: '#10b981', text: '#6ee7b7' },   // emerald
-    { bg: 'rgba(251,191,36,0.25)',  border: '#fbbf24', text: '#fde68a' },   // amber
-    { bg: 'rgba(167,139,250,0.25)', border: '#a78bfa', text: '#c4b5fd' },   // violet
-    { bg: 'rgba(251,113,133,0.25)', border: '#fb7185', text: '#fda4af' },   // rose
-    { bg: 'rgba(56,189,248,0.25)',  border: '#38bdf8', text: '#7dd3fc' },   // sky
-    { bg: 'rgba(52,211,153,0.25)',  border: '#34d399', text: '#6ee7b7' },   // green
-    { bg: 'rgba(249,115,22,0.25)',  border: '#f97316', text: '#fdba74' },   // orange
-    { bg: 'rgba(232,121,249,0.25)', border: '#e879f9', text: '#f0abfc' },   // fuchsia
-  ];
-
-  function renderDetectionOverlay(
-    container: HTMLElement,
-    obsId: string,
-    segments: BirdNetSegment[],
-    durationSec: number,
-  ) {
+  function renderDetectionOverlay(container: HTMLElement, obsId: string, segments: BirdNetSegment[], durationSec: number) {
     const overlayEl  = document.getElementById(`ws-detections-${obsId}`);
     const tooltipEl  = document.getElementById(`ws-tooltip-${obsId}`);
     const legendEl   = document.getElementById(`ws-legend-${obsId}`);
@@ -342,142 +246,228 @@ const timerId   = `ws-time-${obsId}`;
     const isEs       = lang === 'es';
     if (!overlayEl || !durationSec) return;
 
-    // Filter meaningful detections (confidence >= 0.3)
     const CONF_THRESHOLD = 0.3;
-    const filtered = segments
-      .filter(seg => seg.top[0]?.score >= CONF_THRESHOLD)
-      .map(seg => ({ ...seg, best: seg.top[0]! }));
-
+    const filtered = segments.filter(seg => seg.top[0]?.score >= CONF_THRESHOLD).map(seg => ({ ...seg, best: seg.top[0]! }));
     if (filtered.length === 0) return;
 
-    // Assign consistent colors per species
     const speciesOrder: string[] = [];
-    for (const seg of filtered) {
-      if (!speciesOrder.includes(seg.best.scientific_name)) {
-        speciesOrder.push(seg.best.scientific_name);
-      }
-    }
+    for (const seg of filtered) { if (!speciesOrder.includes(seg.best.scientific_name)) speciesOrder.push(seg.best.scientific_name); }
     const colorMap = new Map<string, typeof SPECIES_COLORS[0]>();
     speciesOrder.forEach((sp, i) => colorMap.set(sp, SPECIES_COLORS[i % SPECIES_COLORS.length]!));
 
-    // Build overlay bands
-    const bands: HTMLElement[] = [];
     for (const seg of filtered) {
       const color = colorMap.get(seg.best.scientific_name)!;
       const leftPct  = (seg.startSec / durationSec) * 100;
       const widthPct = ((seg.endSec - seg.startSec) / durationSec) * 100;
-
       const band = document.createElement('div');
-      band.style.cssText = `
-        position: absolute; top: 0; bottom: 0;
-        left: ${leftPct}%; width: ${widthPct}%;
-        background: ${color.bg};
-        border-left: 2px solid ${color.border};
-        border-right: 1px solid ${color.border}40;
-        cursor: pointer;
-        pointer-events: auto;
-        transition: background 0.15s;
-      `;
+      band.style.cssText = `position:absolute;top:0;bottom:0;left:${leftPct}%;width:${widthPct}%;background:${color.bg};border-left:2px solid ${color.border};border-right:1px solid ${color.border}40;cursor:pointer;pointer-events:auto;transition:background 0.15s;`;
       band.setAttribute('role', 'button');
       band.setAttribute('tabindex', '0');
       const confPct = Math.round(seg.best.score * 100);
-      const spName  = seg.best.scientific_name;
+      const spName = seg.best.scientific_name;
       const commonName = seg.best.common_name_en ?? spName;
       const timeRange = `${seg.startSec.toFixed(1)}s – ${seg.endSec.toFixed(1)}s`;
       band.setAttribute('aria-label', `${spName} ${confPct}%`);
 
-      // Hover: show tooltip
-      const showTip = (e: MouseEvent | FocusEvent) => {
+      const showTip = () => {
         if (!tooltipEl) return;
         const confBar = Math.round(seg.best.score * 10);
-        const confBarFill = '█'.repeat(confBar) + '░'.repeat(10 - confBar);
-        tooltipEl.innerHTML = `
-          <div class="font-semibold italic text-zinc-900 dark:text-zinc-100" style="color:${color.border}">${spName}</div>
-          <div class="text-zinc-500 dark:text-zinc-400">${commonName}</div>
-          <div class="mt-1 font-mono text-[10px]" style="color:${color.text}">
-            ${confBarFill} ${confPct}%
-          </div>
-          <div class="text-zinc-500 dark:text-zinc-400 mt-0.5">⏱ ${timeRange}</div>
-          <div class="text-zinc-400 dark:text-zinc-500 mt-1 text-[9px] leading-tight">
-            ${isEs
-              ? `Confianza: ${confPct}% — qué tan seguro está BirdNET de que este es el canto de <em>${spName}</em> en este intervalo. Valores ≥50% son confiables.`
-              : `Confidence: ${confPct}% — how certain BirdNET is that this is a <em>${spName}</em> call in this window. Values ≥50% are reliable.`
-            }
-          </div>
-        `;
-        // Position tooltip above cursor
+        const confBarFill = '\u2588'.repeat(confBar) + '\u2591'.repeat(10 - confBar);
+        tooltipEl.innerHTML = `<div class="font-semibold italic text-zinc-900 dark:text-zinc-100" style="color:${color.border}">${spName}</div><div class="text-zinc-500 dark:text-zinc-400">${commonName}</div><div class="mt-1 font-mono text-[10px]" style="color:${color.text}">${confBarFill} ${confPct}%</div><div class="text-zinc-500 dark:text-zinc-400 mt-0.5">\u23F1 ${timeRange}</div>`;
         const rect = band.getBoundingClientRect();
         const containerRect = overlayEl.getBoundingClientRect();
         let left = rect.left - containerRect.left;
-        const tipWidth = 200;
-        if (left + tipWidth > containerRect.width) left = containerRect.width - tipWidth - 4;
+        if (left + 200 > containerRect.width) left = containerRect.width - 204;
         tooltipEl.style.left = `${Math.max(0, left)}px`;
         tooltipEl.style.top = '-8px';
         tooltipEl.style.transform = 'translateY(-100%)';
         tooltipEl.classList.remove('hidden');
       };
       const hideTip = () => tooltipEl?.classList.add('hidden');
-
       band.addEventListener('mouseenter', showTip);
       band.addEventListener('focusin', showTip);
       band.addEventListener('mouseleave', hideTip);
       band.addEventListener('focusout', hideTip);
-      band.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') showTip(e as unknown as MouseEvent); });
 
-      // Label inside band if wide enough (>8%)
       if (widthPct > 8) {
         const lbl = document.createElement('div');
-        lbl.style.cssText = `
-          position: absolute; top: 4px; left: 4px;
-          font-size: 9px; font-weight: 600;
-          white-space: nowrap; overflow: hidden;
-          color: ${color.text};
-          text-shadow: 0 0 4px rgba(0,0,0,0.9);
-          pointer-events: none;
-        `;
+        lbl.style.cssText = `position:absolute;top:4px;left:4px;font-size:9px;font-weight:600;white-space:nowrap;overflow:hidden;color:${color.text};text-shadow:0 0 4px rgba(0,0,0,0.9);pointer-events:none;`;
         lbl.textContent = `${spName.split(' ')[0]} ${confPct}%`;
         band.appendChild(lbl);
       }
       overlayEl.appendChild(band);
-      bands.push(band);
     }
 
-    // Build species legend below spectrogram
     if (legendEl) {
       legendEl.classList.remove('hidden');
-      legendEl.innerHTML = `
-        <div class="text-[10px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1">
-          ${isEs ? 'Especies detectadas' : 'Detected species'}
-        </div>
-        ${speciesOrder.map(sp => {
-          const color  = colorMap.get(sp)!;
-          const maxConf = Math.round(Math.max(...filtered.filter(s => s.best.scientific_name === sp).map(s => s.best.score)) * 100);
-          const common = filtered.find(s => s.best.scientific_name === sp)?.best.common_name_en ?? sp;
-          const segs   = filtered.filter(s => s.best.scientific_name === sp).length;
-          return `
-            <div class="flex items-center gap-2 text-xs rounded-lg p-2 border" style="border-color:${color.border}40;background:${color.bg}">
-              <div class="w-3 h-3 rounded-sm shrink-0 border" style="background:${color.bg};border-color:${color.border}"></div>
-              <div class="min-w-0">
-                <div class="font-semibold italic text-zinc-900 dark:text-zinc-100 truncate">${sp}</div>
-                <div class="text-zinc-500 dark:text-zinc-400 text-[10px]">${common}</div>
-              </div>
-              <div class="ml-auto text-right shrink-0">
-                <div class="font-mono text-[10px]" style="color:${color.text}">${maxConf}%</div>
-                <div class="text-zinc-500 text-[9px]">${segs} ${isEs ? 'segmentos' : 'segments'}</div>
-              </div>
-            </div>`;
-        }).join('')}
-        <div class="text-[9px] text-zinc-500 dark:text-zinc-400 mt-1 leading-tight">
-          ${isEs
-            ? '% = confianza máxima · seg = segmentos donde se detectó · toca una banda verde para más detalles'
-            : '% = max confidence · seg = segments where detected · tap a green band for details'
+      legendEl.innerHTML = `<div class="text-[10px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1">${isEs ? 'Especies detectadas' : 'Detected species'}</div>${speciesOrder.map(sp => {
+        const color = colorMap.get(sp)!;
+        const maxConf = Math.round(Math.max(...filtered.filter(s => s.best.scientific_name === sp).map(s => s.best.score)) * 100);
+        const common = filtered.find(s => s.best.scientific_name === sp)?.best.common_name_en ?? sp;
+        const segs = filtered.filter(s => s.best.scientific_name === sp).length;
+        return `<div class="flex items-center gap-2 text-xs rounded-lg p-2 border" style="border-color:${color.border}40;background:${color.bg}"><div class="w-3 h-3 rounded-sm shrink-0 border" style="background:${color.bg};border-color:${color.border}"></div><div class="min-w-0"><div class="font-semibold italic text-zinc-900 dark:text-zinc-100 truncate">${sp}</div><div class="text-zinc-500 dark:text-zinc-400 text-[10px]">${common}</div></div><div class="ml-auto text-right shrink-0"><div class="font-mono text-[10px]" style="color:${color.text}">${maxConf}%</div><div class="text-zinc-500 text-[9px]">${segs} ${isEs ? 'seg' : 'seg'}</div></div></div>`;
+      }).join('')}`;
+    }
+    birdInfoEl?.classList.remove('hidden');
+  }
+
+  // ── v4: Radial frequency visualizer ───────────────────────────────────
+  function initRadialVisualizer(
+    container: HTMLElement,
+    obsId: string,
+    getMediaElement: () => HTMLMediaElement,
+    isPlayingFn: () => boolean,
+    getCurrentTimeFn: () => number,
+  ) {
+    const canvas = document.getElementById(`ws-radial-canvas-${obsId}`) as HTMLCanvasElement | null;
+    const speciesEl = document.getElementById(`ws-radial-species-${obsId}`);
+    const commonEl = document.getElementById(`ws-radial-common-${obsId}`);
+    if (!canvas) return { start() {}, stop() {} };
+
+    const ctx = canvas.getContext('2d')!;
+    let audioCtx: AudioContext | null = null;
+    let analyser: AnalyserNode | null = null;
+    let source: MediaElementAudioSourceNode | null = null;
+    let animId = 0;
+    let connected = false;
+
+    // Build species color map from BirdNET data stored on the container
+    type ContainerWithBirdnet = HTMLElement & { __birdnetSegments?: BirdNetSegment[]; __birdnetDuration?: number };
+    function getSpeciesAtTime(timeSec: number): { scientific: string; common: string; color: number[] } | null {
+      const ext = container as ContainerWithBirdnet;
+      const segments = ext.__birdnetSegments;
+      if (!segments) return null;
+      const CONF_THRESHOLD = 0.3;
+      for (const seg of segments) {
+        if (timeSec >= seg.startSec && timeSec <= seg.endSec && seg.top[0]?.score >= CONF_THRESHOLD) {
+          const speciesOrder: string[] = [];
+          for (const s of segments) {
+            if (s.top[0]?.score >= CONF_THRESHOLD && !speciesOrder.includes(s.top[0].scientific_name)) {
+              speciesOrder.push(s.top[0].scientific_name);
+            }
           }
-        </div>
-      `;
+          const idx = speciesOrder.indexOf(seg.top[0].scientific_name);
+          const c = SPECIES_COLORS[idx % SPECIES_COLORS.length];
+          return { scientific: seg.top[0].scientific_name, common: seg.top[0].common_name_en ?? '', color: c.rgb };
+        }
+      }
+      return null;
     }
 
-    // Show BirdNET info line in educational panel
-    birdInfoEl?.classList.remove('hidden');
+    function connectAnalyser() {
+      if (connected) return;
+      try {
+        const media = getMediaElement();
+        audioCtx = new AudioContext();
+        analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 256;
+        source = audioCtx.createMediaElementSource(media);
+        source.connect(analyser);
+        analyser.connect(audioCtx.destination);
+        connected = true;
+      } catch {
+        // createMediaElementSource can only be called once per element;
+        // if it fails the visualizer degrades to the idle animation.
+      }
+    }
+
+    function draw() {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = canvas!.getBoundingClientRect();
+      const w = rect.width;
+      const h = rect.height;
+      canvas!.width = w * dpr;
+      canvas!.height = h * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      ctx.fillStyle = '#09090b';
+      ctx.fillRect(0, 0, w, h);
+
+      const cx = w / 2;
+      const cy = h / 2;
+      const innerR = Math.min(w, h) * 0.18;
+      const maxBarH = Math.min(w, h) * 0.28;
+
+      const playing = isPlayingFn();
+      const currentTime = getCurrentTimeFn();
+
+      // Get frequency data
+      let dataArray: Uint8Array;
+      if (analyser && connected) {
+        dataArray = new Uint8Array(analyser.frequencyBinCount);
+        analyser.getByteFrequencyData(dataArray);
+      } else {
+        // Idle: gentle sine breathing
+        const t = Date.now() / 1000;
+        dataArray = new Uint8Array(64);
+        for (let i = 0; i < 64; i++) {
+          const base = playing ? 40 : 15;
+          dataArray[i] = base + Math.sin(t * 1.5 + i * 0.3) * (playing ? 20 : 8);
+        }
+      }
+
+      // Determine color from BirdNET species at current time
+      const species = playing ? getSpeciesAtTime(currentTime) : null;
+      const baseColor = species ? species.color : DEFAULT_COLOR_RGB;
+
+      // Update species label
+      if (speciesEl && commonEl) {
+        speciesEl.textContent = species?.scientific ?? '';
+        commonEl.textContent = species?.common ?? '';
+      }
+
+      const barCount = dataArray.length;
+      const angleStep = (Math.PI * 2) / barCount;
+
+      for (let i = 0; i < barCount; i++) {
+        const val = dataArray[i] / 255;
+        const barH = val * maxBarH + 2;
+        const angle = i * angleStep - Math.PI / 2;
+
+        const x1 = cx + Math.cos(angle) * innerR;
+        const y1 = cy + Math.sin(angle) * innerR;
+        const x2 = cx + Math.cos(angle) * (innerR + barH);
+        const y2 = cy + Math.sin(angle) * (innerR + barH);
+
+        // Color intensity based on amplitude
+        const alpha = 0.3 + val * 0.7;
+        const bright = 0.7 + val * 0.3;
+        const r = Math.round(baseColor[0] * bright);
+        const g = Math.round(baseColor[1] * bright);
+        const b = Math.round(baseColor[2] * bright);
+
+        ctx.beginPath();
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+        ctx.strokeStyle = `rgba(${r},${g},${b},${alpha})`;
+        ctx.lineWidth = Math.max(2, (w / barCount) * 0.6);
+        ctx.lineCap = 'round';
+        ctx.stroke();
+      }
+
+      // Inner glow circle
+      const glowAlpha = playing ? 0.15 + (dataArray[0] / 255) * 0.15 : 0.08;
+      const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, innerR);
+      gradient.addColorStop(0, `rgba(${baseColor[0]},${baseColor[1]},${baseColor[2]},${glowAlpha})`);
+      gradient.addColorStop(1, 'rgba(0,0,0,0)');
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(cx, cy, innerR, 0, Math.PI * 2);
+      ctx.fill();
+
+      animId = requestAnimationFrame(draw);
+    }
+
+    return {
+      start() {
+        connectAnalyser();
+        if (audioCtx?.state === 'suspended') audioCtx.resume();
+        if (!animId) animId = requestAnimationFrame(draw);
+      },
+      stop() {
+        if (animId) { cancelAnimationFrame(animId); animId = 0; }
+      },
+    };
   }
 
   // ── Main player init ──────────────────────────────────────────────────
@@ -490,21 +480,25 @@ const timerId   = `ws-time-${obsId}`;
     const labelPlay  = container.dataset.labelPlay  ?? 'Play';
     const labelSpec  = container.dataset.labelSpectro ?? 'Show spectrogram';
     const labelSpecH = container.dataset.labelSpectroHide ?? 'Hide spectrogram';
+    const labelRadial  = container.dataset.labelRadial ?? 'Visualize';
+    const labelRadialH = container.dataset.labelRadialHide ?? 'Hide';
 
     if (!audioUrl) return;
 
-    const waveEl     = document.getElementById(`ws-wave-${obsId}`);
-    const playBtn    = document.getElementById(`ws-play-${obsId}`) as HTMLButtonElement | null;
-    const toggleBtn  = document.getElementById(`ws-toggle-spec-${obsId}`) as HTMLButtonElement | null;
+    const waveEl       = document.getElementById(`ws-wave-${obsId}`);
+    const playBtn      = document.getElementById(`ws-play-${obsId}`) as HTMLButtonElement | null;
+    const toggleBtn    = document.getElementById(`ws-toggle-spec-${obsId}`) as HTMLButtonElement | null;
     const spectroPanel = document.getElementById(`ws-spec-${obsId}`);
-    const specHost   = document.getElementById(`ws-spec-host-${obsId}`);
-    const timeEl     = document.getElementById(`ws-time-${obsId}`);
-    const loadingEl  = container.querySelector<HTMLElement>('.loading-label');
-    const errorEl    = container.querySelector<HTMLElement>('.error-label');
-    const freqSelect = document.getElementById(`ws-freq-range-${obsId}`) as HTMLSelectElement | null;
-    const exportBtn  = document.getElementById(`ws-export-${obsId}`) as HTMLButtonElement | null;
-    const infoBtn    = document.getElementById(`ws-info-btn-${obsId}`) as HTMLButtonElement | null;
-    const infoPanel  = document.getElementById(`ws-info-panel-${obsId}`);
+    const specHost     = document.getElementById(`ws-spec-host-${obsId}`);
+    const timeEl       = document.getElementById(`ws-time-${obsId}`);
+    const loadingEl    = container.querySelector<HTMLElement>('.loading-label');
+    const errorEl      = container.querySelector<HTMLElement>('.error-label');
+    const freqSelect   = document.getElementById(`ws-freq-range-${obsId}`) as HTMLSelectElement | null;
+    const exportBtn    = document.getElementById(`ws-export-${obsId}`) as HTMLButtonElement | null;
+    const infoBtn      = document.getElementById(`ws-info-btn-${obsId}`) as HTMLButtonElement | null;
+    const infoPanel    = document.getElementById(`ws-info-panel-${obsId}`);
+    const radialToggle = document.getElementById(`ws-toggle-radial-${obsId}`) as HTMLButtonElement | null;
+    const radialPanel  = document.getElementById(`ws-radial-${obsId}`);
 
     if (!waveEl) return;
 
@@ -514,7 +508,6 @@ const timerId   = `ws-time-${obsId}`;
       return `${m}:${s.toString().padStart(2, '0')}`;
     }
 
-    // Info panel toggle
     infoBtn?.addEventListener('click', () => {
       const hidden = infoPanel?.classList.toggle('hidden');
       infoBtn.setAttribute('aria-expanded', hidden ? 'false' : 'true');
@@ -527,12 +520,8 @@ const timerId   = `ws-time-${obsId}`;
         waveColor: '#10b981',
         progressColor: '#047857',
         cursorColor: '#6ee7b7',
-        barWidth: 2,
-        barGap: 1,
-        barRadius: 2,
-        height: 60,
-        normalize: true,
-        url: audioUrl,
+        barWidth: 2, barGap: 1, barRadius: 2,
+        height: 60, normalize: true, url: audioUrl,
       });
 
       ws.on('ready', () => {
@@ -562,37 +551,56 @@ const timerId   = `ws-time-${obsId}`;
 
       playBtn?.addEventListener('click', () => ws.playPause());
 
+      // ── v4: Radial visualizer ─────────────────────────────────────────
+      let radialViz: { start(): void; stop(): void } | null = null;
+      let radialActive = false;
+
+      if (showSpec && radialToggle && radialPanel) {
+        radialToggle.addEventListener('click', () => {
+          const expanded = radialToggle.getAttribute('aria-expanded') === 'true';
+          if (!expanded) {
+            radialPanel.classList.remove('hidden');
+            radialToggle.setAttribute('aria-expanded', 'true');
+            radialToggle.textContent = labelRadialH;
+            if (!radialViz) {
+              radialViz = initRadialVisualizer(
+                container, obsId,
+                () => (ws as unknown as { getMediaElement(): HTMLMediaElement }).getMediaElement(),
+                () => ws.isPlaying(),
+                () => ws.getCurrentTime(),
+              );
+            }
+            radialViz.start();
+            radialActive = true;
+          } else {
+            radialPanel.classList.add('hidden');
+            radialToggle.setAttribute('aria-expanded', 'false');
+            radialToggle.textContent = labelRadial;
+            radialViz?.stop();
+            radialActive = false;
+          }
+        });
+      }
+
       // ── Lazy spectrogram (v1 + v2 + v3) ──────────────────────────────
       if (showSpec && toggleBtn && spectroPanel) {
-        let spectroLoaded  = false;
+        let spectroLoaded = false;
         let spectroPlugin: unknown = null;
         let currentFreqMax = 12000;
-
         const COLORMAP = buildInfernoColormap();
 
         async function loadSpectrogram(freqMax = 12000) {
-          const host = specHost;
-          if (!host) return null;
+          if (!specHost) return null;
           try {
             const { SpectrogramPlugin } = await import('wavesurfer.js/plugins/spectrogram');
             const plugin = SpectrogramPlugin.create({
-              container: host,
-              labels: true,
-              labelsBackground: 'rgba(9,9,11,0.7)',
-              labelsColor: '#a1a1aa',
-              labelsHzColor: '#a1a1aa',
-              height: 140,
-              frequencyMax: freqMax,
-              frequencyMin: 0,
-              fftSamples: 512,
-              colorMap: COLORMAP,
+              container: specHost, labels: true,
+              labelsBackground: 'rgba(9,9,11,0.7)', labelsColor: '#a1a1aa', labelsHzColor: '#a1a1aa',
+              height: 140, frequencyMax: freqMax, frequencyMin: 0, fftSamples: 512, colorMap: COLORMAP,
             });
             ws.registerPlugin(plugin);
             return plugin;
-          } catch (e) {
-            console.warn('[rastrum] spectrogram failed:', e);
-            return null;
-          }
+          } catch (e) { console.warn('[rastrum] spectrogram failed:', e); return null; }
         }
 
         toggleBtn.addEventListener('click', async () => {
@@ -601,10 +609,7 @@ const timerId   = `ws-time-${obsId}`;
             spectroPanel.classList.remove('hidden');
             toggleBtn.setAttribute('aria-expanded', 'true');
             toggleBtn.textContent = labelSpecH;
-            if (!spectroLoaded) {
-              spectroLoaded = true;
-              spectroPlugin = await loadSpectrogram(currentFreqMax);
-            }
+            if (!spectroLoaded) { spectroLoaded = true; spectroPlugin = await loadSpectrogram(currentFreqMax); }
           } else {
             spectroPanel.classList.add('hidden');
             toggleBtn.setAttribute('aria-expanded', 'false');
@@ -612,20 +617,16 @@ const timerId   = `ws-time-${obsId}`;
           }
         });
 
-        // v3: Frequency zoom
         freqSelect?.addEventListener('change', async () => {
           const newFreq = parseInt(freqSelect.value, 10);
           if (newFreq === currentFreqMax || !spectroLoaded) { currentFreqMax = newFreq; return; }
           currentFreqMax = newFreq;
-          // Update top label
           const topLabel = document.getElementById(`ws-freq-top-${obsId}`);
           if (topLabel) topLabel.textContent = `${newFreq / 1000} kHz`;
-          // Recreate spectrogram with new freq range
           if (specHost) specHost.innerHTML = '';
           spectroPlugin = await loadSpectrogram(newFreq);
         });
 
-        // v3: Export spectrogram as PNG
         exportBtn?.addEventListener('click', async () => {
           const canvas = specHost?.querySelector('canvas');
           if (!canvas) {
@@ -634,10 +635,6 @@ const timerId   = `ws-time-${obsId}`;
             return;
           }
           try {
-            // Use blob URL for cross-origin safety (R2 audio + iOS Safari).
-            // canvas.toDataURL() works when wavesurfer renders from an
-            // in-memory AudioBuffer — no taint issues. Wrap in Blob just in
-            // case the browser restricts the data: scheme for downloads.
             const dataUrl = canvas.toDataURL('image/png');
             const res = await fetch(dataUrl);
             const blob = await res.blob();
@@ -648,7 +645,6 @@ const timerId   = `ws-time-${obsId}`;
             link.click();
             setTimeout(() => URL.revokeObjectURL(blobUrl), 10000);
           } catch {
-            // Last resort: open in new tab (user can long-press to save on iOS)
             const dataUrl = canvas.toDataURL('image/png');
             window.open(dataUrl, '_blank');
           }
@@ -660,37 +656,6 @@ const timerId   = `ws-time-${obsId}`;
       errorEl?.classList.remove('hidden');
       console.warn('[rastrum] WaveSurfer init failed:', err);
     }
-  }
-
-  function buildInfernoColormap(): [number, number, number, number][] {
-    const stops: [number, [number, number, number]][] = [
-      [0,    [0,   0,   4]],
-      [0.13, [31,  12,  72]],
-      [0.25, [85,  15,  109]],
-      [0.38, [139, 34,  82]],
-      [0.50, [188, 55,  84]],
-      [0.63, [229, 107, 54]],
-      [0.75, [246, 163, 10]],
-      [0.88, [250, 213, 43]],
-      [1.0,  [252, 255, 164]],
-    ];
-    const out: [number, number, number, number][] = [];
-    for (let i = 0; i < 256; i++) {
-      const t = i / 255;
-      let lo = stops[0], hi = stops[stops.length - 1];
-      for (let j = 0; j < stops.length - 1; j++) {
-        if (t >= stops[j][0] && t <= stops[j + 1][0]) { lo = stops[j]; hi = stops[j + 1]; break; }
-      }
-      const span = hi[0] - lo[0];
-      const f = span > 0 ? (t - lo[0]) / span : 0;
-      out.push([
-        Math.round(lo[1][0] + f * (hi[1][0] - lo[1][0])) / 255,
-        Math.round(lo[1][1] + f * (hi[1][1] - lo[1][1])) / 255,
-        Math.round(lo[1][2] + f * (hi[1][2] - lo[1][2])) / 255,
-        1,
-      ]);
-    }
-    return out;
   }
 })();
 </script>

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -104,7 +104,7 @@ const sgReport = sgTree.socialgraph.report.button;
     taxa: { common_name_es: string | null; common_name_en: string | null } | null;
   };
 
-  type Media = { url: string | null; is_primary: boolean | null };
+  type Media = { url: string | null; is_primary: boolean | null; media_type: string | null };
 
   type Observer = {
     id: string;
@@ -171,7 +171,10 @@ const sgReport = sgTree.socialgraph.report.button;
       ? (ident?.taxa?.common_name_es ?? ident?.taxa?.common_name_en ?? '')
       : (ident?.taxa?.common_name_en ?? ident?.taxa?.common_name_es ?? '');
     const confidence = typeof ident?.confidence === 'number' ? Math.max(0, Math.min(1, ident.confidence)) : null;
-    const photo = (r.media_files ?? []).find(m => m?.is_primary)?.url ?? (r.media_files ?? []).find(m => !!m?.url)?.url ?? '';
+    const photoMedia = (r.media_files ?? []).filter(m => !m?.media_type || m.media_type === 'photo');
+    const audioMedia = (r.media_files ?? []).filter(m => m?.media_type === 'audio');
+    const photo = photoMedia.find(m => m?.is_primary)?.url ?? photoMedia.find(m => !!m?.url)?.url ?? '';
+    const hasAudioOnly = !photo && audioMedia.length > 0;
     const ago = formatTimeAgo(r.observed_at, lang);
     const isPublic = canShowRealName(observer, viewerAuthed);
     const observerName = isPublic ? (observer?.display_name || observer?.username || '') : '';
@@ -229,7 +232,9 @@ const sgReport = sgTree.socialgraph.report.button;
         <div class="aspect-square w-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
           ${photo
             ? `<img src="${escapeText(photo)}" alt="${escapeText(sci)}" loading="lazy" class="w-full h-full object-cover" />`
-            : ''}
+            : hasAudioOnly
+              ? `<div class="w-full h-full flex flex-col items-center justify-center gap-2 text-zinc-400 dark:text-zinc-500"><svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z"/></svg><span class="text-[10px] font-medium uppercase tracking-wider">${lang === 'es' ? 'Audio' : 'Audio'}</span></div>`
+              : ''}
         </div>
         <div class="p-3 space-y-1">
           <p class="text-sm italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escapeText(sci)}</p>
@@ -306,7 +311,7 @@ const sgReport = sgTree.socialgraph.report.button;
         .select(`
           id, observed_at, state_province, observer_id,
           identifications(scientific_name, is_primary, is_research_grade, confidence, taxa(common_name_es, common_name_en)),
-          media_files(url, is_primary),
+          media_files(url, is_primary, media_type),
           users:observer_id(id, username, display_name, profile_public, profile_privacy)
         `)
         .eq('sync_status', 'synced')

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -157,7 +157,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     id: string;
     location: GeoJSON.Point | null;
     observed_at: string;
-    media_files: { url: string | null; is_primary: boolean | null }[];
+    media_files: { url: string | null; is_primary: boolean | null; media_type?: string | null }[];
   };
 
   function escapeText(s: string): string {
@@ -473,7 +473,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     try {
       const { data, error } = await supabase
         .from('observations')
-        .select('id, location, observed_at, media_files(url, is_primary)')
+        .select('id, location, observed_at, media_files(url, is_primary, media_type)')
         .eq('sync_status', 'synced')
         .eq('primary_taxon_id', taxon.id)
         .order('observed_at', { ascending: false })
@@ -486,11 +486,12 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
 
     if (photosEl) {
       const top = obsRows
-        .filter(o => (o.media_files ?? []).some(m => m?.url))
+        .filter(o => (o.media_files ?? []).some(m => m?.url && (!m.media_type || m.media_type === 'photo')))
         .slice(0, 6)
         .map(o => {
-          const media = (o.media_files ?? []).find(m => m?.is_primary && m?.url) ?? (o.media_files ?? []).find(m => m?.url);
-          const url = media?.url ?? '';
+          const media = (o.media_files ?? []).filter(m => !m?.media_type || m.media_type === 'photo');
+          const pick = media.find(m => m?.is_primary && m?.url) ?? media.find(m => m?.url);
+          const url = pick?.url ?? '';
           return `<li><a href="${shareBase}?id=${encodeURIComponent(o.id)}" class="block aspect-square overflow-hidden rounded-lg bg-zinc-100 dark:bg-zinc-800"><img src="${escapeText(url)}" alt="${escapeText(taxon!.scientific_name)}" loading="lazy" class="w-full h-full object-cover" /></a></li>`;
         });
       photosEl.innerHTML = top.join('');

--- a/src/components/MyObservationsView.astro
+++ b/src/components/MyObservationsView.astro
@@ -190,7 +190,7 @@ const tabs = [
   type Lang = 'en' | 'es';
 
   type Ident = { scientific_name: string; is_primary: boolean; is_research_grade?: boolean };
-  type Media = { url: string; is_primary: boolean };
+  type Media = { url: string; is_primary: boolean; media_type?: string | null };
   type Row = {
     id: string;
     observed_at: string;
@@ -240,7 +240,10 @@ const tabs = [
     const ident = Array.isArray(r.identifications) ? r.identifications[0] : r.identifications;
     const unknown = root?.dataset.labelUnknownSpecies ?? 'Unidentified';
     const name = ident?.scientific_name ?? unknown;
-    const photo = (r.media_files ?? []).find(m => m.is_primary)?.url ?? (r.media_files ?? [])[0]?.url ?? '';
+    const photoMedia = (r.media_files ?? []).filter(m => !m.media_type || m.media_type === 'photo');
+    const audioMedia = (r.media_files ?? []).filter(m => m.media_type === 'audio');
+    const photo = photoMedia.find(m => m.is_primary)?.url ?? photoMedia[0]?.url ?? '';
+    const hasAudioOnly = !photo && audioMedia.length > 0;
     const date = new Date(r.observed_at).toLocaleDateString(lang === 'es' ? 'es' : 'en');
     const region = r.state_province ? ' · ' + r.state_province : '';
     const isSynced = r.sync_status === 'synced';
@@ -291,7 +294,7 @@ const tabs = [
       <div class="flex items-center gap-3 p-3 ${isSynced ? 'hover:bg-zinc-50 dark:hover:bg-zinc-800/40' : 'opacity-90'} ${hiddenOverlayClass}">
         <${wrapTag} ${wrapAttr} class="flex items-center gap-3 min-w-0 flex-1">
           <div class="w-16 h-16 shrink-0 rounded-lg overflow-hidden bg-zinc-100 dark:bg-zinc-800">
-            ${photo ? `<img src="${escapeText(photo)}" alt="${escapeText(name)}" class="w-full h-full object-cover" loading="lazy" />` : ''}
+            ${photo ? `<img src="${escapeText(photo)}" alt="${escapeText(name)}" class="w-full h-full object-cover" loading="lazy" />` : hasAudioOnly ? `<div class="w-full h-full flex items-center justify-center text-zinc-400 dark:text-zinc-500"><svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z"/></svg></div>` : ''}
           </div>
           <div class="min-w-0 flex-1">
             <p class="text-sm italic font-medium text-zinc-900 dark:text-zinc-100 truncate">${escapeText(name)}</p>
@@ -417,7 +420,7 @@ const tabs = [
     const supabase = getSupabase();
     let q = supabase
       .from('observations')
-      .select('id, observed_at, sync_status, state_province, hidden, hidden_reason, identifications(scientific_name, is_primary, is_research_grade), media_files(url, is_primary)')
+      .select('id, observed_at, sync_status, state_province, hidden, hidden_reason, identifications(scientific_name, is_primary, is_research_grade), media_files(url, is_primary, media_type)')
       .eq('observer_id', userId)
       .order('observed_at', { ascending: false })
       .range(offset, offset + PAGE_SIZE - 1);

--- a/src/components/PublicProfileView.astro
+++ b/src/components/PublicProfileView.astro
@@ -136,7 +136,7 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
     observed_at: string;
     state_province: string | null;
     identifications: Array<{ scientific_name: string; is_primary: boolean }> | { scientific_name: string; is_primary: boolean } | null;
-    media_files: Array<{ url: string; is_primary: boolean }>;
+    media_files: Array<{ url: string; is_primary: boolean; media_type?: string | null }>;
   };
 
   type BadgeRow = {
@@ -295,7 +295,7 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
     // Recent observations (top 12)
     const { data: obs } = await supabase
       .from('observations')
-      .select('id, observed_at, state_province, identifications!inner(scientific_name, is_primary), media_files(url, is_primary)')
+      .select('id, observed_at, state_province, identifications!inner(scientific_name, is_primary), media_files(url, is_primary, media_type)')
       .eq('observer_id', profile.id)
       .eq('sync_status', 'synced')
       .eq('identifications.is_primary', true)
@@ -314,7 +314,10 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
     if (obsList) {
       obsList.innerHTML = (obs as ObsRow[]).map(o => {
         const ident = Array.isArray(o.identifications) ? o.identifications[0] : o.identifications;
-        const photo = (o.media_files ?? []).find(m => m.is_primary)?.url ?? (o.media_files ?? [])[0]?.url ?? '';
+        const photoMedia = (o.media_files ?? []).filter(m => !m.media_type || m.media_type === 'photo');
+        const audioMedia = (o.media_files ?? []).filter(m => m.media_type === 'audio');
+        const photo = photoMedia.find(m => m.is_primary)?.url ?? photoMedia[0]?.url ?? '';
+        const hasAudioOnly = !photo && audioMedia.length > 0;
         const date = new Date(o.observed_at).toLocaleDateString(lang === 'es' ? 'es' : 'en');
         const name = ident?.scientific_name ?? unknown;
         const safeName = name.replace(/</g, '&lt;');
@@ -322,7 +325,7 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
         return `<li class="rounded-lg overflow-hidden border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50">
           <a href="${shareBase}?id=${o.id}" class="block">
             <div class="aspect-square bg-zinc-100 dark:bg-zinc-800">
-              ${photo ? `<img src="${photo}" alt="${safeName}" class="w-full h-full object-cover" loading="lazy" />` : ''}
+              ${photo ? `<img src="${photo}" alt="${safeName}" class="w-full h-full object-cover" loading="lazy" />` : hasAudioOnly ? `<div class="w-full h-full flex flex-col items-center justify-center gap-1 text-zinc-400 dark:text-zinc-500"><svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z"/></svg><span class="text-[9px] uppercase tracking-wider">Audio</span></div>` : ''}
             </div>
             <div class="p-2">
               <p class="text-xs italic font-medium text-zinc-900 dark:text-zinc-100 truncate">${safeName}</p>

--- a/src/components/ShareObsView.astro
+++ b/src/components/ShareObsView.astro
@@ -78,6 +78,13 @@ const labels = {
         <!-- The page script replaces innerHTML when audios are found.
              The div stays hidden until then. -->
         <div id="obs-audio-players" class="hidden space-y-3"></div>
+        <!-- Hidden AudioPlayer instance so Astro bundles the <script> that
+             listens for `rastrum:audio-players-ready`. The dynamic HTML
+             injected by the page script creates `.rastrum-audio-player`
+             nodes, but without this anchor the init JS is tree-shaken. -->
+        <div class="hidden" aria-hidden="true">
+          <AudioPlayer audioUrl="" lang={lang} obsId="__anchor" showSpectrogram={false} />
+        </div>
       </aside>
 
       <section class="md:col-span-5 lg:col-span-5 space-y-6">

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -3,9 +3,14 @@
 // Uses is:inline + define:vars to inject env vars without Astro TypeScript processing
 ---
 <script is:inline define:vars={{ apiKey: import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN, apiHost: import.meta.env.PUBLIC_POSTHOG_HOST }}>
-  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-  posthog.init(apiKey || '', {
-    api_host: apiHost || '',
-    defaults: '2026-01-30'
-  });
+  // Guard: skip PostHog entirely when credentials are missing. Without
+  // this, the snippet builds the SDK URL as `"" + "/static/array.js"`,
+  // which resolves to the app's own domain and 404s.
+  if (apiKey && apiHost) {
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init(apiKey, {
+      api_host: apiHost,
+      defaults: '2026-01-30'
+    });
+  }
 </script>

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -123,6 +123,8 @@ const lang: 'en' | 'es' = 'en';
         const timeLabel    = isEs ? 'Tiempo (s)' : 'Time (s)';
         const loadLabel    = isEs ? 'Cargando audio…' : 'Loading audio…';
         const errLabel     = isEs ? 'No se pudo cargar el audio.' : 'Could not load audio.';
+        const radialLabel  = isEs ? 'Visualizar' : 'Visualize';
+        const radialHide   = isEs ? 'Ocultar' : 'Hide';
         return `
             <div
               class="rastrum-audio-player rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 overflow-hidden"
@@ -137,6 +139,8 @@ const lang: 'en' | 'es' = 'en';
               data-label-spectro-hide="${spectroHide}"
               data-label-freq="${freqLabel}"
               data-label-time="${timeLabel}"
+              data-label-radial="${radialLabel}"
+              data-label-radial-hide="${radialHide}"
             >
               <div class="px-3 pt-3">
                 <div id="ws-wave-${obsIdAttr}" style="min-height:60px;"></div>
@@ -152,10 +156,21 @@ const lang: 'en' | 'es' = 'en';
                 <span class="loading-label text-xs text-zinc-400 dark:text-zinc-500">${loadLabel}</span>
                 <span class="error-label hidden text-xs text-red-500">${errLabel}</span>
                 <div class="flex-1"></div>
+                <button id="ws-toggle-radial-${obsIdAttr}" type="button" aria-expanded="false"
+                  class="text-xs text-sky-600 dark:text-sky-400 underline underline-offset-2 hover:no-underline shrink-0">${radialLabel}</button>
                 <button id="ws-toggle-spec-${obsIdAttr}" type="button" aria-expanded="false"
                   class="text-xs text-emerald-700 dark:text-emerald-400 underline underline-offset-2 hover:no-underline shrink-0">
                   ${spectroLabel}
                 </button>
+              </div>
+              <div id="ws-radial-${obsIdAttr}" class="hidden px-3 pb-3">
+                <div class="relative flex items-center justify-center rounded-xl bg-zinc-950 overflow-hidden" style="height:280px;">
+                  <canvas id="ws-radial-canvas-${obsIdAttr}" class="w-full h-full" aria-hidden="true"></canvas>
+                  <div id="ws-radial-label-${obsIdAttr}" class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none select-none">
+                    <span id="ws-radial-species-${obsIdAttr}" class="text-sm font-semibold italic text-white/80 drop-shadow-lg transition-all duration-300"></span>
+                    <span id="ws-radial-common-${obsIdAttr}" class="text-[11px] text-white/50 mt-0.5 transition-all duration-300"></span>
+                  </div>
+                </div>
               </div>
               <div id="ws-spec-${obsIdAttr}" class="hidden px-3 pb-2">
                 <div class="flex items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary

### Bug fixes
- **posthog.astro**: Guard `if (apiKey && apiHost)` prevents 404 on `/static/array.js` when PostHog env vars are missing
- **ShareObsView.astro**: Render a hidden AudioPlayer anchor so Astro includes the wavesurfer.js script in the bundle — the audio player on `/share/obs/` was never loading because the component was imported but never rendered in the template
- **share/obs/index.astro**: Add radial visualizer panel to the dynamic audio player HTML

### New feature — v4 radial frequency visualizer
- Real-time circular frequency bars via Web Audio API `AnalyserNode` connected to wavesurfer's `<audio>` element
- BirdNET species coloring synced to playback position (same 8-color palette as the spectrogram overlay)
- Species name + common name overlay centered in the ring
- Idle breathing animation (gentle sine wave) when paused
- Toggle button in sky blue ("Visualize" / "Hide") next to the existing spectrogram toggle
- Zero new dependencies — uses native Web Audio API + canvas 2D

### Audio card placeholders (4 views)
- Added `media_type` to `media_files` queries in ExploreRecentView, MyObservationsView, ExploreSpeciesView, PublicProfileView
- Audio-only observations now show a music note icon + "Audio" label instead of an empty grey square
- Photo filtering correctly excludes audio URLs from `<img>` tags

## Testing
- `npm run typecheck` — zero errors
- `npm run test` — 738 tests passing
- `npm run build` — 219 pages, zero errors
- Verified locally: audio player renders on `/share/obs/` (CORS blocks R2 audio from localhost, but the player shell + error state confirms the script loads)

## Files changed (8)
| File | What |
|---|---|
| `posthog.astro` | Guard missing env vars |
| `ShareObsView.astro` | AudioPlayer anchor for script bundling |
| `AudioPlayer.astro` | v4 radial visualizer + refactored v1-v3 |
| `share/obs/index.astro` | Dynamic HTML includes radial panel |
| `ExploreRecentView.astro` | media_type query + audio placeholder |
| `MyObservationsView.astro` | media_type query + audio placeholder |
| `ExploreSpeciesView.astro` | media_type query + photo-only filter |
| `PublicProfileView.astro` | media_type query + audio placeholder |