### PR TITLE
fix(bug-report): add version to issue report modal environment block

### DIFF
--- a/src/components/ReportIssueButton.astro
+++ b/src/components/ReportIssueButton.astro
@@ -8,6 +8,7 @@ interface Props {
 const { lang } = Astro.props;
 const tr = t(lang);
 const buildSha = import.meta.env.PUBLIC_BUILD_SHA || 'dev';
+const appVersion = import.meta.env.PUBLIC_VERSION || 'dev';
 const repoSlug = 'ArtemioPadilla/rastrum';
 ---
 
@@ -30,6 +31,7 @@ const repoSlug = 'ArtemioPadilla/rastrum';
   data-repo={repoSlug}
   data-lang={lang}
   data-build-sha={buildSha}
+  data-app-version={appVersion}
   data-l-steps-label={tr.report.steps_label}
   data-l-steps-placeholder={tr.report.steps_placeholder}
   data-l-expected-label={tr.report.expected_label}
@@ -263,6 +265,7 @@ const repoSlug = 'ArtemioPadilla/rastrum';
   var repo = dlg.dataset.repo || '';
   var lang = dlg.dataset.lang || 'en';
   var buildSha = dlg.dataset.buildSha || 'dev';
+  var appVersion = dlg.dataset.appVersion || document.querySelector('meta[name="app-version"]')?.content || 'dev';
   var noneLabel = dlg.dataset.lDiagnosticsNone || 'None captured';
   var copyLabel = dlg.dataset.lCopy || 'Copy diagnostics';
   var copiedLabel = dlg.dataset.lCopied || 'Copied!';
@@ -297,7 +300,8 @@ const repoSlug = 'ArtemioPadilla/rastrum';
     lines.push('URL: ' + location.href);
     lines.push('User Agent: ' + navigator.userAgent);
     lines.push('Locale: ' + lang);
-    lines.push('Build: ' + buildSha);
+    lines.push('Version: ' + appVersion);
+    lines.push('Build SHA: ' + buildSha);
     lines.push('Online: ' + (navigator.onLine ? 'yes' : 'no'));
     lines.push('Viewport: ' + innerWidth + 'x' + innerHeight);
     lines.push('Time: ' + new Date().toISOString());

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -131,6 +131,8 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="application-name" content="Rastrum" />
     <meta name="apple-mobile-web-app-title" content="Rastrum" />
+    <meta name="app-version" content={import.meta.env.PUBLIC_VERSION ?? 'dev'} />
+    <meta name="build-sha" content={import.meta.env.PUBLIC_BUILD_SHA ?? 'dev'} />
     <title>{title}</title>
     <StructuredData type="organization" />
     {currentPath === `/${lang}/` && <StructuredData type="website" lang={lang === 'es' ? 'es' : 'en'} />}

--- a/src/lib/bug-report.ts
+++ b/src/lib/bug-report.ts
@@ -34,9 +34,11 @@ export interface BugReportOptions {
 export async function buildBugReportUrl(opts: BugReportOptions): Promise<string> {
   const { title, errorMsg, obsId, obsName, extra } = opts;
 
-  // App version from meta tag (injected at build time)
+  // App version from meta tags (injected at build time via BaseLayout)
   const appVersion =
     document.querySelector<HTMLMetaElement>('meta[name="app-version"]')?.content ?? 'unknown';
+  const buildSha =
+    document.querySelector<HTMLMetaElement>('meta[name="build-sha"]')?.content ?? 'unknown';
 
   // Service worker version
   let swVersion = 'none';
@@ -59,7 +61,8 @@ export async function buildBugReportUrl(opts: BugReportOptions): Promise<string>
     URL:          location.href,
     'User Agent': navigator.userAgent,
     Locale:       navigator.language,
-    Build:        appVersion,
+    Version:      appVersion,
+    'Build SHA':  buildSha,
     'SW version': swVersion,
     Online:       String(navigator.onLine),
     Viewport:     `${window.innerWidth}x${window.innerHeight}`,


### PR DESCRIPTION
Fixes the version always showing `unknown` in bug reports, and adds `Version: 2026.5.0` to the environment block of the GitHub issue modal.

## Changes

**`BaseLayout.astro`**
- Adds `<meta name="app-version">` and `<meta name="build-sha">` tags to `<head>` — previously missing, causing `bug-report.ts` to always read `'unknown'`

**`bug-report.ts`**
- Reads `build-sha` meta separately from `app-version`
- Renames `Build:` → `Version:` + `Build SHA:` in the environment table so users see the human-readable version number first

**`ReportIssueButton.astro`**
- Passes `PUBLIC_VERSION` as `data-app-version` to the modal
- Reads it in the client script (with meta tag fallback)
- Adds `Version: 2026.5.0` line before `Build SHA` in the environment block shown in the dialog and pre-filled in the GitHub issue