### PR TITLE
fix(sponsoring): skip Anthropic validation for non-Anthropic provider credentials

### DIFF
--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -101,8 +101,13 @@ serve(async (req) => {
     const kind = detectAnyKind(secret);
     if (!kind) return jsonResponse(400, { error: 'unrecognized_secret_prefix' });
 
-    const validation = await validateAnthropicCredential(secret);
-    if (!validation.valid) return jsonResponse(400, { error: 'validation_failed', detail: validation.error });
+    // Only validate Anthropic credentials (api_key / oauth_token) at creation time.
+    // Other providers (OpenAI, Gemini, Bedrock, Azure, Vertex) are stored as-is —
+    // they'll fail at identify-time if invalid, which gives a clearer error.
+    if (kind === 'api_key' || kind === 'oauth_token') {
+      const validation = await validateAnthropicCredential(secret);
+      if (!validation.valid) return jsonResponse(400, { error: 'validation_failed', detail: validation.error });
+    }
 
     const { data: vaultRow, error: vaultErr } = await supabase.rpc('create_vault_secret', {
       p_secret: secret, p_name: `sponsor_credential:${ctx.userId}:${label}`,
@@ -167,8 +172,11 @@ serve(async (req) => {
       if (!secret) return jsonResponse(400, { error: 'secret_required' });
       const kind = detectAnyKind(secret);
       if (!kind) return jsonResponse(400, { error: 'unrecognized_secret_prefix' });
-      const validation = await validateAnthropicCredential(secret);
-      if (!validation.valid) return jsonResponse(400, { error: 'validation_failed', detail: validation.error });
+      // Validate only Anthropic keys at rotate time
+      if (kind === 'api_key' || kind === 'oauth_token') {
+        const validation = await validateAnthropicCredential(secret);
+        if (!validation.valid) return jsonResponse(400, { error: 'validation_failed', detail: validation.error });
+      }
 
       const { data: newSecretId, error: vaultErr } = await supabase.rpc('create_vault_secret', {
         p_secret: secret,


### PR DESCRIPTION
POST /credentials was calling `validateAnthropicCredential()` for all credential types, including OpenAI, Gemini, Bedrock, etc. — which always fails with `validation_failed` because it pings `api.anthropic.com`.

**Fix:** Only validate if `kind === 'api_key'` or `kind === 'oauth_token'` (Anthropic). Other providers are stored as-is; an invalid key will fail at identify-time with a clearer error.

Applies to both `POST /credentials` (create) and `POST /credentials/:id/rotate`.