### PR TITLE
feat(karma): show full karma section on public profiles

### DIFF
--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -19,6 +19,7 @@ import FollowButton from './FollowButton.astro';
 import ShareButton from './ShareButton.astro';
 import ExpertiseLegendBadge from './ExpertiseLegendBadge.astro';
 import ExpertiseCoverageGrid from './ExpertiseCoverageGrid.astro';
+import ProfileKarmaSection from './profile/ProfileKarmaSection.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -201,13 +202,10 @@ const sponsoringI18n = {
       <p data-pp-validation-owner-only data-owner-only-badge class="hidden mt-2 text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400"></p>
     </section>
 
-    <section data-pp-karma-section class="hidden mb-8">
-      <h2 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider mb-3">
-        {lang === 'es' ? 'Karma' : 'Karma'}
-      </h2>
-      <p data-pp-karma-body class="text-sm text-zinc-700 dark:text-zinc-300"></p>
+    <div data-pp-karma-section class="hidden mb-8">
+      <ProfileKarmaSection lang={lang} viewer="anonymous" defer={true} />
       <p data-pp-karma-owner-only data-owner-only-badge class="hidden mt-2 text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400"></p>
-    </section>
+    </div>
 
     <section data-pp-pokedex-section class="hidden mb-8">
       <a data-pp-pokedex-link class="block rounded-lg border border-zinc-200 dark:border-zinc-800 p-4 hover:border-emerald-400 dark:hover:border-emerald-700">
@@ -604,15 +602,23 @@ const sponsoringI18n = {
       }
     }
 
-    // Karma
     if (showKarma) {
-      show(root.querySelector('[data-pp-karma-section]'));
-      const body = root.querySelector<HTMLElement>('[data-pp-karma-body]');
-      if (body) body.textContent = `${profile.karma_total ?? 0}`;
-      if (isOwner && facets.karma_total === false) {
-        const badge = root.querySelector<HTMLElement>('[data-pp-karma-owner-only]');
-        if (badge) { badge.textContent = ownerLabel; badge.classList.remove('hidden'); }
-      }
+      const wrap = root.querySelector<HTMLElement>('[data-pp-karma-section]');
+      const inner = wrap?.querySelector<HTMLElement>('[data-widget="karma-section"]') ?? null;
+      if (inner) inner.dataset.targetUserId = profile.id;
+
+      const onHydrated = (ev: Event) => {
+        const detail = (ev as CustomEvent<{ targetUserId?: string }>).detail;
+        if (detail?.targetUserId !== profile.id) return;
+        document.removeEventListener('rastrum:karma-hydrated', onHydrated);
+        show(wrap);
+        if (isOwner && facets.karma_total === false) {
+          const badge = root.querySelector<HTMLElement>('[data-pp-karma-owner-only]');
+          if (badge) { badge.textContent = ownerLabel; badge.classList.remove('hidden'); }
+        }
+      };
+      document.addEventListener('rastrum:karma-hydrated', onHydrated);
+      document.dispatchEvent(new CustomEvent('rastrum:karma-ready'));
     }
 
     // Pokédex link.

--- a/src/components/profile/ProfileKarmaSection.astro
+++ b/src/components/profile/ProfileKarmaSection.astro
@@ -7,18 +7,22 @@ interface Props {
   viewer: 'self' | 'signed_in' | 'anonymous';
   targetUserId?: string;
   ownerOnly?: boolean;
+  defer?: boolean;
 }
 
-const { lang, ownerOnly = false } = Astro.props;
+const { lang, ownerOnly = false, defer = false } = Astro.props;
 const tr = t(lang);
 const k = (tr as unknown as { karma: Record<string, string> }).karma;
 const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } }).privacy?.owner_only_badge ?? (lang === 'es' ? '🔒 Solo tú lo ves' : '🔒 Only you see this');
+const sectionClass = `rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4 mb-6${defer ? ' hidden' : ''}`;
 ---
 
 <section
   data-widget="karma-section"
   data-target-user-id={Astro.props.targetUserId}
-  class="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4 mb-6"
+  data-defer={defer ? '1' : '0'}
+  data-karma-hydrated="0"
+  class={sectionClass}
 >
   <header class="flex items-baseline justify-between mb-3">
     <h2 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider">
@@ -51,14 +55,19 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
   import { escAttr } from '../../lib/karma';
 
   async function hydrate(el: HTMLElement) {
+    if (el.dataset.karmaHydrated === '1') return;
+
     const totalEl = el.querySelector<HTMLElement>('[data-karma-total]');
     const listEl = el.querySelector<HTMLUListElement>('[data-expertise]');
     if (!totalEl || !listEl) return;
+
+    const deferred = el.dataset.defer === '1';
 
     let supabase;
     try { supabase = getSupabase(); } catch { return; }
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
+      if (deferred) return;
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
       userId = user.id;
@@ -70,6 +79,8 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
       .maybeSingle<{ karma_total: number | null; top_expertise: Array<{ taxon_id: string; scientific_name: string; score: number }> | null }>();
 
     if (!data) return;
+
+    el.dataset.karmaHydrated = '1';
     totalEl.textContent = String(Math.round(data.karma_total ?? 0));
     const rows = data.top_expertise ?? [];
     if (rows.length) {
@@ -77,7 +88,15 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
         .map((r) => `<li class="flex items-center gap-2"><span class="italic">${escAttr(r.scientific_name)}</span><span class="ml-auto font-mono text-xs">${Math.round(r.score)}</span></li>`)
         .join('');
     }
+    if (deferred) el.classList.remove('hidden');
+    document.dispatchEvent(new CustomEvent('rastrum:karma-hydrated', { detail: { targetUserId: userId } }));
   }
 
-  document.querySelectorAll<HTMLElement>('[data-widget="karma-section"]').forEach(hydrate);
+  function hydrateAll() {
+    document.querySelectorAll<HTMLElement>('[data-widget="karma-section"]').forEach((el) => {
+      hydrate(el).catch(() => { /* env not configured */ });
+    });
+  }
+  hydrateAll();
+  document.addEventListener('rastrum:karma-ready', hydrateAll);
 </script>


### PR DESCRIPTION
## Summary

Visitors viewing other users' profiles only saw a single bare karma total. The richer \`ProfileKarmaSection\` (total + top-5 expertise) was only mounted on the OWN profile (\`ProfileView.astro\`). This brings the same UI to every public profile, with privacy still enforced by the \`profile_karma\` view's RLS.

## Implementation

\`ProfileKarmaSection\` gains a \`defer\` prop that mirrors the \`ReactionStrip\` deferred-hydrate pattern:

- When \`defer={true}\`, the section starts hidden and skips the auth-user fallback (so it doesn't accidentally render the visitor's own karma when the target id hasn't arrived yet).
- A \`data-karma-hydrated\` flag makes hydrate idempotent.
- Listens for a \`rastrum:karma-ready\` document event so the host can re-trigger hydration once the target user id is resolved client-side.
- Emits \`rastrum:karma-hydrated\` on a successful row (with the resolved \`targetUserId\`), so the host can conditionally reveal its outer wrapper only when the SQL view actually returned data.

\`PublicProfileViewV2\`:

- Replaces the hand-rolled bare-number block with \`<ProfileKarmaSection lang viewer=\"anonymous\" defer={true} />\` inside the existing \`data-pp-karma-section\` wrapper.
- After fetching the profile and computing \`showKarma\`, stamps \`profile.id\` onto the inner widget's \`data-target-user-id\`, registers a one-shot \`rastrum:karma-hydrated\` listener filtered to that id, then dispatches \`rastrum:karma-ready\`.
- The wrapper div + owner-only badge are revealed inside the listener, so a privacy-blocked visitor sees no orphan empty section.

## Privacy edge cases

- **Visitor blocked at \`karma_total\` facet** → \`profile_karma\` returns no row → component skips reveal → host listener never fires → wrapper stays hidden. Truth source is RLS, not the client-side facet check.
- **Visitor allowed \`karma_total\` but not expertise** → row returned with \`top_expertise=[]\` → existing \`if (rows.length)\` guard leaves the i18n empty-state placeholder; total still paints.
- **OWN profile** → \`ProfileView.astro\` still calls without \`defer\` → defaults to \`false\` → unchanged behavior, auth-user fallback still works.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run test\` — 826 passing
- [x] \`npm run build\` — 231 pages, green
- [ ] Visit a public profile of a user with \`karma_total\` visible → see total + top expertise
- [ ] Visit a public profile of a user with karma_total privacy on → section stays hidden
- [ ] Visit own profile → unchanged (\`ProfileView.astro\` path)
- [ ] EN + ES paths render identically

## Out of scope

- Karma breakdown tooltip (issue #556) — separate work.
- Removing \`karma_total\` from the \`PublicUser\` type / SELECT (still listed but no longer rendered) — intentional minimal diff; cleanup can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)