### PR TITLE
fix(taxa): upsert taxa on identify + backfill from existing identifications

### DIFF
--- a/.github/workflows/db-apply.yml
+++ b/.github/workflows/db-apply.yml
@@ -163,6 +163,9 @@ jobs:
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
+          # First create any missing taxa from scientific_names in identifications,
+          # then resolve taxon_id on identifications + backfill primary_taxon_id.
+          psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f scripts/backfill-taxa-from-identifications.sql
           psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f scripts/backfill-primary-taxon-id.sql
           echo "::notice::primary_taxon_id backfill complete"
 

--- a/scripts/backfill-taxa-from-identifications.sql
+++ b/scripts/backfill-taxa-from-identifications.sql
@@ -1,0 +1,98 @@
+-- backfill-taxa-from-identifications.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Backfill: create taxa rows from scientific_names already stored in
+-- identifications. Needed because the identify Edge Function and sync.ts
+-- client previously inserted identifications without taxon_id, and
+-- because the taxa table was never seeded from these names.
+--
+-- After this runs, re-run backfill-primary-taxon-id.sql to propagate
+-- primary_taxon_id to observations.
+--
+-- Safe to run multiple times (ON CONFLICT DO NOTHING).
+-- Run with: psql "$SUPABASE_DB_URL" -f scripts/backfill-taxa-from-identifications.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+
+BEGIN;
+
+-- ── Step 1: insert missing taxa from identifications ──────────────────────────
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  INSERT INTO public.taxa (scientific_name, common_name_es, common_name_en, taxon_rank)
+  SELECT DISTINCT ON (i.scientific_name)
+    i.scientific_name,
+    -- Extract common names from raw_response if present (PlantNet / Claude store them there)
+    COALESCE(
+      (i.raw_response->>'common_name_es')::text,
+      (i.raw_response->'raw'->>'common_name_es')::text
+    ),
+    COALESCE(
+      (i.raw_response->>'common_name_en')::text,
+      (i.raw_response->'raw'->>'common_name_en')::text
+    ),
+    'species'
+  FROM public.identifications i
+  WHERE i.scientific_name IS NOT NULL
+    AND i.scientific_name <> ''
+    AND NOT EXISTS (
+      SELECT 1 FROM public.taxa t WHERE t.scientific_name = i.scientific_name
+    )
+  ON CONFLICT (scientific_name) DO NOTHING;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Step 1: inserted % new taxa from identifications', v_count;
+END $$;
+
+-- ── Step 2: resolve taxon_id on identifications that still lack it ────────────
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  UPDATE public.identifications i
+  SET taxon_id = t.id
+  FROM public.taxa t
+  WHERE i.taxon_id IS NULL
+    AND i.scientific_name IS NOT NULL
+    AND t.scientific_name = i.scientific_name;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Step 2: resolved taxon_id for % identification(s)', v_count;
+END $$;
+
+-- ── Step 3: backfill observations.primary_taxon_id ────────────────────────────
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  UPDATE public.observations o
+  SET primary_taxon_id = i.taxon_id,
+      updated_at       = now()
+  FROM public.identifications i
+  WHERE i.observation_id   = o.id
+    AND i.is_primary       = true
+    AND i.taxon_id         IS NOT NULL
+    AND o.primary_taxon_id IS NULL;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Step 3: backfilled primary_taxon_id for % observation(s)', v_count;
+END $$;
+
+-- ── Verification ──────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  v_taxa_total   int;
+  v_null_taxon   int;
+  v_total_synced int;
+BEGIN
+  SELECT COUNT(*) INTO v_taxa_total FROM public.taxa;
+  SELECT COUNT(*) INTO v_total_synced FROM public.observations WHERE sync_status = 'synced';
+  SELECT COUNT(*) INTO v_null_taxon
+  FROM public.observations
+  WHERE sync_status = 'synced' AND primary_taxon_id IS NULL;
+
+  RAISE NOTICE 'Verification: % taxa total, % synced observations, % still have primary_taxon_id NULL',
+    v_taxa_total, v_total_synced, v_null_taxon;
+END $$;
+
+COMMIT;

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -195,9 +195,35 @@ async function syncOne(record: ObservationRecord): Promise<void> {
   const hasIdentification = clientId.scientificName || (clientId.confidence > 0 && clientId.source !== 'human');
   if (hasIdentification && (clientId.status === 'accepted' || clientId.status === 'needs_review')) {
     const supabase = getSupabase();
+
+    // Upsert taxa row so observations.primary_taxon_id can be resolved by
+    // the sync_primary_identification trigger. On conflict (scientific_name
+    // already exists) update common names only — kingdom/family come from
+    // authoritative upstream sources.
+    let taxonId: string | null = null;
+    if (clientId.scientificName) {
+      try {
+        const taxonPayload: Record<string, unknown> = {
+          scientific_name: clientId.scientificName,
+          common_name_es: clientId.commonNameEs ?? null,
+          common_name_en: clientId.commonNameEn ?? null,
+          taxon_rank: 'species',
+        };
+        const { data: taxonRow } = await supabase
+          .from('taxa')
+          .upsert(taxonPayload, { onConflict: 'scientific_name', ignoreDuplicates: false })
+          .select('id')
+          .maybeSingle();
+        if (taxonRow?.id) taxonId = taxonRow.id as string;
+      } catch {
+        // taxa upsert is non-fatal — trigger fallback handles scientific_name lookup
+      }
+    }
+
     const { error: clientIdErr } = await supabase.from('identifications').insert({
       observation_id: record.id,
       scientific_name: clientId.scientificName,
+      taxon_id: taxonId,
       confidence: Math.max(0, Math.min(1, clientId.confidence ?? 0)),
       source: clientId.source ?? 'human',
       is_primary: true,

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -680,9 +680,43 @@ serve(async (req) => {
 
   if (body.observation_id !== 'cascade-only') {
     if (serviceRole && supabaseUrl) {
+      // Upsert the taxon so observations.primary_taxon_id can be resolved.
+      // The identify cascade returns enough metadata (scientific_name, kingdom,
+      // family, common names) to create a minimal taxa row. On conflict we
+      // update the common names in case they improved (PlantNet → Claude or
+      // vice-versa). We do NOT overwrite kingdom/family since those come from
+      // authoritative sources (PlantNet / GBIF) and should not be clobbered.
+      let taxonId: string | null = null;
+      try {
+        const taxonPayload = {
+          scientific_name: result.scientific_name,
+          common_name_es: result.common_name_es ?? null,
+          common_name_en: result.common_name_en ?? null,
+          kingdom: result.kingdom !== 'Unknown' ? result.kingdom : null,
+          family: result.family ?? null,
+          taxon_rank: 'species',
+        };
+        const { data: taxonRow, error: taxonErr } = await db()
+          .from('taxa')
+          .upsert(taxonPayload, {
+            onConflict: 'scientific_name',
+            ignoreDuplicates: false,
+          })
+          .select('id')
+          .maybeSingle();
+        if (taxonErr) {
+          console.warn('[identify] taxa upsert failed (non-fatal)', taxonErr.message);
+        } else if (taxonRow?.id) {
+          taxonId = taxonRow.id as string;
+        }
+      } catch (e) {
+        console.warn('[identify] taxa upsert exception (non-fatal)', e);
+      }
+
       await db().from('identifications').insert({
         observation_id: body.observation_id,
         scientific_name: result.scientific_name,
+        taxon_id: taxonId,
         confidence: result.confidence,
         source: result.source,
         raw_response: result.raw as object,


### PR DESCRIPTION
## Root cause

The `/explore/species/` grid was empty because:

1. `identifications` had `scientific_name` but `taxon_id = NULL`
2. The `taxa` table was empty — never populated from identifications
3. The backfill script (`backfill-primary-taxon-id.sql`) resolved 0 rows because step 1 (match by `scientific_name`) found nothing in an empty `taxa` table
4. `observations.primary_taxon_id` stayed NULL → grid query filtered them all out

## Fix (3 parts)

### 1. `identify` Edge Function
Before inserting into `identifications`, upsert a `taxa` row using the data already returned by the cascade (`scientific_name`, `kingdom`, `family`, common names). Pass `taxon_id` in the identification insert so the trigger fires with a real UUID immediately.

### 2. `sync.ts` client
Same pattern for client-side identifications (BirdNET, on-device, human). Non-fatal if upsert fails — the trigger's `scientific_name` fallback still runs.

### 3. `scripts/backfill-taxa-from-identifications.sql` (new)
Idempotent backfill for the 18 existing observations:
- Step 1: INSERT taxa from `identifications.scientific_name` (with common names from `raw_response`)
- Step 2: resolve `identifications.taxon_id` from `taxa`
- Step 3: backfill `observations.primary_taxon_id`

Added to `db-apply.yml` — runs automatically on next schema merge.

## CI flow after merge
`db-apply` will run on the schema change detected in this PR, executing:
1. `backfill-taxa-from-identifications.sql` → creates the 18 missing taxa
2. `backfill-primary-taxon-id.sql` → wires `primary_taxon_id` on observations
3. All 18 observations should appear in the species grid on next page load.