### PR TITLE
fix(obs-detail): stale data + species correction bugs

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -15,6 +15,7 @@ import { resizeImage, uploadMedia } from './upload';
 import { escapeHtml as escAttr } from './escape';
 import { t } from '../i18n/utils';
 import { openConfirmDialog } from './confirm-dialog';
+import { correctIdentificationName } from './taxonomy-synonyms';
 
 type Ident = { scientific_name?: string; is_primary?: boolean } | undefined;
 
@@ -147,6 +148,8 @@ export async function wireManagePanelDetails(
       if (!navigator.onLine) {
         const sci = sciInput?.value.trim();
         if (sci) {
+          // Apply taxonomy synonym correction for known outdated names
+          const correctedSci = correctIdentificationName(sci);
           // Update the Dexie record's identification data
           try {
             const { getDB } = await import('./db');
@@ -155,20 +158,23 @@ export async function wireManagePanelDetails(
             if (record && record.data) {
               record.data.identification = {
                 ...record.data.identification,
-                scientificName: sci,
+                scientificName: correctedSci,
                 source: 'human' as const,
                 status: 'accepted' as const,
                 confidence: 0.95,
               };
-              // Mark for re-sync so the identification gets persisted server-side
+              // Always flip to 'pending' — records stuck in 'error' or 'draft'
+              // must also re-enter the sync queue after a species correction.
               await db.observations.update(obsId, {
                 data: record.data,
-                sync_status: record.sync_status === 'synced' ? 'pending' : record.sync_status,
+                sync_status: 'pending',
                 updated_at: new Date().toISOString(),
               });
               savedEl?.classList.remove('hidden');
               const speciesEl = document.getElementById('species');
-              if (speciesEl) speciesEl.textContent = sci;
+              if (speciesEl) speciesEl.textContent = correctedSci;
+              // If the user typed an outdated name, update the input
+              if (correctedSci !== sci && sciInput) sciInput.value = correctedSci;
               // Show offline indicator
               if (savedEl) {
                 savedEl.textContent = lang === 'es'
@@ -228,6 +234,8 @@ export async function wireManagePanelDetails(
 
         const sci = sciInput?.value.trim();
         if (sci) {
+          // Apply taxonomy synonym correction for known outdated names (#345)
+          const correctedSci = correctIdentificationName(sci);
           // Demote the current primary identification. Capture the error —
           // if RLS rejects this (stale session, wrong owner), we must not
           // proceed to the insert or the unique partial index will reject it.
@@ -247,7 +255,7 @@ export async function wireManagePanelDetails(
 
           const { error: idErr } = await supabase.from('identifications').insert({
             observation_id: obsId,
-            scientific_name: sci,
+            scientific_name: correctedSci,
             confidence: 0.95,
             source: 'human',
             is_primary: true,
@@ -261,8 +269,18 @@ export async function wireManagePanelDetails(
 
       savedEl?.classList.remove('hidden');
       const sci = sciInput?.value.trim();
-      const speciesEl = document.getElementById('species');
-      if (sci && speciesEl) speciesEl.textContent = sci;
+      if (sci) {
+        const correctedSci = correctIdentificationName(sci);
+        const speciesEl = document.getElementById('species');
+        if (speciesEl) speciesEl.textContent = correctedSci;
+        // If the user typed an outdated name, update the input to show the correction
+        if (correctedSci !== sci && sciInput) sciInput.value = correctedSci;
+      }
+      // Notify the page that identification data changed so it can
+      // re-fetch community IDs and other dependent sections.
+      window.dispatchEvent(new CustomEvent('rastrum:observation-updated', {
+        detail: { observationId: obsId },
+      }));
     } catch (err) {
       if (errEl) {
         errEl.textContent = err instanceof Error ? err.message : String(err);

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -28,6 +28,54 @@ const lang: 'en' | 'es' = 'en';
         const err = document.getElementById('err');
         if (err) { err.textContent = e.message; err.classList.remove('hidden'); }
       });
+
+      // ── Stale-data guard ──
+      // Track when the page was last fetched so we can re-fetch when the
+      // user returns to the tab after being away. This covers:
+      //   - AI cascade completing while the user was on another tab
+      //   - Species correction saved in the manage panel (same or other tab)
+      //   - Another user suggesting an identification
+      let lastFetchedAt = Date.now();
+      const STALE_THRESHOLD_MS = 30_000; // 30 seconds
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState !== 'visible') return;
+        if (Date.now() - lastFetchedAt < STALE_THRESHOLD_MS) return;
+        refreshObservationData(id);
+      });
+
+      // Listen for in-page updates from the manage panel (same tab).
+      window.addEventListener('rastrum:observation-updated', () => {
+        refreshObservationData(id);
+      });
+
+      /**
+       * Re-fetch the primary identification and update the species name
+       * without a full page reload. Lightweight: only queries the
+       * identifications table, not the full observation.
+       */
+      async function refreshObservationData(obsId: string) {
+        lastFetchedAt = Date.now();
+        try {
+          const supabase = getSupabase();
+          const { data: ids } = await supabase
+            .from('identifications')
+            .select('scientific_name, is_primary, is_research_grade, confidence')
+            .eq('observation_id', obsId)
+            .order('created_at', { ascending: false });
+
+          if (ids && ids.length > 0) {
+            const primary = (ids as Array<{ scientific_name: string; is_primary: boolean }>)
+              .find(i => i.is_primary) ?? ids[0];
+            const speciesEl = document.getElementById('species');
+            if (speciesEl && primary.scientific_name) {
+              speciesEl.textContent = primary.scientific_name;
+            }
+          }
+        } catch {
+          // Silent — background refresh, not user-initiated.
+        }
+      }
     }
 
     async function load(id: string) {


### PR DESCRIPTION
## Problem

Users report having to manually clear browser data to see updated species names, and species corrections on observations don't stick.

## Root causes found

1. **Offline species corrections silently lost** — when a user corrects the species offline on an observation stuck in `error` or `draft` state, the `sync_status` wasn't flipped to `pending`, so the sync engine never picked it up.

2. **No data refresh on the observation detail page** — the page fetches observation data once at load time and never re-fetches. If the AI cascade completes, or the user corrects the species in the manage panel, the page shows stale data until a hard refresh.

3. **Taxonomy synonym correction missing on manual override** — the sync engine applies `correctIdentificationName()` for known outdated names (e.g. *Aratinga canicularis* → *Psittacara canicularis*), but the manage panel's manual override path skipped this step entirely.

## Fixes

### `src/lib/manage-panel.ts`
- **sync_status always `'pending'`** after offline species correction (was conditional, skipping `error`/`draft` records)
- **Apply `correctIdentificationName()`** on both online and offline species override paths
- **Update the input field** to show the corrected name when a synonym is resolved
- **Dispatch `rastrum:observation-updated`** custom event after successful online save

### `src/pages/share/obs/index.astro`
- **`visibilitychange` listener** re-fetches the primary identification when the user returns to the tab after 30+ seconds away
- **`rastrum:observation-updated` listener** immediately refreshes the species name after in-page saves from the manage panel
- Refresh is lightweight (queries only `identifications` table, not the full observation)

## What was already working

The `SwUpdateToast` component already handles SW update detection with a reload prompt and 30-min polling — no changes needed there.

## Verification

- `npx tsc --noEmit` — zero errors
- `npm run test` — 739 tests passing
- `npm run build` — 219 pages, zero errors