### PR TITLE
fix(m34): sunburst leaf-only navigation + best-shot auth guard

### DIFF
--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -605,11 +605,15 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
           path.setAttribute('fill-opacity', String(0.9 - depth * 0.1));
           path.setAttribute('stroke', '#fff');
           path.setAttribute('stroke-width', '0.005');
-          path.style.cursor = 'pointer';
+          // Only leaf nodes (species) navigate to the detail page.
+          // Intermediate nodes (kingdom → genus) update the center label only
+          // so the user can explore the hierarchy without accidental navigation.
+          const isLeaf = child.children.length === 0;
+          path.style.cursor = isLeaf ? 'pointer' : 'default';
           path.addEventListener('click', () => {
             if (nameEl) nameEl.textContent = child.name;
             if (countEl) countEl.textContent = `${child.count} obs`;
-            if (child.taxonId) showDetail(child.taxonId);
+            if (isLeaf && child.taxonId) showDetail(child.taxonId);
           });
           svg!.appendChild(path);
           renderLevel(child, depth + 1, angle, angle + sweep, maxDepth);

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -459,33 +459,43 @@ const lang: 'en' | 'es' = 'en';
               }
 
               if (btnEl) {
-                btnEl.textContent = hasVoted
-                  ? (isEs ? '\u2713 Nominada' : '\u2713 Nominated')
-                  : (isEs ? '\ud83d\udcf8 Nominar como mejor foto' : '\ud83d\udcf8 Nominate as best shot');
-                btnEl.className = hasVoted
-                  ? 'text-xs text-emerald-700 dark:text-emerald-400'
-                  : 'text-xs text-zinc-600 dark:text-zinc-400 hover:text-emerald-700 dark:hover:text-emerald-400';
+                const isLoggedIn = !!currentViewer?.id;
 
-                btnEl.addEventListener('click', async () => {
-                  if (hasVoted) {
-                    await supabase.from('reactions').delete()
-                      .eq('target_type', 'media').eq('target_id', mediaId)
-                      .eq('reaction_type', 'best_shot').eq('user_id', currentViewer?.id ?? '');
-                    hasVoted = false;
-                  } else {
-                    await supabase.from('reactions').insert({
-                      target_type: 'media', target_id: mediaId,
-                      reaction_type: 'best_shot', user_id: currentViewer?.id,
-                    });
-                    hasVoted = true;
-                  }
+                if (!isLoggedIn) {
+                  // Not logged in: show read-only count, disable button with hint
+                  btnEl.textContent = isEs ? '\ud83d\udcf8 Inicia sesi\u00f3n para nominar' : '\ud83d\udcf8 Sign in to nominate';
+                  btnEl.className = 'text-xs text-zinc-400 dark:text-zinc-600 cursor-not-allowed';
+                  btnEl.disabled = true;
+                  btnEl.title = isEs ? 'Necesitas iniciar sesi\u00f3n para nominar fotos' : 'You need to sign in to nominate photos';
+                } else {
                   btnEl.textContent = hasVoted
                     ? (isEs ? '\u2713 Nominada' : '\u2713 Nominated')
                     : (isEs ? '\ud83d\udcf8 Nominar como mejor foto' : '\ud83d\udcf8 Nominate as best shot');
                   btnEl.className = hasVoted
                     ? 'text-xs text-emerald-700 dark:text-emerald-400'
                     : 'text-xs text-zinc-600 dark:text-zinc-400 hover:text-emerald-700 dark:hover:text-emerald-400';
-                });
+
+                  btnEl.addEventListener('click', async () => {
+                    if (hasVoted) {
+                      await supabase.from('reactions').delete()
+                        .eq('target_type', 'media').eq('target_id', mediaId)
+                        .eq('reaction_type', 'best_shot').eq('user_id', currentViewer!.id ?? '');
+                      hasVoted = false;
+                    } else {
+                      await supabase.from('reactions').insert({
+                        target_type: 'media', target_id: mediaId,
+                        reaction_type: 'best_shot', user_id: currentViewer!.id,
+                      });
+                      hasVoted = true;
+                    }
+                    btnEl.textContent = hasVoted
+                      ? (isEs ? '\u2713 Nominada' : '\u2713 Nominated')
+                      : (isEs ? '\ud83d\udcf8 Nominar como mejor foto' : '\ud83d\udcf8 Nominate as best shot');
+                    btnEl.className = hasVoted
+                      ? 'text-xs text-emerald-700 dark:text-emerald-400'
+                      : 'text-xs text-zinc-600 dark:text-zinc-400 hover:text-emerald-700 dark:hover:text-emerald-400';
+                  });
+                }
               }
             }
           }


### PR DESCRIPTION
## Fixes two M34 follow-ups

### 1. Sunburst — intermediate nodes no longer navigate

**Bug:** clicking any node with a `taxonId` (including kingdom, phylum, class, order, family, genus) triggered `showDetail()` and navigated to the species detail page.

**Fix:** `isLeaf = child.children.length === 0`. Only leaf nodes (species-rank) navigate. Intermediate nodes update the center label/count only. Cursor changes to `default` on intermediate nodes as visual feedback.

### 2. Best shot — auth guard for unauthenticated users

**Bug:** unauthenticated users saw the "Nominate" button and could click it. The click attempted `supabase.from('reactions').insert({ user_id: undefined })` — RLS silently rejected the write (or produced a DB error), with no feedback to the user.

**Fix:** after `getUser()`, check `isLoggedIn = !!currentViewer?.id`:
- **Not logged in:** button is disabled, text changes to "Sign in to nominate" / "Inicia sesión para nominar", cursor is `not-allowed`, tooltip explains why.
- **Logged in:** existing behavior unchanged. `currentViewer?.id` replaced with non-null assertion `currentViewer!.id` now that the guard guarantees it's set.

### Files changed
- `src/components/ExploreSpeciesView.astro` — sunburst click handler
- `src/pages/share/obs/index.astro` — best shot button logic