### PR TITLE
fix(db): jsonb_to_geography — pass jsonb directly, not ::text

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -6852,7 +6852,11 @@ STRICT
 SECURITY INVOKER
 SET search_path = public, pg_temp
 AS $$
-  SELECT ST_SetSRID(ST_GeomFromGeoJSON($1::text), 4326)::geography;
+  -- Pass jsonb directly to ST_GeomFromGeoJSON (PostGIS accepts jsonb natively).
+  -- Do NOT cast to text first: $1::text wraps the value in escaped quotes,
+  -- producing '"{\"type\":\"Point\"}"' instead of '{"type":"Point"}',
+  -- which causes ST_GeomFromGeoJSON to fail with "parse error - invalid geometry".
+  SELECT ST_SetSRID(ST_GeomFromGeoJSON($1), 4326)::geography;
 $$;
 
 DO $$ BEGIN


### PR DESCRIPTION
## Bug

`#483` added the `jsonb → geography` cast but used `ST_GeomFromGeoJSON($1::text)`. The `::text` cast wraps the jsonb value in escaped quotes:

```
{"type":"Point","coordinates":[-99,19]}   -- jsonb
→  "{\"type\":\"Point\",...}"          -- ::text adds outer quotes + escapes
```

PostGIS `ST_GeomFromGeoJSON` receives the double-quoted string and fails with:
> `XX000: parse error - invalid geometry`

## Fix

Remove the `::text` cast. PostGIS `ST_GeomFromGeoJSON` accepts `jsonb` natively (Postgres overloads the function). The jsonb value is passed directly without any text conversion.