### PR TITLE
fix(backfill): DISTINCT ON ORDER BY + step 3b for is_primary=NULL

### DIFF
--- a/scripts/backfill-primary-taxon-id.sql
+++ b/scripts/backfill-primary-taxon-id.sql
@@ -74,7 +74,27 @@ BEGIN
     AND o.primary_taxon_id IS NULL;
 
   GET DIAGNOSTICS v_count = ROW_COUNT;
-  RAISE NOTICE 'Step 3: backfilled primary_taxon_id for % observation(s)', v_count;
+  RAISE NOTICE 'Step 3 (is_primary=true): backfilled primary_taxon_id for % observation(s)', v_count;
+
+  -- Step 3b: also catch observations where the sole identification has
+  -- is_primary = NULL or false but there's only one identification and
+  -- it has a taxon_id. This handles legacy rows inserted before the
+  -- is_primary DEFAULT true was reliable.
+  UPDATE public.observations o
+  SET primary_taxon_id = i.taxon_id,
+      updated_at       = now()
+  FROM public.identifications i
+  WHERE i.observation_id   = o.id
+    AND i.taxon_id         IS NOT NULL
+    AND o.primary_taxon_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.identifications i2
+      WHERE i2.observation_id = o.id
+        AND i2.id <> i.id
+    );
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Step 3b (sole identification fallback): backfilled primary_taxon_id for % observation(s)', v_count;
 END $$;
 
 -- ── Verification ──────────────────────────────────────────────────────────────

--- a/scripts/backfill-taxa-from-identifications.sql
+++ b/scripts/backfill-taxa-from-identifications.sql
@@ -39,7 +39,8 @@ BEGIN
     AND i.scientific_name <> ''
     AND NOT EXISTS (
       SELECT 1 FROM public.taxa t WHERE t.scientific_name = i.scientific_name
-    );
+    )
+  ORDER BY i.scientific_name;  -- required by DISTINCT ON
 
   GET DIAGNOSTICS v_count = ROW_COUNT;
   RAISE NOTICE 'Step 1: inserted % new taxa from identifications', v_count;


### PR DESCRIPTION
Two fixes that unblock the species grid population:

**1. `ORDER BY` for `DISTINCT ON`** (per Nyx's review on #477)
PostgreSQL requires that `DISTINCT ON (col)` is followed by `ORDER BY col` as the first key. Without it the result is undefined. Added `ORDER BY i.scientific_name`.

**2. Step 3b fallback for `is_primary = NULL`**
The main backfill step filters `is_primary = true`, but the previous run resolved 13 taxon_ids and backfilled 0 observations — because those identifications have `is_primary = NULL` (legacy rows before DEFAULT true was enforced). Step 3b catches observations where the sole identification has `taxon_id IS NOT NULL` regardless of `is_primary`.