### PR TITLE
fix(sponsoring): add error logging to 500 responses — expose hint for debugging persistent 500s

### DIFF
--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -144,7 +144,10 @@ serve(async (req) => {
       .select('id, label, provider, kind, validated_at, last_used_at, revoked_at, created_at')
       .eq('user_id', ctx.userId)
       .order('created_at', { ascending: false });
-    if (error) return jsonResponse(500, { error: 'list_failed', detail: error.message });
+    if (error) {
+      console.error('[sponsorships] GET /credentials failed:', JSON.stringify({ code: error.code, message: error.message, details: error.details, hint: error.hint }));
+      return jsonResponse(500, { error: 'list_failed', detail: error.message, hint: error.hint });
+    }
     return jsonResponse(200, data ?? []);
   }
 
@@ -294,7 +297,10 @@ serve(async (req) => {
       .eq(col, ctx.userId)
       .order('priority', { ascending: true })
       .order('created_at', { ascending: false });
-    if (error) return jsonResponse(500, { error: 'list_failed', detail: error.message });
+    if (error) {
+      console.error('[sponsorships] GET /sponsorships failed:', JSON.stringify({ code: error.code, message: error.message, details: error.details, hint: error.hint }));
+      return jsonResponse(500, { error: 'list_failed', detail: error.message, hint: error.hint });
+    }
     return jsonResponse(200, data ?? []);
   }
 
@@ -476,7 +482,10 @@ serve(async (req) => {
       .from('sponsorship_requests').select('*').eq(col, ctx.userId)
       .order('created_at', { ascending: false })
       .limit(100);
-    if (error) return jsonResponse(500, { error: 'list_failed', detail: error.message });
+    if (error) {
+      console.error('[sponsorships] GET /requests failed:', JSON.stringify({ code: error.code, message: error.message, details: error.details, hint: error.hint }));
+      return jsonResponse(500, { error: 'list_failed', detail: error.message, hint: error.hint });
+    }
     return jsonResponse(200, data ?? []);
   }
 


### PR DESCRIPTION
The `/sponsoring/` page returns 500 on all GET endpoints despite the schema being applied. This PR adds `console.error` logging and exposes `error.hint` in the JSON 500 response to surface the actual Supabase error detail in logs and client.

Once merged, the next 500 will include `hint` in the response body and the Supabase Function logs will show the full error context.