### PR TITLE
fix(ci): fix bash syntax error in deploy.yml extract-version step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: Extract version
         id: pkg
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -e "process.stdout.write(require('./package.json').version)")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Typecheck
         run: npx tsc --noEmit
 


### PR DESCRIPTION
The `node -p` with escaped quotes inside YAML double-quoted string caused:
`syntax error near unexpected token '('`

Fix: use `node -e` with `process.stdout.write()` in a multi-line `run: |` block, avoiding the quoting issue entirely.