### PR TITLE
fix(obs-detail): save button spins indefinitely (#395)

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -207,33 +207,60 @@ export async function wireManagePanelDetails(
         weather: weatherEl?.value ?? '',
         establishment_means: estabEl?.value ?? '',
       });
-      const { error: obsErr } = await supabase
-        .from('observations')
-        .update(payload)
-        .eq('id', obsId);
-      if (obsErr) throw obsErr;
 
-      const sci = sciInput?.value.trim();
-      if (sci) {
-        await supabase.from('identifications')
-          .update({ is_primary: false })
-          .eq('observation_id', obsId)
-          .eq('is_primary', true);
-        const { data: { user: viewer } } = await supabase.auth.getUser();
-        const { error: idErr } = await supabase.from('identifications').insert({
-          observation_id: obsId,
-          scientific_name: sci,
-          confidence: 0.95,
-          source: 'human',
-          is_primary: true,
-          validated_by: null,
-          validated_at: new Date().toISOString(),
-          raw_response: { manual_override: true, by: viewer?.id ?? null },
-        });
-        if (idErr) throw idErr;
-      }
+      // Wrap the entire online save in a timeout so the button never
+      // stays disabled indefinitely (e.g. stale auth lock, network limbo).
+      const SAVE_TIMEOUT_MS = 15_000;
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(
+          lang === 'es'
+            ? 'La operación tardó demasiado. Verifica tu conexión e intenta de nuevo.'
+            : 'Operation timed out. Check your connection and try again.'
+        )), SAVE_TIMEOUT_MS),
+      );
+
+      await Promise.race([timeout, (async () => {
+        const { error: obsErr } = await supabase
+          .from('observations')
+          .update(payload)
+          .eq('id', obsId);
+        if (obsErr) throw obsErr;
+
+        const sci = sciInput?.value.trim();
+        if (sci) {
+          // Demote the current primary identification. Capture the error —
+          // if RLS rejects this (stale session, wrong owner), we must not
+          // proceed to the insert or the unique partial index will reject it.
+          const { error: demoteErr } = await supabase.from('identifications')
+            .update({ is_primary: false })
+            .eq('observation_id', obsId)
+            .eq('is_primary', true);
+          if (demoteErr) throw demoteErr;
+
+          let viewerId: string | null = null;
+          try {
+            const { data: { user: viewer } } = await supabase.auth.getUser();
+            viewerId = viewer?.id ?? null;
+          } catch {
+            // Auth fetch failed — proceed without viewer ID rather than hang
+          }
+
+          const { error: idErr } = await supabase.from('identifications').insert({
+            observation_id: obsId,
+            scientific_name: sci,
+            confidence: 0.95,
+            source: 'human',
+            is_primary: true,
+            validated_by: null,
+            validated_at: new Date().toISOString(),
+            raw_response: { manual_override: true, by: viewerId },
+          });
+          if (idErr) throw idErr;
+        }
+      })()]);
 
       savedEl?.classList.remove('hidden');
+      const sci = sciInput?.value.trim();
       const speciesEl = document.getElementById('species');
       if (sci && speciesEl) speciesEl.textContent = sci;
     } catch (err) {


### PR DESCRIPTION
Closes #395

## Problem

The 'Guardar cambios' button on the observation detail manage panel spins indefinitely when saving a species name override, even with active connectivity. Reported by a field tester in Oaxaca.

## Root causes

1. **Silent RLS failure on demote update** — The `UPDATE identifications SET is_primary = false` call did not capture its error. If RLS rejected it (stale session, wrong owner), the code proceeded to INSERT a new primary identification, which failed on the `uniq_primary_id_per_obs` unique partial index. The error message was a confusing constraint violation instead of the real auth issue.

2. **No timeout protection** — If any Supabase call hung (auth lock contention from `navigator.locks`, network limbo, stale TCP), the Promise never resolved and the `finally` block never ran. The button stayed disabled forever.

3. **`getUser()` could abort the save** — If the auth token refresh failed, `supabase.auth.getUser()` threw and aborted the entire save, even though the viewer ID is just optional metadata in `raw_response`.

## Fix

- Capture and throw the error from the `is_primary` demote update
- Wrap the entire online save path in a 15-second `Promise.race` timeout
- Wrap `getUser()` in its own try/catch so auth failures don't block the save
- The `finally` block always re-enables the button and restores the label

## Testing

- `npm run typecheck` — zero errors
- `npm run test` — 739 tests passing
- `npm run build` — 219 pages, zero errors