### PR TITLE
feat(versioning): adopt year.month.N scheme — 2026.5.0 (#422)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Extract version
+        id: pkg
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
       - name: Typecheck
         run: npx tsc --noEmit
 
@@ -53,6 +56,7 @@ jobs:
           PUBLIC_MEGADETECTOR_WEIGHTS_URL: ${{ secrets.PUBLIC_MEGADETECTOR_WEIGHTS_URL }}
           PUBLIC_MEGADETECTOR_ENDPOINT: ${{ secrets.PUBLIC_MEGADETECTOR_ENDPOINT }}
           PUBLIC_BUILD_SHA:           ${{ github.sha }}
+          PUBLIC_VERSION:             ${{ steps.pkg.outputs.version }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -166,3 +166,9 @@ status: ## Short git status
 
 push: ## Push current branch to origin
 	git push origin $$(git rev-parse --abbrev-ref HEAD)
+
+## Release
+.PHONY: release
+release: ## Bump version. Usage: make release VERSION=2026.6.0
+	@if [ -z "$(VERSION)" ]; then echo "✗ VERSION is not set. Usage: make release VERSION=2026.6.0"; exit 1; fi
+	@bash scripts/bump-version.sh "$(VERSION)"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rastrum",
   "type": "module",
-  "version": "0.0.1",
+  "version": "2026.5.0",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,5 +1,6 @@
 {
   "name": "Rastrum",
+  "version": "2026.5.0",
   "short_name": "Rastrum",
   "description": "Offline-first biodiversity identification for Latin America.",
   "start_url": "/en/",

--- a/public/sw.js
+++ b/public/sw.js
@@ -9,7 +9,7 @@
 //   - Manifest, favicon, sw.js itself: network-first so updates land fast.
 //
 // Bump VERSION to invalidate every cached entry on the next visit.
-const VERSION = 'rastrum-shell-v8-2026-04-30-share-target';
+const VERSION = 'rastrum-shell-2026.5.0';
 const SHELL = [
   '/',
   '/en/',

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/bump-version.sh 2026.6.0
+set -euo pipefail
+VERSION="$1"
+# Update package.json
+npm version "$VERSION" --no-git-tag-version
+# Update manifest.webmanifest
+jq --arg v "$VERSION" '.version = $v' public/manifest.webmanifest > /tmp/manifest.tmp && mv /tmp/manifest.tmp public/manifest.webmanifest
+# Update sw.js VERSION constant
+sed -i "s/const VERSION = .*/const VERSION = 'rastrum-shell-${VERSION}';/" public/sw.js
+# Commit + tag
+git add package.json public/manifest.webmanifest public/sw.js
+git commit -m "chore(release): bump version to ${VERSION}"
+git tag "v${VERSION}"
+echo "Done. Push with: git push && git push origin v${VERSION}"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,6 +11,8 @@ const { lang, currentPath = '' } = Astro.props;
 const chromeMode = resolveChromeMode(currentPath, import.meta.env.BASE_URL);
 if (chromeMode === 'app') return;
 
+const appVersion = import.meta.env.PUBLIC_VERSION ?? 'dev';
+
 const tr = t(lang);
 const locale = (lang === 'es' ? 'es' : 'en') as Locale;
 const alt: Locale = locale === 'es' ? 'en' : 'es';
@@ -223,7 +225,7 @@ const mLinkClass = 'text-zinc-500 dark:text-zinc-400';
           target="_blank"
           rel="noopener"
           class="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-400 transition-colors font-mono"
-        >v1.0</a>
+        >v{appVersion}</a>
       </div>
     </div>
   </div>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -15,6 +15,11 @@ interface ImportMetaEnv {
   readonly PUBLIC_VAPID_PUBLIC_KEY?: string;
   readonly PUBLIC_BUILD_SHA?: string;
   /**
+   * App version string (year.month.N format, e.g. "2026.5.0").
+   * Set from package.json in CI; falls back to "dev" locally.
+   */
+  readonly PUBLIC_VERSION?: string;
+  /**
    * Stable per-deploy version string. Used as a CORS preflight cache
    * buster (sent as `x-rastrum-build` on `get-upload-url` calls). Set
    * in CI from the deploy SHA; falls back to today's ISO date when


### PR DESCRIPTION
Closes #422

- package.json: 0.0.1 → 2026.5.0
- manifest.webmanifest: add version field
- sw.js: update VERSION constant to rastrum-shell-2026.5.0
- deploy.yml: add Extract version step + expose PUBLIC_VERSION build var
- env.d.ts: declare PUBLIC_VERSION type
- Footer.astro: version badge reads from import.meta.env.PUBLIC_VERSION (falls back to 'dev' locally)
- scripts/bump-version.sh: end-to-end version bump script
- Makefile: make release target