### PR TITLE
fix(identifiers): decouple EfficientNet from localAI gate + add to live pipeline (#433)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -417,6 +417,7 @@ const fileHint    = document.getElementById('obs2-file-hint');
       { label: 'BirdNET (birds)', labelEs: 'BirdNET (aves)', ok: runners.birdnet },
       { label: 'Claude Vision', labelEs: 'Claude Vision', ok: runners.claude },
       { label: 'Phi Vision (local)', labelEs: 'Phi Vision (local)', ok: runners.phi },
+      { label: 'EfficientNet (local)', labelEs: 'EfficientNet (local)', ok: runners.efficientNet },
     ];
     const allOk = items.every(i => i.ok);
     // Hide setup link if all configured
@@ -552,7 +553,16 @@ async function detectRunners() {
     }
   } catch { /* unavailable */ }
 
-  return { plantnet: plantnetKey, birdnet: birdnetStatus, claude: claudeKey, phi };
+  // EfficientNet-Lite0: runs whenever downloaded (~2.8 MB), no extra toggle needed.
+  let efficientNet = false;
+  try {
+    const { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } = await import('../lib/identifiers/onnx-base-cache');
+    efficientNet = getOnnxBaseWeightsBaseUrl()
+      ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
+      : false;
+  } catch { /* unavailable */ }
+
+  return { plantnet: plantnetKey, birdnet: birdnetStatus, claude: claudeKey, phi, efficientNet };
 }
 
 // ── Pipeline runner ────────────────────────────────────────────────────────
@@ -592,6 +602,26 @@ async function runPipeline(state: PipelineState) {
           if (await resolvePlantNetKey()) runners.plantnet = (await import('../lib/identify-runners')).makePlantNetRunner(lang as 'en' | 'es');
           if (await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
         }
+
+        // EfficientNet-Lite0: always add as fallback if downloaded (~2.8 MB, no key needed).
+        // It runs in-parallel as a zero-cost fallback alongside cloud runners.
+        try {
+          const { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } = await import('../lib/identifiers/onnx-base-cache');
+          const enCached = getOnnxBaseWeightsBaseUrl()
+            ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
+            : false;
+          if (enCached) {
+            const { onnxBaseIdentifier } = await import('../lib/identifiers/onnx-base');
+            runners.onnx_efficientnet_lite0 = async (file: File) => {
+              const result = await onnxBaseIdentifier.identify({
+                media: { kind: 'blob', blob: file },
+                mediaKind: 'photo',
+                locale: lang as 'en' | 'es',
+              });
+              return result;
+            };
+          }
+        } catch { /* EfficientNet unavailable, skip */ }
 
         if (Object.keys(runners).length === 0) {
           setNodeState(state, node.id, 'skipped', undefined, 'No runner available');

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -314,7 +314,15 @@ async function triggerIdentify(observationId: string): Promise<void> {
   const localAIEnabled = isLocalAIEnabled();
 
   const excluded: string[] = [];
-  if (!localAIEnabled) excluded.push('webllm_phi35_vision', 'onnx_efficientnet_lite0', 'birdnet_lite');
+  // Large models (Phi-3.5 2.4 GB, BirdNET ~50 MB) gate on localAIEnabled.
+  // EfficientNet-Lite0 is only ~2.8 MB — run it whenever it's downloaded,
+  // regardless of the localAI bandwidth toggle.
+  if (!localAIEnabled) excluded.push('webllm_phi35_vision', 'birdnet_lite');
+  const { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } = await (await import('./identifiers/onnx-base-cache'));
+  const efficientNetCached = getOnnxBaseWeightsBaseUrl()
+    ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
+    : false;
+  if (!efficientNetCached) excluded.push('onnx_efficientnet_lite0');
   if (!hasAnthropicKey) excluded.push('claude_haiku');
 
   // Camera-trap photos prefer the MegaDetector + SpeciesNet pipeline.


### PR DESCRIPTION
Closes #433

## Changes

### `sync.ts` — decouple from localAIEnabled
EfficientNet-Lite0 was grouped with Phi-3.5 (2.4 GB) and BirdNET (~50 MB) under the `localAIEnabled` bandwidth gate. This made no sense for a ~2.8 MB model. Now:
- Phi and BirdNET: still gated by `localAIEnabled` (large downloads)
- EfficientNet: excluded only when the ONNX weights aren't cached — runs automatically when downloaded

### `ObserveView2.astro` — add to live pipeline  
EfficientNet was registered in the cascade registry but never added to ObserveView2's live runners dict. Now:
- `detectRunners()`: checks EfficientNet cache status and includes it in the capability indicator
- Pipeline: adds EfficientNet as a zero-cost fallback runner for photos whenever the model is cached, running in parallel with cloud identifiers