### PR TITLE
fix(spotlight): center tooltip when target element is invisible (zero-size rect)

### DIFF
--- a/src/components/JourneySpotlight.astro
+++ b/src/components/JourneySpotlight.astro
@@ -107,7 +107,12 @@ const l = labels[lang] ?? labels.en;
     }
 
     function positionTooltip(targetEl: Element | null): void {
-      if (!targetEl) {
+      // Treat zero-size rects (hidden/display:none elements) same as null —
+      // element exists in DOM but is not visible, so we can't point to it.
+      const base = targetEl?.getBoundingClientRect();
+      const isVisible = base && (base.width > 0 || base.height > 0);
+
+      if (!targetEl || !isVisible) {
         tooltip.style.left = '50%';
         tooltip.style.top = '50%';
         tooltip.style.transform = 'translate(-50%, -50%)';
@@ -117,8 +122,7 @@ const l = labels[lang] ?? labels.en;
       }
 
       const PAD = 8;
-      const base = targetEl.getBoundingClientRect();
-      const tr = new DOMRect(base.left - PAD, base.top - PAD, base.width + PAD * 2, base.height + PAD * 2);
+      const tr = new DOMRect(base!.left - PAD, base!.top - PAD, base!.width + PAD * 2, base!.height + PAD * 2);
       const vw = window.innerWidth;
       const vh = window.innerHeight;
 


### PR DESCRIPTION
Fixes journey guide tooltips pointing to the top-left corner (0,0) instead of centering on screen when the target element exists in the DOM but is not visible (e.g. `#obs2-save-btn` which is hidden until after species identification).

## Root cause
`getBoundingClientRect()` on a hidden/`display:none` element returns `{top:0, left:0, width:0, height:0}`. The code found the element (selector resolved), but positioned the ring at `(0,0)` — top-left corner.

## Fix
Check if `width > 0 || height > 0` before positioning. If zero-size, treat as `null` and center the tooltip instead. Same behavior as when the selector finds nothing.