### PR TITLE
ci(gitguardian): add E2E auth fixture to ignored-paths

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -3,6 +3,7 @@ secret:
   ignored-paths:
     - "supabase/functions/_shared/anthropic-validate.test.ts"
     - "supabase/functions/_shared/sponsorship.test.ts"
+    - "tests/e2e/fixtures/auth.ts"
   ignored-detectors:
     - generic_high_entropy_secret
 ignore-default-excludes: false


### PR DESCRIPTION
Adds `tests/e2e/fixtures/auth.ts` to `.gitguardian.yml` ignored-paths on `main`.

The file contains intentional mock tokens (`mock-jwt-for-e2e-testing`, `mock-refresh-for-e2e-testing`) used by Playwright fixtures to inject fake Supabase sessions — not real credentials. GitGuardian was flagging the Supabase project ref + token-shaped strings as a false positive.

The branch `feat/user-journeys-testing` (#402) already has this path in its `.gitguardian.yml` but GG scans against main's config for PR checks — so it needs to land in main first.

Unblocks merge of #402.