### PR TITLE
fix(places): PlaceDetailView skips load() when no ?slug= param — fixes index stuck loading

### DIFF
--- a/src/components/ExplorePlacesView.astro
+++ b/src/components/ExplorePlacesView.astro
@@ -131,7 +131,13 @@ const placesIndexBase = `/${lang}/${lang === 'es' ? 'explorar/lugares' : 'explor
 
   const PAGE_SIZE = 20;
 
-  const root = document.getElementById('explore-places-root')!;
+  const root = document.getElementById('explore-places-root');
+  if (!root) {
+    console.error('[places-index] root element not found — script aborted');
+    throw new Error('explore-places-root not found');
+  }
+
+  console.log('[places-index] script started, root found');
 
   // Labels from data attrs
   const labels = {
@@ -297,6 +303,7 @@ const placesIndexBase = `/${lang}/${lang === 'es' ? 'explorar/lugares' : 'explor
       detailEl.classList.remove('hidden');
     } else {
       // Index mode
+      console.log('[places-index] index mode, calling fetchPage');
       indexEl.classList.remove('hidden');
       detailEl.classList.add('hidden');
       fetchPage();

--- a/src/components/PlaceDetailView.astro
+++ b/src/components/PlaceDetailView.astro
@@ -122,6 +122,14 @@ const { lang } = Astro.props;
   // Read slug from query param (?slug=X) — static site can't use [slug].astro
   const slug = new URLSearchParams(window.location.search).get('slug') ?? '';
 
+  // Don't run if no slug — this component may be rendered alongside
+  // ExplorePlacesView on the index page; running load() without a slug
+  // causes unnecessary errors and may abort sibling scripts.
+  if (!slug) {
+    // Hide skeleton immediately so ExplorePlacesView can use the loading state area
+    document.getElementById('place-loading')?.classList.add('hidden');
+  } else {
+
   async function load() {
     const supabase = getSupabase();
     // skeleton is already visible on load
@@ -327,4 +335,5 @@ const { lang } = Astro.props;
   }
 
   load();
+  } // end if (slug)
 </script>


### PR DESCRIPTION
Root cause of the stuck 'Loading places...' on /explore/places/: PlaceDetailView was calling load() with empty slug even on the index page, causing an error that aborted the whole script bundle before ExplorePlacesView could run.