### PR TITLE
fix(i18n): add missing comma before pool_dashboard — fixes build

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1381,7 +1381,7 @@
     "my_requests_empty": "You haven't requested any sponsors yet.",
     "model_cost_heading": "Estimated cost per 100 calls",
     "model_cost_note": "Costs are approximate and depend on image size and response length.",
-    "model_cost_per_100": "per 100 calls"
+    "model_cost_per_100": "per 100 calls",
     "pool_dashboard": {
       "title": "Pool Dashboard",
       "subtitle": "Analytics for your sponsored pools",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1381,7 +1381,7 @@
     "my_requests_empty": "Aún no has pedido patrocinio.",
     "model_cost_heading": "Costo estimado por 100 llamadas",
     "model_cost_note": "Los costos son aproximados y dependen del tamaño de imagen y longitud de respuesta.",
-    "model_cost_per_100": "por 100 llamadas"
+    "model_cost_per_100": "por 100 llamadas",
     "pool_dashboard": {
       "title": "Panel de pools",
       "subtitle": "Analítica de tus pools patrocinados",


### PR DESCRIPTION
The merge of #533 introduced a missing comma in both en.json and es.json before the `pool_dashboard` key, breaking the build. One-character fix in each file.