### PR TITLE
feat(places-ux): autocomplete search, skeleton loading, compare UX

### DIFF
--- a/src/components/ExplorePlacesView.astro
+++ b/src/components/ExplorePlacesView.astro
@@ -59,12 +59,25 @@ const placesIndexBase = `/${lang}/${lang === 'es' ? 'explorar/lugares' : 'explor
 
     <!-- Search + filter bar -->
     <div class="flex flex-col sm:flex-row gap-3 mb-6">
-      <input
-        id="places-search"
-        type="search"
-        placeholder={page.search_placeholder}
-        class="flex-1 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2 text-sm text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-      />
+      <div class="relative flex-1">
+        <input
+          id="places-search"
+          type="search"
+          autocomplete="off"
+          placeholder={page.search_placeholder}
+          class="w-full rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2 pl-9 text-sm text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+        <!-- Search icon -->
+        <svg class="absolute left-2.5 top-2.5 h-4 w-4 text-zinc-400 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        <!-- Autocomplete dropdown -->
+        <ul
+          id="places-autocomplete"
+          class="hidden absolute z-50 top-full left-0 right-0 mt-1 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg overflow-hidden max-h-60 overflow-y-auto"
+          role="listbox"
+        ></ul>
+      </div>
       <select
         id="places-type-filter"
         class="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-2 focus:ring-emerald-500"
@@ -276,13 +289,98 @@ const placesIndexBase = `/${lang}/${lang === 'es' ? 'explorar/lugares' : 'explor
     }
   }
 
-  // Search — debounce 300ms
+  // Autocomplete
+  const autocompleteEl = document.getElementById('places-autocomplete') as HTMLUListElement;
+  let acTimer: ReturnType<typeof setTimeout>;
+  let acActive = -1;
+
+  function hideAC() {
+    autocompleteEl.classList.add('hidden');
+    autocompleteEl.innerHTML = '';
+    acActive = -1;
+  }
+
+  function showAC(results: { slug: string; name: string; place_type: string; obs_count: number }[]) {
+    if (!results.length) { hideAC(); return; }
+    const placeBase = isEs ? '/es/explorar/lugares/?slug=' : '/en/explore/places/?slug=';
+    const typeLabelFn = (t: string) => ({
+      protected_area: isEs ? 'Área Protegida' : 'Protected Area',
+      h3_cell: isEs ? 'Zona H3' : 'H3 Zone',
+      custom: isEs ? 'Custom' : 'Custom',
+      community: isEs ? 'Comunitario' : 'Community',
+    }[t] ?? t);
+
+    autocompleteEl.innerHTML = results.map((p, i) =>
+      `<li role="option" data-slug="${p.slug}" data-idx="${i}"
+        class="flex items-center justify-between px-4 py-2.5 cursor-pointer hover:bg-emerald-50 dark:hover:bg-emerald-900/20 border-b border-zinc-100 dark:border-zinc-800 last:border-0 text-sm">
+        <span>
+          <span class="font-medium text-zinc-900 dark:text-zinc-100">${p.name}</span>
+          <span class="ml-2 text-xs text-zinc-400">${typeLabelFn(p.place_type)}</span>
+        </span>
+        <span class="text-xs text-zinc-400 shrink-0">${p.obs_count} obs</span>
+      </li>`
+    ).join('');
+    autocompleteEl.classList.remove('hidden');
+
+    autocompleteEl.querySelectorAll('li').forEach(li => {
+      li.addEventListener('mousedown', e => {
+        e.preventDefault();
+        const slug = (li as HTMLElement).dataset.slug!;
+        const name = li.querySelector('.font-medium')!.textContent!;
+        searchEl.value = name;
+        searchQuery = name;
+        hideAC();
+        // Navigate directly to place detail
+        window.location.href = placeBase + slug;
+      });
+    });
+  }
+
+  // Search — debounce 300ms + autocomplete
   searchEl.addEventListener('input', () => {
     clearTimeout(debounceTimer);
+    clearTimeout(acTimer);
+    const val = searchEl.value.trim();
+    if (val.length < 2) { hideAC(); }
+    acTimer = setTimeout(async () => {
+      if (val.length < 2) return;
+      const supabase = getSupabase();
+      const { data } = await supabase
+        .from('places')
+        .select('slug, name, place_type, obs_count')
+        .ilike('name', `${val}%`)
+        .order('obs_count', { ascending: false })
+        .limit(6);
+      showAC(data ?? []);
+    }, 200);
     debounceTimer = setTimeout(() => {
-      searchQuery = searchEl.value.trim();
+      searchQuery = val;
       resetAndFetch();
     }, 300);
+  });
+
+  // Keyboard navigation for autocomplete
+  searchEl.addEventListener('keydown', e => {
+    const items = autocompleteEl.querySelectorAll('li');
+    if (!items.length) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      acActive = Math.min(acActive + 1, items.length - 1);
+      items.forEach((li, i) => li.classList.toggle('bg-emerald-50', i === acActive));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      acActive = Math.max(acActive - 1, -1);
+      items.forEach((li, i) => li.classList.toggle('bg-emerald-50', i === acActive));
+    } else if (e.key === 'Enter' && acActive >= 0) {
+      e.preventDefault();
+      (items[acActive] as HTMLElement).dispatchEvent(new MouseEvent('mousedown'));
+    } else if (e.key === 'Escape') {
+      hideAC();
+    }
+  });
+
+  document.addEventListener('click', e => {
+    if (!searchEl.contains(e.target as Node) && !autocompleteEl.contains(e.target as Node)) hideAC();
   });
 
   // Type filter

--- a/src/components/PlaceDetailView.astro
+++ b/src/components/PlaceDetailView.astro
@@ -9,12 +9,19 @@ const { lang } = Astro.props;
 ---
 <div id="place-detail-root">
   <!-- Loading state -->
-  <div id="place-loading" class="flex items-center justify-center py-16 text-zinc-400">
-    <svg class="animate-spin h-6 w-6 mr-2" fill="none" viewBox="0 0 24 24">
-      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
-    </svg>
-    <span id="place-loading-text">Loading...</span>
+  <div id="place-loading" class="max-w-4xl mx-auto px-4 py-6 space-y-4 animate-pulse">
+    <!-- Skeleton header -->
+    <div class="h-5 w-24 rounded bg-zinc-200 dark:bg-zinc-700"></div>
+    <div class="h-8 w-2/3 rounded bg-zinc-200 dark:bg-zinc-700"></div>
+    <div class="h-4 w-1/3 rounded bg-zinc-200 dark:bg-zinc-700"></div>
+    <!-- Skeleton stats -->
+    <div class="flex gap-6 py-3 border-y border-zinc-100 dark:border-zinc-800">
+      <div class="h-4 w-20 rounded bg-zinc-200 dark:bg-zinc-700"></div>
+      <div class="h-4 w-20 rounded bg-zinc-200 dark:bg-zinc-700"></div>
+      <div class="h-4 w-20 rounded bg-zinc-200 dark:bg-zinc-700"></div>
+    </div>
+    <!-- Skeleton map -->
+    <div class="rounded-lg bg-zinc-200 dark:bg-zinc-700" style="height:min(50vh,360px)"></div>
   </div>
 
   <!-- Error state -->
@@ -117,7 +124,7 @@ const { lang } = Astro.props;
 
   async function load() {
     const supabase = getSupabase();
-    document.getElementById('place-loading-text')!.textContent = tr.loading;
+    // skeleton is already visible on load
 
     // Fetch place with geometry via RPC (geometry is EWKB from REST, use RPC for GeoJSON)
     const { data: place, error } = await supabase

--- a/src/pages/en/explore/places/compare/index.astro
+++ b/src/pages/en/explore/places/compare/index.astro
@@ -7,12 +7,21 @@ import BaseLayout from '../../../../../layouts/BaseLayout.astro';
 
   <!-- Controls -->
   <div class="flex flex-col sm:flex-row gap-3 mb-8">
-    <input id="slug-a" type="text" placeholder="Place slug A (e.g. reserva-biosfera-tehuacan)"
-      class="flex-1 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500" />
-    <input id="slug-b" type="text" placeholder="Place slug B"
-      class="flex-1 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500" />
+    <div class="relative flex-1">
+      <input id="slug-a" type="text" autocomplete="off" placeholder="Search place A..."
+        class="w-full rounded-lg border border-emerald-300 dark:border-emerald-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500" />
+      <span class="absolute left-2.5 top-2 text-emerald-500 font-bold text-xs pointer-events-none">A</span>
+      <ul id="ac-a" class="hidden absolute z-50 top-full left-0 right-0 mt-1 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg overflow-hidden max-h-48 overflow-y-auto" role="listbox"></ul>
+    </div>
+    <div class="relative flex-1">
+      <input id="slug-b" type="text" autocomplete="off" placeholder="Search place B..."
+        class="w-full rounded-lg border border-amber-300 dark:border-amber-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500" />
+      <span class="absolute left-2.5 top-2 text-amber-500 font-bold text-xs pointer-events-none">B</span>
+      <ul id="ac-b" class="hidden absolute z-50 top-full left-0 right-0 mt-1 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg overflow-hidden max-h-48 overflow-y-auto" role="listbox"></ul>
+    </div>
     <button id="compare-btn"
-      class="px-5 py-2 text-sm font-medium rounded-lg bg-emerald-600 text-white hover:bg-emerald-700">
+      class="px-5 py-2 text-sm font-medium rounded-lg bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
+      disabled>
       Compare
     </button>
   </div>
@@ -63,19 +72,74 @@ import BaseLayout from '../../../../../layouts/BaseLayout.astro';
 <script>
   import { getSupabase } from '../../../../../lib/supabase';
 
+  // Autocomplete helper for slug inputs
+  function wireAC(inputId: string, acId: string, onSelect: (slug: string, name: string) => void) {
+    const input = document.getElementById(inputId) as HTMLInputElement;
+    const ac = document.getElementById(acId) as HTMLUListElement;
+    let timer: ReturnType<typeof setTimeout>;
+
+    input.addEventListener('input', () => {
+      clearTimeout(timer);
+      const val = input.value.trim();
+      if (val.length < 2) { ac.classList.add('hidden'); return; }
+      timer = setTimeout(async () => {
+        const supabase = getSupabase();
+        const { data } = await supabase
+          .from('places').select('slug, name, place_type, obs_count')
+          .ilike('name', `${val}%`).order('obs_count', { ascending: false }).limit(5);
+        if (!data?.length) { ac.classList.add('hidden'); return; }
+        ac.innerHTML = (data ?? []).map(p =>
+          `<li data-slug="${p.slug}" data-name="${p.name}"
+            class="px-3 py-2 text-sm cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800 border-b border-zinc-100 dark:border-zinc-800 last:border-0 flex justify-between">
+            <span class="font-medium text-zinc-900 dark:text-zinc-100">${p.name}</span>
+            <span class="text-xs text-zinc-400">${p.obs_count} obs</span>
+          </li>`
+        ).join('');
+        ac.classList.remove('hidden');
+        ac.querySelectorAll('li').forEach(li => {
+          li.addEventListener('mousedown', e => {
+            e.preventDefault();
+            const slug = (li as HTMLElement).dataset.slug!;
+            const name = (li as HTMLElement).dataset.name!;
+            input.value = name;
+            (input as HTMLInputElement & { dataset: DOMStringMap }).dataset.slug = slug;
+            ac.classList.add('hidden');
+            onSelect(slug, name);
+          });
+        });
+      }, 200);
+    });
+    document.addEventListener('click', e => {
+      if (!input.contains(e.target as Node)) ac.classList.add('hidden');
+    });
+  }
+
+  const slugAEl = document.getElementById('slug-a') as HTMLInputElement & { dataset: DOMStringMap };
+  const slugBEl = document.getElementById('slug-b') as HTMLInputElement & { dataset: DOMStringMap };
+  const btn = document.getElementById('compare-btn') as HTMLButtonElement;
+
+  function updateBtn() {
+    btn.disabled = !(slugAEl.dataset.slug && slugBEl.dataset.slug);
+  }
+
+  wireAC('slug-a', 'ac-a', (slug, _name) => { slugAEl.dataset.slug = slug; updateBtn(); });
+  wireAC('slug-b', 'ac-b', (slug, _name) => { slugBEl.dataset.slug = slug; updateBtn(); });
+
   // Pre-fill from query params
   const params = new URLSearchParams(window.location.search);
   const paramA = params.get('a') ?? '';
   const paramB = params.get('b') ?? '';
-  if (paramA) (document.getElementById('slug-a') as HTMLInputElement).value = paramA;
-  if (paramB) (document.getElementById('slug-b') as HTMLInputElement).value = paramB;
+  if (paramA) { slugAEl.value = paramA; slugAEl.dataset.slug = paramA; }
+  if (paramB) { slugBEl.value = paramB; slugBEl.dataset.slug = paramB; }
+  updateBtn();
 
-  document.getElementById('compare-btn')!.addEventListener('click', doCompare);
+  btn.addEventListener('click', doCompare);
   if (paramA && paramB) doCompare();
 
   async function doCompare() {
-    const slugA = (document.getElementById('slug-a') as HTMLInputElement).value.trim();
-    const slugB = (document.getElementById('slug-b') as HTMLInputElement).value.trim();
+    // Use dataset.slug if set (from autocomplete), else treat input value as slug directly
+    const slugA = slugAEl.dataset.slug || slugAEl.value.trim();
+    const slugB = slugBEl.dataset.slug || slugBEl.value.trim();
     if (!slugA || !slugB) return;
 
     const loading = document.getElementById('compare-loading')!;


### PR DESCRIPTION
## Changes

### Search autocomplete (ExplorePlacesView)
- Dropdown below search field with top-6 matching places as you type
- Shows place name, type label, obs count per suggestion
- Keyboard nav: ↑↓ to select, Enter to go, Esc to dismiss
- Click on suggestion navigates directly to place detail page
- Closes on outside click

### Compare page UX
- Autocomplete on both A and B inputs
- Color-coded borders: emerald for A, amber for B
- Compare button disabled until both places picked via autocomplete
- Falls back to typed slug if user skips autocomplete

### Skeleton loading in PlaceDetailView
- Animated placeholder skeleton matching header + stats + map layout
- No spinner flash, no layout shift when data loads