### PR TITLE
fix(admin): role hierarchy + SECURITY DEFINER trigger

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2232,7 +2232,10 @@ ALTER TABLE public.admin_audit ENABLE ROW LEVEL SECURITY;
 
 -- 6. Sync trigger keeps users.is_expert / .credentialed_researcher cached
 CREATE OR REPLACE FUNCTION public.sync_user_role_flags() RETURNS trigger
-LANGUAGE plpgsql AS $$
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
 BEGIN
   IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') THEN
     UPDATE public.users

--- a/supabase/functions/admin/_shared/auth.ts
+++ b/supabase/functions/admin/_shared/auth.ts
@@ -50,8 +50,21 @@ export async function verifyJwtAndLoadRoles(req: Request): Promise<Actor> {
   return { id: userRes.user.id, roles };
 }
 
+/**
+ * Role hierarchy: admin ⊃ moderator. An admin implicitly satisfies any
+ * check that requires moderator. All other roles are independent.
+ */
+const ROLE_IMPLIES: Record<UserRole, UserRole[]> = {
+  admin:      ['moderator'],
+  moderator:  [],
+  expert:     [],
+  researcher: [],
+};
+
 export function requireRole(actor: Actor, required: UserRole): void {
-  if (!actor.roles.has(required)) {
-    throw new HttpError(403, `requires ${required}`);
+  if (actor.roles.has(required)) return;
+  for (const held of actor.roles) {
+    if (ROLE_IMPLIES[held]?.includes(required)) return;
   }
+  throw new HttpError(403, `requires ${required}`);
 }


### PR DESCRIPTION
## Summary

Two bugs prevented admins from granting roles via the console:

### Bug 1 — `requires moderator` (403)
`user.detail` handler has `requiredRole: 'moderator'`. `requireRole()` did exact-match checks, so having `admin` did not satisfy a `moderator` requirement.

**Fix:** Added a `ROLE_IMPLIES` map where `admin ⊃ moderator`. An admin now implicitly satisfies any check that requires moderator.

### Bug 2 — `permission denied for table users` (500)
`role.grant` inserts into `user_roles` via `service_role` (bypasses RLS), but the `sync_user_role_flags()` trigger fires and tries to UPDATE `users`. The trigger was not `SECURITY DEFINER`, so the RLS policy `users_self_update` (`auth.uid() = id`) blocked it — `auth.uid()` is NULL in trigger context.

**Fix:** Made `sync_user_role_flags()` `SECURITY DEFINER SET search_path = public`.

### Files changed
- `supabase/functions/admin/_shared/auth.ts` — role hierarchy in `requireRole()`
- `docs/specs/infra/supabase-schema.sql` — trigger now SECURITY DEFINER

### Tested
- `npm run typecheck` — zero errors
- `npm run test` — 739 passed
- `npm run build` — 219 pages, zero errors

### Deploy notes
After merge:
1. **Schema:** `make db-apply` to update the trigger in Postgres
2. **Edge Function:** CI deploys `admin` function automatically, or manual: `gh workflow run deploy-functions.yml -f function=admin`