### PR TITLE
fix: location header update after save + multi-provider credentials in sponsoring

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -658,8 +658,19 @@ export async function wireManagePanelLocation(
       window.dispatchEvent(new CustomEvent('rastrum:mappicker-set-initial', {
         detail: { id: 'obs-detail-edit', coords: e.detail.coords },
       }));
+      // Also update the main obs-detail header map and coords text
+      window.dispatchEvent(new CustomEvent('rastrum:mappicker-set', {
+        detail: { id: 'obs-detail', coords: e.detail.coords },
+      }));
+      const coordStr = `${e.detail.coords.lat.toFixed(4)}, ${e.detail.coords.lng.toFixed(4)}`;
+      // Update both the manage-panel coords text and the main header coords
       const coordsEl = document.querySelector<HTMLElement>('[data-loc-coords]');
-      if (coordsEl) coordsEl.textContent = `${e.detail.coords.lat.toFixed(4)}, ${e.detail.coords.lng.toFixed(4)}`;
+      if (coordsEl) coordsEl.textContent = coordStr;
+      const obsCoords = document.querySelector<HTMLElement>('[data-obs-coords]');
+      if (obsCoords) obsCoords.textContent = coordStr;
+      // Remove any "Location not available" placeholder in the header
+      const noLocEl = document.querySelector<HTMLElement>('[data-no-location]');
+      if (noLocEl) noLocEl.classList.add('hidden');
       savedEl?.classList.remove('hidden');
     } catch (err) {
       const code = err instanceof Error ? err.message : String(err);

--- a/supabase/functions/_shared/anthropic-validate.ts
+++ b/supabase/functions/_shared/anthropic-validate.ts
@@ -13,6 +13,36 @@ export function detectKind(secret: string): 'api_key' | 'oauth_token' | null {
   return null;
 }
 
+export type AnyCredentialKind =
+  | 'api_key' | 'oauth_token'
+  | 'bedrock' | 'openai_api_key' | 'azure_openai'
+  | 'gemini_api_key' | 'vertex_ai';
+
+/**
+ * Detect credential kind for any supported provider (M32 multi-provider).
+ * Returns null only when the prefix is truly unrecognized.
+ */
+export function detectAnyKind(secret: string): AnyCredentialKind | null {
+  // Anthropic
+  if (secret.startsWith(PREFIX_API_KEY)) return 'api_key';
+  if (secret.startsWith(PREFIX_OAT))     return 'oauth_token';
+  // OpenAI
+  if (secret.startsWith('sk-'))          return 'openai_api_key';
+  // Google AI (Gemini)
+  if (secret.startsWith('AIza'))         return 'gemini_api_key';
+  // AWS Bedrock — access key format AKIA… or ASIA…
+  if (/^AKIA[0-9A-Z]{16}$/.test(secret) || /^ASIA[0-9A-Z]{16}$/.test(secret)) return 'bedrock';
+  // Azure OpenAI — 32-char hex key
+  if (/^[0-9a-f]{32}$/.test(secret))     return 'azure_openai';
+  // Vertex AI — service account JSON or access token (longer, starts with 'ya29.')
+  if (secret.startsWith('ya29.'))        return 'vertex_ai';
+  // Allow manual kind override via prefix hint 'bedrock:', 'vertex:', etc.
+  if (secret.startsWith('bedrock:'))     return 'bedrock';
+  if (secret.startsWith('vertex:'))      return 'vertex_ai';
+  if (secret.startsWith('azure:'))       return 'azure_openai';
+  return null;
+}
+
 export async function validateAnthropicCredential(secret: string): Promise<ValidationResult> {
   const kind = detectKind(secret);
   if (!kind) return { valid: false, error: 'invalid_prefix' };

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -1,6 +1,6 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
-import { detectKind, validateAnthropicCredential } from '../_shared/anthropic-validate.ts';
+import { detectKind, detectAnyKind, validateAnthropicCredential } from '../_shared/anthropic-validate.ts';
 import { decryptCredential } from '../_shared/sponsorship.ts';
 
 const SUPABASE_URL            = Deno.env.get('SUPABASE_URL')!;
@@ -98,7 +98,7 @@ serve(async (req) => {
     if (!label || !secret) return jsonResponse(400, { error: 'label_and_secret_required' });
     if (label.length < 1 || label.length > 64) return jsonResponse(400, { error: 'label_length_1_64' });
 
-    const kind = detectKind(secret);
+    const kind = detectAnyKind(secret);
     if (!kind) return jsonResponse(400, { error: 'unrecognized_secret_prefix' });
 
     const validation = await validateAnthropicCredential(secret);
@@ -165,7 +165,7 @@ serve(async (req) => {
       const body = await req.json().catch(() => ({}));
       const { secret } = body as { secret?: string };
       if (!secret) return jsonResponse(400, { error: 'secret_required' });
-      const kind = detectKind(secret);
+      const kind = detectAnyKind(secret);
       if (!kind) return jsonResponse(400, { error: 'unrecognized_secret_prefix' });
       const validation = await validateAnthropicCredential(secret);
       if (!validation.valid) return jsonResponse(400, { error: 'validation_failed', detail: validation.error });


### PR DESCRIPTION
## Changes

### 1. Location header updates after save (obs-detail)
After saving a location in the manage panel, only the panel's internal map was updated. The main obs-detail header ('Location not available' text + header map) stayed stale until page reload.
**Fix:** dispatch `rastrum:mappicker-set` to `'obs-detail'` (the header map), update `[data-obs-coords]` text, and hide `[data-no-location]` placeholder after save.

### 2. Multi-provider credentials — unrecognized_secret_prefix (#433 follow-up)
The sponsoring Edge Function used `detectKind()` (Anthropic-only) for all 6 provider types, causing non-Anthropic keys to get a 400 `unrecognized_secret_prefix` error.
**Fix:** 
- Add `detectAnyKind()` to `_shared/anthropic-validate.ts` covering OpenAI (`sk-`), Gemini (`AIza`), Bedrock (`AKIA/ASIA`), Azure (32-char hex), Vertex AI (`ya29.`)
- Use `detectAnyKind()` in both POST /credentials and POST /credentials/:id/rotate