### PR TITLE
fix(mcp): id_source→source in identifications + is_primary:true — fixes /explore/species/ empty grid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ preview: build ## Build then preview the built site
 	npm run preview
 
 ## Database — Supabase
-.PHONY: db-ping db-apply db-verify db-reset-local db-diff db-psql db-tables db-policies db-triggers
+.PHONY: db-ping db-apply db-verify db-reset-local db-diff db-psql db-tables db-policies db-triggers db-backfill-taxon-id
 db-ping: ## Verify connection to Supabase
 	$(call require_env,SUPABASE_DB)
 	@psql "$$SUPABASE_DB" -c "SELECT now(), current_database(), current_user, version();"
@@ -131,6 +131,12 @@ db-reset-local: ## Reset a local Supabase branch (requires supabase CLI)
 db-diff: ## Show drift between local and deployed schema (requires supabase CLI)
 	@command -v supabase >/dev/null || { echo "Install: brew install supabase/tap/supabase"; exit 1; }
 	supabase db diff --linked
+
+db-backfill-taxon-id: ## One-time backfill: resolve primary_taxon_id on observations created before PR #416 fix
+	$(call require_env,SUPABASE_DB)
+	@echo "Running backfill: resolve primary_taxon_id for observations missing it (PR #416)"
+	@psql "$$SUPABASE_DB" -v ON_ERROR_STOP=1 -f scripts/backfill-primary-taxon-id.sql
+	@echo "Done. Verify with: make db-tables"
 
 ## Docs & checks
 .PHONY: lint typecheck test docs-check

--- a/scripts/backfill-primary-taxon-id.sql
+++ b/scripts/backfill-primary-taxon-id.sql
@@ -1,0 +1,99 @@
+-- backfill-primary-taxon-id.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+-- One-time backfill for observations whose primary_taxon_id is NULL because
+-- they were submitted via the MCP tool before the fix in PR #416
+-- (id_source → source + is_primary: true).
+--
+-- The bug had two possible failure modes:
+--   A) identifications.source insert failed silently → no identification row at all
+--   B) identification row exists but taxon_id is NULL (scientific_name stored
+--      but never resolved against taxa table)
+--
+-- This script handles both:
+--   Step 1 — For identifications that have scientific_name but taxon_id IS NULL,
+--             resolve taxon_id from the taxa table by exact scientific_name match.
+--   Step 2 — For identifications where is_primary is false/null but they are the
+--             ONLY identification on the observation, promote them to is_primary.
+--   Step 3 — Backfill observations.primary_taxon_id from the primary identification.
+--
+-- Safe to run multiple times (idempotent WHERE clauses).
+-- Run with: psql "$SUPABASE_DB_URL" -f scripts/backfill-primary-taxon-id.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+
+BEGIN;
+
+-- ── Step 1: resolve taxon_id on identifications that have scientific_name ───
+UPDATE public.identifications i
+SET taxon_id = t.id
+FROM public.taxa t
+WHERE i.taxon_id IS NULL
+  AND i.scientific_name IS NOT NULL
+  AND t.scientific_name = i.scientific_name;
+
+-- Log how many were resolved
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Step 1: resolved taxon_id for % identification(s) by scientific_name match', v_count;
+END $$;
+
+-- ── Step 2: promote sole identification to is_primary where not already set ──
+-- Applies to observations that have exactly one identification and it has
+-- is_primary = false. These were likely inserted by the buggy MCP code
+-- (the DEFAULT true should have handled it, but guard anyway).
+UPDATE public.identifications i
+SET is_primary = true
+WHERE i.is_primary = false
+  AND NOT EXISTS (
+    SELECT 1 FROM public.identifications i2
+    WHERE i2.observation_id = i.observation_id
+      AND i2.id <> i.id
+      AND i2.is_primary = true
+  );
+
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Step 2: promoted % identification(s) to is_primary', v_count;
+END $$;
+
+-- ── Step 3: backfill observations.primary_taxon_id ───────────────────────────
+UPDATE public.observations o
+SET primary_taxon_id = i.taxon_id,
+    updated_at       = now()
+FROM public.identifications i
+WHERE i.observation_id = o.id
+  AND i.is_primary     = true
+  AND i.taxon_id       IS NOT NULL
+  AND o.primary_taxon_id IS NULL;
+
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Step 3: backfilled primary_taxon_id for % observation(s)', v_count;
+END $$;
+
+-- ── Verification ──────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  v_null_taxon   int;
+  v_total_synced int;
+BEGIN
+  SELECT COUNT(*) INTO v_total_synced
+  FROM public.observations WHERE sync_status = 'synced';
+
+  SELECT COUNT(*) INTO v_null_taxon
+  FROM public.observations
+  WHERE sync_status = 'synced'
+    AND primary_taxon_id IS NULL;
+
+  RAISE NOTICE 'Verification: % synced observations total, % still have primary_taxon_id NULL (no identification or unresolved species)', v_total_synced, v_null_taxon;
+END $$;
+
+COMMIT;

--- a/scripts/backfill-primary-taxon-id.sql
+++ b/scripts/backfill-primary-taxon-id.sql
@@ -12,8 +12,8 @@
 -- This script handles both:
 --   Step 1 — For identifications that have scientific_name but taxon_id IS NULL,
 --             resolve taxon_id from the taxa table by exact scientific_name match.
---   Step 2 — For identifications where is_primary is false/null but they are the
---             ONLY identification on the observation, promote them to is_primary.
+--   Step 2 — For identifications where is_primary IS NOT TRUE (false OR NULL) but
+--             they are the ONLY identification on the observation, promote them.
 --   Step 3 — Backfill observations.primary_taxon_id from the primary identification.
 --
 -- Safe to run multiple times (idempotent WHERE clauses).
@@ -22,59 +22,57 @@
 
 BEGIN;
 
--- ── Step 1: resolve taxon_id on identifications that have scientific_name ───
-UPDATE public.identifications i
-SET taxon_id = t.id
-FROM public.taxa t
-WHERE i.taxon_id IS NULL
-  AND i.scientific_name IS NOT NULL
-  AND t.scientific_name = i.scientific_name;
-
--- Log how many were resolved
+-- ── Step 1: resolve taxon_id on identifications that have scientific_name ────
 DO $$
 DECLARE
   v_count int;
 BEGIN
+  UPDATE public.identifications i
+  SET taxon_id = t.id
+  FROM public.taxa t
+  WHERE i.taxon_id IS NULL
+    AND i.scientific_name IS NOT NULL
+    AND t.scientific_name = i.scientific_name;
+
   GET DIAGNOSTICS v_count = ROW_COUNT;
   RAISE NOTICE 'Step 1: resolved taxon_id for % identification(s) by scientific_name match', v_count;
 END $$;
 
 -- ── Step 2: promote sole identification to is_primary where not already set ──
--- Applies to observations that have exactly one identification and it has
--- is_primary = false. These were likely inserted by the buggy MCP code
--- (the DEFAULT true should have handled it, but guard anyway).
-UPDATE public.identifications i
-SET is_primary = true
-WHERE i.is_primary = false
-  AND NOT EXISTS (
-    SELECT 1 FROM public.identifications i2
-    WHERE i2.observation_id = i.observation_id
-      AND i2.id <> i.id
-      AND i2.is_primary = true
-  );
-
+-- Uses IS NOT TRUE to catch both false AND NULL (guard for any edge case
+-- even though the schema has DEFAULT true).
 DO $$
 DECLARE
   v_count int;
 BEGIN
+  UPDATE public.identifications i
+  SET is_primary = true
+  WHERE i.is_primary IS NOT TRUE
+    AND NOT EXISTS (
+      SELECT 1 FROM public.identifications i2
+      WHERE i2.observation_id = i.observation_id
+        AND i2.id <> i.id
+        AND i2.is_primary = true
+    );
+
   GET DIAGNOSTICS v_count = ROW_COUNT;
   RAISE NOTICE 'Step 2: promoted % identification(s) to is_primary', v_count;
 END $$;
 
 -- ── Step 3: backfill observations.primary_taxon_id ───────────────────────────
-UPDATE public.observations o
-SET primary_taxon_id = i.taxon_id,
-    updated_at       = now()
-FROM public.identifications i
-WHERE i.observation_id = o.id
-  AND i.is_primary     = true
-  AND i.taxon_id       IS NOT NULL
-  AND o.primary_taxon_id IS NULL;
-
 DO $$
 DECLARE
   v_count int;
 BEGIN
+  UPDATE public.observations o
+  SET primary_taxon_id = i.taxon_id,
+      updated_at       = now()
+  FROM public.identifications i
+  WHERE i.observation_id   = o.id
+    AND i.is_primary       = true
+    AND i.taxon_id         IS NOT NULL
+    AND o.primary_taxon_id IS NULL;
+
   GET DIAGNOSTICS v_count = ROW_COUNT;
   RAISE NOTICE 'Step 3: backfilled primary_taxon_id for % observation(s)', v_count;
 END $$;

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -154,7 +154,8 @@ const TOOLS: Tool[] = [
           observation_id:   obs.id,
           identifier_id:    ctx.user_id,
           scientific_name:  args.scientific_name,
-          id_source:        'human',
+          source:           'human',
+          is_primary:       true,
           confidence:       1.0,
         });
       }
@@ -191,7 +192,7 @@ const TOOLS: Tool[] = [
         .select(`
           id, observed_at, notes, habitat, evidence_type, created_at,
           media_files(url, is_primary),
-          identifications(scientific_name, confidence, id_source)
+          identifications(scientific_name, confidence, source)
         `)
         .eq('observer_id', ctx.user_id)
         .order('observed_at', { ascending: false })
@@ -218,7 +219,7 @@ const TOOLS: Tool[] = [
         .select(`
           id, observed_at, notes, habitat, evidence_type, location, created_at,
           media_files(url, is_primary, media_type),
-          identifications(scientific_name, confidence, id_source, created_at)
+          identifications(scientific_name, confidence, source, created_at)
         `)
         .eq('observer_id', ctx.user_id)
         .eq('id', args.id)
@@ -245,7 +246,7 @@ const TOOLS: Tool[] = [
         .from('observations')
         .select(`
           id, observed_at, notes, habitat, location,
-          identifications(scientific_name, confidence, id_source)
+          identifications(scientific_name, confidence, source)
         `)
         .eq('observer_id', ctx.user_id)
         .order('observed_at', { ascending: false });
@@ -264,7 +265,7 @@ const TOOLS: Tool[] = [
         const lng = match ? match[1] : '';
         const lat = match ? match[2] : '';
         const ids = Array.isArray(row.identifications) ? row.identifications : [];
-        const primary = (ids as Array<{ scientific_name?: string; confidence?: number; id_source?: string }>)
+        const primary = (ids as Array<{ scientific_name?: string; confidence?: number; source?: string }>)
           .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))[0];
         return [
           row.id,
@@ -275,7 +276,7 @@ const TOOLS: Tool[] = [
           row.habitat ?? '',
           `"${((row.notes as string) ?? '').replace(/"/g, '""')}"`,
           'HumanObservation',
-          primary?.id_source ?? '',
+          primary?.source ?? '',
         ].join(',');
       });
       return { csv: [header, ...rows].join('\n'), rows: rows.length };


### PR DESCRIPTION
## Bugs fixed

### 1. `/explore/species/` shows empty grid despite 18 observations
**Root cause:** `submit_observation` inserted identifications with `id_source: 'human'` but the schema column is `source`. The insert was failing silently (PostgREST ignores unknown columns or the `source` NOT NULL constraint caused the row to be skipped). Either way, the trigger `sync_primary_id_trigger` never ran, so `primary_taxon_id` stayed NULL on every observation.

The client-side query in `ExploreSpeciesView` filters `.not('primary_taxon_id', 'is', null)` → 0 results.

Also missing `is_primary: true` — without it the trigger does nothing even if the row inserted (trigger checks `IF NOT NEW.is_primary THEN RETURN NEW`).

**Fix:** `id_source → source` + `is_primary: true` in the insert.

### 2. `list_observations` / `get_observation` MCP calls crash
**Root cause:** PostgREST select expressions used `identifications(scientific_name, confidence, id_source)` — same wrong column name. Returned: *"column identifications_1.id_source does not exist"* on every call.

**Fix:** `id_source → source` in all 3 select expressions + TypeScript type annotation.

## Note on existing data
The 18 observations already in prod have `primary_taxon_id = NULL`. A one-time backfill is needed to fix them:
```sql
UPDATE observations o
SET primary_taxon_id = i.taxon_id
FROM identifications i
WHERE i.observation_id = o.id
  AND i.is_primary = true
  AND i.taxon_id IS NOT NULL
  AND o.primary_taxon_id IS NULL;
```
