### PR TITLE
feat(push): streak reminder opt-in toggle (#188)

### DIFF
--- a/src/components/ProfileBasicForm.astro
+++ b/src/components/ProfileBasicForm.astro
@@ -402,9 +402,10 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
     if (!sppBtn) return;
     sppBtn.disabled = true;
     const state = sppBtn.dataset.state;
-    setSppLabel(state === 'on' ? SPP_TXT.disabling : SPP_TXT.enabling);
+    const turningOn = state !== 'on';
+    setSppLabel(turningOn ? SPP_TXT.enabling : SPP_TXT.disabling);
     const lib = await import('../lib/push');
-    const r = state === 'on' ? await lib.disableStreakPush() : await lib.enableStreakPush();
+    const r = turningOn ? await lib.enableStreakPush() : await lib.disableStreakPush();
     sppBtn.disabled = false;
     if (!r.ok) {
       const reasonMap: Record<string, string> = {
@@ -413,6 +414,12 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
         vapid_missing: SPP_TXT.vapid_missing,
       };
       setSppWarn(reasonMap[r.reason ?? 'unknown'] ?? r.message ?? '');
+    } else {
+      const supabase = getSupabase();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        await supabase.from('users').update({ streak_digest_opt_in: turningOn }).eq('id', user.id);
+      }
     }
     await refreshSpp();
   });

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -1576,9 +1576,10 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
     if (!sppBtn) return;
     sppBtn.disabled = true;
     const state = sppBtn.dataset.state;
-    setSppLabel(state === 'on' ? SPP_TXT.disabling : SPP_TXT.enabling);
+    const turningOn = state !== 'on';
+    setSppLabel(turningOn ? SPP_TXT.enabling : SPP_TXT.disabling);
     const lib = await import('../lib/push');
-    const r = state === 'on' ? await lib.disableStreakPush() : await lib.enableStreakPush();
+    const r = turningOn ? await lib.enableStreakPush() : await lib.disableStreakPush();
     sppBtn.disabled = false;
     if (!r.ok) {
       const reasonMap: Record<string, string> = {
@@ -1587,6 +1588,12 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
         vapid_missing: SPP_TXT.vapid_missing,
       };
       setSppWarn(reasonMap[r.reason ?? 'unknown'] ?? r.message ?? '');
+    } else {
+      const supabase = getSupabase();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        await supabase.from('users').update({ streak_digest_opt_in: turningOn }).eq('id', user.id);
+      }
     }
     await refreshSpp();
   });

--- a/src/lib/push.test.ts
+++ b/src/lib/push.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock navigator.serviceWorker + PushManager ──
+// happy-dom doesn't provide a full PushManager, so we wire up the
+// minimum surface that push.ts touches.
+
+const mockUnsubscribe = vi.fn().mockResolvedValue(true);
+const mockSubscription = {
+  endpoint: 'https://push.example.com/sub/abc',
+  unsubscribe: mockUnsubscribe,
+  toJSON: () => ({ keys: { p256dh: 'dGVzdA', auth: 'dGVzdA' } }),
+  getKey: () => new ArrayBuffer(0),
+};
+
+const mockGetSubscription = vi.fn<() => Promise<PushSubscription | null>>();
+const mockPushManager = { getSubscription: mockGetSubscription };
+const mockRegistration = { pushManager: mockPushManager, showNotification: vi.fn() };
+
+Object.defineProperty(navigator, 'serviceWorker', {
+  configurable: true,
+  value: { ready: Promise.resolve(mockRegistration) },
+});
+
+// PushManager must exist on window for pushSupported() to return true.
+if (!('PushManager' in window)) {
+  Object.defineProperty(window, 'PushManager', { configurable: true, value: class {} });
+}
+
+// Notification must exist for pushSupported().
+if (typeof globalThis.Notification === 'undefined') {
+  Object.defineProperty(globalThis, 'Notification', {
+    configurable: true,
+    value: { requestPermission: vi.fn().mockResolvedValue('granted') },
+  });
+}
+
+// ── Mock supabase client ──
+const mockDelete = vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }) });
+const mockFrom = vi.fn().mockReturnValue({ delete: mockDelete });
+const mockGetUser = vi.fn().mockResolvedValue({ data: { user: { id: 'user-123' } } });
+const mockSupabase = { from: mockFrom, auth: { getUser: mockGetUser } };
+
+vi.mock('./supabase', () => ({
+  getSupabase: () => mockSupabase,
+}));
+
+import { disableStreakPush, isStreakPushEnabled } from './push';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('disableStreakPush', () => {
+  it('returns unsupported when push APIs are missing', async () => {
+    // Temporarily remove PushManager to simulate unsupported browser.
+    const origSW = Object.getOwnPropertyDescriptor(navigator, 'serviceWorker');
+    // @ts-expect-error — deleting to simulate unsupported env
+    delete (navigator as Record<string, unknown>).serviceWorker;
+
+    const result = await disableStreakPush();
+    expect(result).toEqual({ ok: false, reason: 'unsupported' });
+
+    // Restore.
+    if (origSW) Object.defineProperty(navigator, 'serviceWorker', origSW);
+  });
+
+  it('unsubscribes and deletes the push subscription from the DB', async () => {
+    mockGetSubscription.mockResolvedValue(mockSubscription as unknown as PushSubscription);
+
+    const eqUser = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    mockDelete.mockReturnValue({ eq: eqUser });
+
+    const result = await disableStreakPush();
+    expect(result).toEqual({ ok: true });
+    expect(mockUnsubscribe).toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenCalledWith('push_subscriptions');
+    expect(mockDelete).toHaveBeenCalled();
+    expect(eqUser).toHaveBeenCalledWith('user_id', 'user-123');
+  });
+
+  it('returns ok even when there is no active subscription', async () => {
+    mockGetSubscription.mockResolvedValue(null);
+
+    const result = await disableStreakPush();
+    expect(result).toEqual({ ok: true });
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+  });
+});
+
+describe('isStreakPushEnabled', () => {
+  it('returns true when a subscription exists', async () => {
+    mockGetSubscription.mockResolvedValue(mockSubscription as unknown as PushSubscription);
+    expect(await isStreakPushEnabled()).toBe(true);
+  });
+
+  it('returns false when no subscription exists', async () => {
+    mockGetSubscription.mockResolvedValue(null);
+    expect(await isStreakPushEnabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds the UI opt-in toggle for streak push notifications in Profile → Edit, plus the service worker push/notificationclick handlers.

The streak-push Edge Function already exists and fires nightly. This PR completes the user-facing side.

## Changes

- **ProfileEditForm / ProfileBasicForm**: streak push toggle now updates `users.streak_digest_opt_in` in the DB on toggle (enable → true, disable → false), so the nightly EF correctly filters opted-in users.
- **push.test.ts**: 5 new tests covering `disableStreakPush` (unsupported env, happy path with DB cleanup, no-subscription case) and `isStreakPushEnabled` (subscription present / absent).

## Already in place (pre-existing on this branch)

- `disableStreakPush()` in `src/lib/push.ts`
- Push + notificationclick handlers in `public/sw.js` (bilingual, locale-aware)
- Streak push section HTML in both profile forms
- i18n strings in `profile_streak_push` (en.json + es.json)

## Verified

- `npx tsc --noEmit` — zero errors
- `npm run test` — 744 tests pass (including 5 new)

Closes #188