### PR TITLE
fix(manage-panel): proper error serialization + 403/session-expired message

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -702,19 +702,28 @@ export async function wireManagePanelLocation(
       if (noLocEl) noLocEl.classList.add('hidden');
       savedEl?.classList.remove('hidden');
     } catch (err) {
-      const code = err instanceof Error ? err.message : String(err);
-      console.error('[manage-panel] location save error', { obsId, code, message: err instanceof Error ? err.message : String(err) });
+      // Serialize error properly — supabase-js PostgrestError is a POJO, not an Error
+      // instance, so err instanceof Error is false and String(err) = "[object Object]".
+      // Use JSON.stringify with a fallback to expose the full error object in the log.
+      const safeStr = (v: unknown): string => {
+        if (v instanceof Error) return v.message;
+        try { return JSON.stringify(v); } catch { return String(v); }
+      };
+      const code = err instanceof Error ? err.message : safeStr(err);
+      console.error('[manage-panel] location save error', safeStr(err));
       if (errEl) {
-        if (code === 'coords_invalid') {
+        // PostgREST 403 = RLS blocked the UPDATE. Most common cause: JWT expired.
+        const is403 = code.includes('403') || code.includes('PGRST116') || code.includes('rls_filtered') || code.includes('JWT expired') || code.includes('permission denied');
+        if (code === 'coords_invalid' || code.includes('coords_invalid')) {
           errEl.textContent = errCopy.invalidCoords;
-        } else if (code === 'save_timeout') {
+        } else if (code === 'save_timeout' || code.includes('save_timeout')) {
           errEl.textContent = isEs
             ? 'Tiempo de espera agotado. Revisa tu conexión o intenta de nuevo.'
             : 'Save timed out. Check your connection and try again.';
-        } else if (code === 'rls_filtered') {
+        } else if (is403) {
           errEl.textContent = isEs
-            ? 'No tienes permiso para editar esta observación.'
-            : 'You do not have permission to edit this observation.';
+            ? 'Sesión expirada. Vuelve a iniciar sesión para guardar cambios.'
+            : 'Session expired. Sign in again to save changes.';
         } else {
           errEl.textContent = `${errCopy.saveFailed} (${code})`;
         }


### PR DESCRIPTION
## Root cause

The PATCH `/observations` returns **403** (not 500). Confirmed via Supabase analytics logs. Root cause: the user's JWT had expired — RLS policy `obs_owner` requires `auth.uid() = observer_id`, and an expired JWT means `auth.uid()` returns null.

The browser console showed `500` instead of `403` — likely supabase-js wrapping it.

## Fixes

**1. JSON.stringify for error serialization**
`PostgrestError` is a POJO, not an `Error` instance. `String(err)` = `'[object Object]'`. Now using `JSON.stringify` so the real message/code is visible in the log.

**2. 403 → friendly session-expired message**
When PostgREST returns 403 (JWT expired, RLS filtered), user sees:
- ES: _"Sesión expirada. Vuelve a iniciar sesión para guardar cambios."_
- EN: _"Session expired. Sign in again to save changes."_

## Immediate workaround for Artemio
Sign out and sign back in to rastrum.org — the JWT will refresh and the location save will work.