### PR TITLE
fix(schema): GRANT service_role on sponsoring tables — fixes permission denied 500s

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4613,6 +4613,16 @@ ALTER TYPE public.audit_op ADD VALUE IF NOT EXISTS 'sponsorship_request_create';
 ALTER TYPE public.audit_op ADD VALUE IF NOT EXISTS 'sponsorship_request_approve';
 ALTER TYPE public.audit_op ADD VALUE IF NOT EXISTS 'sponsorship_request_reject';
 ALTER TYPE public.audit_op ADD VALUE IF NOT EXISTS 'sponsorship_request_withdraw';
+-- ── Sponsoring table grants — service_role needs explicit GRANT even with BYPASSRLS ──
+-- The Edge Function (sponsorships/index.ts) uses the service_role key. In Supabase,
+-- service_role bypasses RLS but still requires table-level GRANT from the schema owner.
+-- Without these, all sponsoring Edge Function calls get "permission denied for table …".
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.sponsor_credentials    TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.sponsorships           TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.sponsorship_requests   TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.ai_usage               TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.ai_errors_log          TO service_role;
+
 -- ════════════════════════════════════════════════════════════════════════════
 -- PR8 — admin console hardening
 -- ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Root cause
The sponsoring Edge Function uses `SUPABASE_SERVICE_ROLE_KEY` to create a Supabase client. Service role bypasses RLS but **still requires table-level GRANT** from the schema owner.

All 5 core sponsoring tables were missing `GRANT SELECT, INSERT, UPDATE, DELETE TO service_role`:
- `sponsor_credentials`
- `sponsorships`
- `sponsorship_requests`
- `ai_usage`
- `ai_errors_log`

This caused all GET endpoints to return 500 with `permission denied for table ...`.

## How it will be applied
Since `supabase-schema.sql` is modified, the `db-apply` workflow will trigger automatically on merge to main and apply the GRANTs to production.