### PR TITLE
fix(validate): render audio player for audio observations (#436)

### DIFF
--- a/src/components/ValidationQueueView.astro
+++ b/src/components/ValidationQueueView.astro
@@ -100,7 +100,8 @@ const sharePathBase = '/share/obs/';
     /** Render the 80×80 media thumbnail based on media type. */
     function mediaThumbnail(url: string | null, type: string | null): string {
       if (!url) return '';
-      if (type === 'audio') {
+      const isAudio = type === 'audio' || /\.(mp3|ogg|wav|m4a|webm)$/i.test(url);
+      if (isAudio) {
         return `<div class="w-full h-full flex flex-col items-center justify-center gap-1 p-1">
           <span class="text-xl" aria-hidden="true">🔊</span>
           <audio controls src="${escapeText(url)}" class="w-full" style="height:24px;max-width:72px;min-width:0;" preload="none" onclick="event.stopPropagation()" ontouchstart="event.stopPropagation()"></audio>


### PR DESCRIPTION
Audio observations in the validation queue showed a broken `<img>` element because `media_type` can be null or incorrect (especially on iOS Safari where MIME type is empty for MediaRecorder). Now detects audio media by URL extension (`.mp3`, `.ogg`, `.wav`, `.m4a`, `.webm`) in addition to the existing `media_type === 'audio'` check, and renders `<audio controls>` instead.

Closes #436