### PR TITLE
feat(sponsorships): pool dashboard with usage analytics (#226)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7235,3 +7235,35 @@ END;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.recompute_species_hero(uuid) TO authenticated;
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Pool analytics: top taxa + daily usage (#226)
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- Top taxa identified via a specific pool (last 30 days)
+CREATE OR REPLACE FUNCTION public.pool_top_taxa(p_pool_id uuid)
+RETURNS TABLE(scientific_name text, call_count bigint)
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT i.scientific_name, COUNT(*) as call_count
+  FROM public.ai_usage u
+  JOIN public.identifications i ON i.observation_id = u.observation_id
+  WHERE u.pool_id = p_pool_id
+    AND u.created_at >= (now() - interval '30 days')
+  GROUP BY i.scientific_name
+  ORDER BY call_count DESC
+  LIMIT 10;
+$$;
+
+-- Daily usage for a pool (current month)
+CREATE OR REPLACE FUNCTION public.pool_daily_usage(p_pool_id uuid)
+RETURNS TABLE(usage_date date, calls bigint)
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT DATE(u.created_at) as usage_date, COUNT(*) as calls
+  FROM public.ai_usage u
+  WHERE u.pool_id = p_pool_id
+    AND u.created_at >= date_trunc('month', now())
+  GROUP BY DATE(u.created_at)
+  ORDER BY usage_date;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.pool_top_taxa(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.pool_daily_usage(uuid) TO authenticated;

--- a/src/components/PoolDashboardView.astro
+++ b/src/components/PoolDashboardView.astro
@@ -1,0 +1,208 @@
+---
+import { t } from '../i18n/utils';
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const tr = t(lang);
+const poolTr = tr.sponsoring.pool_dashboard;
+---
+
+<section id="pool-dashboard-section" class="space-y-4">
+  <div class="flex items-center justify-between gap-2 flex-wrap">
+    <div>
+      <h2 class="text-lg font-semibold">{poolTr.title}</h2>
+      <p class="text-xs text-zinc-500 dark:text-zinc-400">{poolTr.subtitle}</p>
+    </div>
+    <button id="pool-dash-refresh" type="button"
+      class="text-xs text-emerald-700 dark:text-emerald-400 hover:text-emerald-900 dark:hover:text-emerald-200 px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700 min-h-[28px]"
+      aria-label={lang === 'es' ? 'Actualizar' : 'Refresh'}>
+      ↻
+    </button>
+  </div>
+
+  <div id="pool-dash-loading" class="text-sm text-zinc-500 dark:text-zinc-400">
+    {lang === 'es' ? 'Cargando…' : 'Loading…'}
+  </div>
+
+  <div id="pool-dash-empty" class="hidden text-sm text-zinc-500 dark:text-zinc-400">
+    {lang === 'es' ? 'Aún no has donado al pool.' : 'You haven\'t donated to the pool yet.'}
+  </div>
+
+  <div id="pool-dash-cards" class="grid grid-cols-1 gap-6"></div>
+</section>
+
+<script type="application/json" id="pool-dash-i18n" set:html={JSON.stringify({
+  capacity: poolTr.capacity,
+  used: poolTr.used,
+  unique_users: poolTr.unique_users,
+  top_taxa: poolTr.top_taxa,
+  top_taxa_coming: poolTr.top_taxa_coming,
+  daily_usage: poolTr.daily_usage,
+  no_taxa: poolTr.no_taxa,
+  no_usage: poolTr.no_usage,
+})} />
+
+<script>
+  import { listMyPools } from '../lib/sponsorships';
+  import { fetchPoolAnalytics } from '../lib/pool-analytics';
+  import type { PoolAnalytics } from '../lib/pool-analytics';
+
+  type DashI18n = {
+    capacity: string;
+    used: string;
+    unique_users: string;
+    top_taxa: string;
+    top_taxa_coming: string;
+    daily_usage: string;
+    no_taxa: string;
+    no_usage: string;
+  };
+
+  const i18n: DashI18n = JSON.parse(
+    (document.getElementById('pool-dash-i18n') as HTMLScriptElement | null)?.textContent ?? '{}'
+  ) as DashI18n;
+
+  const escHtml = (s: string): string => s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+  function statusBadgeClass(status: string): string {
+    if (status === 'active')  return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300';
+    if (status === 'paused')  return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300';
+    return 'bg-zinc-200 text-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-300';
+  }
+
+  function renderCapacityBar(used: number, total: number, pct: number): string {
+    const clampedPct = Math.min(100, Math.round(pct));
+    const barColor = pct >= 90 ? 'bg-red-500' : pct >= 70 ? 'bg-amber-500' : 'bg-emerald-600';
+    return `
+      <div>
+        <div class="flex items-center justify-between text-xs text-zinc-600 dark:text-zinc-400 mb-1">
+          <span class="font-medium">${escHtml(i18n.capacity)}</span>
+          <span>${used} / ${total} (${clampedPct}%)</span>
+        </div>
+        <div class="h-2 w-full rounded-full bg-zinc-200 dark:bg-zinc-800 overflow-hidden">
+          <div class="h-full ${barColor} transition-all" style="width: ${clampedPct}%"></div>
+        </div>
+      </div>`;
+  }
+
+  function renderUniqueUsers(count: number): string {
+    return `
+      <div class="flex items-center justify-between text-xs text-zinc-600 dark:text-zinc-400">
+        <span class="font-medium">${escHtml(i18n.unique_users)}</span>
+        <span class="tabular-nums">${count}</span>
+      </div>`;
+  }
+
+  function renderTopTaxa(taxa: PoolAnalytics['topTaxa']): string {
+    if (taxa.length === 0) {
+      return `<p class="text-xs text-zinc-500 dark:text-zinc-400 italic">${escHtml(i18n.top_taxa_coming)}</p>`;
+    }
+    const items = taxa.map((taxon, idx) => {
+      const rank = idx + 1;
+      const common = taxon.common_name ? ` <span class="text-zinc-500">(${escHtml(taxon.common_name)})</span>` : '';
+      const kingdom = taxon.kingdom ? ` <span class="text-[10px] text-zinc-400 uppercase">${escHtml(taxon.kingdom)}</span>` : '';
+      return `<li class="flex items-center justify-between text-sm">
+        <span><span class="text-zinc-400 mr-1.5">${rank}.</span> <span class="italic">${escHtml(taxon.scientific_name)}</span>${common}${kingdom}</span>
+        <span class="text-zinc-500 tabular-nums">${taxon.count}</span>
+      </li>`;
+    }).join('');
+    return `<ol class="space-y-1">${items}</ol>`;
+  }
+
+  function renderDailyUsage(daily: PoolAnalytics['dailyUsage']): string {
+    if (daily.length === 0) {
+      return `<p class="text-xs text-zinc-500 dark:text-zinc-400 italic">${escHtml(i18n.no_usage)}</p>`;
+    }
+    const maxCalls = Math.max(...daily.map(d => d.calls), 1);
+    const bars = daily.map(d => {
+      const heightPct = Math.max(4, Math.round((d.calls / maxCalls) * 100));
+      const dayLabel = d.date.slice(8);
+      return `<div class="flex flex-col items-center gap-0.5 flex-1 min-w-0" title="${escHtml(d.date)}: ${d.calls}">
+        <div class="w-full max-w-[12px] rounded-t bg-emerald-500 dark:bg-emerald-400" style="height: ${heightPct}%"></div>
+        <span class="text-[9px] text-zinc-400 leading-none">${dayLabel}</span>
+      </div>`;
+    }).join('');
+    return `<div class="flex items-end gap-px h-16">${bars}</div>`;
+  }
+
+  function renderPoolCard(pool: { id: string; status: string; preferred_model: string }, analytics: PoolAnalytics): string {
+    return `
+      <div class="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4 space-y-4" data-pool-dash-id="${escHtml(pool.id)}">
+        <div class="flex items-center justify-between gap-2 flex-wrap">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-mono font-medium text-zinc-700 dark:text-zinc-300">${escHtml(pool.preferred_model)}</span>
+            <span class="text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wider ${statusBadgeClass(pool.status)}">${escHtml(pool.status)}</span>
+          </div>
+          <span class="text-[10px] font-mono text-zinc-400">${escHtml(pool.id.slice(0, 8))}…</span>
+        </div>
+        ${renderCapacityBar(analytics.used, analytics.totalCap, analytics.pctUsed)}
+        ${renderUniqueUsers(analytics.uniqueUsers)}
+        <div>
+          <h4 class="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-2">${escHtml(i18n.top_taxa)}</h4>
+          ${renderTopTaxa(analytics.topTaxa)}
+        </div>
+        <div>
+          <h4 class="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-2">${escHtml(i18n.daily_usage)}</h4>
+          ${renderDailyUsage(analytics.dailyUsage)}
+        </div>
+      </div>`;
+  }
+
+  async function loadDashboard() {
+    const loadingEl = document.getElementById('pool-dash-loading');
+    const emptyEl   = document.getElementById('pool-dash-empty');
+    const cardsEl   = document.getElementById('pool-dash-cards');
+    if (!cardsEl) return;
+
+    loadingEl?.classList.remove('hidden');
+    emptyEl?.classList.add('hidden');
+    cardsEl.innerHTML = '';
+
+    try {
+      const pools = await listMyPools();
+      if (pools.length === 0) {
+        loadingEl?.classList.add('hidden');
+        emptyEl?.classList.remove('hidden');
+        return;
+      }
+
+      const { getSupabase } = await import('../lib/supabase');
+      const sb = getSupabase();
+
+      const cards: string[] = [];
+      for (const pool of pools) {
+        const analytics = await fetchPoolAnalytics(sb, pool.id);
+        if (analytics) {
+          cards.push(renderPoolCard(pool, analytics));
+        }
+      }
+
+      loadingEl?.classList.add('hidden');
+      if (cards.length === 0) {
+        emptyEl?.classList.remove('hidden');
+      } else {
+        cardsEl.innerHTML = cards.join('');
+      }
+    } catch {
+      loadingEl?.classList.add('hidden');
+      emptyEl?.classList.remove('hidden');
+    }
+  }
+
+  document.getElementById('pool-dash-refresh')?.addEventListener('click', () => {
+    loadDashboard();
+  });
+
+  // Allow external trigger from pool list "View dashboard" buttons
+  document.addEventListener('pool-dash:load', () => {
+    const section = document.getElementById('pool-dashboard-section');
+    section?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    loadDashboard();
+  });
+
+  loadDashboard();
+</script>

--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -1,6 +1,7 @@
 ---
 import { t } from '../i18n/utils';
 import { MODEL_COSTS, formatCostBadge } from '../lib/model-costs';
+import PoolDashboardView from './PoolDashboardView.astro';
 interface Props { lang: 'en' | 'es' }
 const { lang } = Astro.props;
 const tr = t(lang);
@@ -18,6 +19,7 @@ const i18nBag = {
   request_approve:            tr.sponsoring.request_approve,
   request_reject:             tr.sponsoring.request_reject,
   add_credential:             tr.sponsoring.add_credential,
+  pool_dashboard_view:        tr.sponsoring.pool_dashboard.view,
   confirm_reject_request:     lang === 'es' ? '¿Rechazar esta solicitud?' : 'Reject this request?',
   paused_reason: {
     rate_limit:         tr.sponsoring.paused_reason_rate_limit,
@@ -664,6 +666,8 @@ const langJson = JSON.stringify(lang);
             </div>
           </div>
           <div class="flex items-center gap-1 flex-wrap justify-end">
+          <div class="flex items-center gap-1">
+            <button data-pool-view="${escHtml(p.id)}" class="text-xs text-sky-700 hover:text-sky-900 dark:text-sky-400 dark:hover:text-sky-200 px-2 py-1">${escHtml(poolDashViewLabel)}</button>
             ${p.status === 'active'
               ? `<button data-pool-pause="${escHtml(p.id)}" class="text-xs px-2 py-1 rounded border border-amber-400 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20">Pause</button>`
               : p.status === 'paused'

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1382,6 +1382,19 @@
     "model_cost_heading": "Estimated cost per 100 calls",
     "model_cost_note": "Costs are approximate and depend on image size and response length.",
     "model_cost_per_100": "per 100 calls"
+    "pool_dashboard": {
+      "title": "Pool Dashboard",
+      "subtitle": "Analytics for your sponsored pools",
+      "capacity": "Capacity",
+      "used": "Used",
+      "unique_users": "Unique users",
+      "top_taxa": "Top detected taxa",
+      "top_taxa_coming": "Top taxa breakdown available after next migration.",
+      "daily_usage": "Daily usage",
+      "no_taxa": "No identifications yet.",
+      "no_usage": "No usage recorded yet.",
+      "view": "View dashboard"
+    }
   },
   "expert": {
     "apply_title": "Apply as an expert",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1382,6 +1382,19 @@
     "model_cost_heading": "Costo estimado por 100 llamadas",
     "model_cost_note": "Los costos son aproximados y dependen del tamaño de imagen y longitud de respuesta.",
     "model_cost_per_100": "por 100 llamadas"
+    "pool_dashboard": {
+      "title": "Panel de pools",
+      "subtitle": "Analítica de tus pools patrocinados",
+      "capacity": "Capacidad",
+      "used": "Usado",
+      "unique_users": "Usuarios únicos",
+      "top_taxa": "Taxa más detectados",
+      "top_taxa_coming": "Desglose de taxa disponible tras la próxima migración.",
+      "daily_usage": "Uso diario",
+      "no_taxa": "Aún no hay identificaciones.",
+      "no_usage": "Aún no se ha registrado uso.",
+      "view": "Ver panel"
+    }
   },
   "expert": {
     "apply_title": "Postularse como experto",

--- a/src/lib/pool-analytics.test.ts
+++ b/src/lib/pool-analytics.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { fetchPoolAnalytics } from './pool-analytics';
+
+function mockSupabase(overrides: {
+  pool?: { id: string; total_cap: number; used: number } | null;
+  taxa?: Array<{ scientific_name: string; call_count: number }> | null;
+  daily?: Array<{ usage_date: string; calls: number }> | null;
+} = {}): SupabaseClient {
+  const pool = 'pool' in overrides ? overrides.pool : { id: 'p1', total_cap: 100, used: 42 };
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: pool }),
+        }),
+      }),
+    }),
+    rpc: vi.fn().mockImplementation((fn: string) => {
+      if (fn === 'pool_top_taxa') {
+        return Promise.resolve({ data: overrides.taxa ?? [] });
+      }
+      if (fn === 'pool_daily_usage') {
+        return Promise.resolve({ data: overrides.daily ?? [] });
+      }
+      return Promise.resolve({ data: null });
+    }),
+  } as unknown as SupabaseClient;
+}
+
+describe('fetchPoolAnalytics', () => {
+  it('returns analytics for a valid pool', async () => {
+    const sb = mockSupabase({
+      pool: { id: 'p1', total_cap: 200, used: 50 },
+      taxa: [
+        { scientific_name: 'Quercus robur', call_count: 12 },
+        { scientific_name: 'Pinus sylvestris', call_count: 8 },
+      ],
+      daily: [
+        { usage_date: '2026-05-01', calls: 3 },
+        { usage_date: '2026-05-02', calls: 7 },
+      ],
+    });
+
+    const result = await fetchPoolAnalytics(sb, 'p1');
+
+    expect(result).not.toBeNull();
+    expect(result!.poolId).toBe('p1');
+    expect(result!.totalCap).toBe(200);
+    expect(result!.used).toBe(50);
+    expect(result!.pctUsed).toBe(25);
+    expect(result!.topTaxa).toHaveLength(2);
+    expect(result!.topTaxa[0].scientific_name).toBe('Quercus robur');
+    expect(result!.dailyUsage).toHaveLength(2);
+  });
+
+  it('returns null when pool is not found', async () => {
+    const sb = mockSupabase({ pool: null });
+    const result = await fetchPoolAnalytics(sb, 'nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('calculates pctUsed = 0 when total_cap is 0', async () => {
+    const sb = mockSupabase({ pool: { id: 'p2', total_cap: 0, used: 0 } });
+    const result = await fetchPoolAnalytics(sb, 'p2');
+    expect(result).not.toBeNull();
+    expect(result!.pctUsed).toBe(0);
+  });
+
+  it('calculates pctUsed = 100 when fully used', async () => {
+    const sb = mockSupabase({ pool: { id: 'p3', total_cap: 50, used: 50 } });
+    const result = await fetchPoolAnalytics(sb, 'p3');
+    expect(result!.pctUsed).toBe(100);
+  });
+
+  it('handles pctUsed > 100 when over-consumed', async () => {
+    const sb = mockSupabase({ pool: { id: 'p4', total_cap: 10, used: 15 } });
+    const result = await fetchPoolAnalytics(sb, 'p4');
+    expect(result!.pctUsed).toBe(150);
+  });
+
+  it('returns empty arrays when taxa/daily are null', async () => {
+    const sb = mockSupabase({ taxa: null, daily: null });
+    const result = await fetchPoolAnalytics(sb, 'p1');
+    expect(result).not.toBeNull();
+    expect(result!.topTaxa).toEqual([]);
+    expect(result!.dailyUsage).toEqual([]);
+  });
+
+  it('slices topTaxa to 10 items max', async () => {
+    const taxa = Array.from({ length: 15 }, (_, i) => ({
+      scientific_name: `Species ${i}`,
+      call_count: 15 - i,
+    }));
+    const sb = mockSupabase({ taxa });
+    const result = await fetchPoolAnalytics(sb, 'p1');
+    expect(result!.topTaxa).toHaveLength(10);
+    expect(result!.topTaxa[0].scientific_name).toBe('Species 0');
+  });
+
+  it('calls rpc with correct function names and pool id', async () => {
+    const sb = mockSupabase();
+    await fetchPoolAnalytics(sb, 'test-pool-id');
+    expect(sb.rpc).toHaveBeenCalledWith('pool_top_taxa', { p_pool_id: 'test-pool-id' });
+    expect(sb.rpc).toHaveBeenCalledWith('pool_daily_usage', { p_pool_id: 'test-pool-id' });
+  });
+});

--- a/src/lib/pool-analytics.ts
+++ b/src/lib/pool-analytics.ts
@@ -1,0 +1,123 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface PoolAnalytics {
+  poolId: string;
+  totalCap: number;
+  used: number;
+  pctUsed: number;
+  uniqueUsers: number;
+  topTaxa: Array<{
+    scientific_name: string;
+    common_name: string | null;
+    kingdom: string;
+    count: number;
+  }>;
+  dailyUsage: Array<{
+    date: string;
+    calls: number;
+  }>;
+}
+
+/** Shape returned by the pool_top_taxa RPC. */
+interface RpcTaxaRow {
+  scientific_name: string;
+  common_name: string | null;
+  kingdom: string;
+  count: number;
+}
+
+/** Shape returned by the pool_daily_usage RPC. */
+interface RpcDailyRow {
+  date: string;
+  calls: number;
+}
+
+/** Shape returned by the pool_unique_users RPC. */
+interface RpcUniqueUsersRow {
+  unique_users: number;
+}
+
+/**
+ * Fetch analytics for a single sponsor pool.
+ *
+ * Accepts a Supabase client so the caller controls auth context and the
+ * function stays testable (no singleton import).
+ */
+export async function fetchPoolAnalytics(
+  supabase: SupabaseClient,
+  poolId: string,
+): Promise<PoolAnalytics | null> {
+  // Pool metadata
+  const { data: pool } = await supabase
+    .from('sponsor_pools')
+    .select('id, total_cap, used')
+    .eq('id', poolId)
+    .single();
+
+  if (!pool) return null;
+
+  const typedPool = pool as { id: string; total_cap: number; used: number };
+
+  // Top taxa detected via this pool
+  const { data: taxa } = await supabase.rpc('pool_top_taxa', { p_pool_id: poolId });
+
+  // Daily usage histogram
+  const { data: daily } = await supabase.rpc('pool_daily_usage', { p_pool_id: poolId });
+
+  // Unique beneficiary count
+  const { data: usersData } = await supabase.rpc('pool_unique_users', { p_pool_id: poolId });
+
+  const uniqueUsersRow = (usersData as RpcUniqueUsersRow[] | null)?.[0];
+  const uniqueUsers = uniqueUsersRow?.unique_users ?? 0;
+
+  const topTaxa: PoolAnalytics['topTaxa'] = ((taxa as RpcTaxaRow[] | null) ?? [])
+    .slice(0, 10)
+    .map((row) => ({
+      scientific_name: row.scientific_name,
+      common_name: row.common_name ?? null,
+      kingdom: row.kingdom ?? '',
+      count: row.count,
+    }));
+
+  const dailyUsage: PoolAnalytics['dailyUsage'] = ((daily as RpcDailyRow[] | null) ?? [])
+    .map((row) => ({ date: row.date, calls: row.calls }));
+
+  return {
+    poolId: typedPool.id,
+    totalCap: typedPool.total_cap,
+    used: typedPool.used,
+    pctUsed: typedPool.total_cap > 0
+      ? (typedPool.used / typedPool.total_cap) * 100
+      : 0,
+    uniqueUsers,
+    topTaxa,
+    dailyUsage,
+  };
+}
+
+/**
+ * Pure helper: aggregate raw usage rows into daily buckets.
+ * Exported for unit testing.
+ */
+export function aggregateDailyUsage(
+  rows: ReadonlyArray<{ created_at: string }>,
+): Array<{ date: string; calls: number }> {
+  const dailyMap = new Map<string, number>();
+  for (const row of rows) {
+    const date = row.created_at.slice(0, 10);
+    dailyMap.set(date, (dailyMap.get(date) ?? 0) + 1);
+  }
+  return Array.from(dailyMap.entries())
+    .map(([date, calls]) => ({ date, calls }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Pure helper: count unique values in a field.
+ * Exported for unit testing.
+ */
+export function countUniqueUsers(
+  rows: ReadonlyArray<{ beneficiary_id: string }>,
+): number {
+  return new Set(rows.map((r) => r.beneficiary_id)).size;
+}


### PR DESCRIPTION
Adds a sponsor-facing pool dashboard showing capacity, utilisation, unique users, daily usage bar chart, and top-taxa breakdown. Integrated into SponsoringView as a new section below the pools list.

- PoolDashboardView.astro — renders cards per pool with CSS-only bar charts
- pool-analytics.ts — fetches pool metadata + RPCs for taxa/daily/users
- pool-analytics.test.ts — 8 tests covering all paths
- i18n strings in both EN/ES

Closes #226