### PR TITLE
fix(ux): move journey replay (?) button to left side — avoid overlap with report button

### DIFF
--- a/src/components/JourneyReplayButton.astro
+++ b/src/components/JourneyReplayButton.astro
@@ -17,7 +17,7 @@ const label = lang === 'es' ? '¿Cómo funciona?' : 'How does this work?';
 {guide && (
   <button
     id="journey-replay-btn"
-    class="fixed bottom-20 right-4 z-40 rounded-full bg-stone-100 dark:bg-stone-800
+    class="fixed bottom-20 left-4 z-40 rounded-full bg-stone-100 dark:bg-stone-800
            px-3 py-1.5 text-sm shadow-md hover:shadow-lg transition-shadow
            sm:bottom-6 print:hidden"
     data-guide-id={guide.id}


### PR DESCRIPTION
Both the report bug button and the journey replay (?) button were positioned `right-4`, causing overlap on mobile.

Move the ? button to `left-4` so the two FABs are on opposite sides of the screen:
- **Left**: Journey replay button (?)
- **Right**: Report issue button (🐛)

One-line change: `right-4` → `left-4` in `JourneyReplayButton.astro`.