### PR TITLE
fix(sponsoring): dark mode for rotate, add-beneficiary, and confirm dialogs

### DIFF
--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -234,7 +234,7 @@ const langJson = JSON.stringify(lang);
     </form>
   </dialog>
 
-  <dialog id="rotate-cred-dialog" class="rounded-xl p-6 max-w-md backdrop:bg-black/50">
+  <dialog id="rotate-cred-dialog" class="rounded-xl p-6 max-w-md w-full backdrop:bg-black/50 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100">
     <h3 class="text-lg font-semibold mb-2">{tr.sponsoring.rotate_btn}</h3>
     <form method="dialog" class="space-y-3">
       <input id="rotate-cred-id" type="hidden" />
@@ -249,7 +249,7 @@ const langJson = JSON.stringify(lang);
     </form>
   </dialog>
 
-  <dialog id="add-ben-dialog" class="rounded-xl p-6 max-w-md backdrop:bg-black/50">
+  <dialog id="add-ben-dialog" class="rounded-xl p-6 max-w-md w-full backdrop:bg-black/50 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100">
     <h3 class="text-lg font-semibold mb-2">{tr.sponsoring.add_beneficiary}</h3>
     <form method="dialog" class="space-y-3">
       <div>
@@ -271,7 +271,7 @@ const langJson = JSON.stringify(lang);
     </form>
   </dialog>
 
-  <dialog id="confirm-dialog" class="rounded-xl p-6 max-w-md backdrop:bg-black/50">
+  <dialog id="confirm-dialog" class="rounded-xl p-6 max-w-md w-full backdrop:bg-black/50 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100">
     <p id="confirm-message" class="text-sm">—</p>
     <div class="mt-4 flex gap-2 justify-end">
       <button type="button" id="confirm-no" class="px-3 py-1.5 text-sm rounded border border-zinc-300 dark:border-zinc-700">{cancelLabel}</button>


### PR DESCRIPTION
Three remaining dialogs in SponsoringView were missing dark mode classes and `w-full`:
- `rotate-cred-dialog`
- `add-ben-dialog`
- `confirm-dialog`

Added `bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 w-full` to match the existing `add-pool-dialog` and `add-cred-dialog` pattern.