### PR TITLE
fix(auth,onboarding): PKCE-verifier race + skip privacy step when already set

### DIFF
--- a/src/components/OnboardingTour.astro
+++ b/src/components/OnboardingTour.astro
@@ -589,6 +589,21 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     try { sb = getSupabase(); } catch { return; }
     const { data: { user } } = await sb.auth.getUser();
     if (!user) return;
+    // Cross-device dedupe: if this user already configured privacy on another
+    // browser/session, the server holds profile_privacy. Treat that as proof
+    // the tour ran before and skip — otherwise users hit the privacy step
+    // every time their localStorage is cleared (incognito, ITP, new device).
+    try {
+      const { data: profile } = await sb
+        .from('users')
+        .select('profile_privacy')
+        .eq('id', user.id)
+        .maybeSingle<{ profile_privacy: Record<string, string> | null }>();
+      if (profile?.profile_privacy && Object.keys(profile.profile_privacy).length > 0) {
+        markSeen();
+        return;
+      }
+    } catch { /* env not configured / column missing — fall through and show */ }
     setTimeout(() => show(), 600);
   }
 

--- a/src/pages/auth/callback.astro
+++ b/src/pages/auth/callback.astro
@@ -74,10 +74,30 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
         return;
       }
 
+      // Whether or not we hold a code, the singleton's _initialize() may have
+      // already exchanged it (BaseLayout chrome scripts — Header, MobileBottomBar,
+      // BellIcon, MobileDrawer — call getSupabase() at module-load and trigger
+      // initialize() before our run() reaches its strip+exchange step). getSession
+      // awaits initialize internally, so if a session exists by now the exchange
+      // already happened and we just redirect.
+      const { data: { session: existing } } = await supabase.auth.getSession();
+      if (existing) {
+        redirectToHome();
+        return;
+      }
+
       // PKCE flow — preferred since we now set flowType: 'pkce' in supabase.ts
       if (code) {
         const { error } = await exchangeCode(code);
-        if (error) { showError(error.message); return; }
+        if (error) {
+          // Last-chance recovery: the verifier may have just been consumed
+          // by a parallel _initialize() that completed between our getSession
+          // above and this exchange call. Check session one more time.
+          const { data: { session: post } } = await supabase.auth.getSession();
+          if (post) { redirectToHome(); return; }
+          showError(error.message);
+          return;
+        }
         redirectToHome();
         return;
       }
@@ -90,14 +110,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
           refresh_token: refreshToken,
         });
         if (error) { showError(error.message); return; }
-        redirectToHome();
-        return;
-      }
-
-      // No code, no tokens — maybe detectSessionInUrl already consumed them
-      // before we could, or the user navigated here directly.
-      const { data: { session } } = await supabase.auth.getSession();
-      if (session) {
         redirectToHome();
         return;
       }


### PR DESCRIPTION
## Summary

Two bugs reported after a Google OAuth sign-in on rastrum.org:

1. **\`/auth/callback/?code=…\` shows \"PKCE code verifier not found in storage\"** even though sign-in actually succeeded.
2. **Privacy preset is asked again** during onboarding even though the user already configured it.

## Bug 1 — PKCE callback race

PR #350 stripped the URL before \`getSupabase()\` to keep \`detectSessionInUrl\` from racing the manual \`exchangeCode()\`. But \`callback.astro\` is wrapped in \`BaseLayout\`, which mounts \`Header\`, \`MobileBottomBar\`, \`BellIcon\`, and \`MobileDrawer\` — all of which call \`getSupabase()\` at module-load. The first one wins: \`new GoTrueClient()\` → \`this.initialize()\` → reads \`window.location.href\` while it still has \`?code=\` → \`_isPKCECallback === true\` → \`_exchangeCodeForSession\` consumes the verifier and strips the URL. By the time the callback's \`run()\` calls \`exchangeCode(code)\`, the verifier is gone.

Fix: in \`run()\`, await \`getSession()\` *before* attempting \`exchangeCode\`. \`getSession()\` internally awaits \`initialize()\`, so by then the auto-exchange has settled. If a session exists, redirect home. Only fall back to manual exchange when truly needed. Plus a last-chance \`getSession()\` after a failed exchange covers the narrow window where init completes between the two checks.

## Bug 2 — Onboarding asks privacy again

\`OnboardingTour.maybeShow()\` only checked \`localStorage.rastrum.onboarding.seen\`. The chosen preset is persisted to \`users.profile_privacy\` server-side, but the seen flag is local-only — so a new device, incognito, ITP-cleared storage, or cleared cookies all re-fire the tour from step 0 including the privacy preset step.

Fix: after the local-flag fast path, query \`users.profile_privacy\`. If non-empty, mark seen locally and return — cross-device dedupe without changing the schema.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` — 826/826 green
- [x] \`npm run build\` — 231 pages, no errors
- [ ] Manual: deploy preview → sign in via Google in fresh browser → expect home redirect, no error
- [ ] Manual: clear localStorage on signed-in account that has \`profile_privacy\` set → reload → expect tour does NOT show

🤖 Generated with [Claude Code](https://claude.com/claude-code)