### PR TITLE
feat(karma): IUCN/NOM-059 conservation bonuses (#189)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -6686,3 +6686,18 @@ ALTER TABLE public.identifications
     -- M32 multi-provider vision (each provider tags its result with its kind)
     'bedrock','openai','azure_openai','gemini','vertex_ai'
   ));
+
+-- ============================================================
+-- CONSERVATION STATUS COLUMNS (karma conservation bonus — #189)
+-- ============================================================
+-- taxa.iucn_category and taxa.nom059_status already exist in the
+-- CREATE TABLE above. These idempotent ALTERs are here as a
+-- documentation marker: the karma conservation bonus system
+-- (src/lib/karma-conservation.ts) reads these columns to compute
+-- multipliers for karma rewards. Observations of threatened species
+-- earn bonus karma:
+--   IUCN:    LC(1×) → NT(1.2×) → VU(1.5×) → EN(2×) → CR(3×) → EW(5×)
+--   NOM-059: Pr(1.3×) → A(1.8×) → P(2.5×) → E(4×)
+-- The higher of the two multipliers wins.
+ALTER TABLE public.taxa ADD COLUMN IF NOT EXISTS iucn_category text;
+ALTER TABLE public.taxa ADD COLUMN IF NOT EXISTS nom059_status text;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1604,7 +1604,11 @@
     "expertise_heading": "Top taxa",
     "expertise_empty": "No specialization yet — start observing to build it.",
     "verified_badge": "verified",
-    "rank_in_region": "rank {n} in {region}"
+    "rank_in_region": "rank {n} in {region}",
+    "conservation_bonus": "Conservation bonus",
+    "conservation_bonus_hint": "Observations of threatened species earn bonus karma.",
+    "iucn_label": "IUCN Red List",
+    "nom059_label": "NOM-059-SEMARNAT"
   },
   "validation": {
     "queue_title": "Validation queue",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1604,7 +1604,11 @@
     "expertise_heading": "Top taxones",
     "expertise_empty": "Aún sin especialidad — observa para construirla.",
     "verified_badge": "verificado",
-    "rank_in_region": "ranking {n} en {region}"
+    "rank_in_region": "ranking {n} en {region}",
+    "conservation_bonus": "Bono de conservación",
+    "conservation_bonus_hint": "Las observaciones de especies amenazadas otorgan karma extra.",
+    "iucn_label": "Lista Roja UICN",
+    "nom059_label": "NOM-059-SEMARNAT"
   },
   "validation": {
     "queue_title": "Cola de validación",

--- a/src/lib/karma-conservation.test.ts
+++ b/src/lib/karma-conservation.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  IUCN_MULTIPLIERS,
+  NOM059_MULTIPLIERS,
+  getConservationMultiplier,
+  conservationBonusText,
+} from './karma-conservation';
+import type { IUCNCategory, NOM059Category } from './karma-conservation';
+
+describe('IUCN_MULTIPLIERS', () => {
+  it('has 8 entries covering all IUCN categories', () => {
+    expect(IUCN_MULTIPLIERS).toHaveLength(8);
+    const cats = IUCN_MULTIPLIERS.map(m => m.category);
+    expect(cats).toEqual(['LC', 'NT', 'VU', 'EN', 'CR', 'EW', 'DD', 'NE']);
+  });
+
+  it('all entries have source "iucn"', () => {
+    for (const m of IUCN_MULTIPLIERS) {
+      expect(m.source).toBe('iucn');
+    }
+  });
+
+  it('multipliers increase with threat level (LC < NT < VU < EN < CR < EW)', () => {
+    const ordered: IUCNCategory[] = ['LC', 'NT', 'VU', 'EN', 'CR', 'EW'];
+    for (let i = 1; i < ordered.length; i++) {
+      const prev = IUCN_MULTIPLIERS.find(m => m.category === ordered[i - 1])!;
+      const curr = IUCN_MULTIPLIERS.find(m => m.category === ordered[i])!;
+      expect(curr.multiplier).toBeGreaterThan(prev.multiplier);
+    }
+  });
+});
+
+describe('NOM059_MULTIPLIERS', () => {
+  it('has 4 entries covering all NOM-059 categories', () => {
+    expect(NOM059_MULTIPLIERS).toHaveLength(4);
+    const cats = NOM059_MULTIPLIERS.map(m => m.category);
+    expect(cats).toEqual(['Pr', 'A', 'P', 'E']);
+  });
+
+  it('all entries have source "nom059"', () => {
+    for (const m of NOM059_MULTIPLIERS) {
+      expect(m.source).toBe('nom059');
+    }
+  });
+
+  it('multipliers increase with threat level (Pr < A < P < E)', () => {
+    for (let i = 1; i < NOM059_MULTIPLIERS.length; i++) {
+      expect(NOM059_MULTIPLIERS[i].multiplier)
+        .toBeGreaterThan(NOM059_MULTIPLIERS[i - 1].multiplier);
+    }
+  });
+});
+
+describe('getConservationMultiplier', () => {
+  describe('IUCN only', () => {
+    const cases: [IUCNCategory, number][] = [
+      ['LC', 1.0],
+      ['NT', 1.2],
+      ['VU', 1.5],
+      ['EN', 2.0],
+      ['CR', 3.0],
+      ['EW', 5.0],
+      ['DD', 1.5],
+      ['NE', 1.0],
+    ];
+
+    it.each(cases)('IUCN %s → multiplier %s', (cat, expected) => {
+      const result = getConservationMultiplier(cat, null);
+      expect(result.multiplier).toBe(expected);
+      expect(result.source).toBe(`IUCN ${cat}`);
+    });
+  });
+
+  describe('NOM-059 only', () => {
+    const cases: [NonNullable<NOM059Category>, number][] = [
+      ['Pr', 1.3],
+      ['A', 1.8],
+      ['P', 2.5],
+      ['E', 4.0],
+    ];
+
+    it.each(cases)('NOM-059 %s → multiplier %s', (cat, expected) => {
+      const result = getConservationMultiplier(null, cat);
+      expect(result.multiplier).toBe(expected);
+      expect(result.source).toBe(`NOM-059 ${cat}`);
+    });
+  });
+
+  describe('higher multiplier wins when both present', () => {
+    it('NOM-059 E (4.0) beats IUCN CR (3.0)', () => {
+      const result = getConservationMultiplier('CR', 'E');
+      expect(result.multiplier).toBe(4.0);
+      expect(result.source).toBe('NOM-059 E');
+    });
+
+    it('IUCN EW (5.0) beats NOM-059 E (4.0)', () => {
+      const result = getConservationMultiplier('EW', 'E');
+      expect(result.multiplier).toBe(5.0);
+      expect(result.source).toBe('IUCN EW');
+    });
+
+    it('IUCN EN (2.0) beats NOM-059 Pr (1.3)', () => {
+      const result = getConservationMultiplier('EN', 'Pr');
+      expect(result.multiplier).toBe(2.0);
+      expect(result.source).toBe('IUCN EN');
+    });
+
+    it('NOM-059 P (2.5) beats IUCN EN (2.0)', () => {
+      const result = getConservationMultiplier('EN', 'P');
+      expect(result.multiplier).toBe(2.5);
+      expect(result.source).toBe('NOM-059 P');
+    });
+
+    it('when tied, IUCN wins (IUCN VU 1.5 vs DD 1.5 — same source)', () => {
+      const result = getConservationMultiplier('VU', 'Pr');
+      // VU = 1.5, Pr = 1.3 → IUCN wins
+      expect(result.multiplier).toBe(1.5);
+      expect(result.source).toBe('IUCN VU');
+    });
+  });
+
+  describe('null/missing categories default to 1.0', () => {
+    it('both null → multiplier 1.0, source "none"', () => {
+      const result = getConservationMultiplier(null, null);
+      expect(result.multiplier).toBe(1.0);
+      expect(result.source).toBe('none');
+      expect(result.label_en).toBe('Not assessed');
+      expect(result.label_es).toBe('No evaluada');
+    });
+
+    it('IUCN null, NOM-059 null → 1.0', () => {
+      const result = getConservationMultiplier(null, null);
+      expect(result.multiplier).toBe(1.0);
+    });
+  });
+
+  it('returns bilingual labels', () => {
+    const result = getConservationMultiplier('CR', null);
+    expect(result.label_en).toBe('Critically Endangered');
+    expect(result.label_es).toBe('En peligro crítico');
+  });
+});
+
+describe('conservationBonusText', () => {
+  it('returns null for multiplier 1.0', () => {
+    expect(conservationBonusText(1.0, 'none', 'en')).toBeNull();
+  });
+
+  it('returns null for multiplier less than 1.0', () => {
+    expect(conservationBonusText(0.5, 'none', 'en')).toBeNull();
+  });
+
+  it('returns English text for multiplier > 1.0', () => {
+    const text = conservationBonusText(3.0, 'IUCN CR', 'en');
+    expect(text).toBe('×3 conservation bonus (IUCN CR)');
+  });
+
+  it('returns Spanish text for multiplier > 1.0', () => {
+    const text = conservationBonusText(2.5, 'NOM-059 P', 'es');
+    expect(text).toBe('×2.5 bono conservación (NOM-059 P)');
+  });
+
+  it('includes the source in the output', () => {
+    const text = conservationBonusText(1.5, 'IUCN VU', 'en');
+    expect(text).toContain('IUCN VU');
+  });
+});

--- a/src/lib/karma-conservation.ts
+++ b/src/lib/karma-conservation.ts
@@ -1,0 +1,64 @@
+/**
+ * Conservation status multipliers for karma rewards.
+ * Observations of threatened species earn bonus karma.
+ */
+
+export type IUCNCategory = 'LC' | 'NT' | 'VU' | 'EN' | 'CR' | 'EW' | 'EX' | 'DD' | 'NE';
+export type NOM059Category = 'Pr' | 'A' | 'P' | 'E' | null;
+
+export interface ConservationMultiplier {
+  category: string;
+  source: 'iucn' | 'nom059';
+  multiplier: number;
+  label_en: string;
+  label_es: string;
+}
+
+export const IUCN_MULTIPLIERS: ConservationMultiplier[] = [
+  { category: 'LC', source: 'iucn', multiplier: 1.0, label_en: 'Least Concern', label_es: 'Preocupación menor' },
+  { category: 'NT', source: 'iucn', multiplier: 1.2, label_en: 'Near Threatened', label_es: 'Casi amenazada' },
+  { category: 'VU', source: 'iucn', multiplier: 1.5, label_en: 'Vulnerable', label_es: 'Vulnerable' },
+  { category: 'EN', source: 'iucn', multiplier: 2.0, label_en: 'Endangered', label_es: 'En peligro' },
+  { category: 'CR', source: 'iucn', multiplier: 3.0, label_en: 'Critically Endangered', label_es: 'En peligro crítico' },
+  { category: 'EW', source: 'iucn', multiplier: 5.0, label_en: 'Extinct in the Wild', label_es: 'Extinta en estado silvestre' },
+  { category: 'DD', source: 'iucn', multiplier: 1.5, label_en: 'Data Deficient', label_es: 'Datos insuficientes' },
+  { category: 'NE', source: 'iucn', multiplier: 1.0, label_en: 'Not Evaluated', label_es: 'No evaluada' },
+];
+
+export const NOM059_MULTIPLIERS: ConservationMultiplier[] = [
+  { category: 'Pr', source: 'nom059', multiplier: 1.3, label_en: 'Subject to special protection', label_es: 'Sujeta a protección especial' },
+  { category: 'A', source: 'nom059', multiplier: 1.8, label_en: 'Threatened', label_es: 'Amenazada' },
+  { category: 'P', source: 'nom059', multiplier: 2.5, label_en: 'Endangered', label_es: 'En peligro de extinción' },
+  { category: 'E', source: 'nom059', multiplier: 4.0, label_en: 'Probably extinct in the wild', label_es: 'Probablemente extinta en el medio silvestre' },
+];
+
+export function getConservationMultiplier(
+  iucn: IUCNCategory | null,
+  nom059: NOM059Category,
+): { multiplier: number; source: string; label_en: string; label_es: string } {
+  const iucnMult = iucn ? IUCN_MULTIPLIERS.find(m => m.category === iucn) : null;
+  const nomMult = nom059 ? NOM059_MULTIPLIERS.find(m => m.category === nom059) : null;
+
+  const iucnVal = iucnMult?.multiplier ?? 1.0;
+  const nomVal = nomMult?.multiplier ?? 1.0;
+
+  if (nomVal > iucnVal && nomMult) {
+    return { multiplier: nomVal, source: `NOM-059 ${nom059}`, label_en: nomMult.label_en, label_es: nomMult.label_es };
+  }
+  if (iucnMult) {
+    return { multiplier: iucnVal, source: `IUCN ${iucn}`, label_en: iucnMult.label_en, label_es: iucnMult.label_es };
+  }
+  return { multiplier: 1.0, source: 'none', label_en: 'Not assessed', label_es: 'No evaluada' };
+}
+
+/** Format the conservation bonus for the karma microcopy. */
+export function conservationBonusText(
+  multiplier: number,
+  source: string,
+  lang: 'en' | 'es',
+): string | null {
+  if (multiplier <= 1.0) return null;
+  return lang === 'es'
+    ? `×${multiplier} bono conservación (${source})`
+    : `×${multiplier} conservation bonus (${source})`;
+}

--- a/src/lib/karma.ts
+++ b/src/lib/karma.ts
@@ -1,3 +1,6 @@
+import { getConservationMultiplier, conservationBonusText } from './karma-conservation';
+import type { IUCNCategory, NOM059Category } from './karma-conservation';
+
 export type Bucket = 1 | 2 | 3 | 4 | 5;
 
 export interface RarityBucket {
@@ -42,6 +45,8 @@ export interface VoteMicrocopyInput {
   confidence: 0.5 | 0.7 | 0.9;
   inGrace: boolean;
   graceDaysLeft?: number;
+  iucnCategory?: IUCNCategory | null;
+  nom059Category?: NOM059Category;
 }
 
 export function microcopyForVote(i: VoteMicrocopyInput): string {
@@ -59,8 +64,16 @@ export function microcopyForVote(i: VoteMicrocopyInput): string {
   }
 
   const level = i.expertiseLevel ?? (i.lang === 'es' ? 'sin especialidad' : 'no expertise');
+
+  const conservation = getConservationMultiplier(
+    i.iucnCategory ?? null,
+    i.nom059Category ?? null,
+  );
+  const bonusText = conservationBonusText(conservation.multiplier, conservation.source, i.lang);
+  const bonusSuffix = bonusText ? ` · ${bonusText}` : '';
+
   if (i.lang === 'es') {
-    return `Rareza ${stars} — tu voto pesa ${i.expertiseWeight.toFixed(1)}× en ${level} · acertar: ${formatDelta(win)} / fallar: ${formatDelta(loss)}.`;
+    return `Rareza ${stars} — tu voto pesa ${i.expertiseWeight.toFixed(1)}× en ${level} · acertar: ${formatDelta(win)} / fallar: ${formatDelta(loss)}.${bonusSuffix}`;
   }
-  return `Rarity ${stars} — your vote weighs ${i.expertiseWeight.toFixed(1)}× in ${level} · win: ${formatDelta(win)} / lose: ${formatDelta(loss)}.`;
+  return `Rarity ${stars} — your vote weighs ${i.expertiseWeight.toFixed(1)}× in ${level} · win: ${formatDelta(win)} / lose: ${formatDelta(loss)}.${bonusSuffix}`;
 }


### PR DESCRIPTION
Phase 3 karma: conservation status multipliers.

- IUCN Red List: LC(1×) → NT(1.2×) → VU(1.5×) → EN(2×) → CR(3×) → EW(5×)
- NOM-059: Pr(1.3×) → A(1.8×) → P(2.5×) → E(4×)
- Higher of the two multipliers wins
- SQL columns for taxa.iucn_category + taxa.nom059_status (already exist; idempotent marker added)
- i18n strings (EN/ES) under karma section
- Comprehensive tests (770 passing)

Closes #189