### PR TITLE
feat(identifiers): distilled SpeciesNet on-device animal classifier (#175)

### DIFF
--- a/src/lib/identifiers/index.ts
+++ b/src/lib/identifiers/index.ts
@@ -16,6 +16,7 @@ import { phiVisionIdentifier } from './phi-vision';
 import { birdnetIdentifier } from './birdnet';
 import { onnxBaseIdentifier } from './onnx-base';
 import { cameraTrapMegadetectorIdentifier } from './camera-trap-megadetector';
+import { speciesnetIdentifier } from './speciesnet';
 
 let booted = false;
 export function bootstrapIdentifiers() {
@@ -26,6 +27,7 @@ export function bootstrapIdentifiers() {
   registry.register(birdnetIdentifier);
   registry.register(onnxBaseIdentifier);
   registry.register(cameraTrapMegadetectorIdentifier);
+  registry.register(speciesnetIdentifier);
   booted = true;
   return registry;
 }

--- a/src/lib/identifiers/speciesnet-cache.ts
+++ b/src/lib/identifiers/speciesnet-cache.ts
@@ -1,0 +1,139 @@
+/**
+ * SpeciesNet distilled model weight cache — mirrors `megadetector-cache.ts`.
+ *
+ * Files we cache (Cache API, key = absolute URL):
+ *   - speciesnet_distilled_v1.onnx  (~100 MB; distilled EfficientNet ONNX)
+ *
+ * The weights URL comes from `import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL`.
+ * Until the operator trains, converts, and hosts the file the plugin
+ * reports `model_not_bundled` and the cascade transparently falls through.
+ *
+ * Operator action: train a distilled SpeciesNet on iWildCam categories,
+ * export to ONNX, INT8-quantise, and upload to a CORS-open public URL
+ * (e.g. Cloudflare R2 under media.rastrum.org/models/). Set
+ * `PUBLIC_SPECIESNET_WEIGHTS_URL` to the full URL of the ONNX file.
+ *
+ * License: code MIT (this file). Model: TBD (depends on training data).
+ */
+
+export const SPECIESNET_CACHE_NAME = 'rastrum/speciesnet';
+export const SPECIESNET_MODEL_FILE = 'speciesnet_distilled_v1.onnx';
+
+export interface SpeciesNetCacheStatus {
+  modelCached: boolean;
+  approxBytes: number;
+}
+
+export function getSpeciesNetWeightsUrl(): string | null {
+  const raw = import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL;
+  if (!raw || typeof raw !== 'string') return null;
+  return raw.replace(/\/+$/, '') || null;
+}
+
+function modelUrl(): string | null {
+  const base = getSpeciesNetWeightsUrl();
+  return base ? `${base}/${SPECIESNET_MODEL_FILE}` : null;
+}
+
+async function openCache(): Promise<Cache | null> {
+  if (typeof caches === 'undefined') return null;
+  return caches.open(SPECIESNET_CACHE_NAME).catch(() => null);
+}
+
+async function matchByFile(cache: Cache, file: string): Promise<Response | undefined> {
+  const keys = await cache.keys();
+  for (const req of keys) {
+    if (req.url.endsWith(`/${file}`)) return cache.match(req);
+  }
+  return undefined;
+}
+
+export async function getSpeciesNetCacheStatus(): Promise<SpeciesNetCacheStatus> {
+  const cache = await openCache();
+  if (!cache) return { modelCached: false, approxBytes: 0 };
+  const res = await matchByFile(cache, SPECIESNET_MODEL_FILE);
+  if (!res) return { modelCached: false, approxBytes: 0 };
+  const len = res.headers.get('content-length');
+  return { modelCached: true, approxBytes: len ? parseInt(len, 10) : 0 };
+}
+
+export interface SpeciesNetDownloadProgress {
+  bytesLoaded: number;
+  bytesTotal: number;
+  /** 0..1 when totals are known. */
+  progress: number;
+  text: string;
+}
+
+export async function downloadSpeciesNetWeights(
+  onProgress: (p: SpeciesNetDownloadProgress) => void = () => {},
+  signal?: AbortSignal,
+): Promise<void> {
+  const url = modelUrl();
+  if (!url) {
+    throw new Error(
+      'SpeciesNet weights URL is not configured. Set PUBLIC_SPECIESNET_WEIGHTS_URL to the base URL hosting speciesnet_distilled_v1.onnx.',
+    );
+  }
+  if (typeof caches === 'undefined') {
+    throw new Error('Cache API is not available in this browser.');
+  }
+  const cache = await caches.open(SPECIESNET_CACHE_NAME);
+
+  const res = await fetch(url, { mode: 'cors', signal });
+  if (!res.ok || !res.body) {
+    throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);
+  }
+
+  const lenHeader = res.headers.get('content-length');
+  const bytesTotal = lenHeader ? parseInt(lenHeader, 10) : 0;
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytesLoaded = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      bytesLoaded += value.length;
+      const ratio = bytesTotal > 0 ? bytesLoaded / bytesTotal : 0;
+      onProgress({
+        bytesLoaded,
+        bytesTotal,
+        progress: ratio,
+        text: bytesTotal > 0 ? `${Math.round(ratio * 100)}%` : `${bytesLoaded}`,
+      });
+    }
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const body = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) { body.set(c, off); off += c.length; }
+  const headers = new Headers(res.headers);
+  if (!headers.has('content-length')) headers.set('content-length', String(total));
+  await cache.put(url, new Response(body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  }));
+}
+
+export async function getCachedSpeciesNetBuffer(): Promise<ArrayBuffer | null> {
+  const cache = await openCache();
+  if (!cache) return null;
+  const res = await matchByFile(cache, SPECIESNET_MODEL_FILE);
+  if (!res) return null;
+  return res.arrayBuffer();
+}
+
+export async function clearSpeciesNetCache(): Promise<{ deleted: number }> {
+  const cache = await openCache();
+  if (!cache) return { deleted: 0 };
+  const keys = await cache.keys();
+  let deleted = 0;
+  for (const req of keys) {
+    const ok = await cache.delete(req);
+    if (ok) deleted++;
+  }
+  return { deleted };
+}

--- a/src/lib/identifiers/speciesnet-labels.ts
+++ b/src/lib/identifiers/speciesnet-labels.ts
@@ -1,0 +1,50 @@
+/**
+ * Placeholder label map for the distilled SpeciesNet ONNX classifier.
+ *
+ * ~20 representative Neotropical species from the iWildCam / camera-trap
+ * domain. The real label map ships with the trained model — the training
+ * pipeline emits a JSON file that replaces this array verbatim.
+ *
+ * Each entry maps a class index (output neuron) to taxonomy metadata.
+ * The `index` field must be unique and contiguous starting from 0.
+ */
+
+export interface SpeciesNetLabel {
+  index: number;
+  scientific_name: string;
+  common_name_en: string;
+  common_name_es: string;
+  family: string;
+  kingdom: 'Animalia';
+}
+
+export const SPECIESNET_LABELS: readonly SpeciesNetLabel[] = [
+  { index: 0,  scientific_name: 'Odocoileus virginianus',       common_name_en: 'White-tailed deer',              common_name_es: 'Venado cola blanca',       family: 'Cervidae',        kingdom: 'Animalia' },
+  { index: 1,  scientific_name: 'Pecari tajacu',                common_name_en: 'Collared peccary',               common_name_es: 'Pecarí de collar',         family: 'Tayassuidae',     kingdom: 'Animalia' },
+  { index: 2,  scientific_name: 'Nasua narica',                 common_name_en: 'White-nosed coati',              common_name_es: 'Coatí',                    family: 'Procyonidae',     kingdom: 'Animalia' },
+  { index: 3,  scientific_name: 'Leopardus pardalis',           common_name_en: 'Ocelot',                         common_name_es: 'Ocelote',                  family: 'Felidae',         kingdom: 'Animalia' },
+  { index: 4,  scientific_name: 'Herpailurus yagouaroundi',     common_name_en: 'Jaguarundi',                     common_name_es: 'Jaguarundi',               family: 'Felidae',         kingdom: 'Animalia' },
+  { index: 5,  scientific_name: 'Panthera onca',                common_name_en: 'Jaguar',                         common_name_es: 'Jaguar',                   family: 'Felidae',         kingdom: 'Animalia' },
+  { index: 6,  scientific_name: 'Dasypus novemcinctus',         common_name_en: 'Nine-banded armadillo',          common_name_es: 'Armadillo',                family: 'Dasypodidae',     kingdom: 'Animalia' },
+  { index: 7,  scientific_name: 'Cuniculus paca',               common_name_en: 'Lowland paca',                   common_name_es: 'Tepezcuintle',             family: 'Cuniculidae',     kingdom: 'Animalia' },
+  { index: 8,  scientific_name: 'Didelphis virginiana',         common_name_en: 'Virginia opossum',               common_name_es: 'Tlacuache',                family: 'Didelphidae',     kingdom: 'Animalia' },
+  { index: 9,  scientific_name: 'Urocyon cinereoargenteus',     common_name_en: 'Gray fox',                       common_name_es: 'Zorra gris',               family: 'Canidae',         kingdom: 'Animalia' },
+  { index: 10, scientific_name: 'Procyon lotor',                common_name_en: 'Raccoon',                        common_name_es: 'Mapache',                  family: 'Procyonidae',     kingdom: 'Animalia' },
+  { index: 11, scientific_name: 'Sciurus aureogaster',          common_name_en: 'Red-bellied squirrel',           common_name_es: 'Ardilla',                  family: 'Sciuridae',       kingdom: 'Animalia' },
+  { index: 12, scientific_name: 'Sylvilagus floridanus',        common_name_en: 'Eastern cottontail',             common_name_es: 'Conejo',                   family: 'Leporidae',       kingdom: 'Animalia' },
+  { index: 13, scientific_name: 'Mephitis macroura',            common_name_en: 'Hooded skunk',                   common_name_es: 'Zorrillo',                 family: 'Mephitidae',      kingdom: 'Animalia' },
+  { index: 14, scientific_name: 'Canis latrans',                common_name_en: 'Coyote',                         common_name_es: 'Coyote',                   family: 'Canidae',         kingdom: 'Animalia' },
+  { index: 15, scientific_name: 'Puma concolor',                common_name_en: 'Puma',                           common_name_es: 'Puma',                     family: 'Felidae',         kingdom: 'Animalia' },
+  { index: 16, scientific_name: 'Tapirus bairdii',              common_name_en: "Baird's tapir",                  common_name_es: 'Tapir',                    family: 'Tapiridae',       kingdom: 'Animalia' },
+  { index: 17, scientific_name: 'Mazama temama',                common_name_en: 'Central American red brocket',   common_name_es: 'Temazate',                 family: 'Cervidae',        kingdom: 'Animalia' },
+  { index: 18, scientific_name: 'Crax rubra',                   common_name_en: 'Great curassow',                 common_name_es: 'Hocofaisán',               family: 'Cracidae',        kingdom: 'Animalia' },
+  { index: 19, scientific_name: 'Penelope purpurascens',        common_name_en: 'Crested guan',                   common_name_es: 'Pava cojolita',            family: 'Cracidae',        kingdom: 'Animalia' },
+] as const;
+
+/**
+ * Look up a label by class index. Returns `undefined` for out-of-range
+ * indices — callers should treat that as "unknown species".
+ */
+export function lookupSpeciesNetLabel(classIdx: number): SpeciesNetLabel | undefined {
+  return SPECIESNET_LABELS.find(l => l.index === classIdx);
+}

--- a/src/lib/identifiers/speciesnet.test.ts
+++ b/src/lib/identifiers/speciesnet.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  speciesnetIdentifier,
+  SPECIESNET_PLUGIN_ID,
+} from './speciesnet';
+import { registry } from './registry';
+import { bootstrapIdentifiers } from './index';
+import { getSpeciesNetWeightsUrl } from './speciesnet-cache';
+import {
+  SPECIESNET_LABELS,
+  lookupSpeciesNetLabel,
+} from './speciesnet-labels';
+import type { SpeciesNetLabel } from './speciesnet-labels';
+
+beforeEach(() => {
+  const env = import.meta.env as unknown as Record<string, unknown>;
+  delete env.PUBLIC_SPECIESNET_WEIGHTS_URL;
+});
+
+describe('speciesnet plugin (on-device)', () => {
+  it('exposes a stable plugin id', () => {
+    expect(SPECIESNET_PLUGIN_ID).toBe('speciesnet_distilled');
+    expect(speciesnetIdentifier.id).toBe(SPECIESNET_PLUGIN_ID);
+  });
+
+  it('has the correct name and description', () => {
+    expect(speciesnetIdentifier.name).toBe('SpeciesNet (distilled)');
+    expect(speciesnetIdentifier.description).toMatch(/on-device animal species classifier/i);
+  });
+
+  it('declares photo media + Animalia taxa + client runtime', () => {
+    const cap = speciesnetIdentifier.capabilities;
+    expect(cap.media).toContain('photo');
+    expect(cap.taxa).toContain('Animalia');
+    expect(cap.runtime).toBe('client');
+    expect(cap.license).toBe('free');
+    expect(cap.confidence_ceiling).toBe(0.85);
+    expect(cap.cost_per_id_usd).toBe(0);
+  });
+
+  it('is registered into the singleton via bootstrapIdentifiers()', () => {
+    bootstrapIdentifiers();
+    const got = registry.get(SPECIESNET_PLUGIN_ID);
+    expect(got).toBeDefined();
+    expect(got?.id).toBe(SPECIESNET_PLUGIN_ID);
+  });
+
+  it('reports model_not_bundled when env var is unset', async () => {
+    expect(getSpeciesNetWeightsUrl()).toBeNull();
+    const av = await speciesnetIdentifier.isAvailable();
+    expect(av.ready).toBe(false);
+    if (!av.ready) {
+      expect(av.reason).toBe('model_not_bundled');
+      expect(av.message).toMatch(/PUBLIC_SPECIESNET_WEIGHTS_URL/);
+    }
+  });
+
+  it('reports needs_download when env set but cache is empty', async () => {
+    (import.meta.env as unknown as Record<string, string>).PUBLIC_SPECIESNET_WEIGHTS_URL = 'https://example.com/models';
+    const av = await speciesnetIdentifier.isAvailable();
+    expect(av.ready).toBe(false);
+    if (!av.ready) {
+      expect(av.reason).toBe('needs_download');
+    }
+  });
+
+  it('strips trailing slash in getSpeciesNetWeightsUrl', () => {
+    (import.meta.env as unknown as Record<string, string>).PUBLIC_SPECIESNET_WEIGHTS_URL = 'https://example.com/models/';
+    expect(getSpeciesNetWeightsUrl()).toBe('https://example.com/models');
+  });
+
+  it('throws when identify is called without a cached model', async () => {
+    (import.meta.env as unknown as Record<string, string>).PUBLIC_SPECIESNET_WEIGHTS_URL = 'https://example.com/models';
+    await expect(
+      speciesnetIdentifier.identify({
+        media: { kind: 'url', url: 'https://example.com/x.jpg' },
+        mediaKind: 'photo',
+      }),
+    ).rejects.toThrow(/not cached|SpeciesNet|onnxruntime/i);
+  });
+
+  it('rejects non-photo media', async () => {
+    (import.meta.env as unknown as Record<string, string>).PUBLIC_SPECIESNET_WEIGHTS_URL = 'https://example.com/models';
+    await expect(
+      speciesnetIdentifier.identify({
+        media: { kind: 'url', url: 'https://example.com/x.wav' },
+        mediaKind: 'audio',
+      }),
+    ).rejects.toThrow(/mediaKind=photo/);
+  });
+
+  it('is found by registry.findFor for photo + Animalia', () => {
+    bootstrapIdentifiers();
+    const matches = registry.findFor({ media: 'photo', taxa: 'Animalia' }).map(p => p.id);
+    expect(matches).toContain(SPECIESNET_PLUGIN_ID);
+  });
+});
+
+describe('speciesnet-labels', () => {
+  it('contains 20 placeholder species', () => {
+    expect(SPECIESNET_LABELS.length).toBe(20);
+  });
+
+  it('has contiguous indices starting from 0', () => {
+    const indices = SPECIESNET_LABELS.map(l => l.index);
+    for (let i = 0; i < indices.length; i++) {
+      expect(indices[i]).toBe(i);
+    }
+  });
+
+  it('every label has kingdom Animalia', () => {
+    for (const label of SPECIESNET_LABELS) {
+      expect(label.kingdom).toBe('Animalia');
+    }
+  });
+
+  it('every label has non-empty scientific_name, common_name_en, common_name_es, family', () => {
+    for (const label of SPECIESNET_LABELS) {
+      expect(label.scientific_name.length).toBeGreaterThan(0);
+      expect(label.common_name_en.length).toBeGreaterThan(0);
+      expect(label.common_name_es.length).toBeGreaterThan(0);
+      expect(label.family.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('lookupSpeciesNetLabel returns the correct entry by index', () => {
+    const label = lookupSpeciesNetLabel(5);
+    expect(label).toBeDefined();
+    expect((label as SpeciesNetLabel).scientific_name).toBe('Panthera onca');
+    expect((label as SpeciesNetLabel).common_name_en).toBe('Jaguar');
+    expect((label as SpeciesNetLabel).common_name_es).toBe('Jaguar');
+  });
+
+  it('lookupSpeciesNetLabel returns undefined for out-of-range index', () => {
+    expect(lookupSpeciesNetLabel(999)).toBeUndefined();
+    expect(lookupSpeciesNetLabel(-1)).toBeUndefined();
+  });
+
+  it('includes expected species', () => {
+    const names = SPECIESNET_LABELS.map(l => l.scientific_name);
+    expect(names).toContain('Odocoileus virginianus');
+    expect(names).toContain('Panthera onca');
+    expect(names).toContain('Tapirus bairdii');
+    expect(names).toContain('Crax rubra');
+    expect(names).toContain('Penelope purpurascens');
+  });
+});

--- a/src/lib/identifiers/speciesnet.ts
+++ b/src/lib/identifiers/speciesnet.ts
@@ -1,0 +1,280 @@
+/**
+ * Distilled SpeciesNet — on-device ONNX animal species classifier.
+ *
+ * Classifies camera-trap photos into ~20 Neotropical species (placeholder
+ * label map; the real map ships with the trained model). Pipeline:
+ *
+ *   1. Optionally crop to a MegaDetector bbox via `mediaCrop`.
+ *   2. Decode the photo into a 224×224 RGB canvas.
+ *   3. Normalise to [0,1] then ImageNet mean/std (EfficientNet-style).
+ *   4. Run the cached ONNX session (top-5).
+ *   5. Map class indices through the bundled label map.
+ *   6. Return the top prediction as an IDResult.
+ *
+ * Weights aren't bundled — the operator hosts the ONNX file at
+ * `PUBLIC_SPECIESNET_WEIGHTS_URL` and the user downloads it once via
+ * Profile → Edit → AI settings. Until the model is trained and hosted,
+ * the plugin reports `model_not_bundled` and the cascade falls through.
+ *
+ * License: code MIT (this file). Model: TBD (depends on training data
+ * and base architecture license).
+ */
+import type { Identifier, IDResult, IdentifyInput } from './types';
+import {
+  ONNX_BASE_INPUT_SIZE,
+  IMAGENET_MEAN, IMAGENET_STD,
+  preprocessRgba, softmax, topK,
+} from './onnx-base-image';
+import {
+  getSpeciesNetWeightsUrl, getSpeciesNetCacheStatus, getCachedSpeciesNetBuffer,
+} from './speciesnet-cache';
+import { SPECIESNET_LABELS, lookupSpeciesNetLabel } from './speciesnet-labels';
+import { clampAndPad } from './bbox-crop';
+
+export const SPECIESNET_PLUGIN_ID = 'speciesnet_distilled';
+
+/** Minimum device memory (GB) to attempt loading the ~100 MB model. */
+const MIN_DEVICE_MEMORY_GB = 4;
+
+/** Top-K predictions to surface per identification. */
+const SPECIESNET_TOP_K = 5;
+
+type OrtSession = {
+  inputNames: string[];
+  outputNames: string[];
+  run(feeds: Record<string, unknown>): Promise<Record<string, { data: Float32Array | unknown }>>;
+};
+let session: OrtSession | null = null;
+
+async function ensureSession(): Promise<OrtSession> {
+  if (session) return session;
+  const buffer = await getCachedSpeciesNetBuffer();
+  if (!buffer) {
+    throw new Error(
+      'SpeciesNet model is not cached. Open Profile → Edit → AI settings (or replay the onboarding tour) to download it.',
+    );
+  }
+  const ort = await import('onnxruntime-web');
+  const factory = (ort as unknown as {
+    InferenceSession: { create(buf: ArrayBuffer, opts?: unknown): Promise<OrtSession> };
+  }).InferenceSession;
+  session = await factory.create(buffer, { executionProviders: ['wasm'] });
+  return session;
+}
+
+/**
+ * Decode the input media into RGBA pixel data. When `mediaCrop` is
+ * provided, crop to the bbox first (with 10% padding) so the classifier
+ * sees only the animal, not the full frame.
+ */
+async function decodeImageToRgba(
+  input: IdentifyInput,
+): Promise<{ data: Uint8ClampedArray; width: number; height: number }> {
+  let blob: Blob;
+  if (input.media.kind === 'url') {
+    const res = await fetch(input.media.url, { mode: 'cors' });
+    if (!res.ok) throw new Error(`SpeciesNet: photo fetch failed (HTTP ${res.status})`);
+    blob = await res.blob();
+  } else if (input.media.kind === 'blob') {
+    blob = input.media.blob;
+  } else {
+    blob = new Blob([new Uint8Array(input.media.bytes)], { type: input.media.mime });
+  }
+
+  const bitmap = await createImageBitmap(blob);
+  const srcW = bitmap.width;
+  const srcH = bitmap.height;
+
+  // Draw full image to a canvas so we can read pixels / crop.
+  const fullCanvas = typeof OffscreenCanvas !== 'undefined'
+    ? new OffscreenCanvas(srcW, srcH)
+    : (() => {
+        const c = document.createElement('canvas');
+        c.width = srcW; c.height = srcH;
+        return c as unknown as OffscreenCanvas;
+      })();
+  const fullCtx = fullCanvas.getContext('2d') as
+    | OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
+  if (!fullCtx) throw new Error('SpeciesNet: 2D canvas unavailable');
+  fullCtx.drawImage(bitmap as unknown as CanvasImageSource, 0, 0);
+  bitmap.close?.();
+
+  // If a crop hint is available, extract just the animal region.
+  if (input.mediaCrop) {
+    const rect = clampAndPad(input.mediaCrop.bbox, srcW, srcH, 0.1);
+    const cropData = fullCtx.getImageData(rect.x, rect.y, rect.w, rect.h);
+    return { data: cropData.data, width: rect.w, height: rect.h };
+  }
+
+  const imgData = fullCtx.getImageData(0, 0, srcW, srcH);
+  return { data: imgData.data, width: srcW, height: srcH };
+}
+
+/**
+ * Resize RGBA pixel data to the target square size using a canvas.
+ * Uses cover-crop (scale shortest edge, centre-crop) to match the
+ * standard ImageNet eval recipe.
+ */
+async function resizeToSquare(
+  rgba: Uint8ClampedArray,
+  srcW: number,
+  srcH: number,
+  size: number,
+): Promise<Uint8ClampedArray> {
+  // Build an ImageData from the raw RGBA, then draw it scaled.
+  const srcCanvas = typeof OffscreenCanvas !== 'undefined'
+    ? new OffscreenCanvas(srcW, srcH)
+    : (() => {
+        const c = document.createElement('canvas');
+        c.width = srcW; c.height = srcH;
+        return c as unknown as OffscreenCanvas;
+      })();
+  const srcCtx = srcCanvas.getContext('2d') as
+    | OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
+  if (!srcCtx) throw new Error('SpeciesNet: 2D canvas unavailable');
+  const imgData = new ImageData(new Uint8ClampedArray(rgba), srcW, srcH);
+  srcCtx.putImageData(imgData, 0, 0);
+
+  const dstCanvas = typeof OffscreenCanvas !== 'undefined'
+    ? new OffscreenCanvas(size, size)
+    : (() => {
+        const c = document.createElement('canvas');
+        c.width = size; c.height = size;
+        return c as unknown as OffscreenCanvas;
+      })();
+  const dstCtx = dstCanvas.getContext('2d') as
+    | OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
+  if (!dstCtx) throw new Error('SpeciesNet: 2D canvas unavailable');
+
+  // Cover crop: scale shortest edge to `size`, centre-crop the rest.
+  const scale = Math.max(size / srcW, size / srcH);
+  const drawW = srcW * scale;
+  const drawH = srcH * scale;
+  const dx = (size - drawW) / 2;
+  const dy = (size - drawH) / 2;
+  dstCtx.drawImage(srcCanvas as unknown as CanvasImageSource, dx, dy, drawW, drawH);
+
+  return dstCtx.getImageData(0, 0, size, size).data;
+}
+
+export const speciesnetIdentifier: Identifier = {
+  id: SPECIESNET_PLUGIN_ID,
+  name: 'SpeciesNet (distilled)',
+  brand: '🐾',
+  description:
+    'On-device animal species classifier (~100 MB ONNX, iWildCam categories). Identifies common camera-trap species without cloud LLMs.',
+  setupSteps: [
+    {
+      text: 'Profile → Edit → AI settings → SpeciesNet → Download (~100 MB).',
+    },
+    {
+      text: 'After download, species classification runs offline. Photos never leave your device.',
+    },
+    {
+      text: 'Operator: train a distilled SpeciesNet, export to ONNX, and host as speciesnet_distilled_v1.onnx behind PUBLIC_SPECIESNET_WEIGHTS_URL (CORS-open).',
+      details: 'The placeholder label map ships 20 Neotropical species. The real label map is generated by the training pipeline.',
+    },
+  ],
+  capabilities: {
+    media: ['photo'],
+    taxa: ['Animalia'],
+    runtime: 'client',
+    license: 'free',
+    confidence_ceiling: 0.85,
+    cost_per_id_usd: 0,
+  },
+
+  async isAvailable() {
+    if (!getSpeciesNetWeightsUrl()) {
+      return {
+        ready: false,
+        reason: 'model_not_bundled',
+        message: 'PUBLIC_SPECIESNET_WEIGHTS_URL is not set.',
+      };
+    }
+    // Check device memory when the API is available.
+    if (typeof navigator !== 'undefined' && 'deviceMemory' in navigator) {
+      const mem = (navigator as unknown as { deviceMemory: number }).deviceMemory;
+      if (mem < MIN_DEVICE_MEMORY_GB) {
+        return {
+          ready: false,
+          reason: 'insufficient_memory',
+          message: `Device reports ${mem} GB RAM; SpeciesNet needs ≥${MIN_DEVICE_MEMORY_GB} GB.`,
+        };
+      }
+    }
+    const status = await getSpeciesNetCacheStatus();
+    if (!status.modelCached) {
+      return { ready: false, reason: 'needs_download', message: '~100 MB download (model only).' };
+    }
+    return { ready: true };
+  },
+
+  async identify(input: IdentifyInput): Promise<IDResult> {
+    if (input.mediaKind !== 'photo') {
+      throw new Error('speciesnet_distilled: requires mediaKind=photo');
+    }
+    const onProgress = input.onProgress ?? (() => {});
+
+    onProgress({ progress: 0.05, text: 'Loading SpeciesNet…' });
+    const sess = await ensureSession();
+
+    onProgress({ progress: 0.25, text: 'Decoding photo…' });
+    const rgba = await decodeImageToRgba(input);
+
+    onProgress({ progress: 0.4, text: 'Resizing to 224×224…' });
+    const resized = await resizeToSquare(rgba.data, rgba.width, rgba.height, ONNX_BASE_INPUT_SIZE);
+
+    onProgress({ progress: 0.55, text: 'Preparing tensor…' });
+    const tensorData = preprocessRgba(resized, ONNX_BASE_INPUT_SIZE, ONNX_BASE_INPUT_SIZE);
+    const ort = await import('onnxruntime-web');
+    const TensorCtor = (ort as unknown as {
+      Tensor: new (type: string, data: Float32Array, dims: number[]) => unknown;
+    }).Tensor;
+    const inputTensor = new TensorCtor(
+      'float32', tensorData,
+      [1, 3, ONNX_BASE_INPUT_SIZE, ONNX_BASE_INPUT_SIZE],
+    );
+
+    onProgress({ progress: 0.7, text: 'Running classifier…' });
+    const inputName = sess.inputNames[0] ?? 'input';
+    const feeds: Record<string, unknown> = { [inputName]: inputTensor };
+    const out = await sess.run(feeds);
+    const outputName = sess.outputNames[0] ?? Object.keys(out)[0];
+    const scoresRaw = out[outputName]?.data;
+    if (!(scoresRaw instanceof Float32Array)) {
+      throw new Error('SpeciesNet output tensor missing or wrong type.');
+    }
+
+    onProgress({ progress: 0.9, text: 'Reading top predictions…' });
+    const probs = softmax(scoresRaw);
+    const top = topK(probs, SPECIESNET_TOP_K);
+    const best = top[0];
+    if (!best) throw new Error('SpeciesNet returned no predictions.');
+
+    const label = lookupSpeciesNetLabel(best.classIdx);
+    const candidates = top.map(t => {
+      const l = lookupSpeciesNetLabel(t.classIdx);
+      return {
+        classIdx: t.classIdx,
+        score: t.score,
+        scientific_name: l?.scientific_name ?? `unknown:${t.classIdx}`,
+        common_name_en: l?.common_name_en ?? null,
+        common_name_es: l?.common_name_es ?? null,
+      };
+    });
+
+    onProgress({ progress: 1, text: 'Done.' });
+
+    return {
+      scientific_name: label?.scientific_name ?? `unknown:${best.classIdx}`,
+      common_name_en: label?.common_name_en ?? null,
+      common_name_es: label?.common_name_es ?? null,
+      family: label?.family ?? null,
+      kingdom: 'Animalia',
+      confidence: Math.min(best.score, 0.85),
+      source: SPECIESNET_PLUGIN_ID,
+      raw: { top: candidates, labelCount: SPECIESNET_LABELS.length },
+    };
+  },
+};


### PR DESCRIPTION
Adds a new identifier plugin for on-device animal species classification using a distilled SpeciesNet ONNX model. Reports model_not_bundled until the operator trains and hosts the weights.

20 Neotropical species in the placeholder label map. The real label map ships with the trained model.

Closes #175