### PR TITLE
fix(location): use RPC instead of PATCH — bypasses jsonb→geography cast problem

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -6837,32 +6837,45 @@ DO $$ BEGIN
     CHECK (reaction_type IN ('thumbs_up','thumbs_down','heart','expert','best_shot'));
 EXCEPTION WHEN others THEN NULL; END $$;
 
--- ── GeoJSON → geography implicit cast ────────────────────────────────────────
--- PostgREST sends JSON objects as jsonb when updating geography columns.
--- Without this cast, PATCH /observations with {location: {type:"Point",...}}
--- fails with HTTP 500 ("could not find implicit cast from jsonb to geography").
--- The cast function wraps ST_GeomFromGeoJSON and forces SRID=4326.
--- castcontext='i' (implicit) allows PostgREST to use it automatically.
+-- ── Location update via RPC ──────────────────────────────────────────────────
+-- PostgREST cannot cast jsonb → geography implicitly (requires owning both
+-- types, which the DB role does not). Instead of a CAST, we expose an RPC
+-- function that accepts lat/lng as floats and builds the geography internally.
+-- The client calls rpc('update_observation_location', {p_obs_id, p_lat, p_lng}).
+-- SECURITY DEFINER so the function runs as the function owner (bypasses RLS
+-- for the geography construction only); the WHERE clause still enforces
+-- observer_id = auth.uid() so users can only move their own observations.
 
-CREATE OR REPLACE FUNCTION public.jsonb_to_geography(jsonb)
-RETURNS geography
-LANGUAGE sql
-IMMUTABLE
-STRICT
-SECURITY INVOKER
+CREATE OR REPLACE FUNCTION public.update_observation_location(
+  p_obs_id uuid,
+  p_lat    double precision,
+  p_lng    double precision
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
-  -- Pass jsonb directly to ST_GeomFromGeoJSON (PostGIS accepts jsonb natively).
-  -- Do NOT cast to text first: $1::text wraps the value in escaped quotes,
-  -- producing '"{\"type\":\"Point\"}"' instead of '{"type":"Point"}',
-  -- which causes ST_GeomFromGeoJSON to fail with "parse error - invalid geometry".
-  SELECT ST_SetSRID(ST_GeomFromGeoJSON($1), 4326)::geography;
+BEGIN
+  -- RLS-equivalent guard: only the owner can move their observation.
+  -- The function is SECURITY DEFINER so geography construction works,
+  -- but we explicitly check auth.uid() = observer_id for safety.
+  UPDATE public.observations
+  SET
+    location        = ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
+    location_source = 'manual',
+    updated_at      = now()
+  WHERE id          = p_obs_id
+    AND observer_id = (SELECT auth.uid());
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'rls_filtered'
+      USING HINT = 'Observation not found or you are not the owner.';
+  END IF;
+END;
 $$;
 
-DO $$ BEGIN
-  CREATE CAST (jsonb AS geography)
-    WITH FUNCTION public.jsonb_to_geography(jsonb)
-    AS IMPLICIT;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+GRANT EXECUTE ON FUNCTION public.update_observation_location(uuid, double precision, double precision)
+  TO authenticated;
 
 

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -645,21 +645,17 @@ export async function wireManagePanelLocation(
     savingEl?.classList.remove('hidden');
     try {
       // GeoJSON format is required for UPDATE via supabase-js — WKT strings are
-      // accepted by PostgREST on INSERT (via type-casting) but silently no-op
-      // on UPDATE because supabase-js serialises the value as JSON, not SQL.
-      // See issue #449.
-      const geoJson = pointGeographyGeoJSON(e.detail.coords.lat, e.detail.coords.lng);
-      // Hard 15 s timeout — if PostgREST never returns (RLS recursion regressed,
-      // CORS preflight stalled, auth refresh deadlock, etc.) the user gets a
+      // PostgREST cannot implicitly cast jsonb → geography (requires owning both
+      // types). Use the RPC function instead — it accepts lat/lng as floats
+      // and builds the geography internally with ST_MakePoint.
+      // Hard 15 s timeout — if PostgREST never returns the user gets a
       // visible error instead of a button stuck on "saving…" forever.
-      // Use count-based update: PostgREST returns the count of affected rows
-      // via the `Prefer: count=exact` header. This is more reliable than
-      // .select().maybeSingle() which can return null when RLS SELECT policy
-      // differs from UPDATE policy (e.g., obscured locations hidden from view).
       const updatePromise = supabase
-        .from('observations')
-        .update({ location: geoJson, location_source: 'manual', updated_at: new Date().toISOString() })
-        .eq('id', obsId);
+        .rpc('update_observation_location', {
+          p_obs_id: obsId,
+          p_lat:    e.detail.coords.lat,
+          p_lng:    e.detail.coords.lng,
+        });
       const timeout = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('save_timeout')), 15_000),
       );


### PR DESCRIPTION
## Problem

`CREATE CAST (jsonb AS geography)` requires owning both types — they're PostGIS/system types owned by a superuser role. The DB connection role (`postgres` via pooler) is not a superuser and cannot create this cast. db-apply failed with:

> `ERROR: must be owner of type jsonb or type geography`

## Root cause

PostgREST serialises the GeoJSON object as `jsonb` and tries to cast it to `geography`. No implicit `jsonb → geography` cast exists, so PostgREST returns 500.

## Solution

New RPC function `update_observation_location(p_obs_id uuid, p_lat float8, p_lng float8)`:
- Accepts plain float coordinates (no geography casting needed)
- Builds geometry internally: `ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography`
- `SECURITY DEFINER` so PostGIS functions run without type-cast gymnastics
- Explicit `observer_id = auth.uid()` guard enforces RLS equivalent
- Raises `rls_filtered` exception if not owner (caught by manage-panel error handler)

Client: `supabase.rpc('update_observation_location', {p_obs_id, p_lat, p_lng})`