### PR TITLE
fix(community): append karma_total at end of view column list — unblocks db-apply

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4299,8 +4299,8 @@ SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
-  karma_total,
-  last_observation_at, joined_at
+  last_observation_at, joined_at,
+  karma_total
 FROM public.users
 WHERE hide_from_leaderboards = false;
 -- 2026-04-30: dropped `profile_public = true AND` — M28 visibility is now
@@ -4321,8 +4321,8 @@ SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
-  karma_total,
-  centroid_geog, last_observation_at, joined_at
+  centroid_geog, last_observation_at, joined_at,
+  karma_total
 FROM public.users
 WHERE hide_from_leaderboards = false;
 -- 2026-04-30: same change as community_observers above — M28-only opt-out.


### PR DESCRIPTION
## Summary

Hotfix for the failing `db-apply` workflow on `main` (broke after PR #543, masked PR #544's apply too).

Postgres `CREATE OR REPLACE VIEW` only allows **appending** columns at the end of the SELECT list. PR #543 inserted `karma_total` between `obs_count_30d` and `last_observation_at`, which shifted `last_observation_at` from position 11 to 12. PG read that as a rename of column 11:

```
ERROR:  cannot change name of view column "last_observation_at" to "karma_total"
HINT:   Use ALTER VIEW ... RENAME COLUMN ... to change name of view column instead.
```

This blocked db-apply on the merge of both #543 and #544.

## Fix

Move `karma_total` to the tail of both view SELECT lists. PostgREST clients that name-select `karma_total` (i.e. `KarmaLeaderboardView`) are unaffected; the column is still present, just last.

## Why db-validate didn't catch this

`db-validate.yml` applies the schema to a fresh PG container, so `CREATE OR REPLACE VIEW` succeeds (no prior view to compare against). The position-rename rule only fires on a replay against an existing view. Worth adding a regression test that pre-creates the prior view shape, but out of scope for this hotfix.

## Test plan

- [ ] db-validate.yml passes (fresh container — should pass)
- [ ] After merge: db-apply.yml runs cleanly on production (replays against existing views)
- [ ] `/en/community/leaderboard/` renders, no 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)