### PR TITLE
fix(console): mount Report-an-issue FAB in ConsoleLayout

### DIFF
--- a/src/components/ConsoleLayout.astro
+++ b/src/components/ConsoleLayout.astro
@@ -15,6 +15,7 @@ import type { UserRole } from '../lib/types';
 import { CONSOLE_TABS } from '../lib/console-tabs';
 import { t, getLocalizedPath, routes } from '../i18n/utils';
 import ConsoleOnboarding from './console/ConsoleOnboarding.astro';
+import ReportIssueButton from './ReportIssueButton.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -453,6 +454,7 @@ const knownPills: Set<UserRole> | null = allRoles ?? null;
       })();
     </script>
 
+    <ReportIssueButton lang={lang} />
     <ConsoleOnboarding lang={lang} />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- The "Report an issue" floating button was missing on every `/console/*` and `/consola/*` route — admin, moderator, and expert dashboards.
- Root cause: `ReportIssueButton` was only mounted in `BaseLayout`, which `ConsoleLayout` intentionally bypasses for privileged-chrome reasons (per `CLAUDE.md`).
- Fix: import + mount `ReportIssueButton` in `ConsoleLayout.astro` alongside `ConsoleOnboarding`. The component is self-contained (own dialog + inline diagnostics-capture script).
- Stacking: FAB is `z-40`, console mobile drawer is `z-50` → drawer correctly overlays the FAB.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 826 / 826 pass
- [x] `npm run build` — 231 pages, no errors
- [x] Verified `id="report-issue-btn"` ships in `dist/en/console/`, `dist/es/consola/`, `dist/en/console/audit/`
- [ ] Click the FAB on `/en/console/` and `/es/consola/`, confirm modal opens and "Open on GitHub" produces a valid issue URL
- [ ] Confirm mobile drawer (md:hidden) still opens cleanly with the FAB present

🤖 Generated with [Claude Code](https://claude.com/claude-code)