### PR TITLE
fix(obs-detail): use GeoJSON for location UPDATE — fixes #449

### DIFF
--- a/src/lib/manage-panel.test.ts
+++ b/src/lib/manage-panel.test.ts
@@ -4,6 +4,7 @@ import {
   isoToLocalDatetimeInput,
   localDatetimeInputToIso,
   pointGeographyLiteral,
+  pointGeographyGeoJSON,
 } from './manage-panel';
 
 describe('manage-panel helpers', () => {
@@ -94,6 +95,34 @@ describe('manage-panel helpers', () => {
       const t = new Date(p.updated_at).getTime();
       expect(t).toBeGreaterThanOrEqual(before);
       expect(t).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('pointGeographyGeoJSON', () => {
+    it('emits a GeoJSON Point with [lng, lat] coordinates — used for supabase-js UPDATE', () => {
+      // CDMX: lat=19.4326, lng=-99.1332
+      // GeoJSON spec: coordinates are [longitude, latitude]
+      const pt = pointGeographyGeoJSON(19.4326, -99.1332);
+      expect(pt).toEqual({ type: 'Point', coordinates: [-99.1332, 19.4326] });
+    });
+
+    it('handles whole-number coords', () => {
+      expect(pointGeographyGeoJSON(0, 0)).toEqual({ type: 'Point', coordinates: [0, 0] });
+    });
+
+    it('rejects out-of-range latitudes', () => {
+      expect(() => pointGeographyGeoJSON(90.1, 0)).toThrow('coords_invalid');
+      expect(() => pointGeographyGeoJSON(-90.1, 0)).toThrow('coords_invalid');
+    });
+
+    it('rejects out-of-range longitudes', () => {
+      expect(() => pointGeographyGeoJSON(0, 180.1)).toThrow('coords_invalid');
+      expect(() => pointGeographyGeoJSON(0, -180.1)).toThrow('coords_invalid');
+    });
+
+    it('rejects non-finite numbers', () => {
+      expect(() => pointGeographyGeoJSON(Number.NaN, 0)).toThrow('coords_invalid');
+      expect(() => pointGeographyGeoJSON(0, Number.POSITIVE_INFINITY)).toThrow('coords_invalid');
     });
   });
 

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -532,10 +532,25 @@ export async function wireManagePanelPhotos(obsId: string): Promise<void> {
 }
 
 /**
- * Build the WKT geography literal Postgres expects for a `geography(POINT,4326)`
- * column. Note longitude precedes latitude per PostGIS / GeoJSON convention,
- * matching how `src/lib/sync.ts` and `ObservationForm.astro` write coords.
+ * Build a GeoJSON Point object for PostgREST / supabase-js UPDATE calls on
+ * `geography(Point,4326)` columns. PostgREST accepts WKT on INSERT via the
+ * PostgREST type-casting path, but UPDATE through supabase-js serialises the
+ * value as JSON — sending a raw WKT string results in a no-op write (the
+ * column stays at its old value). GeoJSON is the safe format for both paths.
+ *
+ * Note: longitude precedes latitude per GeoJSON spec.
  */
+export function pointGeographyGeoJSON(lat: number, lng: number): { type: 'Point'; coordinates: [number, number] } {
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    throw new Error('coords_invalid');
+  }
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+    throw new Error('coords_invalid');
+  }
+  return { type: 'Point', coordinates: [lng, lat] };
+}
+
+/** @deprecated Use pointGeographyGeoJSON — WKT silently no-ops on UPDATE via supabase-js */
 export function pointGeographyLiteral(lat: number, lng: number): string {
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
     throw new Error('coords_invalid');
@@ -629,19 +644,21 @@ export async function wireManagePanelLocation(
     savedEl?.classList.add('hidden');
     savingEl?.classList.remove('hidden');
     try {
-      const literal = pointGeographyLiteral(e.detail.coords.lat, e.detail.coords.lng);
+      // GeoJSON format is required for UPDATE via supabase-js — WKT strings are
+      // accepted by PostgREST on INSERT (via type-casting) but silently no-op
+      // on UPDATE because supabase-js serialises the value as JSON, not SQL.
+      // See issue #449.
+      const geoJson = pointGeographyGeoJSON(e.detail.coords.lat, e.detail.coords.lng);
       // Hard 15 s timeout — if PostgREST never returns (RLS recursion regressed,
       // CORS preflight stalled, auth refresh deadlock, etc.) the user gets a
       // visible error instead of a button stuck on "saving…" forever.
-      // Returning the explicit `select()` makes PostgREST send back the updated
-      // row, which forces the round-trip to complete instead of fire-and-forget.
       // Use count-based update: PostgREST returns the count of affected rows
       // via the `Prefer: count=exact` header. This is more reliable than
       // .select().maybeSingle() which can return null when RLS SELECT policy
       // differs from UPDATE policy (e.g., obscured locations hidden from view).
       const updatePromise = supabase
         .from('observations')
-        .update({ location: literal, location_source: 'manual', updated_at: new Date().toISOString() })
+        .update({ location: geoJson, location_source: 'manual', updated_at: new Date().toISOString() })
         .eq('id', obsId);
       const timeout = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('save_timeout')), 15_000),


### PR DESCRIPTION
## Root cause

`pointGeographyLiteral()` returns a WKT string (`SRID=4326;POINT(lng lat)`). This works on **INSERT** via PostgREST's implicit type-casting path — but on **UPDATE** through `supabase-js`, the value is serialised as JSON. PostgREST sends `{"location": "SRID=4326;POINT(...)"}` to PostGIS, which can't cast a plain JSON string to `geography(Point,4326)` and silently drops the write. The UPDATE returns 200 OK (no error), but the column is never written — hence the revert on reload.

## Fix

New `pointGeographyGeoJSON(lat, lng)` helper returns `{type: 'Point', coordinates: [lng, lat]}`. PostgREST and PostGIS both accept GeoJSON objects for geography columns through both INSERT and UPDATE paths.

`wireManagePanelLocation()` now calls `pointGeographyGeoJSON()` for the UPDATE.

`pointGeographyLiteral()` is kept with a `@deprecated` JSDoc so `sync.ts` (INSERT path, not affected by this bug) continues to compile without changes.

## Tests

- Added 5-case `pointGeographyGeoJSON` test suite in `manage-panel.test.ts`
- All 19 manage-panel tests pass ✅

Closes #449