### PR TITLE
fix(obs-detail): sci name pre-fill + GPS button + location_source on update (#445)

### DIFF
--- a/src/components/ObsManagePanel.astro
+++ b/src/components/ObsManagePanel.astro
@@ -239,6 +239,14 @@ const observe = tr.observe;
     <p class="text-xs text-zinc-500 dark:text-zinc-400">{od.location.edit_intro}</p>
 
     <div class="flex flex-wrap items-center gap-2">
+      <button
+        id="m-loc-gps"
+        type="button"
+        class="hidden inline-flex items-center gap-1.5 rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-1.5 text-xs font-semibold text-white"
+      >
+        <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg>
+        {lang === 'es' ? 'Usar mi ubicación GPS' : 'Use my GPS location'}
+      </button>
       <MapPicker
         mode="edit"
         lang={lang}
@@ -249,6 +257,7 @@ const observe = tr.observe;
       <span id="m-loc-saving" class="hidden text-xs text-zinc-500 dark:text-zinc-400" aria-live="polite">{od.location.saving}</span>
       <span id="m-loc-saved"  class="hidden text-xs text-emerald-700 dark:text-emerald-400" aria-live="polite">{od.saved}</span>
     </div>
+    <p id="m-loc-gps-status" class="hidden text-xs text-zinc-500 dark:text-zinc-400" aria-live="polite"></p>
     <p id="m-loc-error" class="hidden text-xs text-red-600 dark:text-red-400" role="alert"></p>
   </div>
 

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -596,6 +596,32 @@ export async function wireManagePanelLocation(
   const savedEl  = document.getElementById('m-loc-saved');
   const errEl    = document.getElementById('m-loc-error');
 
+  // GPS button — use device location
+  const gpsBtn = document.getElementById('m-loc-gps');
+  if (gpsBtn && 'geolocation' in navigator) {
+    gpsBtn.classList.remove('hidden');
+    gpsBtn.addEventListener('click', () => {
+      const gpsStatus = document.getElementById('m-loc-gps-status');
+      gpsBtn.disabled = true;
+      if (gpsStatus) { gpsStatus.textContent = isEs ? 'Obteniendo ubicación…' : 'Getting location…'; gpsStatus.classList.remove('hidden'); }
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          gpsBtn.disabled = false;
+          if (gpsStatus) gpsStatus.classList.add('hidden');
+          const coords = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+          window.dispatchEvent(new CustomEvent('rastrum:mappicker-set-initial', { detail: { id: 'obs-detail-edit', coords } }));
+          window.dispatchEvent(new CustomEvent('rastrum:mappicker-set', { detail: { id: 'obs-detail-edit', coords } }));
+        },
+        (err) => {
+          gpsBtn.disabled = false;
+          if (gpsStatus) { gpsStatus.textContent = isEs ? 'No se pudo obtener la ubicación GPS.' : 'Could not get GPS location.'; }
+          console.warn('[manage-panel] GPS error', err);
+        },
+        { enableHighAccuracy: true, timeout: 10000, maximumAge: 30000 }
+      );
+    });
+  }
+
   window.addEventListener('rastrum:mappicker-save', async (ev) => {
     const e = ev as CustomEvent<{ id: string; coords: { lat: number; lng: number } }>;
     if (e.detail.id !== 'obs-detail-edit') return;

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -641,7 +641,7 @@ export async function wireManagePanelLocation(
       // differs from UPDATE policy (e.g., obscured locations hidden from view).
       const updatePromise = supabase
         .from('observations')
-        .update({ location: literal, updated_at: new Date().toISOString() })
+        .update({ location: literal, location_source: 'manual', updated_at: new Date().toISOString() })
         .eq('id', obsId);
       const timeout = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('save_timeout')), 15_000),

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -597,7 +597,7 @@ export async function wireManagePanelLocation(
   const errEl    = document.getElementById('m-loc-error');
 
   // GPS button — use device location
-  const gpsBtn = document.getElementById('m-loc-gps');
+  const gpsBtn = document.getElementById('m-loc-gps') as HTMLButtonElement | null;
   if (gpsBtn && 'geolocation' in navigator) {
     gpsBtn.classList.remove('hidden');
     gpsBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Bugs fixed

### Fix 1 — Scientific name not pre-filled in edit form

**File:** `src/lib/manage-panel.ts`

`wireManagePanelDetails()` initialized `sciInput.value = ''` unconditionally, discarding the existing species name from the loaded observation. Fixed to read from the `_ident` parameter (the primary identification already loaded by the page).

```diff
- if (sciInput)   sciInput.value   = '';
+ if (sciInput)   sciInput.value   = (_ident?.scientific_name ?? '');
```

### Fix 2 — Location saves but doesn't persist / shows "Saving…" forever

**File:** `src/lib/manage-panel.ts`

The location update was not passing `location_source`. The `assign_observation_to_project_trigger` (BEFORE UPDATE OF location) runs whenever `location` changes — adding `location_source: 'manual'` makes the update semantically correct and avoids any edge case where the trigger might skip or cause a delay.

Also simplified the `.select('id, location')` to `.select('id')` — returning the geography column via PostgREST adds serialization overhead and the client only needs to confirm the row was updated (not re-read the stored coordinates).

### Fix 3 — GPS button for location editor

**Files:** `src/lib/manage-panel.ts`, `src/components/ObsManagePanel.astro`

Added a "Use my GPS location" button (`#m-loc-gps`) to the Location tab. The button:
- Only appears when the browser supports `navigator.geolocation` (hidden otherwise)
- Calls `getCurrentPosition()` with `enableHighAccuracy: true`
- Dispatches `rastrum:mappicker-set-initial` to center the map picker on the GPS coords
- Shows a status message while acquiring (`#m-loc-gps-status`)
- Falls back gracefully with an error message if geolocation is denied/unavailable