### PR TITLE
fix(pwa): bump SW version to 2026.5.1 — forces cache refresh for new logo

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -9,7 +9,7 @@
 //   - Manifest, favicon, sw.js itself: network-first so updates land fast.
 //
 // Bump VERSION to invalidate every cached entry on the next visit.
-const VERSION = 'rastrum-shell-2026.5.0';
+const VERSION = 'rastrum-shell-2026.5.1';
 const SHELL = [
   '/',
   '/en/',


### PR DESCRIPTION
Bumps `VERSION` in `sw.js` from `rastrum-shell-2026.5.0` → `rastrum-shell-2026.5.1`.

On next visit, the new SW installs, wipes the old cache, and re-fetches the manifest with the updated logo URLs. This triggers icon refresh on Android Chrome and Desktop Chrome.

> **iOS:** No-op for homescreen icon — Safari doesn't update PWA icons post-install regardless. Users need to delete and re-add to Home Screen.