### PR TITLE
fix(schema): unbreak db-apply by appending karma_total to community_observers views

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4294,13 +4294,17 @@ GRANT EXECUTE ON FUNCTION public.normalize_country_code(text) TO anon, authentic
 -- The eligibility predicate lives in exactly one place per view; both
 -- views read profile_public live (no caching), so toggling private
 -- drops a user from the list on the next request.
+-- Column order note: karma_total is appended last because Postgres
+-- CREATE OR REPLACE VIEW only allows adding columns at the end.
+-- Inserting karma_total mid-list is treated as a column rename and
+-- breaks db-apply on databases with the previous view definition.
 CREATE OR REPLACE VIEW public.community_observers AS
 SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
-  karma_total,
-  last_observation_at, joined_at
+  last_observation_at, joined_at,
+  karma_total
 FROM public.users
 WHERE hide_from_leaderboards = false;
 -- 2026-04-30: dropped `profile_public = true AND` — M28 visibility is now
@@ -4321,8 +4325,8 @@ SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
-  karma_total,
-  centroid_geog, last_observation_at, joined_at
+  centroid_geog, last_observation_at, joined_at,
+  karma_total
 FROM public.users
 WHERE hide_from_leaderboards = false;
 -- 2026-04-30: same change as community_observers above — M28-only opt-out.


### PR DESCRIPTION
## Summary

PR #543 inserted \`karma_total\` mid-list in \`community_observers\` and \`community_observers_with_centroid\`. Postgres \`CREATE OR REPLACE VIEW\` only allows **appending** columns — inserting mid-list is interpreted as renaming the column at that position, which the planner rejects:

\`\`\`
ERROR: cannot change name of view column "last_observation_at" to "karma_total"
\`\`\`

The \`validate\` gate runs on an ephemeral DB and never has a prior view to conflict with, so it didn't catch this. \`db-apply\` runs against the existing live schema and fails — every merge to main since #543 has triggered the same error (PRs #543 and #544's auto-apply runs both went red here).

## Fix

Move \`karma_total\` to the end of both \`SELECT\` lists. Column position is invisible to query consumers (everything selects by name). Added a header comment so the next person editing these views doesn't reintroduce the same bug.

## Test plan

- [x] Schema diff is purely additive at the SQL level (only column ordering changed; no consumer references break)
- [ ] CI: \`validate\` (db-validate) passes
- [ ] After merge: \`db-apply\` workflow runs to green for the first time since #543
- [ ] Verify \`SELECT karma_total FROM community_observers LIMIT 1\` works post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)