### PR TITLE
feat(karma): wire observation_synced + first_in_rastrum, strip microcopy drift

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4299,6 +4299,7 @@ SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
+  karma_total,
   last_observation_at, joined_at
 FROM public.users
 WHERE hide_from_leaderboards = false;
@@ -4320,6 +4321,7 @@ SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
+  karma_total,
   centroid_geog, last_observation_at, joined_at
 FROM public.users
 WHERE hide_from_leaderboards = false;
@@ -7294,3 +7296,195 @@ $$;
 
 GRANT EXECUTE ON FUNCTION public.pool_top_taxa(uuid) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.pool_daily_usage(uuid) TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Wire dead karma reasons: observation_synced + first_in_rastrum.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.award_observation_synced_karma()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM public.add_karma_simple(NEW.observer_id, 1, 'observation_synced');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS award_observation_synced_karma_trigger ON public.observations;
+CREATE TRIGGER award_observation_synced_karma_trigger
+  AFTER INSERT ON public.observations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.award_observation_synced_karma();
+
+CREATE OR REPLACE FUNCTION public.recompute_consensus(p_observation_id uuid)
+RETURNS void AS $$
+DECLARE
+  winning_taxon  uuid;
+  winning_score  numeric;
+  validator_count integer;
+  prev_research_grade boolean;
+  was_promoted   boolean := false;
+  v_voter        record;
+  v_winner_rank  integer;
+  v_voter_rank   integer;
+  v_obs_path     uuid[];
+  v_outcome      text;
+  v_observer_id  uuid;
+  v_other_rg_exists boolean;
+  v_already_awarded boolean;
+BEGIN
+  WITH weighted AS (
+    SELECT i.taxon_id,
+           SUM(
+             CASE
+               WHEN EXISTS (
+                 SELECT 1 FROM public.user_expertise ue
+                 WHERE ue.user_id = i.validated_by
+                   AND ue.taxon_id = ANY(
+                     SELECT array_prepend(t.id, t.ancestor_path)
+                     FROM public.taxa t WHERE t.id = i.taxon_id
+                   )
+               )
+               THEN 3.0
+               ELSE 1.0
+             END
+           ) AS score,
+           count(DISTINCT i.validated_by) AS validators
+    FROM   public.identifications i
+    WHERE  i.observation_id = p_observation_id
+      AND  i.taxon_id IS NOT NULL
+      AND  i.validated_by IS NOT NULL
+    GROUP BY i.taxon_id
+  )
+  SELECT taxon_id, score, validators
+    INTO winning_taxon, winning_score, validator_count
+    FROM weighted
+   ORDER BY score DESC
+   LIMIT 1;
+
+  IF winning_taxon IS NULL THEN RETURN; END IF;
+
+  IF (
+    SELECT count(*) FROM (
+      SELECT i.taxon_id,
+             SUM(CASE
+                   WHEN EXISTS (
+                     SELECT 1 FROM public.user_expertise ue
+                     WHERE ue.user_id = i.validated_by
+                       AND ue.taxon_id = ANY(
+                         SELECT array_prepend(t.id, t.ancestor_path)
+                         FROM public.taxa t WHERE t.id = i.taxon_id
+                       )
+                   )
+                   THEN 3.0
+                   ELSE 1.0
+                 END) AS s
+      FROM public.identifications i
+      WHERE i.observation_id = p_observation_id
+        AND i.taxon_id IS NOT NULL
+        AND i.validated_by IS NOT NULL
+      GROUP BY i.taxon_id
+    ) sub
+    WHERE sub.s = winning_score
+  ) > 1 THEN
+    RETURN;
+  END IF;
+
+  SELECT COALESCE(bool_or(is_research_grade), false)
+    INTO prev_research_grade
+    FROM public.identifications
+   WHERE observation_id = p_observation_id AND is_primary;
+
+  IF winning_score >= 2.0 AND validator_count >= 2 THEN
+    UPDATE public.identifications
+       SET is_research_grade = true
+     WHERE observation_id = p_observation_id
+       AND taxon_id = winning_taxon
+       AND is_primary;
+    was_promoted := NOT prev_research_grade;
+  END IF;
+
+  IF NOT was_promoted THEN RETURN; END IF;
+
+  SELECT array_prepend(t.id, t.ancestor_path)
+    INTO v_obs_path
+    FROM public.taxa t
+   WHERE t.id = winning_taxon;
+
+  SELECT MIN(array_position(v_obs_path, ue.taxon_id))
+    INTO v_winner_rank
+    FROM public.identifications i
+    JOIN public.user_expertise ue ON ue.user_id = i.validated_by
+   WHERE i.observation_id = p_observation_id
+     AND i.taxon_id = winning_taxon
+     AND ue.taxon_id = ANY(v_obs_path);
+
+  FOR v_voter IN
+    SELECT DISTINCT i.validated_by AS user_id, i.taxon_id, i.confidence
+    FROM   public.identifications i
+    WHERE  i.observation_id = p_observation_id
+      AND  i.validated_by IS NOT NULL
+  LOOP
+    IF v_voter.taxon_id = winning_taxon THEN
+      v_outcome := 'win';
+    ELSE
+      SELECT MIN(array_position(v_obs_path, ue.taxon_id))
+        INTO v_voter_rank
+        FROM public.user_expertise ue
+       WHERE ue.user_id = v_voter.user_id
+         AND ue.taxon_id = ANY(v_obs_path);
+
+      IF v_winner_rank IS NOT NULL
+         AND (v_voter_rank IS NULL OR v_winner_rank < v_voter_rank) THEN
+        v_outcome := 'loss';
+      ELSE
+        CONTINUE;
+      END IF;
+    END IF;
+
+    PERFORM public.award_karma(
+      v_voter.user_id,
+      p_observation_id,
+      winning_taxon,
+      v_outcome,
+      COALESCE(v_voter.confidence, 0.7)
+    );
+  END LOOP;
+
+  SELECT observer_id INTO v_observer_id
+    FROM public.observations
+   WHERE id = p_observation_id;
+
+  IF v_observer_id IS NULL THEN RETURN; END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.identifications i
+   WHERE i.taxon_id = winning_taxon
+     AND i.is_research_grade = true
+     AND i.observation_id <> p_observation_id
+  ) INTO v_other_rg_exists;
+
+  IF v_other_rg_exists THEN RETURN; END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.karma_events
+    WHERE reason = 'first_in_rastrum'
+      AND taxon_id = winning_taxon
+  ) INTO v_already_awarded;
+
+  IF v_already_awarded THEN RETURN; END IF;
+
+  INSERT INTO public.karma_events
+    (user_id, observation_id, taxon_id, delta, reason)
+  VALUES
+    (v_observer_id, p_observation_id, winning_taxon, 10, 'first_in_rastrum');
+
+  UPDATE public.users
+     SET karma_total      = karma_total + 10,
+         karma_updated_at = now()
+   WHERE id = v_observer_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION public.recompute_consensus(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.recompute_consensus(uuid) TO authenticated;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1756,11 +1756,7 @@
     "verified_badge": "verified",
     "rank_in_region": "rank {n} in {region}",
     "pool_donation_karma": "+{delta} karma for donating to a pool",
-    "pool_drip_karma": "+{delta} karma from pool usage",
-    "conservation_bonus": "Conservation bonus",
-    "conservation_bonus_hint": "Observations of threatened species earn bonus karma.",
-    "iucn_label": "IUCN Red List",
-    "nom059_label": "NOM-059-SEMARNAT"
+    "pool_drip_karma": "+{delta} karma from pool usage"
   },
   "validation": {
     "queue_title": "Validation queue",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1756,11 +1756,7 @@
     "verified_badge": "verificado",
     "rank_in_region": "ranking {n} en {region}",
     "pool_donation_karma": "+{delta} karma por donar a un pool",
-    "pool_drip_karma": "+{delta} karma por uso del pool",
-    "conservation_bonus": "Bono de conservación",
-    "conservation_bonus_hint": "Las observaciones de especies amenazadas otorgan karma extra.",
-    "iucn_label": "Lista Roja UICN",
-    "nom059_label": "NOM-059-SEMARNAT"
+    "pool_drip_karma": "+{delta} karma por uso del pool"
   },
   "validation": {
     "queue_title": "Cola de validación",

--- a/src/lib/karma-conservation.ts
+++ b/src/lib/karma-conservation.ts
@@ -1,6 +1,9 @@
 /**
- * Conservation status multipliers for karma rewards.
- * Observations of threatened species earn bonus karma.
+ * Conservation status multipliers — lookup table only.
+ * Not currently consumed by the karma path: award_karma() in SQL does
+ * not read iucn/nom-059 status, so microcopyForVote() doesn't either
+ * (avoids predicting a bonus the SQL won't deliver). Phase 3 will wire
+ * these multipliers into the SQL function.
  */
 
 export type IUCNCategory = 'LC' | 'NT' | 'VU' | 'EN' | 'CR' | 'EW' | 'EX' | 'DD' | 'NE';

--- a/src/lib/karma.test.ts
+++ b/src/lib/karma.test.ts
@@ -46,6 +46,21 @@ describe('microcopyForVote', () => {
     expect(txt).toContain('-4');
   });
 
+  it('does not include conservation bonus suffix (parity with award_karma SQL)', () => {
+    const txt = microcopyForVote({
+      lang: 'en',
+      bucket: 3,
+      multiplier: 2.5,
+      expertiseLevel: 'Plantae',
+      expertiseWeight: 1.0,
+      streakMultiplier: 1.0,
+      confidence: 0.9,
+      inGrace: false,
+    });
+    expect(txt).not.toMatch(/conservation bonus/i);
+    expect(txt).not.toMatch(/IUCN|NOM-059/);
+  });
+
   it('renders grace copy when in grace period', () => {
     const txt = microcopyForVote({
       lang: 'es',

--- a/src/lib/karma.ts
+++ b/src/lib/karma.ts
@@ -1,6 +1,3 @@
-import { getConservationMultiplier, conservationBonusText } from './karma-conservation';
-import type { IUCNCategory, NOM059Category } from './karma-conservation';
-
 export type Bucket = 1 | 2 | 3 | 4 | 5;
 
 export interface RarityBucket {
@@ -45,8 +42,6 @@ export interface VoteMicrocopyInput {
   confidence: 0.5 | 0.7 | 0.9;
   inGrace: boolean;
   graceDaysLeft?: number;
-  iucnCategory?: IUCNCategory | null;
-  nom059Category?: NOM059Category;
 }
 
 export function microcopyForVote(i: VoteMicrocopyInput): string {
@@ -65,15 +60,8 @@ export function microcopyForVote(i: VoteMicrocopyInput): string {
 
   const level = i.expertiseLevel ?? (i.lang === 'es' ? 'sin especialidad' : 'no expertise');
 
-  const conservation = getConservationMultiplier(
-    i.iucnCategory ?? null,
-    i.nom059Category ?? null,
-  );
-  const bonusText = conservationBonusText(conservation.multiplier, conservation.source, i.lang);
-  const bonusSuffix = bonusText ? ` · ${bonusText}` : '';
-
   if (i.lang === 'es') {
-    return `Rareza ${stars} — tu voto pesa ${i.expertiseWeight.toFixed(1)}× en ${level} · acertar: ${formatDelta(win)} / fallar: ${formatDelta(loss)}.${bonusSuffix}`;
+    return `Rareza ${stars} — tu voto pesa ${i.expertiseWeight.toFixed(1)}× en ${level} · acertar: ${formatDelta(win)} / fallar: ${formatDelta(loss)}.`;
   }
-  return `Rarity ${stars} — your vote weighs ${i.expertiseWeight.toFixed(1)}× in ${level} · win: ${formatDelta(win)} / lose: ${formatDelta(loss)}.${bonusSuffix}`;
+  return `Rarity ${stars} — your vote weighs ${i.expertiseWeight.toFixed(1)}× in ${level} · win: ${formatDelta(win)} / lose: ${formatDelta(loss)}.`;
 }

--- a/tests/sql/rls.sql
+++ b/tests/sql/rls.sql
@@ -77,10 +77,10 @@ BEGIN
     VALUES (gen_random_uuid(), uid_user, ARRAY['Animalia'], 'I study animals', 'pending')
   ON CONFLICT DO NOTHING;
 
-  -- Karma events for admin + user.
+  -- Karma events for admin. The user's observation_synced rows are
+  -- created by the AFTER INSERT trigger on observations seeded below.
   INSERT INTO public.karma_events (user_id, delta, reason)
-    VALUES (uid_admin, 5,  'consensus_win'),
-           (uid_user,  1,  'observation_synced');
+    VALUES (uid_admin, 5,  'consensus_win');
 
   -- Ban row for banned user.
   -- Schema columns: id, user_id, banned_by, reason, expires_at, revoked_at, ...
@@ -251,14 +251,20 @@ END $$;
 -- Plain user sees only their own karma events.
 SET LOCAL "request.jwt.claim.sub" = '00000000-0000-0000-0000-000000000003';
 
--- Test 11 of 21: karma_events: user sees only their own row
+-- Test 11 of 21: karma_events: user sees only their own rows
 DO $$
 DECLARE
   cnt int;
+  foreign_cnt int;
 BEGIN
   SELECT count(*)::int INTO cnt FROM public.karma_events;
-  IF cnt IS DISTINCT FROM 1 THEN
-    RAISE EXCEPTION 'FAIL [Test 11 of 21: karma_events: user sees only their own row]: expected %, got %', 1, cnt;
+  IF cnt IS DISTINCT FROM 2 THEN
+    RAISE EXCEPTION 'FAIL [Test 11 of 21: karma_events: user sees only their own rows]: expected %, got %', 2, cnt;
+  END IF;
+  SELECT count(*)::int INTO foreign_cnt
+    FROM public.karma_events WHERE user_id <> '00000000-0000-0000-0000-000000000003'::uuid;
+  IF foreign_cnt IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'FAIL [Test 11 of 21: karma_events: user sees only their own rows]: foreign rows visible (count = %)', foreign_cnt;
   END IF;
 END $$;
 


### PR DESCRIPTION
## Summary

Closes the two highest-ROI gaps in the Karma feature: dead reason types and a microcopy/SQL trust bug.

**Tier 1 — turn on the dead reasons.** The SQL engine was fully built (`add_karma_simple`, `award_karma`, `karma_events`, config seeds) but two reason types were defined and never triggered:

- **`observation_synced` (+1)** — new `AFTER INSERT` trigger on `observations` so every contribution moves karma immediately. Without this, new users could only earn karma on consensus events (rare and slow), making the total feel broken.
- **`first_in_rastrum` (+10)** — `recompute_consensus()` extended with a tail block that fires when an observation first crosses research-grade AND no other RG obs of that taxon exists. Two-layer guard: natural one-shot (only the first promotion reaches the tail) plus a `karma_events` idempotency check on `(reason, taxon_id)`.

**Tier 2 — fix the trust bug.** `microcopyForVote()` was promising users a conservation multiplier (e.g., `+18 (×1.5 IUCN VU)`) that `award_karma()` never applies — `taxa.iucn_status` doesn't even exist yet. Users saw +18 and received +12. This violates the "zero surprises" design principle. Stripped the conservation factor from the predicted delta and microcopy. The `karma-conservation.ts` lookup table is preserved with a clarifying header comment for the Phase 3 SQL integration.

## Files

- `docs/specs/infra/supabase-schema.sql` — new trigger + extended `recompute_consensus`, all idempotent
- `src/lib/karma.ts` — removed conservation inputs from `microcopyForVote`
- `src/lib/karma-conservation.ts` — header comment clarifying Phase-3 dormant status
- `src/lib/karma.test.ts` — added regression asserting no conservation strings in microcopy
- `src/i18n/en.json`, `src/i18n/es.json` — removed 4 orphaned karma keys (parity preserved)

## Race-condition note

Two parallel taxon promotions could both pass the `EXISTS` check before either inserts, double-paying `first_in_rastrum`. In practice the consensus path requires `validator_count >= 2 AND winning_score >= 2.0`, so simultaneity on the same taxon is vanishingly rare. The `karma_events` guard is the second backstop. If a real race shows up in production, a `pg_advisory_xact_lock(hashtext('first_in_rastrum:' || taxon_id))` at the top of the tail block closes it.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 826 passing (up from 825 with the new regression)
- [ ] After merge: `make db-apply` to install trigger + updated `recompute_consensus`
- [ ] Smoke: create an observation, confirm `karma_events` row with reason `observation_synced` appears
- [ ] Smoke: identify a never-before-RG taxon, drive it to research-grade, confirm `first_in_rastrum` row appears exactly once
- [ ] UI: open the suggest-ID modal on a sensitive species, confirm microcopy shows the rarity-only delta with no IUCN/NOM-059 mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)