### PR TITLE
fix(manage-panel): console.warn for RPC debug — captured by bug reporter

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -673,7 +673,8 @@ export async function wireManagePanelLocation(
       );
       const updatePromise = refreshPromise.then(() => {
         // Log params before calling RPC to verify they are valid
-        console.log('[manage-panel] calling update_observation_location', {
+        // console.warn so ReportIssueButton captures it in __rastrum_diag
+        console.warn('[manage-panel] calling update_observation_location', {
           p_obs_id: obsId,
           p_lat: e.detail.coords.lat,
           p_lng: e.detail.coords.lng,


### PR DESCRIPTION
The debug log from #489 uses `console.log`, which `ReportIssueButton` does not intercept. The `__rastrum_diag` capture only hooks `console.error` and `console.warn`.

Switching to `console.warn` means the RPC call params appear in the bug report modal and the pre-filled GitHub issue automatically — no DevTools needed on mobile.