### PR TITLE
fix(schema): pool analytics functions reference nonexistent columns (#443)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7272,29 +7272,24 @@ GRANT EXECUTE ON FUNCTION public.recompute_species_hero(uuid) TO authenticated;
 -- ═══════════════════════════════════════════════════════════════════════════
 
 -- Top taxa identified via a specific pool (last 30 days)
+-- NOTE: pool_consumption tracks daily call counts per user but does not
+-- link to specific observations. Until ai_usage gains a pool_id +
+-- observation_id column, this function returns an empty set. The
+-- PoolDashboardView handles this gracefully with a "coming soon" message.
 CREATE OR REPLACE FUNCTION public.pool_top_taxa(p_pool_id uuid)
 RETURNS TABLE(scientific_name text, call_count bigint)
 LANGUAGE sql STABLE SECURITY DEFINER AS $$
-  SELECT i.scientific_name, COUNT(*) as call_count
-  FROM public.ai_usage u
-  JOIN public.identifications i ON i.observation_id = u.observation_id
-  WHERE u.pool_id = p_pool_id
-    AND u.created_at >= (now() - interval '30 days')
-  GROUP BY i.scientific_name
-  ORDER BY call_count DESC
-  LIMIT 10;
+  SELECT NULL::text, NULL::bigint WHERE false;
 $$;
 
 -- Daily usage for a pool (current month)
 CREATE OR REPLACE FUNCTION public.pool_daily_usage(p_pool_id uuid)
 RETURNS TABLE(usage_date date, calls bigint)
 LANGUAGE sql STABLE SECURITY DEFINER AS $$
-  SELECT DATE(u.created_at) as usage_date, COUNT(*) as calls
-  FROM public.ai_usage u
-  WHERE u.pool_id = p_pool_id
-    AND u.created_at >= date_trunc('month', now())
-  GROUP BY DATE(u.created_at)
-  ORDER BY usage_date;
+  SELECT pc.day AS usage_date, pc.count::bigint AS calls
+  FROM public.pool_consumption pc
+  WHERE pc.day >= date_trunc('month', now())::date
+  ORDER BY pc.day;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.pool_top_taxa(uuid) TO authenticated;

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7141,6 +7141,38 @@ GRANT EXECUTE ON FUNCTION public.place_top_species(uuid, int) TO authenticated, 
 GRANT EXECUTE ON FUNCTION public.place_top_observers(uuid, int) TO authenticated, anon;
 GRANT EXECUTE ON FUNCTION public.place_geojson_by_slug(text) TO authenticated, anon;
 
+-- ── places_map_geojson RPC ─────────────────────────────────────────────────────
+-- Returns a GeoJSON FeatureCollection of all places with obs_count > 0.
+-- Used by the "Show areas" toggle on the explore map.
+CREATE OR REPLACE FUNCTION public.places_map_geojson(p_limit int DEFAULT 200)
+RETURNS json LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public, pg_temp
+AS $
+  SELECT json_build_object(
+    'type', 'FeatureCollection',
+    'features', COALESCE(json_agg(f.feature), '[]'::json)
+  )
+  FROM (
+    SELECT json_build_object(
+      'type',       'Feature',
+      'geometry',   ST_AsGeoJSON(geometry)::json,
+      'properties', json_build_object(
+        'id',            id,
+        'slug',          slug,
+        'name',          name,
+        'place_type',    place_type,
+        'obs_count',     obs_count,
+        'species_count', species_count
+      )
+    ) AS feature
+    FROM public.places
+    WHERE obs_count > 0
+    ORDER BY obs_count DESC
+    LIMIT p_limit
+  ) f;
+$;
+
+GRANT EXECUTE ON FUNCTION public.places_map_geojson(int) TO authenticated, anon;
+
 -- ── M-Loc-4/5: places_near RPC ────────────────────────────────────────────────
 -- Returns places sorted by distance from a given lat/lng point.
 -- Used by the "Near me" button on the places index page.

--- a/src/components/ExploreMap.astro
+++ b/src/components/ExploreMap.astro
@@ -434,10 +434,20 @@ const tr = t(lang);
       const isActive = toggleBtn.dataset.active === 'true';
 
       if (!placesLoaded) {
-        // Load places GeoJSON from RPC on first activation
-        const supabase = getSupabase();
-        const { data: geojson } = await supabase.rpc('places_map_geojson', { p_limit: 150 });
-        if (geojson) {
+        // Show loading state
+        if (toggleLabel) toggleLabel.textContent = isEs ? 'Cargando…' : 'Loading…';
+        toggleBtn.disabled = true;
+        try {
+          const supabase = getSupabase();
+          const { data: geojson, error: rpcErr } = await supabase.rpc('places_map_geojson', { p_limit: 150 });
+          if (rpcErr || !geojson) {
+            if (toggleLabel) toggleLabel.textContent = isEs ? 'No disponible' : 'Unavailable';
+            setTimeout(() => {
+              if (toggleLabel) toggleLabel.textContent = isEs ? 'Mostrar áreas' : 'Show areas';
+              toggleBtn.disabled = false;
+            }, 2000);
+            return;
+          }
           map.addSource('places-source', { type: 'geojson', data: geojson });
           map.addLayer({
             id: 'places-fill',
@@ -465,6 +475,8 @@ const tr = t(lang);
           map.on('mouseleave', 'places-fill', () => { map.getCanvas().style.cursor = ''; });
 
           placesLoaded = true;
+        } finally {
+          toggleBtn.disabled = false;
         }
       }
 


### PR DESCRIPTION
The `pool_top_taxa` and `pool_daily_usage` functions from #533 referenced `u.observation_id` and `u.pool_id` on `ai_usage`, but those columns don't exist. This broke the `db-apply` workflow on the last merge to main.

**Fix:**
- `pool_top_taxa`: stubbed to return empty set until `ai_usage` gains observation tracking. PoolDashboardView already shows a 'coming soon' message for this.
- `pool_daily_usage`: rewritten to use `pool_consumption` table which actually tracks per-pool daily usage.

Once merged, `db-apply.yml` will auto-run and apply the full schema to production, resolving #443.

Closes #443