### PR TITLE
fix(sponsoring): dark mode dialogs + CORS handler for sponsorships Edge Function (#438, #439)

### DIFF
--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -91,7 +91,7 @@ const langJson = JSON.stringify(lang);
     </p>
   </section>
 
-  <dialog id="add-pool-dialog" class="rounded-xl p-6 max-w-md backdrop:bg-black/50">
+  <dialog id="add-pool-dialog" class="rounded-xl p-6 max-w-md w-full backdrop:bg-black/50 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100">
     <h3 class="text-lg font-semibold mb-2">{lang === 'es' ? 'Donar al pool' : 'Donate to pool'}</h3>
     <form method="dialog" class="space-y-3">
       <div>
@@ -183,8 +183,8 @@ const langJson = JSON.stringify(lang);
     </div>
   </section>
 
-  <dialog id="add-cred-dialog" class="rounded-xl p-6 max-w-md backdrop:bg-black/50">
-    <h3 class="text-lg font-semibold mb-2">{tr.sponsoring.add_credential}</h3>
+  <dialog id="add-cred-dialog" class="rounded-xl p-6 max-w-md w-full backdrop:bg-black/50 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100">
+    <h3 class="text-lg font-semibold mb-2 text-zinc-900 dark:text-zinc-100">{tr.sponsoring.add_credential}</h3>
     <form method="dialog" class="space-y-3">
       <div>
         <label class="block text-sm font-medium" for="cred-label-input">{tr.sponsoring.credential_label}</label>

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -34,7 +34,8 @@ const UUID_RE = /^[0-9a-f-]{36}$/;
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': 'authorization, content-type',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, x-client-info, x-rastrum-build',
+  'Access-Control-Max-Age': '86400',
 };
 
 serve(async (req) => {

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -10,7 +10,7 @@ const SPONSORSHIPS_CRON_TOKEN = Deno.env.get('SPONSORSHIPS_CRON_TOKEN');
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...CORS_HEADERS },
   });
 }
 
@@ -31,7 +31,18 @@ function withCronToken(req: Request): boolean {
 
 const UUID_RE = /^[0-9a-f-]{36}$/;
 
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, content-type',
+};
+
 serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
   const url = new URL(req.url);
   const path = url.pathname.replace(/^\/sponsorships/, '') || '/';
 

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -7,6 +7,13 @@ const SUPABASE_URL            = Deno.env.get('SUPABASE_URL')!;
 const SUPABASE_SERVICE_ROLE   = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 const SPONSORSHIPS_CRON_TOKEN = Deno.env.get('SPONSORSHIPS_CRON_TOKEN');
 
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, x-client-info, x-rastrum-build',
+  'Access-Control-Max-Age': '86400',
+};
+
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -30,13 +37,6 @@ function withCronToken(req: Request): boolean {
 }
 
 const UUID_RE = /^[0-9a-f-]{36}$/;
-
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, x-client-info, x-rastrum-build',
-  'Access-Control-Max-Age': '86400',
-};
 
 serve(async (req) => {
   // Handle CORS preflight


### PR DESCRIPTION
## Fixes

Closes #438, closes #439.

---

## Fix 1 — Dark mode for dialogs (#438)

**File:** `src/components/SponsoringView.astro`

The `<dialog>` elements for "Add credential" and "Add pool" had no dark mode background — the browser rendered them with its built-in white background in dark mode, making the content unreadable against the dark app chrome.

```diff
- <dialog id="add-cred-dialog" class="rounded-xl p-6 max-w-md backdrop:bg-black/50">
+ <dialog id="add-cred-dialog" class="rounded-xl p-6 max-w-md w-full backdrop:bg-black/50 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100">

- <dialog id="add-pool-dialog" class="rounded-xl p-6 max-w-md backdrop:bg-black/50">
+ <dialog id="add-pool-dialog" class="rounded-xl p-6 max-w-md w-full backdrop:bg-black/50 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100">
```

Also added explicit `text-zinc-900 dark:text-zinc-100` to the `<h3>` heading inside the credential dialog (was inheriting incorrectly in dark mode).

---

## Fix 2 — CORS handler for sponsorships Edge Function (#439)

**File:** `supabase/functions/sponsorships/index.ts`

All requests to `/functions/v1/sponsorships/*` were failing with `TypeError: Failed to fetch` (network error, not HTTP). The function had no CORS handling — the browser's preflight `OPTIONS` request got no valid response, causing the browser to block all subsequent requests.

Added:
1. `CORS_HEADERS` constant with standard `Access-Control-Allow-*` headers
2. `OPTIONS` preflight handler at the top of `serve()` returning `204`
3. `...CORS_HEADERS` spread into `jsonResponse()` so every response includes the headers

```diff
+ const CORS_HEADERS = {
+   'Access-Control-Allow-Origin': '*',
+   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+   'Access-Control-Allow-Headers': 'authorization, content-type',
+ };
+
serve(async (req) => {
+ if (req.method === 'OPTIONS') {
+   return new Response(null, { status: 204, headers: CORS_HEADERS });
+ }
```

Merging this will trigger the `deploy-functions.yml` workflow (path-filtered on `supabase/functions/**`) and re-deploy the `sponsorships` function automatically.