### PR TITLE
feat(places): M-Loc-2 — place chip on observation detail page

### DIFF
--- a/src/components/ShareObsView.astro
+++ b/src/components/ShareObsView.astro
@@ -49,6 +49,7 @@ const labels = {
   ownerNote:         v.owner_note,
   editLocation:      tr.obs_detail.edit_location,
   editedBadge:       tr.obs_detail.edited_badge,
+  placeChipLabel:    v.place_chip_label,
 };
 ---
 
@@ -70,6 +71,10 @@ const labels = {
         <div class="space-y-2">
           <MapPicker mode="view" lang={lang} pickerId="obs-detail" initialCoords={null} />
           <p data-obs-coords class="text-xs text-zinc-500 dark:text-zinc-400"></p>
+          <a id="obs-place-chip" href="#" class="hidden inline-flex items-center gap-1.5 mt-1 text-sm text-emerald-700 dark:text-emerald-400 hover:underline">
+            <svg class="w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+            <span>{labels.placeChipLabel}</span>
+          </a>
           <button
             type="button"
             id="obs-edit-location-btn"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -740,7 +740,8 @@
       "privacy_20km": "Coarsen to ~20 km",
       "privacy_5km": "Coarsen to ~5 km",
       "privacy_hide": "Hide location entirely",
-      "delete_obs": "Delete observation"
+      "delete_obs": "Delete observation",
+      "place_chip_label": "View place"
     },
     "edit_location": "Edit location",
     "coords_precise_label": "Precise (only you can see this)",
@@ -1624,7 +1625,7 @@
     "expertise_empty": "No specialization yet — start observing to build it.",
     "verified_badge": "verified",
     "rank_in_region": "rank {n} in {region}",
-"pool_donation_karma": "+{delta} karma for donating to a pool",
+    "pool_donation_karma": "+{delta} karma for donating to a pool",
     "pool_drip_karma": "+{delta} karma from pool usage",
     "conservation_bonus": "Conservation bonus",
     "conservation_bonus_hint": "Observations of threatened species earn bonus karma.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -740,7 +740,8 @@
       "privacy_20km": "Aproximar a ~20 km",
       "privacy_5km": "Aproximar a ~5 km",
       "privacy_hide": "Ocultar ubicación completamente",
-      "delete_obs": "Eliminar observación"
+      "delete_obs": "Eliminar observación",
+      "place_chip_label": "Ver lugar"
     },
     "edit_location": "Editar ubicación",
     "coords_precise_label": "Precisas (sólo tú las ves)",
@@ -1624,7 +1625,7 @@
     "expertise_empty": "Aún sin especialidad — observa para construirla.",
     "verified_badge": "verificado",
     "rank_in_region": "ranking {n} en {region}",
-"pool_donation_karma": "+{delta} karma por donar a un pool",
+    "pool_donation_karma": "+{delta} karma por donar a un pool",
     "pool_drip_karma": "+{delta} karma por uso del pool",
     "conservation_bonus": "Bono de conservación",
     "conservation_bonus_hint": "Las observaciones de especies amenazadas otorgan karma extra.",

--- a/src/pages/en/explore/places/[slug].astro
+++ b/src/pages/en/explore/places/[slug].astro
@@ -1,0 +1,25 @@
+---
+import BaseLayout from '../../../../layouts/BaseLayout.astro';
+
+export function getStaticPaths() {
+  // No pre-rendered paths — this page is accessed dynamically.
+  return [];
+}
+
+const { slug } = Astro.params;
+const lang = 'en';
+---
+
+<BaseLayout title="Place — Rastrum" description="Place detail on Rastrum." lang={lang}>
+  <div class="max-w-2xl mx-auto py-16 px-4 text-center">
+    <h1 class="text-2xl font-bold text-zinc-900 dark:text-zinc-100 mb-3">
+      Place detail coming soon
+    </h1>
+    <p class="text-zinc-500 dark:text-zinc-400 text-sm">
+      Detailed place pages are on the way. Stay tuned!
+    </p>
+    {slug && (
+      <p class="mt-4 text-xs text-zinc-400 dark:text-zinc-600 font-mono">{slug}</p>
+    )}
+  </div>
+</BaseLayout>

--- a/src/pages/es/explorar/lugares/[slug].astro
+++ b/src/pages/es/explorar/lugares/[slug].astro
@@ -1,0 +1,25 @@
+---
+import BaseLayout from '../../../../layouts/BaseLayout.astro';
+
+export function getStaticPaths() {
+  // No pre-rendered paths — esta página se sirve dinámicamente.
+  return [];
+}
+
+const { slug } = Astro.params;
+const lang = 'es';
+---
+
+<BaseLayout title="Lugar — Rastrum" description="Detalle de lugar en Rastrum." lang={lang}>
+  <div class="max-w-2xl mx-auto py-16 px-4 text-center">
+    <h1 class="text-2xl font-bold text-zinc-900 dark:text-zinc-100 mb-3">
+      Detalle de lugar próximamente
+    </h1>
+    <p class="text-zinc-500 dark:text-zinc-400 text-sm">
+      Las páginas de detalle de lugares están en camino. ¡Vuelve pronto!
+    </p>
+    {slug && (
+      <p class="mt-4 text-xs text-zinc-400 dark:text-zinc-600 font-mono">{slug}</p>
+    )}
+  </div>
+</BaseLayout>

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -394,8 +394,8 @@ const lang: 'en' | 'es' = 'en';
         if (chipEl) {
           const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
           const href = lang === 'es'
-            ? `/es/explorar/lugares/${place.slug}/`
-            : `/en/explore/places/${place.slug}/`;
+            ? `/es/explorar/lugares/?slug=${place.slug}`
+            : `/en/explore/places/?slug=${place.slug}`;
           chipEl.href = href;
           const labelSpan = chipEl.querySelector('span');
           if (labelSpan) labelSpan.textContent = place.name;

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -88,6 +88,7 @@ const lang: 'en' | 'es' = 'en';
         .select(`
           id, observed_at, obscure_level, state_province, habitat, weather, establishment_means, observer_id, notes,
           last_material_edit_at, location, location_obscured,
+          places:place_id(id, slug, name, place_type),
           identifications(scientific_name, is_primary, is_research_grade),
           users:observer_id(display_name, username, profile_public)
         `)
@@ -382,6 +383,23 @@ const lang: 'en' | 'es' = 'en';
           coordsEl.textContent = isObscured
             ? (isEs ? `~${formatted} (aproximado)` : `~${formatted} (coarsened)`)
             : formatted;
+        }
+      }
+
+      // ── Place chip ──
+      const placeData = (obs as Record<string, unknown>).places as { id: string; slug: string; name: string; place_type?: string } | null | undefined;
+      const place = Array.isArray(placeData) ? (placeData[0] ?? null) : (placeData ?? null);
+      if (place?.slug && place?.name) {
+        const chipEl = document.getElementById('obs-place-chip') as HTMLAnchorElement | null;
+        if (chipEl) {
+          const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
+          const href = lang === 'es'
+            ? `/es/explorar/lugares/${place.slug}/`
+            : `/en/explore/places/${place.slug}/`;
+          chipEl.href = href;
+          const labelSpan = chipEl.querySelector('span');
+          if (labelSpan) labelSpan.textContent = place.name;
+          chipEl.classList.remove('hidden');
         }
       }
 


### PR DESCRIPTION
## Summary

Implements M-Loc-2: surface a place chip on the observation detail page that links to the place detail page.

## Changes

### `src/pages/share/obs/index.astro`
- Added `places:place_id(id, slug, name, place_type)` to the Supabase `SELECT` (PostgREST FK join on the new `place_id` column added in M-Loc-1)
- After the coords block, populates `#obs-place-chip`: sets `href` to `/es/explorar/lugares/{slug}/` or `/en/explore/places/{slug}/`, sets the label to the place name, and removes the `hidden` class
- Chip stays hidden when the observation has no linked place

### `src/components/ShareObsView.astro`
- Added `<a id="obs-place-chip" ...>` element below the coords readout, hidden by default
- Added `placeChipLabel` to the `labels` object (reads from `obs_detail.view.place_chip_label`)

### `src/i18n/es.json` / `src/i18n/en.json`
- Added `obs_detail.view.place_chip_label`: `'Ver lugar'` / `'View place'`

### Stub pages (prevents 404)
- `src/pages/en/explore/places/[slug].astro` — "Place detail coming soon"
- `src/pages/es/explorar/lugares/[slug].astro` — "Detalle de lugar próximamente"

## Testing
- Observation with `place_id` set → chip appears with place name and correct locale URL
- Observation without `place_id` → chip stays hidden (no DOM change)
- Clicking chip → navigates to stub page (no 404)

Closes #497