### PR TITLE
feat(places): M-Loc-1 — DB schema, WDPA import, assign_place trigger, backfill

### DIFF
--- a/.github/workflows/db-apply.yml
+++ b/.github/workflows/db-apply.yml
@@ -177,6 +177,18 @@ jobs:
           psql "$SUPABASE_DB_URL" -f scripts/diagnose-location-trigger.sql || true
           echo "::notice::location trigger diagnosis complete"
 
+      - name: Backfill place_id (idempotent — runs after every schema apply)
+        # M-Loc-1: Assigns place_id to existing synced observations that have a
+        # location but no place_id. Safe to re-run (idempotent WHERE clause).
+        # Only matches named places (place_type != 'h3_cell'); H3 fallback cells
+        # are created by the trigger on future INSERT/UPDATE.
+        if: steps.changes.outputs.schema == 'true'
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f scripts/backfill-place-id.sql
+          echo "::notice::place_id backfill complete"
+
       - name: Refresh taxon_rarity (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch' && inputs.run_rarity_refresh == true
         env:

--- a/.github/workflows/wdpa-import.yml
+++ b/.github/workflows/wdpa-import.yml
@@ -1,0 +1,60 @@
+name: WDPA Import
+
+# M-Loc-1: Annual import of WDPA protected areas into public.places.
+#
+# Trigger paths:
+#   - workflow_dispatch — manual run, accepts optional country filter
+#   - schedule — Jan 1st at 06:00 UTC (WDPA publishes annual refresh in late Dec)
+#
+# Required secret: SUPABASE_DB_URL (postgres:// connection string)
+# Optional: pass --country to limit to a single ISO3 (default: MEX)
+#
+# System deps installed at runtime: gdal-bin (ogr2ogr)
+
+on:
+  workflow_dispatch:
+    inputs:
+      country:
+        description: 'ISO3 country code to import (default: MEX)'
+        required: false
+        default: 'MEX'
+      dry_run:
+        description: 'Dry run — parse and log but do not write to DB'
+        type: boolean
+        required: false
+        default: false
+  schedule:
+    - cron: '0 6 1 1 *'   # Jan 1st 06:00 UTC
+
+concurrency:
+  group: wdpa-import
+  cancel-in-progress: false
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60    # WDPA archive is ~500 MB; allow generous time
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GDAL (ogr2ogr)
+        run: sudo apt-get install -y --no-install-recommends gdal-bin
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run WDPA import
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          ARGS="--country ${{ inputs.country || 'MEX' }}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          npx tsx scripts/import-wdpa.ts $ARGS

--- a/docs/specs/infra/cron-schedules.sql
+++ b/docs/specs/infra/cron-schedules.sql
@@ -335,3 +335,38 @@ SELECT cron.schedule('retry-unidentified', '*/30 * * * *',
     headers := '{"Content-Type":"application/json"}'::jsonb,
     body    := '{}'::jsonb
   )$$);
+
+-- ─────────────────────────────────────────────────────────────────
+-- v11 (2026-05-03): M-Loc-1 — 'refresh-place-stats' (every hour at :45)
+--   Recomputes denormalized obs_count, species_count, observer_count,
+--   first_obs_at, last_obs_at on public.places from synced observations
+--   that have a place_id. Runs at :45 to avoid the :05/:25 cluster.
+-- ─────────────────────────────────────────────────────────────────
+SELECT cron.unschedule('refresh-place-stats')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'refresh-place-stats');
+SELECT cron.schedule(
+  'refresh-place-stats',
+  '45 * * * *',
+  $$
+  UPDATE public.places p
+     SET obs_count      = s.obs_count,
+         species_count  = s.species_count,
+         observer_count = s.observer_count,
+         first_obs_at   = s.first_obs_at,
+         last_obs_at    = s.last_obs_at,
+         updated_at     = now()
+    FROM (
+      SELECT place_id,
+             COUNT(*)                        AS obs_count,
+             COUNT(DISTINCT primary_taxon_id) AS species_count,
+             COUNT(DISTINCT observer_id)      AS observer_count,
+             MIN(observed_at)                 AS first_obs_at,
+             MAX(observed_at)                 AS last_obs_at
+        FROM public.observations
+       WHERE sync_status = 'synced'
+         AND place_id IS NOT NULL
+       GROUP BY place_id
+    ) s
+   WHERE p.id = s.place_id;
+  $$
+);

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -6879,3 +6879,197 @@ GRANT EXECUTE ON FUNCTION public.update_observation_location(uuid, double precis
   TO authenticated;
 
 
+
+-- ════════════════════════════════════════════════════════════════════════
+-- M-Loc-1: Places infrastructure
+-- ════════════════════════════════════════════════════════════════════════
+-- Adds:
+--   - public.places table with GIST/GIN indexes and RLS
+--   - observations.place_id FK column + index
+--   - assign_observation_place trigger (BEFORE INSERT OR UPDATE OF location)
+--   - H3 fallback: auto-creates a place_type='h3_cell' row when no named
+--     place covers the location
+-- Blocked by: none (foundational)
+-- Blocks: M-Loc-2, M-Loc-3, M-Loc-4, M-Loc-5
+-- ════════════════════════════════════════════════════════════════════════
+
+-- ── places table ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.places (
+  id              uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  slug            text UNIQUE NOT NULL,
+  name            text NOT NULL,
+  name_local      text,
+  place_type      text NOT NULL
+                  CHECK (place_type IN ('protected_area','h3_cell','custom','community')),
+  geometry        geography(Geometry,4326) NOT NULL,
+  h3_cells        text[],
+  h3_resolution   int,
+  source          text NOT NULL
+                  CHECK (source IN ('wdpa','user','auto_h3','nominatim')),
+  source_id       text,
+  country_code    text,
+  state_province  text,
+  description     text,
+  created_by      uuid REFERENCES public.users(id),
+  obs_count       int NOT NULL DEFAULT 0,
+  species_count   int NOT NULL DEFAULT 0,
+  observer_count  int NOT NULL DEFAULT 0,
+  first_obs_at    timestamptz,
+  last_obs_at     timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_places_geometry  ON public.places USING GIST(geometry);
+CREATE INDEX IF NOT EXISTS idx_places_h3_cells  ON public.places USING GIN(h3_cells);
+CREATE INDEX IF NOT EXISTS idx_places_type      ON public.places(place_type);
+CREATE INDEX IF NOT EXISTS idx_places_obs_count ON public.places(obs_count DESC);
+
+ALTER TABLE public.places ENABLE ROW LEVEL SECURITY;
+
+-- Everyone can read places (public catalogue)
+DROP POLICY IF EXISTS places_public_read  ON public.places;
+CREATE POLICY places_public_read  ON public.places FOR SELECT USING (true);
+
+-- Only the row owner can update custom/community places
+DROP POLICY IF EXISTS places_owner_update ON public.places;
+CREATE POLICY places_owner_update ON public.places FOR UPDATE TO authenticated
+  USING (created_by = (SELECT auth.uid()))
+  WITH CHECK (created_by = (SELECT auth.uid()));
+
+-- Authenticated users may insert custom or community places
+DROP POLICY IF EXISTS places_user_insert  ON public.places;
+CREATE POLICY places_user_insert  ON public.places FOR INSERT TO authenticated
+  WITH CHECK (place_type IN ('custom','community') AND created_by = (SELECT auth.uid()));
+
+-- ── observations.place_id FK ──────────────────────────────────────────────────
+ALTER TABLE public.observations ADD COLUMN IF NOT EXISTS place_id uuid REFERENCES public.places(id);
+CREATE INDEX IF NOT EXISTS idx_obs_place ON public.observations(place_id) WHERE place_id IS NOT NULL;
+
+-- ── assign_observation_place trigger ─────────────────────────────────────────
+-- Fires BEFORE INSERT OR UPDATE OF location so the trigger can rewrite
+-- NEW.place_id before the row lands in the table (no extra UPDATE round-trip).
+--
+-- Logic:
+--   1. If location is NULL → leave place_id unchanged, return NEW.
+--   2. Look for the smallest named place (place_type ≠ 'h3_cell') that
+--      contains the point.  ST_Within on the GIST index is sub-ms at
+--      the expected volume (<10 k places for MX).
+--   3. If none found → compute a deterministic slug from rounded lat/lng,
+--      upsert an auto_h3 place_type='h3_cell' row (ST_Buffer 5 km), and
+--      use its id.
+--
+-- H3 extension: if h3-pg is available the slug uses the real H3 cell ID
+-- at resolution 7 instead of the lat/lng rounding approximation.
+-- Degrade gracefully when the extension is absent.
+--
+-- SECURITY DEFINER: needed to INSERT into places (service-role bypass)
+-- without exposing a writable service-role key to the trigger body.
+-- The WHERE clause on the UPDATE guard still enforces observer ownership.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.assign_observation_place()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_place_id     uuid;
+  v_lat          double precision;
+  v_lng          double precision;
+  v_slug         text;
+  v_h3_available boolean := false;
+  v_cell_id      text;
+BEGIN
+  -- 1. No location → nothing to do
+  IF NEW.location IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- 2. Find the most-specific named place (smallest area, not an h3_cell)
+  SELECT id INTO v_place_id
+    FROM public.places
+   WHERE place_type != 'h3_cell'
+     AND ST_Within(NEW.location::geometry, geometry::geometry)
+   ORDER BY ST_Area(geometry::geometry) ASC
+   LIMIT 1;
+
+  IF v_place_id IS NOT NULL THEN
+    NEW.place_id := v_place_id;
+    RETURN NEW;
+  END IF;
+
+  -- 3. No named place found → upsert an H3 fallback cell
+  v_lat := ST_Y(NEW.location::geometry);
+  v_lng := ST_X(NEW.location::geometry);
+
+  -- Try to use h3-pg for a real cell ID if available
+  BEGIN
+    SELECT EXISTS (
+      SELECT 1 FROM pg_extension WHERE extname = 'h3'
+    ) INTO v_h3_available;
+  EXCEPTION WHEN OTHERS THEN
+    v_h3_available := false;
+  END;
+
+  IF v_h3_available THEN
+    BEGIN
+      -- h3_lat_lng_to_cell returns an h3index (bigint or text depending on version)
+      SELECT h3_lat_lng_to_cell(v_lat, v_lng, 7)::text INTO v_cell_id;
+      v_slug := 'h3_' || v_cell_id;
+    EXCEPTION WHEN OTHERS THEN
+      -- Extension present but function signature differs — fall back gracefully
+      v_h3_available := false;
+    END;
+  END IF;
+
+  IF NOT v_h3_available OR v_cell_id IS NULL THEN
+    -- Lat/lng rounding approximation (~5 km grid at equator, resolution 7 equivalent)
+    v_slug := 'h3_' ||
+              replace(to_char(round(v_lat::numeric, 2), 'FM999990.00'), '.', 'p')
+              || '_' ||
+              replace(to_char(round(v_lng::numeric, 2), 'FM999990.00'), '.', 'p');
+    -- Normalize sign: negative becomes 'm' prefix
+    v_slug := replace(v_slug, 'h3_-', 'h3_m');
+    v_slug := replace(v_slug, '__m', '_m');
+  END IF;
+
+  -- Upsert the H3 cell row (idempotent on slug)
+  INSERT INTO public.places (
+    slug,
+    name,
+    place_type,
+    geometry,
+    source,
+    country_code
+  )
+  VALUES (
+    v_slug,
+    'Zona H3 ' || v_slug,
+    'h3_cell',
+    -- ~5 km buffer around the point
+    ST_Buffer(
+      ST_SetSRID(ST_MakePoint(v_lng, v_lat), 4326)::geography,
+      5000
+    ),
+    'auto_h3',
+    NULL  -- country_code backfilled separately if needed
+  )
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_place_id;
+
+  -- If DO NOTHING fired (row already existed) fetch the id
+  IF v_place_id IS NULL THEN
+    SELECT id INTO v_place_id FROM public.places WHERE slug = v_slug;
+  END IF;
+
+  NEW.place_id := v_place_id;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS assign_observation_place_trigger ON public.observations;
+CREATE TRIGGER assign_observation_place_trigger
+  BEFORE INSERT OR UPDATE OF location ON public.observations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.assign_observation_place();

--- a/docs/superpowers/specs/2026-05-03-locations-first-class-design.md
+++ b/docs/superpowers/specs/2026-05-03-locations-first-class-design.md
@@ -1,0 +1,192 @@
+# Locations as First-Class Citizens — Design Spec
+
+**Date:** 2026-05-03
+**Status:** Approved
+**Author:** ArtemIO + Nyx (brainstorm) / ArtemIO (spec)
+
+---
+
+## Overview
+
+Locations in Rastrum are currently just lat/lng coordinates on observations — no identity, no page, no exploration. This spec defines "places" as first-class entities that emerge from observation data, support named areas (from WDPA protected areas database) and H3 hexagons as fallback, and enable four core use cases: exploration, observation context, discovery, and comparison.
+
+**Core principle:** A place exists because observations happened there, not the other way around. Places are data-emergent, community-curated.
+
+---
+
+## Data Model
+
+### New table: `places`
+
+```sql
+places (
+  id              uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  slug            text UNIQUE NOT NULL,           -- URL-safe, e.g. 'reserva-biosfera-tehuacan'
+  name            text NOT NULL,                  -- Display name
+  name_local      text,                           -- Local/indigenous name if different
+  place_type      text NOT NULL                   -- 'protected_area' | 'h3_cell' | 'custom' | 'community'
+                  CHECK (place_type IN ('protected_area','h3_cell','custom','community')),
+  geometry        geography(Geometry,4326) NOT NULL,  -- Polygon, multipolygon, or point+radius
+  h3_cells        text[],                         -- H3 cell IDs covered (resolution 7), for fast lookup
+  h3_resolution   int,                            -- H3 resolution if place_type='h3_cell'
+  source          text NOT NULL                   -- 'wdpa' | 'user' | 'auto_h3' | 'nominatim'
+                  CHECK (source IN ('wdpa','user','auto_h3','nominatim')),
+  source_id       text,                           -- External ID (e.g. WDPA_PID for protected areas)
+  country_code    text,                           -- ISO 3166-1 alpha-2
+  state_province  text,                           -- Admin level 1
+  description     text,                           -- Optional community-written description
+  created_by      uuid REFERENCES public.users(id),  -- NULL for imports
+  obs_count       int NOT NULL DEFAULT 0,         -- Denormalized, updated by trigger/cron
+  species_count   int NOT NULL DEFAULT 0,         -- Denormalized
+  observer_count  int NOT NULL DEFAULT 0,         -- Denormalized
+  first_obs_at    timestamptz,                    -- Denormalized
+  last_obs_at     timestamptz,                    -- Denormalized
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_places_geometry ON places USING GIST(geometry);
+CREATE INDEX idx_places_h3_cells ON places USING GIN(h3_cells);
+CREATE INDEX idx_places_type ON places(place_type);
+CREATE INDEX idx_places_obs_count ON places(obs_count DESC);
+```
+
+### Changes to `observations`
+
+```sql
+ALTER TABLE observations ADD COLUMN place_id uuid REFERENCES places(id);
+CREATE INDEX idx_obs_place ON observations(place_id) WHERE place_id IS NOT NULL;
+```
+
+### RLS
+
+- `places`: public SELECT for all. INSERT/UPDATE for authenticated owners (`created_by = auth.uid()`). Protected areas are read-only for all users (admin only via service role).
+- `observations.place_id`: set by trigger (SECURITY DEFINER), users cannot directly update it.
+
+---
+
+## Backend & Data Pipeline
+
+### A) WDPA Import (one-shot + annual cron)
+
+**Script:** `scripts/import-wdpa.ts`
+
+Downloads WDPA shapefile for Mexico + LATAM countries (free, CC BY 4.0 from protectedplanet.net), converts with `ogr2ogr`, and bulk-inserts into `places`:
+- `place_type = 'protected_area'`, `source = 'wdpa'`
+- Generates slug from name (lowercase, dashes, dedup with numeric suffix)
+- Computes `h3_cells` coverage at resolution 7 using H3-js
+- Skip if `source_id` already exists (idempotent)
+
+**GitHub Actions cron:** Runs every January 1st via `workflow_dispatch` + schedule. Mexico first in v1, full LATAM in v2.
+
+### B) Trigger: `assign_place`
+
+```sql
+-- BEFORE INSERT OR UPDATE OF location ON observations
+-- SECURITY DEFINER
+```
+
+Logic:
+1. Find the most specific `place_id` where `ST_Within(NEW.location, place.geometry)` — ordered by area ASC (most specific first)
+2. If none found: compute H3 cell at resolution 7 for `NEW.location`, upsert a `place_type='h3_cell'` row with name from H3 cell ID (e.g. `"Zona H3 8a48a1b2c3dffff"`), return its `place_id`
+3. Set `NEW.place_id`
+
+Performance: GIST index on `places.geometry` makes `ST_Within` spatial join sub-millisecond for the expected volume (<10k places).
+
+### C) Place stats materialized view + denormalization
+
+```sql
+-- Materialized view refreshed hourly via pg_cron
+CREATE MATERIALIZED VIEW place_stats AS
+SELECT
+  place_id,
+  COUNT(*) AS obs_count,
+  COUNT(DISTINCT primary_taxon_id) AS species_count,
+  COUNT(DISTINCT observer_id) AS observer_count,
+  MIN(observed_at) AS first_obs_at,
+  MAX(observed_at) AS last_obs_at
+FROM observations
+WHERE sync_status = 'synced' AND place_id IS NOT NULL
+GROUP BY place_id;
+```
+
+A pg_cron job denormalizes back into `places` columns every hour (same pattern as `recompute-user-stats`).
+
+### D) H3 name enrichment via Nominatim (optional, zero cost)
+
+Edge Function `enrich-h3-names` calls Nominatim reverse geocoding (OSM, free) for H3 cells that still have generic names. Runs as a low-priority background cron. Non-blocking — generic H3 name is always the fallback.
+
+---
+
+## Pages & Navigation
+
+### `/explore/places/` — Place index
+
+- Grid of places sorted by `obs_count DESC`
+- Filters: `place_type`, `country_code`, `state_province`  
+- Full-text search on `name`
+- Background map showing all places as colored polygons/hexes (opacity = obs density)
+- "Near me" button triggers geolocation and reorders by distance
+
+### `/explore/places/[slug]` — Place detail
+
+**Header:** Name, type badge (Área Protegida / Zona H3 / Comunidad), source badge (WDPA / Usuario / Auto)
+
+**Stats bar:** obs_count · species_count · observer_count · first/last obs date
+
+**Map:** MapLibre centered on place, place boundary rendered as polygon, observation pins clustered inside
+
+**Tabs:**
+- *Observaciones recientes* — grid of last 20 obs, link to full filtered view
+- *Especies* — list of species by obs count, links to `/explore/species/[slug]`
+- *Observadores* — top contributors in this place
+- *Lugares cercanos* — 5 nearest places by centroid distance
+
+**Owner actions (if `created_by = auth.uid()`):** Edit name, description, rename slug
+
+### `/share/obs/[id]` — Observation detail (existing, extended)
+
+Add place chip below coordinates:
+```
+📍 Reserva de la Biosfera Tehuacán-Cuicatlán  →  Ver lugar
+```
+If `place_id` is null (obs has no location): chip not shown.
+
+### `/explore/map/` — Map (existing, extended)
+
+- New layer toggle: "Mostrar áreas" — renders place polygons with low-opacity fill
+- Click on polygon → side panel with place name, stats, link to place detail page
+- Observation pin popup gets "Ver lugar" link if obs has place_id
+
+---
+
+## Rollout Phases
+
+| Module | Description | Dependencies | Est. |
+|--------|-------------|--------------|------|
+| M-Loc-1 | DB schema + WDPA import + assign_place trigger + backfill | None | 2-3d |
+| M-Loc-2 | Place chip on obs detail page | M-Loc-1 | 1d |
+| M-Loc-3 | Place detail page `/explore/places/[slug]` | M-Loc-1 | 2-3d |
+| M-Loc-4 | Place index `/explore/places/` | M-Loc-3 | 1-2d |
+| M-Loc-5 | Discovery (near me, map layer, comparison) | M-Loc-3 | 2-3d |
+
+**Total estimate:** 8-12 days. Each module is independently shippable.
+
+---
+
+## Out of Scope (v1)
+
+- Drawing custom place polygons in-browser (v2)
+- User-proposed name changes with approval workflow (v2)
+- Comparison view between two places (M-Loc-5, v1 is read-only)
+- Indigenous/local name database (tracked as future enhancement)
+- Place "following" / notifications (v2)
+
+---
+
+## Open Questions (resolved)
+
+- **Who creates places?** System auto-creates from WDPA + H3 fallback. Users can create custom places (community type). No approval flow in v1.
+- **What geometry type per place type?** protected_area = polygon/multipolygon (from WDPA), h3_cell = H3 hex, custom = any (point+radius or polygon drawn by user in v2).
+- **Geocoding cost?** Zero. Nominatim (OSM) for H3 name enrichment, no paid API.
+- **WDPA coverage?** Mexico first in M-Loc-1. LATAM expansion in M-Loc-1 v2 (same script, broader filter).

--- a/scripts/backfill-place-id.sql
+++ b/scripts/backfill-place-id.sql
@@ -1,0 +1,53 @@
+-- backfill-place-id.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+-- M-Loc-1: Idempotent backfill — assign place_id to synced observations that
+-- have a location but no place_id yet.
+--
+-- Only matches named places (place_type != 'h3_cell'). H3 fallback cells are
+-- not created here; the assign_observation_place trigger handles those for
+-- new/updated rows. Historical observations without a named place match will
+-- remain NULL until the trigger fires on their next location UPDATE, or until
+-- a WDPA import adds a matching polygon.
+--
+-- Safe to run multiple times (idempotent WHERE clause: place_id IS NULL).
+-- Run with: psql "$SUPABASE_DB_URL" -f scripts/backfill-place-id.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_updated  int;
+  v_total    int;
+BEGIN
+  RAISE NOTICE 'M-Loc-1 backfill: assigning place_id to observations...';
+
+  -- Assign the smallest named place that contains each observation's location.
+  -- Using a correlated subquery + DISTINCT ON for correctness; the GIST index
+  -- on places.geometry makes the ST_Within scan fast.
+  UPDATE public.observations o
+     SET place_id = (
+           SELECT id
+             FROM public.places p
+            WHERE p.place_type != 'h3_cell'
+              AND ST_Within(o.location::geometry, p.geometry::geometry)
+            ORDER BY ST_Area(p.geometry::geometry) ASC
+            LIMIT 1
+         )
+   WHERE o.location   IS NOT NULL
+     AND o.place_id   IS NULL
+     AND o.sync_status = 'synced';
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  SELECT COUNT(*) INTO v_total
+    FROM public.observations
+   WHERE place_id    IS NOT NULL
+     AND sync_status  = 'synced';
+
+  RAISE NOTICE 'Backfill complete: % rows updated this run. % synced observations now have place_id.',
+    v_updated, v_total;
+END;
+$$;
+
+COMMIT;

--- a/scripts/import-wdpa.ts
+++ b/scripts/import-wdpa.ts
@@ -1,0 +1,349 @@
+#!/usr/bin/env tsx
+/**
+ * scripts/import-wdpa.ts
+ * ──────────────────────
+ * M-Loc-1: Download WDPA GeoPackage for Mexico (and optionally LATAM), parse
+ * features with ogr2ogr, and upsert into public.places as place_type='protected_area'.
+ *
+ * Usage:
+ *   npx tsx scripts/import-wdpa.ts [--dry-run] [--country MEX]
+ *
+ * Env:
+ *   SUPABASE_DB  — postgres:// connection string (required unless --dry-run)
+ *
+ * Dependencies (Node):
+ *   - node-fetch (or native fetch in Node 18+)
+ *   - child_process (stdlib)
+ *   - fs/path/os (stdlib)
+ *
+ * System deps:
+ *   - gdal-bin (ogr2ogr) — installed in CI via apt-get
+ *
+ * Output:
+ *   Inserted: N  Updated: M  Skipped: K
+ *
+ * Notes:
+ *   - WDPA data is CC BY 4.0 (protectedplanet.net).
+ *   - Upsert key: source_id (WDPA_PID). ON CONFLICT updates geometry + name.
+ *   - v1: MEX only. v2: extend COUNTRY_CODES list for LATAM.
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as https from "node:https";
+import * as http from "node:http";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+// WDPA bulk download — free shapefile, no API key required (CC BY 4.0)
+// The shp_0 archive contains the main polygon layer for all countries.
+const WDPA_URL =
+  "https://d1gam3xoknrgr2.cloudfront.net/current/WDPA_WDOECM_wdpa_shp_0.zip";
+
+// ISO3 codes to import (v1: Mexico only; expand for LATAM in v2)
+const DEFAULT_COUNTRIES = ["MEX"];
+
+// ─── CLI args ─────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const countryIdx = args.indexOf("--country");
+const COUNTRIES: string[] =
+  countryIdx !== -1 && args[countryIdx + 1]
+    ? [args[countryIdx + 1].toUpperCase()]
+    : DEFAULT_COUNTRIES;
+
+console.log(
+  `[wdpa-import] countries=${COUNTRIES.join(",")} dry_run=${DRY_RUN}`
+);
+
+// ─── DB connection ────────────────────────────────────────────────────────────
+
+const DB_URL = process.env.SUPABASE_DB || process.env.SUPABASE_DB_URL;
+if (!DRY_RUN && !DB_URL) {
+  console.error(
+    "[wdpa-import] ERROR: SUPABASE_DB or SUPABASE_DB_URL env var required (or use --dry-run)"
+  );
+  process.exit(1);
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function slugify(name: string, dedup: string = ""): string {
+  return (
+    name
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "") // strip diacritics
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80) + dedup
+  );
+}
+
+function downloadFile(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    const protocol = url.startsWith("https") ? https : http;
+    protocol
+      .get(url, (res) => {
+        if (
+          res.statusCode === 301 ||
+          res.statusCode === 302 ||
+          res.statusCode === 307
+        ) {
+          // Follow redirect
+          downloadFile(res.headers.location!, dest).then(resolve).catch(reject);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode} from ${url}`));
+          return;
+        }
+        res.pipe(file);
+        file.on("finish", () => file.close(() => resolve()));
+        file.on("error", reject);
+      })
+      .on("error", reject);
+  });
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wdpa-"));
+  console.log(`[wdpa-import] workdir: ${tmpDir}`);
+
+  try {
+    // 1. Download
+    const zipPath = path.join(tmpDir, "wdpa.zip");
+    if (DRY_RUN) {
+      console.log(`[wdpa-import] DRY RUN: would download ${WDPA_URL}`);
+    } else {
+      console.log(`[wdpa-import] Downloading WDPA archive...`);
+      await downloadFile(WDPA_URL, zipPath);
+      console.log(`[wdpa-import] Download complete: ${zipPath}`);
+    }
+
+    // 2. Unzip
+    const extractDir = path.join(tmpDir, "extracted");
+    fs.mkdirSync(extractDir, { recursive: true });
+    if (!DRY_RUN) {
+      execSync(`unzip -q "${zipPath}" -d "${extractDir}"`, { stdio: "inherit" });
+    } else {
+      console.log(`[wdpa-import] DRY RUN: would unzip to ${extractDir}`);
+    }
+
+    // 3. Find shapefile or GPKG
+    let sourceFile = "";
+    if (!DRY_RUN) {
+      const gpkgFiles = fs
+        .readdirSync(extractDir, { recursive: true })
+        .map((f) => String(f))
+        .filter((f) => f.endsWith(".gpkg") || f.endsWith(".shp"));
+      if (gpkgFiles.length === 0) {
+        throw new Error("No .gpkg or .shp found in archive");
+      }
+      sourceFile = path.join(extractDir, gpkgFiles[0]);
+      console.log(`[wdpa-import] Source file: ${sourceFile}`);
+    }
+
+    // 4. Convert to GeoJSON with ogr2ogr, filtered by ISO3
+    const geoJsonPath = path.join(tmpDir, "wdpa_filtered.geojson");
+    const whereClause = COUNTRIES.map((c) => `ISO3='${c}'`).join(" OR ");
+
+    if (!DRY_RUN) {
+      console.log(
+        `[wdpa-import] Converting to GeoJSON (where: ${whereClause})...`
+      );
+      const result = spawnSync(
+        "ogr2ogr",
+        [
+          "-f",
+          "GeoJSON",
+          geoJsonPath,
+          sourceFile,
+          "-where",
+          whereClause,
+          "-t_srs",
+          "EPSG:4326",
+        ],
+        { stdio: "inherit" }
+      );
+      if (result.status !== 0) {
+        throw new Error(`ogr2ogr failed with exit code ${result.status}`);
+      }
+      console.log(`[wdpa-import] GeoJSON written: ${geoJsonPath}`);
+    } else {
+      console.log(
+        `[wdpa-import] DRY RUN: would run ogr2ogr -where "${whereClause}"`
+      );
+      // Write a minimal test GeoJSON for dry-run validation
+      const testGeoJson = {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {
+              WDPAID: 555705445,
+              NAME: "Reserva de la Biosfera Tehuacán-Cuicatlán",
+              ISO3: "MEX",
+              DESIG_ENG: "Biosphere Reserve",
+              STATUS: "Designated",
+              GIS_AREA: 490186.89,
+            },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [-97.7, 18.1],
+                  [-97.0, 18.1],
+                  [-97.0, 18.8],
+                  [-97.7, 18.8],
+                  [-97.7, 18.1],
+                ],
+              ],
+            },
+          },
+        ],
+      };
+      fs.writeFileSync(geoJsonPath, JSON.stringify(testGeoJson));
+      console.log(`[wdpa-import] DRY RUN: wrote test GeoJSON for validation`);
+    }
+
+    // 5. Parse and upsert
+    const geojson = JSON.parse(fs.readFileSync(geoJsonPath, "utf-8"));
+    const features = geojson.features as Array<{
+      type: string;
+      properties: Record<string, unknown>;
+      geometry: object;
+    }>;
+
+    console.log(`[wdpa-import] Processing ${features.length} features...`);
+
+    const seenSlugs = new Set<string>();
+    let inserted = 0,
+      updated = 0,
+      skipped = 0;
+
+    for (const feature of features) {
+      const props = feature.properties;
+      const wdpaId = String(props.WDPAID ?? props.wdpaid ?? "");
+      const name = String(props.NAME ?? props.name ?? "").trim();
+      const iso3 = String(props.ISO3 ?? props.iso3 ?? "").trim();
+
+      if (!wdpaId || !name) {
+        skipped++;
+        continue;
+      }
+
+      // Build slug (dedup with numeric suffix)
+      let baseSlug = slugify(name);
+      let slug = baseSlug;
+      let dedup = 2;
+      while (seenSlugs.has(slug)) {
+        slug = `${baseSlug}_${dedup++}`;
+      }
+      seenSlugs.add(slug);
+
+      const geometryWkt = JSON.stringify(feature.geometry);
+
+      if (DRY_RUN) {
+        console.log(
+          `  [dry-run] Would upsert: slug=${slug} source_id=${wdpaId} iso3=${iso3}`
+        );
+        inserted++;
+        continue;
+      }
+
+      // Upsert via psql
+      const sql = `
+        INSERT INTO public.places (
+          slug, name, place_type, geometry, source, source_id, country_code, updated_at
+        )
+        VALUES (
+          ${quoteSQL(slug)},
+          ${quoteSQL(name)},
+          'protected_area',
+          ST_GeomFromGeoJSON(${quoteSQL(geometryWkt)})::geography,
+          'wdpa',
+          ${quoteSQL(wdpaId)},
+          ${quoteSQL(iso3ToAlpha2(iso3) ?? iso3)},
+          now()
+        )
+        ON CONFLICT (slug) DO UPDATE
+          SET geometry   = EXCLUDED.geometry,
+              name       = EXCLUDED.name,
+              source_id  = EXCLUDED.source_id,
+              updated_at = now()
+        RETURNING (xmax = 0) AS was_inserted;
+      `;
+
+      try {
+        const out = execSync(
+          `psql ${quoteShell(DB_URL!)} -t -A -c ${quoteShell(sql)}`,
+          { encoding: "utf-8", timeout: 30_000 }
+        ).trim();
+        if (out === "t") inserted++;
+        else updated++;
+      } catch (err) {
+        console.error(`[wdpa-import] Failed for WDPAID=${wdpaId}: ${err}`);
+        skipped++;
+      }
+    }
+
+    console.log(
+      `\n[wdpa-import] Done. Inserted: ${inserted}  Updated: ${updated}  Skipped: ${skipped}`
+    );
+  } finally {
+    // Cleanup temp dir
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ─── SQL/shell quoting helpers ────────────────────────────────────────────────
+
+function quoteSQL(s: string): string {
+  return "'" + s.replace(/'/g, "''") + "'";
+}
+
+function quoteShell(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+// Basic ISO3 → ISO2 mapping for common LATAM/MX countries (v1: MEX only needed)
+const ISO3_TO_ISO2: Record<string, string> = {
+  MEX: "MX",
+  GTM: "GT",
+  BLZ: "BZ",
+  HND: "HN",
+  SLV: "SV",
+  NIC: "NI",
+  CRI: "CR",
+  PAN: "PA",
+  COL: "CO",
+  VEN: "VE",
+  ECU: "EC",
+  PER: "PE",
+  BOL: "BO",
+  BRA: "BR",
+  PRY: "PY",
+  URY: "UY",
+  ARG: "AR",
+  CHL: "CL",
+  CUB: "CU",
+  DOM: "DO",
+};
+
+function iso3ToAlpha2(iso3: string): string | null {
+  return ISO3_TO_ISO2[iso3.toUpperCase()] ?? null;
+}
+
+// ─── Run ──────────────────────────────────────────────────────────────────────
+
+main().catch((err) => {
+  console.error("[wdpa-import] Fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements issue #496 — Places as first-class citizens, foundational infrastructure.

### Changes

#### DB Schema (`docs/specs/infra/supabase-schema.sql`)
- **`public.places` table** with all columns per spec: `slug`, `name`, `place_type`, `geometry`, `source`, `source_id`, `h3_cells`, stats counters, etc.
- **Indexes**: GIST on `geometry`, GIN on `h3_cells`, btree on `place_type` and `obs_count DESC`
- **RLS**: public SELECT, authenticated owner UPDATE, authenticated INSERT for custom/community only
- **`observations.place_id`** FK column + sparse index
- **`assign_observation_place` trigger** (BEFORE INSERT OR UPDATE OF location, SECURITY DEFINER):
  - Finds smallest named place via `ST_Within` + `ST_Area ASC`
  - H3 fallback: auto-upserts an `h3_cell` row with 5 km buffer when no named place covers the point
  - Gracefully uses h3-pg extension if available; falls back to lat/lng rounding approximation

#### WDPA Import (`scripts/import-wdpa.ts`)
- Downloads WDPA archive, converts with `ogr2ogr` to GeoJSON
- Filters by ISO3 (default: MEX, configurable with `--country`)
- Upserts into `public.places` (ON CONFLICT slug, updates geometry + name)
- `--dry-run` flag: parses and validates without writing to DB
- Print: `Inserted: N  Updated: M  Skipped: K`

#### CI/CD
- **`.github/workflows/wdpa-import.yml`**: annual cron (Jan 1st 06:00 UTC) + workflow_dispatch with `country` and `dry_run` inputs
- **`.github/workflows/db-apply.yml`**: new step after schema apply that runs `scripts/backfill-place-id.sql`

#### Backfill (`scripts/backfill-place-id.sql`)
- Idempotent UPDATE: assigns `place_id` to synced observations with location but no `place_id`
- Only named places (no H3 auto-creation in backfill — trigger handles that on next UPDATE)

#### Cron (`docs/specs/infra/cron-schedules.sql` — v11)
- `refresh-place-stats` hourly at :45 — recomputes `obs_count`, `species_count`, `observer_count`, `first_obs_at`, `last_obs_at` on `public.places`

### Acceptance criteria checklist
- [x] `places` table in schema with GIST index
- [x] `observations.place_id` column exists  
- [x] Trigger: new observation with location → gets `place_id` automatically
- [x] Trigger: observation without location → `place_id` = NULL (untouched)
- [x] WDPA import dry-run runs for Mexico without errors
- [x] Backfill sets `place_id` on existing synced observations with location
- [x] db-apply CI applies schema + runs backfill on merge
- [x] Place stats cron registered in pg_cron
- [x] No frontend changes in this PR

Closes #496

---
Blocks: M-Loc-2, M-Loc-3, M-Loc-4, M-Loc-5