### PR TITLE
fix(pokedex): resolve taxon_id on identification insert

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -622,6 +622,37 @@ CREATE TRIGGER update_obs_count_trigger
   WHEN (NEW.sync_status = 'synced')
   EXECUTE FUNCTION public.update_user_obs_count();
 
+-- Auto-resolve taxon_id from scientific_name when an identification is
+-- inserted without an explicit taxon_id. This ensures the profile_pokedex
+-- view (which JOINs on taxa) can find the row.
+CREATE OR REPLACE FUNCTION public.resolve_identification_taxon()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.taxon_id IS NULL AND NEW.scientific_name IS NOT NULL THEN
+    SELECT id INTO NEW.taxon_id
+    FROM public.taxa
+    WHERE scientific_name = NEW.scientific_name
+    LIMIT 1;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS resolve_id_taxon_trigger ON public.identifications;
+CREATE TRIGGER resolve_id_taxon_trigger
+  BEFORE INSERT OR UPDATE OF scientific_name ON public.identifications
+  FOR EACH ROW
+  EXECUTE FUNCTION public.resolve_identification_taxon();
+
+-- Backfill: resolve taxon_id for existing identifications that were inserted
+-- before the resolve_id_taxon_trigger existed.
+UPDATE public.identifications i
+SET taxon_id = t.id
+FROM public.taxa t
+WHERE i.taxon_id IS NULL
+  AND i.scientific_name IS NOT NULL
+  AND t.scientific_name = i.scientific_name;
+
 -- Keep observations.primary_taxon_id / obscure_level / location_obscured
 -- in sync with the primary identification. Runs whenever an identification
 -- row is flagged is_primary = true.
@@ -2761,7 +2792,7 @@ CREATE OR REPLACE VIEW public.profile_pokedex AS
 SELECT
   o.observer_id   AS user_id,
   i.taxon_id,
-  t.scientific_name,
+  COALESCE(t.scientific_name, i.scientific_name) AS scientific_name,
   t.kingdom,
   tr.bucket       AS rarity_bucket,
   MIN(o.observed_at) AS first_observed_at,
@@ -2769,13 +2800,14 @@ SELECT
 FROM public.observations o
 JOIN public.identifications i
   ON i.observation_id = o.id AND i.is_primary = true
-JOIN public.taxa t                ON t.id = i.taxon_id
-LEFT JOIN public.taxon_rarity tr  ON tr.taxon_id = i.taxon_id
+LEFT JOIN public.taxa t               ON t.id = i.taxon_id
+LEFT JOIN public.taxon_rarity tr      ON tr.taxon_id = i.taxon_id
 WHERE
   o.sync_status = 'synced'
   AND o.obscure_level <> 'private'
+  AND i.scientific_name IS NOT NULL
   AND public.can_see_facet(o.observer_id, 'pokedex', (SELECT auth.uid()))
-GROUP BY o.observer_id, i.taxon_id, t.scientific_name, t.kingdom, tr.bucket;
+GROUP BY o.observer_id, i.taxon_id, COALESCE(t.scientific_name, i.scientific_name), t.kingdom, tr.bucket;
 
 GRANT SELECT ON public.profile_pokedex TO anon, authenticated;
 

--- a/src/components/PokedexView.astro
+++ b/src/components/PokedexView.astro
@@ -150,29 +150,32 @@ const exploreRecentHref = `/${lang}/${lang === 'es' ? 'explorar/recientes' : 'ex
       .order('observed_at', { ascending: false });
     const rows = (data ?? []) as Array<{
       observed_at: string;
-      identifications: Array<{ scientific_name: string; taxon_id: string; is_primary: boolean }>;
+      identifications: Array<{ scientific_name: string; taxon_id: string | null; is_primary: boolean }>;
     }>;
-    const byTaxon = new Map<string, { name: string; first: string; count: number }>();
+    const bySpecies = new Map<string, { taxonId: string | null; name: string; first: string; count: number }>();
     for (const r of rows) {
       for (const id of r.identifications) {
-        const prev = byTaxon.get(id.taxon_id);
+        if (!id.scientific_name) continue;
+        const key = id.taxon_id ?? id.scientific_name;
+        const prev = bySpecies.get(key);
         if (prev) { prev.count++; if (r.observed_at < prev.first) prev.first = r.observed_at; }
-        else byTaxon.set(id.taxon_id, { name: id.scientific_name, first: r.observed_at, count: 1 });
+        else bySpecies.set(key, { taxonId: id.taxon_id, name: id.scientific_name, first: r.observed_at, count: 1 });
       }
     }
-    const taxonIds = Array.from(byTaxon.keys());
-    if (!taxonIds.length) return [];
-    const { data: rarity } = await supabase
-      .from('taxon_rarity').select('taxon_id, bucket').in('taxon_id', taxonIds);
+    const taxonIds = Array.from(bySpecies.values()).map(v => v.taxonId).filter((id): id is string => id != null);
     const rarityMap = new Map<string, number>();
-    for (const r of (rarity ?? []) as Array<{ taxon_id: string; bucket: number }>) {
-      rarityMap.set(r.taxon_id, r.bucket ?? 1);
+    if (taxonIds.length) {
+      const { data: rarity } = await supabase
+        .from('taxon_rarity').select('taxon_id, bucket').in('taxon_id', taxonIds);
+      for (const r of (rarity ?? []) as Array<{ taxon_id: string; bucket: number }>) {
+        rarityMap.set(r.taxon_id, r.bucket ?? 1);
+      }
     }
-    return Array.from(byTaxon.entries()).map(([taxonId, v]) => ({
-      taxon_id: taxonId,
+    return Array.from(bySpecies.entries()).map(([key, v]) => ({
+      taxon_id: v.taxonId ?? key,
       scientific_name: v.name,
       kingdom: null,
-      rarity_bucket: rarityMap.get(taxonId) ?? 1,
+      rarity_bucket: v.taxonId ? (rarityMap.get(v.taxonId) ?? 1) : 1,
       first_observed_at: v.first,
       obs_count: v.count,
     }));


### PR DESCRIPTION
## Problem

The Pokédex shows empty even when the user has synced observations with identifications (e.g. Columbina inca).

## Root cause

All three identification insertion paths (client-side sync, server cascade, and the identify Edge Function) insert into `identifications` with only `scientific_name` set — `taxon_id` is always `NULL`. The `profile_pokedex` SQL view uses `JOIN public.taxa t ON t.id = i.taxon_id` (inner join), which silently drops every row when `taxon_id` is `NULL`.

## Fix

1. **New BEFORE INSERT trigger** (`resolve_id_taxon_trigger`) on `identifications` — auto-resolves `taxon_id` by looking up `taxa.scientific_name`. Future inserts get `taxon_id` populated automatically.
2. **Backfill statement** — one-time `UPDATE` resolves `taxon_id` for all existing identifications that were inserted before the trigger.
3. **`profile_pokedex` view → LEFT JOIN** on `taxa` — observations still appear even if the species isn't in the `taxa` table yet, using `i.scientific_name` as fallback.
4. **`loadFallback` in PokedexView.astro** — client-side fallback now handles `null` `taxon_id`, grouping by `scientific_name` instead.

## Post-merge

Run `make db-apply` to deploy the trigger + backfill + updated view.

## Verification

- `npm run typecheck` — 0 errors
- `npm run test` — 739 passed
- `npm run build` — 219 pages, 0 errors