### PR TITLE
fix(backfill): add diagnostic output for NULL primary_taxon_id observations

### DIFF
--- a/scripts/backfill-taxa-from-identifications.sql
+++ b/scripts/backfill-taxa-from-identifications.sql
@@ -98,3 +98,28 @@ BEGIN
 END $$;
 
 COMMIT;
+
+-- ── Diagnostic: show what the remaining NULL observations look like ───────────
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT
+      o.id,
+      o.sync_status,
+      (SELECT COUNT(*) FROM public.identifications i WHERE i.observation_id = o.id) AS id_count,
+      (SELECT string_agg(
+         COALESCE(i.scientific_name,'(null)') ||
+         '[taxon=' || COALESCE(i.taxon_id::text,'NULL') ||
+         ',primary=' || COALESCE(i.is_primary::text,'NULL') || ']',
+         ', ')
+       FROM public.identifications i WHERE i.observation_id = o.id) AS ids
+    FROM public.observations o
+    WHERE o.primary_taxon_id IS NULL AND o.sync_status = 'synced'
+    LIMIT 20
+  LOOP
+    RAISE NOTICE 'NULL-obs: id=% id_count=% identifications=%',
+      r.id, r.id_count, COALESCE(r.ids, 'NONE');
+  END LOOP;
+END $$;


### PR DESCRIPTION
Adds a diagnostic DO block at the end of `backfill-taxa-from-identifications.sql` that prints the state of each observation that still has `primary_taxon_id = NULL` after the backfill runs — including how many identifications they have and what `taxon_id`/`is_primary` values those identifications have. This will tell us whether the 13 stuck observations have: no identifications at all, identifications with NULL taxon_id, or identifications with taxon_id but is_primary=NULL/false.