### PR TITLE
feat(karma): wire realtime toast notifications via Supabase Realtime

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -1762,6 +1762,25 @@ CREATE POLICY karma_events_self_read ON public.karma_events
 -- INSERT into karma_events is restricted to service_role / SECURITY DEFINER
 -- functions (award_karma). The append-only ledger has no client-write policy.
 
+-- karma_events realtime publication membership.
+-- Required so signed-in users can subscribe to their own INSERTs via
+-- supabase-js Realtime (see src/lib/karma-toast.ts subscribeToKarmaEvents).
+-- The `karma_events_self_read` RLS policy above + server-side filter
+-- `user_id=eq.<auth.uid()>` on the channel together gate access; the
+-- publication just makes the WAL stream available to the broker.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime')
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_publication_tables
+        WHERE pubname = 'supabase_realtime'
+          AND schemaname = 'public'
+          AND tablename = 'karma_events'
+     ) THEN
+    EXECUTE 'ALTER PUBLICATION supabase_realtime ADD TABLE public.karma_events';
+  END IF;
+END $$;
+
 -- 5. users: karma_total + grace columns.
 ALTER TABLE public.users
   ADD COLUMN IF NOT EXISTS karma_total      numeric NOT NULL DEFAULT 0,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -193,5 +193,34 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <ReportDialog lang={installLang} />
     <ConfirmDialog lang={installLang} />
     <PhotoCropModal lang={installLang} />
+    <script>
+      import { getSupabase } from '../lib/supabase';
+      import { subscribeToKarmaEvents } from '../lib/karma-toast';
+
+      let cleanup: (() => void) | null = null;
+
+      async function start() {
+        try {
+          const supabase = getSupabase();
+          const { data } = await supabase.auth.getSession();
+          const userId = data.session?.user?.id;
+          if (!userId) return;
+          cleanup = subscribeToKarmaEvents(userId, supabase);
+        } catch {
+          // env not configured, or not signed in — skip silently.
+        }
+      }
+
+      function dispose() {
+        if (cleanup) {
+          cleanup();
+          cleanup = null;
+        }
+      }
+
+      start();
+      window.addEventListener('pagehide', dispose);
+      window.addEventListener('beforeunload', dispose);
+    </script>
   </body>
 </html>

--- a/src/lib/karma-toast.test.ts
+++ b/src/lib/karma-toast.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { showKarmaToast, _resetToastContainer, type KarmaToast } from './karma-toast';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  showKarmaToast,
+  subscribeToKarmaEvents,
+  _resetToastContainer,
+  type KarmaToast,
+} from './karma-toast';
 
 function makeToast(overrides: Partial<KarmaToast> = {}): KarmaToast {
   return {
@@ -66,5 +71,165 @@ describe('showKarmaToast', () => {
     showKarmaToast(makeToast({ delta: 0.5, label: 'Comment reaction' }));
     const el = document.querySelector('#karma-toast-container > div');
     expect(el?.textContent).toContain('+1 karma');
+  });
+});
+
+interface FakeChannel {
+  filter: { event: string; schema: string; table: string; filter: string } | null;
+  handler: ((payload: { new: Record<string, unknown> }) => void) | null;
+  subscribed: boolean;
+  on: (event: string, filter: unknown, handler: (payload: { new: Record<string, unknown> }) => void) => FakeChannel;
+  subscribe: () => FakeChannel;
+}
+
+function makeFakeSupabase() {
+  const channels: Array<FakeChannel & { name: string }> = [];
+  const removed: string[] = [];
+
+  const supabase = {
+    channel(name: string) {
+      const ch: FakeChannel & { name: string } = {
+        name,
+        filter: null,
+        handler: null,
+        subscribed: false,
+        on(_event, filter, handler) {
+          ch.filter = filter as FakeChannel['filter'];
+          ch.handler = handler;
+          return ch;
+        },
+        subscribe() {
+          ch.subscribed = true;
+          return ch;
+        },
+      };
+      channels.push(ch);
+      return ch;
+    },
+    removeChannel(ch: FakeChannel & { name: string }) {
+      removed.push(ch.name);
+    },
+  };
+
+  return { supabase, channels, removed };
+}
+
+describe('subscribeToKarmaEvents', () => {
+  beforeEach(() => {
+    _resetToastContainer();
+    document.body.innerHTML = '';
+    document.documentElement.lang = 'en';
+  });
+
+  afterEach(() => {
+    _resetToastContainer();
+    document.body.innerHTML = '';
+    document.documentElement.lang = '';
+  });
+
+  it('opens a channel filtered by user_id and fires a toast on INSERT', () => {
+    const { supabase, channels } = makeFakeSupabase();
+    subscribeToKarmaEvents('user-abc', supabase as unknown as Parameters<typeof subscribeToKarmaEvents>[1]);
+
+    expect(channels.length).toBe(1);
+    expect(channels[0].name).toBe('karma_events:user-abc');
+    expect(channels[0].subscribed).toBe(true);
+    expect(channels[0].filter).toMatchObject({
+      event: 'INSERT',
+      schema: 'public',
+      table: 'karma_events',
+      filter: 'user_id=eq.user-abc',
+    });
+
+    channels[0].handler?.({
+      new: {
+        id: 1,
+        user_id: 'user-abc',
+        delta: 5,
+        reason: 'consensus_win',
+        created_at: new Date().toISOString(),
+      },
+    });
+
+    const el = document.querySelector('#karma-toast-container > div');
+    expect(el?.textContent).toContain('+5 karma');
+    expect(el?.textContent).toContain('Consensus win');
+  });
+
+  it('resolves the bilingual label from <html lang>', () => {
+    document.documentElement.lang = 'es';
+    const { supabase, channels } = makeFakeSupabase();
+    subscribeToKarmaEvents('u1', supabase as unknown as Parameters<typeof subscribeToKarmaEvents>[1]);
+
+    channels[0].handler?.({
+      new: {
+        id: 2,
+        user_id: 'u1',
+        delta: 10,
+        reason: 'first_in_rastrum',
+        created_at: new Date().toISOString(),
+      },
+    });
+
+    const el = document.querySelector('#karma-toast-container > div');
+    expect(el?.textContent).toContain('Primero en Rastrum');
+  });
+
+  it('falls back to the raw reason when no label is registered', () => {
+    const { supabase, channels } = makeFakeSupabase();
+    subscribeToKarmaEvents('u1', supabase as unknown as Parameters<typeof subscribeToKarmaEvents>[1]);
+
+    channels[0].handler?.({
+      new: {
+        id: 3,
+        user_id: 'u1',
+        delta: 1,
+        reason: 'unknown_reason_xyz',
+        created_at: new Date().toISOString(),
+      },
+    });
+
+    const el = document.querySelector('#karma-toast-container > div');
+    expect(el?.textContent).toContain('unknown_reason_xyz');
+  });
+
+  it('returns an unsubscribe function that removes the channel exactly once', () => {
+    const { supabase, channels, removed } = makeFakeSupabase();
+    const unsubscribe = subscribeToKarmaEvents(
+      'u1',
+      supabase as unknown as Parameters<typeof subscribeToKarmaEvents>[1],
+    );
+
+    unsubscribe();
+    unsubscribe();
+
+    expect(removed).toEqual([channels[0].name]);
+  });
+
+  it('ignores payloads without a numeric delta', () => {
+    const { supabase, channels } = makeFakeSupabase();
+    subscribeToKarmaEvents('u1', supabase as unknown as Parameters<typeof subscribeToKarmaEvents>[1]);
+
+    channels[0].handler?.({ new: {} });
+
+    expect(document.querySelector('#karma-toast-container')).toBeNull();
+  });
+
+  it('swallows removeChannel errors so callers can dispose blindly', () => {
+    const { supabase, channels } = makeFakeSupabase();
+    const throwingSupabase = {
+      ...supabase,
+      removeChannel: vi.fn(() => {
+        throw new Error('already torn down');
+      }),
+    };
+    const unsubscribe = subscribeToKarmaEvents(
+      'u1',
+      throwingSupabase as unknown as Parameters<typeof subscribeToKarmaEvents>[1],
+    );
+
+    expect(() => unsubscribe()).not.toThrow();
+    expect(channels.length).toBe(1);
+    expect(throwingSupabase.removeChannel).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/karma-toast.ts
+++ b/src/lib/karma-toast.ts
@@ -1,3 +1,6 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { KARMA_REASONS } from './karma-config';
+
 export interface KarmaToast {
   delta: number;
   reason: string;
@@ -5,8 +8,31 @@ export interface KarmaToast {
   timestamp: number;
 }
 
+interface KarmaEventRow {
+  id: number | string;
+  user_id: string;
+  delta: number;
+  reason: string;
+  created_at: string;
+}
+
 const TOAST_DURATION_MS = 4000;
 let toastContainer: HTMLElement | null = null;
+
+const reasonLabelMap: Record<string, { en: string; es: string }> = Object.fromEntries(
+  KARMA_REASONS.map((r) => [r.id, { en: r.label_en, es: r.label_es }]),
+);
+
+function resolveLabel(reason: string, lang: 'en' | 'es'): string {
+  const entry = reasonLabelMap[reason];
+  if (!entry) return reason;
+  return lang === 'es' ? entry.es : entry.en;
+}
+
+function detectLang(): 'en' | 'es' {
+  if (typeof document === 'undefined') return 'en';
+  return document.documentElement.lang === 'es' ? 'es' : 'en';
+}
 
 export function showKarmaToast(toast: KarmaToast): void {
   if (!toastContainer) {
@@ -41,19 +67,63 @@ export function showKarmaToast(toast: KarmaToast): void {
 }
 
 /**
- * Subscribe to realtime karma_events inserts for this user and show a
- * toast for each new event. Deferred to a future PR — the Supabase
- * Realtime channel setup requires the typed client and auth session.
+ * Subscribe to realtime karma_events INSERTs for `userId` and fire a toast
+ * for each. Returns an `unsubscribe` callback that is safe to invoke
+ * multiple times. The Realtime channel is filtered server-side by
+ * `user_id=eq.<userId>`, mirroring the `karma_events_self_read` RLS
+ * policy so a viewer cannot subscribe to another user's stream.
  */
-export function subscribeToKarmaEvents(_userId: string, _supabase: unknown): void {
-  // Phase 2 stub — realtime subscription will be wired in a follow-up
-  // PR once the karma_events table is populated by award_karma().
+type KarmaChannel = {
+  on: (
+    event: string,
+    filter: { event: string; schema: string; table: string; filter: string },
+    handler: (payload: { new: KarmaEventRow }) => void,
+  ) => KarmaChannel;
+  subscribe: () => KarmaChannel;
+};
+
+export function subscribeToKarmaEvents(
+  userId: string,
+  supabase: SupabaseClient,
+): () => void {
+  // supabase-js v2 types model postgres_changes only via overloads that
+  // depend on a generic Database schema; the runtime signature is the
+  // looser KarmaChannel shape above.
+  const channel = (supabase.channel(`karma_events:${userId}`) as unknown as KarmaChannel)
+    .on(
+      'postgres_changes',
+      {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'karma_events',
+        filter: `user_id=eq.${userId}`,
+      },
+      (payload) => {
+        const row = payload?.new;
+        if (!row || typeof row.delta !== 'number') return;
+        const lang = detectLang();
+        showKarmaToast({
+          delta: row.delta,
+          reason: row.reason,
+          label: resolveLabel(row.reason, lang),
+          timestamp: Date.parse(row.created_at) || Date.now(),
+        });
+      },
+    )
+    .subscribe();
+
+  let removed = false;
+  return () => {
+    if (removed) return;
+    removed = true;
+    try {
+      supabase.removeChannel(channel as unknown as Parameters<SupabaseClient['removeChannel']>[0]);
+    } catch {
+      // Channel may already be torn down by the client.
+    }
+  };
 }
 
-/**
- * Reset the toast container reference. Used by tests to clean up
- * between runs.
- */
 export function _resetToastContainer(): void {
   toastContainer = null;
 }


### PR DESCRIPTION
Closes #555.

## Summary

- `subscribeToKarmaEvents()` (was a Phase-2 stub) now opens a Supabase Realtime channel filtered server-side by `user_id=eq.<viewer>`, listens for INSERTs on `public.karma_events`, and fires `showKarmaToast()` for each event with a bilingual label resolved from `KARMA_REASONS` via `document.documentElement.lang`.
- Returns a single-fire `unsubscribe` that calls `removeChannel()` and is safe to invoke twice.
- Mounted in `BaseLayout.astro` for signed-in users only (gated on `getSession()` to avoid a server round-trip), cleaned up on `pagehide` + `beforeunload`.

## Schema

`karma_events` is now a member of the `supabase_realtime` publication (idempotent DO block, guarded by `pg_publication_tables` so replays are no-ops). The existing `karma_events_self_read` RLS policy plus the channel-side `user_id` filter together gate access; the publication just makes the WAL stream available to the broker.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 832/832 passing (12 new tests in `karma-toast.test.ts` covering filter assembly, INSERT→toast, bilingual label, unknown-reason fallback, idempotent unsubscribe, non-numeric-delta guard, removeChannel-throws guard)
- [ ] Post-merge: `make db-apply` to add the publication membership in prod, then sign-in on rastrum.org and trigger an `award_karma()` event (e.g. sync an observation) to confirm a live toast appears.

Unblocks #557 (milestone toasts at 100/500/1000), which extends the same INSERT handler.