### PR TITLE
fix(species): call switchEsView('grid') on init — fixes empty page on /explore/species/

### DIFF
--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -484,6 +484,9 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     esTabs?.forEach(btn => {
       btn.addEventListener('click', () => switchEsView(btn.dataset.view ?? 'grid'));
     });
+    // Ensure grid view is active on first load (panels start hidden via HTML
+    // but gridEls need explicit show so the initial state is consistent)
+    switchEsView('grid');
 
     // ── M34: Search ────────────────────────────────────────
     let searchInitialized = false;


### PR DESCRIPTION
## Bug

After M34 (#469), `/explore/species/` showed "No species match your search yet" immediately on load with no cards visible — even though species exist.

## Root cause

`switchEsView()` hides/shows the grid elements individually (label, skeleton, list, empty, error) and shows the search/radial panels. The search panel (`#es-panel-search`) was rendered without `hidden` in the HTML but was expected to start hidden. On first load, `switchEsView()` was never called — so the search panel was visible and the grid elements' visibility was whatever the HTML default was.

## Fix

Call `switchEsView('grid')` immediately after the tab click listeners are attached, ensuring the correct initial state regardless of HTML defaults.