### PR TITLE
fix(nav): add community experts/country links to mobile drawer (#418)

### DIFF
--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -34,6 +34,8 @@ const projectsPath          = getLocalizedPath(lang, routes.projects[locale] + '
 const communityObserversBase    = getLocalizedPath(lang, routes.communityObservers[locale] + '/');
 const communityObserversTopHref    = `${communityObserversBase}?sort=obs_count_30d`;
 const communityObserversNearbyHref = `${communityObserversBase}?nearby=true`;
+const communityObserversExpertsHref = `${communityObserversBase}?expert=true`;
+const communityObserversCountryHref = `${communityObserversBase}?country=`;
 const communityMapHref             = getLocalizedPath(lang, routes.communityMap[locale] + '/');
 const communityLeaderboardHref     = getLocalizedPath(lang, routes.leaderboard[locale] + '/');
 interface ExploreMegaMenu {
@@ -98,6 +100,8 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
       <a href={communityObserversBase}       class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{em.community_all}</a>
       <a href={communityObserversTopHref}    class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{em.community_top}</a>
       <a href={communityObserversNearbyHref} class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{em.community_nearby}</a>
+      <a href={communityObserversExpertsHref} class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{em.community_experts}</a>
+      <a href={communityObserversCountryHref} class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{em.community_country}</a>
       <a href={communityMapHref}             class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{em.community_map}</a>
       <a href={communityLeaderboardHref}     class="block py-1.5 hover:text-emerald-600 dark:hover:text-emerald-400">{em.community_leaderboard ?? (lang === 'es' ? 'Tabla de líderes' : 'Leaderboard')}</a>
     </section>


### PR DESCRIPTION
Closes #418

Adds the 2 missing community filtered links to the mobile drawer (MobileDrawer.astro) to match desktop parity:
- **Experts by taxon** (`?expert=true`)
- **By country** (`?country=`)

As noted in the issue comment by Nyx, Top and Nearby were already present. Only these 2 were missing.

**Changes:** 2 href consts in frontmatter + 2 `<a>` tags in the community section of the drawer, in the same order as the desktop megamenu.