### PR TITLE
fix(sponsoring): replace undefined isEs with pageLang — fixes delete/revoke credential buttons

### DIFF
--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -712,13 +712,13 @@ const langJson = JSON.stringify(lang);
       (document.getElementById('rotate-cred-id') as HTMLInputElement).value = target.dataset.rotate;
       rotateDialog?.showModal();
     } else if (target.dataset.delete) {
-      if (await showConfirm(isEs ? '¿Eliminar esta credencial? Los patrocinios que la usen serán pausados.' : 'Delete this credential? Sponsorships using it will be paused.')) {
+      if (await showConfirm(pageLang === 'es' ? '¿Eliminar esta credencial? Los patrocinios que la usen serán pausados.' : 'Delete this credential? Sponsorships using it will be paused.')) {
         await deleteCredential(target.dataset.delete);
         await refreshCreds();
         await refreshBens();
       }
     } else if (target.dataset.revoke) {
-      if (await showConfirm('Revoke this credential? Sponsorships using it will be paused.')) {
+      if (await showConfirm(pageLang === 'es' ? '¿Revocar esta credencial? Los patrocinios que la usen serán pausados.' : 'Revoke this credential? Sponsorships using it will be paused.')) {
         await deleteCredential(target.dataset.revoke);
         await refreshCreds();
         await refreshBens();


### PR DESCRIPTION
## Bug

`isEs is not defined` ReferenceError in `SponsoringView.astro` broke the delete credential and revoke credential buttons. The script uses `pageLang` (the variable that holds `'en' | 'es'`) but the PR that added the delete/revoke confirm dialogs accidentally referenced `isEs` which was never defined in this script's scope.

## Fix

```diff
- if (await showConfirm(isEs ? '¿Eliminar...' : 'Delete...'))
+ if (await showConfirm(pageLang === 'es' ? '¿Eliminar...' : 'Delete...'))

- if (await showConfirm('Revoke this credential? ...'))
+ if (await showConfirm(pageLang === 'es' ? '¿Revocar...' : 'Revoke this credential?...'))
```

Also localizes the revoke confirm message (was hardcoded English).