### PR TITLE
fix(location): improve error logging + diagnose 500 on location PATCH

### DIFF
--- a/.github/workflows/db-apply.yml
+++ b/.github/workflows/db-apply.yml
@@ -169,6 +169,14 @@ jobs:
           psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f scripts/backfill-primary-taxon-id.sql
           echo "::notice::primary_taxon_id backfill complete"
 
+      - name: Diagnose location trigger (always — non-fatal)
+        if: always()
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          psql "$SUPABASE_DB_URL" -f scripts/diagnose-location-trigger.sql || true
+          echo "::notice::location trigger diagnosis complete"
+
       - name: Refresh taxon_rarity (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch' && inputs.run_rarity_refresh == true
         env:

--- a/scripts/diagnose-location-trigger.sql
+++ b/scripts/diagnose-location-trigger.sql
@@ -1,0 +1,118 @@
+-- diagnose-location-trigger.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Diagnoses the assign_observation_to_project trigger and related RLS setup
+-- to identify why PATCH /observations?id=eq.* → 500 on location update.
+--
+-- Run with: psql "$SUPABASE_DB_URL" -f scripts/diagnose-location-trigger.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ── 1. Check trigger exists and is SECURITY DEFINER ───────────────────────
+DO $$
+DECLARE
+  v_security text;
+  v_trigger_exists boolean;
+BEGIN
+  SELECT EXISTS(
+    SELECT 1 FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'observations'
+      AND t.tgname = 'assign_observation_to_project_trigger'
+  ) INTO v_trigger_exists;
+  RAISE NOTICE 'assign_observation_to_project_trigger exists: %', v_trigger_exists;
+
+  SELECT CASE p.prosecdef WHEN true THEN 'SECURITY DEFINER' ELSE 'SECURITY INVOKER' END
+  INTO v_security
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'assign_observation_to_project';
+  RAISE NOTICE 'assign_observation_to_project security: %', COALESCE(v_security, 'NOT FOUND');
+END $$;
+
+-- ── 2. Check is_project_owner / is_project_member exist and are SECURITY DEFINER ──
+DO $$
+DECLARE
+  v_owner_sec text;
+  v_member_sec text;
+BEGIN
+  SELECT CASE p.prosecdef WHEN true THEN 'SECURITY DEFINER' ELSE 'SECURITY INVOKER' END
+  INTO v_owner_sec
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'is_project_owner';
+  RAISE NOTICE 'is_project_owner security: %', COALESCE(v_owner_sec, 'NOT FOUND');
+
+  SELECT CASE p.prosecdef WHEN true THEN 'SECURITY DEFINER' ELSE 'SECURITY INVOKER' END
+  INTO v_member_sec
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'is_project_member';
+  RAISE NOTICE 'is_project_member security: %', COALESCE(v_member_sec, 'NOT FOUND');
+END $$;
+
+-- ── 3. Check RLS policies on projects reference is_project_member inline ──
+-- If any policy still uses inline EXISTS on project_members, it can recurse.
+DO $$
+DECLARE
+  r record;
+  v_count int := 0;
+BEGIN
+  FOR r IN
+    SELECT polname, pg_get_expr(polqual, polrelid) AS using_expr
+    FROM pg_policy pol
+    JOIN pg_class c ON c.oid = pol.polrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relname IN ('projects', 'project_members')
+  LOOP
+    v_count := v_count + 1;
+    RAISE NOTICE 'Policy % USING: %', r.polname, r.using_expr;
+  END LOOP;
+  RAISE NOTICE 'Total policies on projects/project_members: %', v_count;
+END $$;
+
+-- ── 4. Dry-run the trigger logic as service role (bypasses RLS) ───────────
+-- Simulates what the trigger does: find a project covering the observation's location
+DO $$
+DECLARE
+  v_obs_id uuid := '1db35875-e7b8-4aab-b1c9-c0fb4b164d29';
+  v_location geography;
+  v_project_id uuid;
+BEGIN
+  SELECT location INTO v_location FROM public.observations WHERE id = v_obs_id;
+  RAISE NOTICE 'Observation location: %', v_location;
+
+  IF v_location IS NOT NULL THEN
+    SELECT id INTO v_project_id
+    FROM public.projects
+    WHERE ST_Covers(polygon, v_location)
+    ORDER BY created_at ASC
+    LIMIT 1;
+    RAISE NOTICE 'Matching project_id: %', COALESCE(v_project_id::text, 'none');
+  ELSE
+    RAISE NOTICE 'Location is NULL — trigger would early-return, no ST_Covers call';
+  END IF;
+END $$;
+
+-- ── 5. Check for any OTHER triggers on observations.location ──────────────
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT t.tgname,
+           p.proname AS func_name,
+           CASE p.prosecdef WHEN true THEN 'SECURITY DEFINER' ELSE 'INVOKER' END AS security,
+           CASE t.tgtype & 2 WHEN 2 THEN 'BEFORE' ELSE 'AFTER' END AS timing
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_proc p ON p.oid = t.tgfoid
+    WHERE n.nspname = 'public'
+      AND c.relname = 'observations'
+      AND NOT t.tgisinternal
+    ORDER BY t.tgname
+  LOOP
+    RAISE NOTICE 'Trigger: % → %() [% %]', r.tgname, r.func_name, r.timing, r.security;
+  END LOOP;
+END $$;

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -665,8 +665,20 @@ export async function wireManagePanelLocation(
       );
       const result = await Promise.race([updatePromise, timeout]) as { error: { message?: string; code?: string } | null };
       if (result.error) {
-        console.error('[manage-panel] location update failed', { obsId, err: result.error });
-        throw new Error(result.error.message || result.error.code || 'update_failed');
+        // Log full error details so the console report includes the actual
+        // Supabase/PostgREST message instead of "[object Object]"
+        const errMsg = result.error.message ?? result.error.code ?? 'unknown';
+        const errCode = (result.error as { code?: string }).code ?? '';
+        const errDetails = (result.error as { details?: string }).details ?? '';
+        const errHint = (result.error as { hint?: string }).hint ?? '';
+        console.error('[manage-panel] location update failed', {
+          obsId,
+          message: errMsg,
+          code: errCode,
+          details: errDetails,
+          hint: errHint,
+        });
+        throw new Error(`${errCode ? errCode + ': ' : ''}${errMsg}`);
       }
 
       window.dispatchEvent(new CustomEvent('rastrum:mappicker-set', {
@@ -691,7 +703,7 @@ export async function wireManagePanelLocation(
       savedEl?.classList.remove('hidden');
     } catch (err) {
       const code = err instanceof Error ? err.message : String(err);
-      console.error('[manage-panel] location save error', { obsId, code, err });
+      console.error('[manage-panel] location save error', { obsId, code, message: err instanceof Error ? err.message : String(err) });
       if (errEl) {
         if (code === 'coords_invalid') {
           errEl.textContent = errCopy.invalidCoords;


### PR DESCRIPTION
## Problem

PATCH `/rest/v1/observations?id=eq.*` returns 500 when updating `location`. The client logs `[manage-panel] location update failed [object Object]` — no actual error message visible.

Suspected cause: the `assign_observation_to_project_trigger` (`BEFORE UPDATE OF location`) does a `ST_Covers(polygon, NEW.location)` scan on `projects`. If that table's RLS policies still reference `project_members` via inline EXISTS (instead of the helper functions), Postgres throws 42P17 recursion → 500.

The schema has the fix (SECURITY DEFINER + helper functions), but the 500 persists after the latest deploy — this PR adds diagnostics to confirm what's actually in the DB.

## Changes

### 1. `src/lib/manage-panel.ts` — better error logging
Log full Supabase error fields (`message`, `code`, `details`, `hint`) instead of `{ err: [object Object] }`. Next error report will show the real PostgREST/Postgres error string.

### 2. `scripts/diagnose-location-trigger.sql` (new)
Diagnostic script that checks:
- `assign_observation_to_project_trigger` exists and is SECURITY DEFINER
- `is_project_owner` / `is_project_member` helper functions exist and are SECURITY DEFINER  
- All RLS policies on `projects` / `project_members` (flags inline EXISTS that could recurse)
- Dry-runs the `ST_Covers` lookup for obs `1db35875` to confirm it doesn't error
- Lists all triggers on `observations` with their security mode

### 3. `.github/workflows/db-apply.yml`
Run the diagnostic on every db-apply (non-fatal: `|| true`). Output will appear in CI logs immediately on merge.