### PR TITLE
fix(community): expose karma_total on community_observers views — fixes leaderboard 400

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4299,6 +4299,7 @@ SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
+  karma_total,
   last_observation_at, joined_at
 FROM public.users
 WHERE hide_from_leaderboards = false;
@@ -4320,6 +4321,7 @@ SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
+  karma_total,
   centroid_geog, last_observation_at, joined_at
 FROM public.users
 WHERE hide_from_leaderboards = false;


### PR DESCRIPTION
## Summary

The Karma Leaderboard at `/{en,es}/community/leaderboard/` returns 400 from PostgREST because `KarmaLeaderboardView.astro` selects and orders by `community_observers.karma_total`, but the view doesn't expose that column.

Failing request:
```
GET /rest/v1/community_observers?select=id,username,display_name,avatar_url,karma_total,species_count&order=karma_total.desc.nullslast&limit=20 → 400
```

## Root cause

- `users.karma_total` (`numeric NOT NULL DEFAULT 0`) exists at `supabase-schema.sql:1767`.
- `community_observers` view (line 4297) projects `species_count`, `obs_count_*`, `is_expert`, etc., but **not** `karma_total`.
- `KarmaLeaderboardView.astro:154-155` queries the view for `karma_total` → 400.

## Fix

Add `karma_total` to both views (`community_observers` and `community_observers_with_centroid`) — kept in lockstep per the existing schema comment ("same change as community_observers above"). Purely additive; `CREATE OR REPLACE VIEW` is idempotent.

No client code change required — `KarmaLeaderboardView` already queries the right shape.

## Privacy note

This makes `karma_total` anon-readable for any user with `hide_from_leaderboards = false`. That matches documented intent — `CommunityDocView` advertises "Sort (species, 7d/30d activity, karma)" as the leaderboard's purpose, and `hide_from_leaderboards` is the M28 single-switch opt-out. The `can_see_facet(_, 'karma_total', _)` gate on `profile_karma` continues to govern profile-page visibility independently (M25 facet privacy ≠ M28 leaderboard opt-in).

## Test plan

- [ ] `db-validate.yml` (PG17 + PostGIS, idempotent replay) passes
- [ ] After merge: `db-apply.yml` runs cleanly on push to main
- [ ] Visit `/en/community/leaderboard/` — table renders, no 400 in DevTools network
- [ ] Visit `/es/community/leaderboard/` — same
- [ ] Sort by other columns on `/en/community/observers/` still works (no regression on the broader `community.ts` query path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)