### PR TITLE
fix(journey-guides): spotlight hints misaligned on mobile — RC1–RC4

### DIFF
--- a/src/components/JourneyGuideLoader.astro
+++ b/src/components/JourneyGuideLoader.astro
@@ -74,15 +74,34 @@ const resolvedGuides = journeyGuides.map(g => ({
     );
   }
 
+  function waitForTarget(selector, callback, maxWaitMs = 4000) {
+    const selectors = selector.split(',').map(s => s.trim());
+    const start = Date.now();
+    function poll() {
+      for (const sel of selectors) {
+        try {
+          if (document.querySelector(sel)) { callback(); return; }
+        } catch { /* invalid selector */ }
+      }
+      if (Date.now() - start < maxWaitMs) {
+        setTimeout(poll, 200);
+      } else {
+        callback(); // fire anyway (tooltip will center if target not found)
+      }
+    }
+    setTimeout(poll, 500); // minimum delay before first check
+  }
+
   function initGuides() {
     const guide = findGuide(currentPath);
     if (!guide || guide.activation !== 'first-visit' || isGuideSeen(guide.storageKey)) return;
 
-    setTimeout(() => {
+    const firstTarget = guide.steps[0]?.target ?? 'body';
+    waitForTarget(firstTarget, () => {
       window.dispatchEvent(new CustomEvent('rastrum:journey-guide-start', {
         detail: { guideId: guide.id, steps: guide.steps },
       }));
-    }, 1500);
+    });
   }
 
   // Replay handler — dispatched by JourneyReplayButton or any other UI

--- a/src/components/JourneySpotlight.astro
+++ b/src/components/JourneySpotlight.astro
@@ -123,7 +123,7 @@ const l = labels[lang] ?? labels.en;
       const vh = window.innerHeight;
 
       ring.style.left = `${tr.left}px`;
-      ring.style.top = `${tr.top + window.scrollY}px`;
+      ring.style.top = `${tr.top}px`;
       ring.style.width = `${tr.width}px`;
       ring.style.height = `${tr.height}px`;
       ring.classList.remove('hidden');
@@ -145,7 +145,7 @@ const l = labels[lang] ?? labels.en;
       else ty = Math.max(M, Math.min(vh / 2 - TH / 2, vh - TH - M));
 
       tooltip.style.left = `${tx}px`;
-      tooltip.style.top = `${ty + window.scrollY}px`;
+      tooltip.style.top = `${ty}px`;
       tooltip.style.transform = 'none';
     }
 
@@ -186,8 +186,8 @@ const l = labels[lang] ?? labels.en;
       document.documentElement.style.overflow = 'hidden';
       document.body.style.overflow = 'hidden';
 
-      render();
       requestAnimationFrame(() => {
+        render();
         tooltip.focus();
         emit('guide_opened');
       });

--- a/src/lib/journey-guides.ts
+++ b/src/lib/journey-guides.ts
@@ -39,22 +39,22 @@ export const journeyGuides: JourneyGuide[] = [
     activation: 'first-visit',
     steps: [
       {
-        target: '[data-dropzone], #obs-dropzone, input[type="file"]',
+        target: '#obs2-media-trigger, [data-dropzone], input[type="file"]',
         titleKey: 'guides.observe.step1_title',
         bodyKey: 'guides.observe.step1_body',
       },
       {
-        target: '#obs-id-result, [data-id-result]',
+        target: '#obs2-id-card, #obs-id-result, [data-id-result]',
         titleKey: 'guides.observe.step2_title',
         bodyKey: 'guides.observe.step2_body',
       },
       {
-        target: '#obs-species-confirm, [data-species-confirm]',
+        target: '#obs2-id-card, #obs-species-confirm, [data-species-confirm]',
         titleKey: 'guides.observe.step3_title',
         bodyKey: 'guides.observe.step3_body',
       },
       {
-        target: '#obs-save-btn, [data-save-btn], button[type="submit"]',
+        target: '#obs2-save-btn, #obs-save-btn, [data-save-btn]',
         titleKey: 'guides.observe.step4_title',
         bodyKey: 'guides.observe.step4_body',
       },
@@ -67,17 +67,17 @@ export const journeyGuides: JourneyGuide[] = [
     activation: 'first-visit',
     steps: [
       {
-        target: '[data-explore-tabs], .explore-tabs, nav[aria-label]',
+        target: '[data-explore-tabs], .explore-tabs, main nav, nav[role="tablist"]',
         titleKey: 'guides.explore.step1_title',
         bodyKey: 'guides.explore.step1_body',
       },
       {
-        target: '[data-explore-map], a[href*="map"]',
+        target: '[data-explore-map], main a[href*="map"], .explore-card a[href*="map"]',
         titleKey: 'guides.explore.step2_title',
         bodyKey: 'guides.explore.step2_body',
       },
       {
-        target: '[data-explore-filters], .explore-filters',
+        target: '[data-explore-filters], .explore-filters, #cf-sort',
         titleKey: 'guides.explore.step3_title',
         bodyKey: 'guides.explore.step3_body',
       },
@@ -141,12 +141,12 @@ export const journeyGuides: JourneyGuide[] = [
         bodyKey: 'guides.community.step1_body',
       },
       {
-        target: '.observer-card, [data-observer-card]',
+        target: '[data-observer-card], ul[data-observers] li:first-child, .community-list li:first-child',
         titleKey: 'guides.community.step2_title',
         bodyKey: 'guides.community.step2_body',
       },
       {
-        target: '#follow-btn, [data-follow-btn]',
+        target: '[data-follow-btn], #follow-btn, a[href*="/profile/u"]',
         titleKey: 'guides.community.step3_title',
         bodyKey: 'guides.community.step3_body',
       },
@@ -159,17 +159,17 @@ export const journeyGuides: JourneyGuide[] = [
     activation: 'first-visit',
     steps: [
       {
-        target: '[data-console-tabs], .console-tabs',
+        target: '[data-console-tabs], .console-tabs, nav[aria-label*="console"], nav[aria-label*="consola"]',
         titleKey: 'guides.console.step1_title',
         bodyKey: 'guides.console.step1_body',
       },
       {
-        target: '[data-console-health], a[href*="health"]',
+        target: '[data-console-health], a[href*="health"], a[href*="salud"]',
         titleKey: 'guides.console.step2_title',
         bodyKey: 'guides.console.step2_body',
       },
       {
-        target: '[data-console-keyboard], .keyboard-hint',
+        target: '[data-console-keyboard], .keyboard-hint, [data-shortcut]',
         titleKey: 'guides.console.step3_title',
         bodyKey: 'guides.console.step3_body',
       },


### PR DESCRIPTION
## Summary

Fixes journey guide spotlights misaligned on mobile. Addresses 4 root causes documented in issue #420.

---

### RC1 — Selector fallback chains updated (`src/lib/journey-guides.ts`)

Updated all guide step selectors to include the real DOM element IDs with higher priority, with the original generic selectors as fallbacks:

- **guide-observe:** steps now target `#obs2-media-trigger`, `#obs2-id-card`, `#obs2-save-btn` as primary selectors
- **guide-explore:** tabs target `main nav, nav[role="tablist"]`; map adds `.explore-card a[href*="map"]`; filters add `#cf-sort`
- **guide-community:** observer card targets `ul[data-observers] li:first-child`; follow targets `a[href*="/profile/u"]`
- **guide-console:** tabs target `nav[aria-label*="console/consola"]`; health adds `a[href*="salud"]`; keyboard adds `[data-shortcut]`

### RC2 — Remove `+ window.scrollY` from positioning (`src/components/JourneySpotlight.astro`)

The overlay is `fixed inset-0`. For `absolute` children inside a fixed container, `getBoundingClientRect()` values already map to viewport coordinates — adding `window.scrollY` double-counts scroll, breaking positioning on any scrolled page.

- Removed `+ window.scrollY` from `ring.style.top`
- Removed `+ window.scrollY` from `tooltip.style.top`

### RC3 — Move `render()` inside `requestAnimationFrame` in `show()` (`src/components/JourneySpotlight.astro`)

Setting `overflow: hidden` can trigger a layout reflow on some mobile browsers. Wrapping `render()` inside the existing `requestAnimationFrame` callback ensures positions are calculated after the browser processes the layout change.

### RC4 — Smart target-wait strategy replaces fixed timeout (`src/components/JourneyGuideLoader.astro`)

Replaced the fixed `setTimeout(..., 1500)` with a `waitForTarget()` function that polls every 200ms (up to 4s) until the first step's target element is present in the DOM. This handles async-rendered pages where the guide target may not be available at 1.5s on slower devices.

---

Closes #420
