### PR TITLE
feat(identify): server-side bbox crop hints (#174)

### DIFF
--- a/supabase/functions/_shared/vision-provider.test.ts
+++ b/supabase/functions/_shared/vision-provider.test.ts
@@ -81,3 +81,54 @@ Deno.test('defaultModelFor — non-empty for every kind', () => {
     if (!m || m.length === 0) throw new Error(`empty default model for ${k}`);
   }
 });
+
+// ── crop_bbox / buildBboxHint tests (#174) ──────────────────────────
+
+import { buildBboxHint, type VisionInput } from './vision-provider.ts';
+
+Deno.test('buildBboxHint — formats pixel coordinates into focus instruction', () => {
+  const hint = buildBboxHint([100, 200, 400, 600]);
+  assertEquals(hint.includes('(100,200)'), true);
+  assertEquals(hint.includes('(400,600)'), true);
+  assertEquals(hint.includes('Focus your identification'), true);
+});
+
+Deno.test('buildBboxHint — handles zero-origin bbox', () => {
+  const hint = buildBboxHint([0, 0, 50, 50]);
+  assertEquals(hint.includes('(0,0)'), true);
+  assertEquals(hint.includes('(50,50)'), true);
+});
+
+Deno.test('effectiveSystemPrompt — appends bbox hint when crop_bbox is set', () => {
+  // We can't call the private effectiveSystemPrompt directly, but we
+  // can verify the contract via buildBboxHint + string concatenation
+  // (effectiveSystemPrompt is just systemPrompt + buildBboxHint).
+  const base = 'You are a biologist.';
+  const bbox: [number, number, number, number] = [10, 20, 300, 400];
+  const result = base + buildBboxHint(bbox);
+  assertEquals(result.startsWith(base), true);
+  assertEquals(result.includes('(10,20)'), true);
+  assertEquals(result.includes('(300,400)'), true);
+});
+
+Deno.test('VisionInput — crop_bbox is optional (omitted = no hint)', () => {
+  // Type-level check: a VisionInput without crop_bbox compiles fine.
+  const input: VisionInput = {
+    imageBase64: 'abc',
+    mimeType: 'image/jpeg',
+    systemPrompt: 'test',
+    userText: 'identify',
+  };
+  assertEquals(input.crop_bbox, undefined);
+});
+
+Deno.test('VisionInput — crop_bbox is accepted when provided', () => {
+  const input: VisionInput = {
+    imageBase64: 'abc',
+    mimeType: 'image/jpeg',
+    systemPrompt: 'test',
+    userText: 'identify',
+    crop_bbox: [50, 100, 200, 300],
+  };
+  assertEquals(input.crop_bbox, [50, 100, 200, 300]);
+});

--- a/supabase/functions/_shared/vision-provider.ts
+++ b/supabase/functions/_shared/vision-provider.ts
@@ -56,6 +56,18 @@ export interface VisionInput {
   systemPrompt: string;
   userText: string;
   signal?: AbortSignal;
+  /** Pixel-space bounding box [x1, y1, x2, y2] from MegaDetector.
+   *  When set, providers append a focus instruction to the system prompt
+   *  so the model concentrates on the detected animal region. */
+  crop_bbox?: [number, number, number, number];
+}
+
+/** Build the bbox focus instruction appended to the system prompt when
+ *  a MegaDetector bounding box is supplied. Pure helper — exported for
+ *  unit testing. */
+export function buildBboxHint(bbox: [number, number, number, number]): string {
+  const [x1, y1, x2, y2] = bbox;
+  return `\nAn animal detector identified a subject in the bounding box from pixel (${x1},${y1}) to (${x2},${y2}). Focus your identification on the animal in that region.`;
 }
 
 export interface VisionProvider {
@@ -136,6 +148,15 @@ export function toVisionResult(
   };
 }
 
+// ── Shared prompt helper ─────────────────────────────────────────────
+
+/** Resolve the effective system prompt, appending bbox hint when present. */
+function effectiveSystemPrompt(input: VisionInput): string {
+  return input.crop_bbox
+    ? input.systemPrompt + buildBboxHint(input.crop_bbox)
+    : input.systemPrompt;
+}
+
 // ── Anthropic direct ────────────────────────────────────────────────
 class AnthropicProvider implements VisionProvider {
   constructor(private readonly cred: ResolvedCredential) {}
@@ -148,10 +169,11 @@ class AnthropicProvider implements VisionProvider {
     if (this.cred.kind === 'oauth_token') headers['Authorization'] = `Bearer ${this.cred.secret}`;
     else                                  headers['x-api-key']     = this.cred.secret;
 
+    const sysPrompt = effectiveSystemPrompt(input);
     const body = {
       model: this.cred.model,
       max_tokens: 512,
-      system: [{ type: 'text', text: input.systemPrompt, cache_control: { type: 'ephemeral' } }],
+      system: [{ type: 'text', text: sysPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{
         role: 'user',
         content: [
@@ -190,7 +212,7 @@ class BedrockProvider implements VisionProvider {
     const body = {
       anthropic_version: 'bedrock-2023-05-31',
       max_tokens: 512,
-      system: input.systemPrompt,
+      system: effectiveSystemPrompt(input),
       messages: [{
         role: 'user',
         content: [
@@ -378,7 +400,7 @@ async function callOpenAICompatible(
     model,
     max_tokens: 512,
     messages: [
-      { role: 'system', content: input.systemPrompt },
+      { role: 'system', content: effectiveSystemPrompt(input) },
       {
         role: 'user',
         content: [
@@ -451,7 +473,7 @@ async function callGeminiCompatible(
   source: string,
 ): Promise<VisionResult | null> {
   const body = {
-    systemInstruction: { parts: [{ text: input.systemPrompt }] },
+    systemInstruction: { parts: [{ text: effectiveSystemPrompt(input) }] },
     contents: [{
       role: 'user',
       parts: [

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -71,6 +71,13 @@ type IdentifyRequest = {
    * parallel race). Values: 'plantnet' | 'claude_haiku'.
    */
   force_provider?: 'plantnet' | 'claude_haiku';
+  /**
+   * Pixel-space bounding box [x1, y1, x2, y2] from MegaDetector. When
+   * provided, vision providers append a focus instruction to their system
+   * prompt so the model concentrates on the detected animal region.
+   * PlantNet ignores this (plant-focused, no bbox hint support).
+   */
+  crop_bbox?: [number, number, number, number];
 };
 
 type IDResult = {
@@ -165,6 +172,8 @@ interface ClaudeContext {
    */
   credential?: { secret: string; kind: CredentialKind };
   signal?: AbortSignal;
+  /** MegaDetector bounding box forwarded to the vision provider. */
+  crop_bbox?: [number, number, number, number];
 }
 
 async function callClaudeHaiku(
@@ -220,6 +229,7 @@ async function callViaProvider(
       systemPrompt: DEFAULT_SYSTEM_PROMPT,
       userText,
       signal: context.signal,
+      crop_bbox: context.crop_bbox,
     });
   } catch (err) {
     console.warn(`[identify] provider.identify failed kind=${cred.kind}: ${err instanceof Error ? err.message : String(err)}`);
@@ -502,6 +512,7 @@ serve(async (req) => {
       lng: body.location?.lng,
       credential: claudeCred ?? undefined,
       resolvedCredential: resolvedClaudeCred ?? undefined,
+      crop_bbox: body.crop_bbox,
     });
   } else {
     // Default: race PlantNet, Claude Haiku, and (placeholder) ONNX-base in
@@ -518,6 +529,7 @@ serve(async (req) => {
       lng: body.location?.lng,
       credential: claudeCred ?? undefined,
       resolvedCredential: resolvedClaudeCred ?? undefined,
+      crop_bbox: body.crop_bbox,
       signal,
     });
     runners.onnx_base = (signal) => callOnnxBase(imageBytes, signal);


### PR DESCRIPTION
Adds crop_bbox field to the identify Edge Function. When MegaDetector detects an animal bbox, the client can forward it; all vision providers append a focus instruction to their prompt.

Closes #174