### PR TITLE
fix(sponsoring): allow x-http-method-override + PATCH in CORS preflight

### DIFF
--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -9,8 +9,8 @@ const SPONSORSHIPS_CRON_TOKEN = Deno.env.get('SPONSORSHIPS_CRON_TOKEN');
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, x-client-info, x-rastrum-build',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, x-client-info, x-rastrum-build, x-http-method-override',
   'Access-Control-Max-Age': '86400',
 };
 


### PR DESCRIPTION
## Summary
- Pool/credential/sponsorship delete buttons and the pool edit dialog were failing with "Failed to fetch" on `/en/profile/sponsoring/`. Network log shows `POST .../sponsorships/pools/<uuid> → ERR Failed to fetch` with no HTTP status — classic CORS preflight rejection.
- The EF's `CORS_HEADERS` (added before #467) didn't list `x-http-method-override` in `Access-Control-Allow-Headers`, so preflight failed for the override-based DELETE callers (`deletePool`, `deleteCredential`, `deleteSponsorship`, request-delete).
- `Access-Control-Allow-Methods` was also missing `PATCH`, which would break `updatePool` (line 152 of `src/lib/sponsorships.ts` — real PATCH).

## Test plan
- [ ] Merge → `deploy-functions.yml` auto-deploys `sponsorships` (diff-detected).
- [ ] On `/en/profile/sponsoring/`: delete a pool succeeds (204 in network).
- [ ] Edit a pool's `daily_user_cap` via the dialog succeeds (200 in network, real PATCH).
- [ ] Delete a credential succeeds.
- [ ] Preflight OPTIONS now responds with `Access-Control-Allow-Headers: …, x-http-method-override` and `Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)