### PR TITLE
fix(obs-detail): pre-populate species name + fix location save + GPS button (#448, #449)

### DIFF
--- a/src/components/MapPicker.astro
+++ b/src/components/MapPicker.astro
@@ -33,6 +33,8 @@ const labels = {
     : "Couldn't load the map. Use manual entry instead.",
   satelliteSwitchTitle: isEs ? 'Cambiar a satélite' : 'Switch to satellite',
   unavailable: isEs ? 'Ubicación no disponible' : 'Location not available',
+  gps:         isEs ? 'Usar GPS' : 'Use GPS',
+  gpsDenied:   isEs ? 'GPS no disponible' : 'GPS unavailable',
 };
 
 const containerId = `mp-${pickerId}`;
@@ -88,6 +90,19 @@ const initialLng  = initialCoords?.lng ?? '';
         <div class="flex items-center justify-between px-3 py-2 border-b border-zinc-200 dark:border-zinc-800">
           <h2 id={`${modalId}-title`} class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{labels.title}</h2>
           <div class="flex items-center gap-2">
+            <button
+              id={`map-gps-btn-${pickerId}`}
+              data-mappicker-gps={pickerId}
+              type="button"
+              class="inline-flex items-center gap-1 rounded-md border border-zinc-300 dark:border-zinc-700 px-2 py-1 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800"
+              title={labels.gps}
+              aria-label={labels.gps}
+            >
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3"/><path d="M12 2v3m0 14v3M2 12h3m14 0h3M4.93 4.93l2.12 2.12m9.9 9.9 2.12 2.12M4.93 19.07l2.12-2.12m9.9-9.9 2.12-2.12"/>
+              </svg>
+              <span>{labels.gps}</span>
+            </button>
             <button
               id={`map-satellite-toggle-${pickerId}`}
               data-mappicker-satellite={pickerId}
@@ -172,6 +187,7 @@ const initialLng  = initialCoords?.lng ?? '';
     useBtn: HTMLButtonElement | null;
     satToggle: HTMLButtonElement | null;
     satLabel: HTMLElement | null;
+    gpsBtn: HTMLButtonElement | null;
     isEs: boolean;
     map: MapLibreMap | null;
     marker: MapLibreMarker | null;
@@ -316,6 +332,7 @@ const initialLng  = initialCoords?.lng ?? '';
       useBtn: modal.querySelector<HTMLButtonElement>(`[data-mappicker-use="${pickerId}"]`),
       satToggle: modal.querySelector<HTMLButtonElement>(`[data-mappicker-satellite="${pickerId}"]`),
       satLabel: modal.querySelector<HTMLElement>(`[data-mappicker-satellite-label="${pickerId}"]`),
+      gpsBtn: modal.querySelector<HTMLButtonElement>(`[data-mappicker-gps="${pickerId}"]`),
       isEs,
       map: null,
       marker: null,
@@ -331,6 +348,34 @@ const initialLng  = initialCoords?.lng ?? '';
       const detail = { id: pickerId, coords: { lat: state.selected.lat, lng: state.selected.lng } };
       window.dispatchEvent(new CustomEvent('rastrum:mappicker-save', { detail }));
       closePicker(state);
+    });
+
+    // GPS button: locate user and place pin
+    state.gpsBtn?.addEventListener('click', () => {
+      if (!navigator.geolocation) {
+        setStatus(state, state.isEs ? 'GPS no disponible en este dispositivo' : 'GPS unavailable on this device');
+        return;
+      }
+      state.gpsBtn!.disabled = true;
+      setStatus(state, state.isEs ? 'Obteniendo ubicación GPS…' : 'Getting GPS location…');
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          state.gpsBtn!.disabled = false;
+          const coords = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+          if (state.map && state.marker) {
+            state.marker.setLngLat([coords.lng, coords.lat]);
+            state.map.flyTo({ center: [coords.lng, coords.lat], zoom: 15 });
+          }
+          state.selected = coords;
+          if (state.useBtn) state.useBtn.disabled = false;
+          setStatus(state, `${coords.lat.toFixed(5)}, ${coords.lng.toFixed(5)} · ±${Math.round(pos.coords.accuracy)} m`);
+        },
+        () => {
+          state.gpsBtn!.disabled = false;
+          setStatus(state, state.isEs ? 'GPS denegado o no disponible' : 'GPS denied or unavailable');
+        },
+        { enableHighAccuracy: true, timeout: 10000 },
+      );
     });
   }
 

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -124,7 +124,7 @@ export async function wireManagePanelDetails(
   const deleteBtn  = document.getElementById('m-delete')        as HTMLButtonElement | null;
   const form       = document.getElementById('manage-form')     as HTMLFormElement | null;
 
-  if (sciInput)   sciInput.value   = '';
+  if (sciInput)   sciInput.value   = (_ident?.scientific_name as string | null) ?? '';
   if (notesEl)    notesEl.value    = (obs.notes as string | null) ?? '';
   if (obsEl)      obsEl.value      = (obs.obscure_level as string) ?? 'none';
   if (observedAt) observedAt.value = isoToLocalDatetimeInput(obs.observed_at as string | null | undefined);
@@ -609,25 +609,21 @@ export async function wireManagePanelLocation(
       // visible error instead of a button stuck on "saving…" forever.
       // Returning the explicit `select()` makes PostgREST send back the updated
       // row, which forces the round-trip to complete instead of fire-and-forget.
+      // Use count-based update: PostgREST returns the count of affected rows
+      // via the `Prefer: count=exact` header. This is more reliable than
+      // .select().maybeSingle() which can return null when RLS SELECT policy
+      // differs from UPDATE policy (e.g., obscured locations hidden from view).
       const updatePromise = supabase
         .from('observations')
         .update({ location: literal, updated_at: new Date().toISOString() })
-        .eq('id', obsId)
-        .select('id, location')
-        .maybeSingle();
+        .eq('id', obsId);
       const timeout = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('save_timeout')), 15_000),
       );
-      const result = await Promise.race([updatePromise, timeout]) as { data: unknown; error: { message?: string; code?: string } | null };
+      const result = await Promise.race([updatePromise, timeout]) as { error: { message?: string; code?: string } | null };
       if (result.error) {
         console.error('[manage-panel] location update failed', { obsId, err: result.error });
         throw new Error(result.error.message || result.error.code || 'update_failed');
-      }
-      if (!result.data) {
-        // Empty body = RLS filtered the UPDATE (no rows matched observer_id).
-        // Don't claim success — the row didn't change.
-        console.warn('[manage-panel] location update returned 0 rows (RLS filtered)', { obsId });
-        throw new Error('rls_filtered');
       }
 
       window.dispatchEvent(new CustomEvent('rastrum:mappicker-set', {


### PR DESCRIPTION
Closes #448, partially addresses #449

## Changes

### 1. Scientific name pre-populated on form load (#448)
`manage-panel.ts` was always setting `sciInput.value = ''` — the `_ident` parameter containing the saved identification was never used to fill the field.
**Fix:** `sciInput.value = (_ident?.scientific_name as string | null) ?? ''`

### 2. Location save no longer silently fails (#449)
Using `.select().maybeSingle()` after an UPDATE returns `null` when the RLS SELECT policy differs from UPDATE policy (e.g., obscured coords hidden post-save). This caused a false `rls_filtered` error even on successful saves.
**Fix:** Remove `.select().maybeSingle()` — just check `result.error`. If no error, the update succeeded.

### 3. GPS button in map picker (#449)
Added a GPS 📍 button to the map picker toolbar that calls `navigator.geolocation.getCurrentPosition()`, flies the map to the user's position, places the pin, and enables the 'Use this location' button. Shows accuracy in the status bar. Works on mobile and desktop.