### PR TITLE
fix(explore-map): show sensitive observations using obscured coords

### DIFF
--- a/src/components/ExploreMap.astro
+++ b/src/components/ExploreMap.astro
@@ -204,7 +204,7 @@ const tr = t(lang);
     // RLS still gates the rows.
     const { data, error } = await supabase
       .from('observations')
-      .select('id, location, obscure_level, observed_at, taxa:primary_taxon_id(kingdom)')
+      .select('id, location, location_obscured, obscure_level, observed_at, taxa:primary_taxon_id(kingdom)')
       .eq('sync_status', 'synced')
       .limit(500);
 
@@ -215,7 +215,14 @@ const tr = t(lang);
 
     const features: GeoJSON.Feature[] = [];
     for (const row of data ?? []) {
-      const geom = (row as { location: unknown }).location as GeoJSON.Point | null;
+      // Prefer location_obscured for sensitive observations (non-owner
+      // viewers should see the coarsened point, not precise coords).
+      // Fall back to precise location when obscure_level is 'none' or
+      // when location_obscured is unavailable.
+      const precise = (row as { location: unknown }).location as GeoJSON.Point | null;
+      const obscured = (row as { location_obscured: unknown }).location_obscured as GeoJSON.Point | null;
+      const level = (row as { obscure_level?: string }).obscure_level;
+      const geom = (level && level !== 'none' && obscured?.coordinates) ? obscured : precise;
       if (!geom?.coordinates) continue;
       const observedAt = (row as { observed_at?: string | null }).observed_at ?? null;
       const observedMonth = observedAt ? new Date(observedAt).getUTCMonth() : null;


### PR DESCRIPTION
## Problem

The explore map page (`/en/explore/map/`) appeared empty — observations visible in the detail view were missing from the map.

## Root cause

The ExploreMap Supabase query only selected `location` (precise coordinates) but not `location_obscured` (coarsened coordinates for sensitive species). For observations with `obscure_level != 'none'`, the map either:
- Leaked precise coordinates to non-owner viewers, or
- Skipped the observation entirely when `location` was unavailable

## Fix

- Added `location_obscured` to the `.select()` query
- When `obscure_level` is not `'none'` and `location_obscured` has coordinates, the map now uses the coarsened point
- Falls back to precise `location` for non-sensitive observations

This matches the pattern already used by the observation detail/share page (`src/pages/share/obs/index.astro`).

## Verified

- `tsc --noEmit` — no new errors
- `vitest run` — 817 tests pass
- `astro build` — 229 pages, zero errors