### PR TITLE
fix(community-map): expose centroid_lat/lng on community_observers_with_centroid

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4326,7 +4326,12 @@ SELECT
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
   centroid_geog, last_observation_at, joined_at,
-  karma_total
+  karma_total,
+  -- Scalar lat/lng for clients that can't decode the geography WKB
+  -- (the /community/map/ heatmap reads these directly). PostGIS
+  -- geography → geometry cast is a zero-copy reinterpret for points.
+  ST_Y(centroid_geog::geometry) AS centroid_lat,
+  ST_X(centroid_geog::geometry) AS centroid_lng
 FROM public.users
 WHERE hide_from_leaderboards = false;
 -- 2026-04-30: same change as community_observers above — M28-only opt-out.


### PR DESCRIPTION
## Summary

- `/community/map/` heatmap has been broken for authenticated users since it shipped in PR #160 — `CommunityMapView.astro` queries `community_observers_with_centroid` selecting `centroid_lat, centroid_lng`, but the view only exposed `centroid_geog` (PostGIS geography). PostgREST returned 400 on every request.
- Append the two scalar columns to the view via `ST_Y(centroid_geog::geometry) AS centroid_lat, ST_X(centroid_geog::geometry) AS centroid_lng`.
- No client change needed — the `ObserverRow` type already declares `centroid_lat?: number | null; centroid_lng?: number | null`.

## Why this shape

- `CREATE OR REPLACE VIEW` permits append-only column changes; the two `nearby` RPCs that `RETURN SETOF community_observers_with_centroid` pick up the new columns automatically on the same `db-apply` run.
- Privacy gate is unchanged — `GRANT SELECT … TO authenticated` only; no anon grant. ST_X/ST_Y over the same `centroid_geog` doesn't widen the privilege boundary.
- Cheaper than introducing a dedicated RPC; the view is unmaterialized and ST_X/ST_Y of a point is a few bytes from the WKB.

## Verification

- `make db-apply` — applied cleanly to prod Supabase.
- `psql` smoke against `community_observers_with_centroid` returns three rows with sane `centroid_lat`/`centroid_lng` floats.
- `npx tsc --noEmit` — clean.
- `npx vitest run` — 825/825 pass.

## Test plan

- [ ] CI db-validate passes (idempotent double-apply).
- [ ] After merge + auto db-apply, visit `https://rastrum.org/en/community/map/` while signed in. Heatmap renders without a 400 in DevTools network panel.
- [ ] Anon path on the same page still returns country-level data (no regression to `community_observers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)