### PR TITLE
fix(sponsoring): crash on page load

### DIFF
--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -311,6 +311,7 @@ const langJson = JSON.stringify(lang);
     request_approve: string;
     request_reject: string;
     add_credential: string;
+    pool_dashboard_view: string;
     confirm_reject_request: string;
     paused_reason: {
       rate_limit: string;
@@ -323,6 +324,8 @@ const langJson = JSON.stringify(lang);
   const tr: I18nBag = JSON.parse(
     (document.getElementById('sponsoring-i18n') as HTMLScriptElement | null)?.textContent ?? '{}'
   ) as I18nBag;
+
+  const poolDashViewLabel = tr.pool_dashboard_view ?? 'View';
 
   const HAIKU_45_INPUT_USD_PER_1K  = 0.001;
   const HAIKU_45_OUTPUT_USD_PER_1K = 0.005;

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -46,15 +46,9 @@ serve(async (req) => {
 
   // Support X-HTTP-Method-Override for environments that block DELETE/PUT (mobile carriers)
   const methodOverride = req.headers.get('X-HTTP-Method-Override');
-  const effectiveMethod = (methodOverride === 'DELETE' || methodOverride === 'PATCH' || methodOverride === 'PUT')
+  const method = (methodOverride === 'DELETE' || methodOverride === 'PATCH' || methodOverride === 'PUT')
     ? methodOverride
-    : method;
-  const req2 = effectiveMethod !== method
-    ? new Request(req.url, { method: effectiveMethod, headers: req.headers, body: req.body })
-    : req;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const req = req2 as typeof req2;  // use effective method
+    : req.method;
   const url = new URL(req.url);
   const path = url.pathname.replace(/^\/sponsorships/, '') || '/';
 


### PR DESCRIPTION
Fixes the /profile/sponsoring/ page being completely broken in production.

## What was wrong

Two ReferenceErrors fired on every page load:

1. **Edge function: `method is not defined`** — the `sponsorships` Edge Function used a bare `method` variable ~20 times but never declared it. A botched `X-HTTP-Method-Override` refactor introduced `effectiveMethod` / `req2` / re-declared `req` — none of which worked. Every non-OPTIONS request threw immediately, causing the three `Failed to fetch` errors the browser reported for `/credentials`, `/sponsorships`, and `/requests`.

2. **Frontend: `poolDashViewLabel is not defined`** — the pool list template string used `poolDashViewLabel` but the variable was never extracted from the i18n bag in the `<script>` block. The frontmatter already passed `pool_dashboard_view` into the bag — the script just never read it.

## What changed

- `supabase/functions/sponsorships/index.ts`: Declare `const method` from the override header or `req.method`; drop the broken request-cloning block.
- `src/components/SponsoringView.astro`: Add `pool_dashboard_view` to the `I18nBag` type and extract it as a const with a fallback.

## Verified

- `npm run typecheck` — 0 errors
- `npm run test` — 825/825 pass
- `npm run build` — 231 pages, 0 errors

The edge function deploy will trigger automatically on merge via `deploy-functions.yml`.