### PR TITLE
fix(manage-panel): remove duplicate rastrum:mappicker-save listener — fixes location save_timeout

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -637,7 +637,16 @@ export async function wireManagePanelLocation(
     });
   }
 
-  window.addEventListener('rastrum:mappicker-save', async (ev) => {
+  // Use a named handler so we can remove any previously registered listener
+  // before adding a new one. wireManagePanelLocation can be called more than
+  // once (page navigation, panel re-init), and window.addEventListener without
+  // cleanup stacks duplicate listeners — each one fires on the same event,
+  // causing concurrent refreshSession() + RPC calls that deadlock the
+  // supabase-js auth mutex and trigger save_timeout.
+  const existingHandler = (window as Window & { __rastrum_loc_handler?: EventListener }).__rastrum_loc_handler;
+  if (existingHandler) window.removeEventListener('rastrum:mappicker-save', existingHandler);
+
+  const locHandler: EventListener = async (ev) => {
     const e = ev as CustomEvent<{ id: string; coords: { lat: number; lng: number } }>;
     if (e.detail.id !== 'obs-detail-edit') return;
     errEl?.classList.add('hidden');
@@ -744,5 +753,9 @@ export async function wireManagePanelLocation(
     } finally {
       savingEl?.classList.add('hidden');
     }
-  });
+  };
+
+  // Register and store the handler so future calls can remove the old one
+  window.addEventListener('rastrum:mappicker-save', locHandler);
+  (window as Window & { __rastrum_loc_handler?: EventListener }).__rastrum_loc_handler = locHandler;
 }


### PR DESCRIPTION
## Root cause (found via debug log)

The debug log showed the RPC being called **twice** on each save attempt:
```
[manage-panel] calling update_observation_location {p_obs_id: '...', p_lat: 19.375, p_lng: -99.19}
[manage-panel] calling update_observation_location {p_obs_id: '...', p_lat: 19.375, p_lng: -99.19}
```

`wireManagePanelLocation()` used `window.addEventListener` without cleanup. On page navigation or panel re-init (which happens when the obs detail page loads), the listener stacked — two concurrent handlers fired on the same `rastrum:mappicker-save` event.

Both called `refreshSession()` concurrently. **`supabase-js` has an internal auth mutex** that serializes concurrent auth calls — one call blocks waiting for the other, and after ~8 s the 15 s `save_timeout` fired before the blocked call could proceed to the actual RPC fetch.

## Fix

Store the handler on `window.__rastrum_loc_handler`. Before registering a new listener, remove the previous one. Only one handler is active at a time.