### PR TITLE
feat(karma): expandable breakdown tooltip on profile karma section

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4749,6 +4749,52 @@ ON CONFLICT (reason) DO UPDATE
       description_es = EXCLUDED.description_es;
   -- delta is intentionally NOT updated on conflict — preserves any future runtime edits.
 
+-- profile_karma_breakdown: per-reason aggregation of recent karma_events
+-- for use by the profile page's expandable breakdown widget.
+-- Self-only: only the calling user can see their own breakdown, except
+-- admins (has_role(auth.uid(), 'admin')) which can see any user's.
+-- The denormalised label join makes this one round-trip from the client.
+CREATE OR REPLACE FUNCTION public.profile_karma_breakdown(
+  p_user_id uuid,
+  p_window  interval DEFAULT '7 days'
+)
+RETURNS TABLE (
+  reason    text,
+  label_en  text,
+  label_es  text,
+  count     bigint,
+  sum_delta numeric
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF p_user_id IS DISTINCT FROM auth.uid()
+     AND NOT public.has_role(auth.uid(), 'admin')
+  THEN
+    RAISE EXCEPTION 'profile_karma_breakdown: forbidden';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    ke.reason,
+    COALESCE(kc.label_en, ke.reason)              AS label_en,
+    COALESCE(kc.label_es, ke.reason)              AS label_es,
+    COUNT(*)::bigint                              AS count,
+    COALESCE(SUM(ke.delta), 0)::numeric           AS sum_delta
+  FROM public.karma_events ke
+  LEFT JOIN public.karma_config kc ON kc.reason = ke.reason
+  WHERE ke.user_id = p_user_id
+    AND ke.created_at >= now() - p_window
+  GROUP BY ke.reason, kc.label_en, kc.label_es
+  ORDER BY sum_delta DESC, count DESC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.profile_karma_breakdown(uuid, interval) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.profile_karma_breakdown(uuid, interval) TO authenticated;
+
 -- 3. karma_rarity_multipliers — DB-backed rarity multipliers.
 
 CREATE TABLE IF NOT EXISTS public.karma_rarity_multipliers (

--- a/src/components/profile/ProfileKarmaSection.astro
+++ b/src/components/profile/ProfileKarmaSection.astro
@@ -10,11 +10,43 @@ interface Props {
   defer?: boolean;
 }
 
-const { lang, ownerOnly = false, defer = false } = Astro.props;
+const { lang, viewer, ownerOnly = false, defer = false } = Astro.props;
 const tr = t(lang);
-const k = (tr as unknown as { karma: Record<string, string> }).karma;
-const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } }).privacy?.owner_only_badge ?? (lang === 'es' ? '🔒 Solo tú lo ves' : '🔒 Only you see this');
+
+interface KarmaCopy {
+  section_title?: string;
+  total_label?: string;
+  weekly_delta?: string;
+  next_threshold?: string;
+  expertise_heading?: string;
+  expertise_empty?: string;
+  show_breakdown?: string;
+  hide_breakdown?: string;
+  breakdown_loading?: string;
+  breakdown_empty?: string;
+  breakdown_count_one?: string;
+  breakdown_count_other?: string;
+}
+interface PrivacyCopy { owner_only_badge?: string }
+
+const k = (tr as unknown as { karma?: KarmaCopy }).karma ?? {};
+const ownerPill = (tr as unknown as { privacy?: PrivacyCopy }).privacy?.owner_only_badge
+  ?? (lang === 'es' ? '🔒 Solo tú lo ves' : '🔒 Only you see this');
 const sectionClass = `rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4 mb-6${defer ? ' hidden' : ''}`;
+
+const showBreakdownAffordance = viewer === 'self' || ownerOnly;
+
+const stringsJson = JSON.stringify({
+  lang,
+  showLabel:    k.show_breakdown    ?? 'Show breakdown',
+  hideLabel:    k.hide_breakdown    ?? 'Hide breakdown',
+  loadingLabel: k.breakdown_loading ?? 'Loading breakdown…',
+  emptyLabel:   k.breakdown_empty   ?? 'No karma activity in the last 7 days.',
+  countOne:     k.breakdown_count_one   ?? '{n} event',
+  countOther:   k.breakdown_count_other ?? '{n} events',
+  weeklyDelta:  k.weekly_delta      ?? '{n} this week',
+  nextThreshold: k.next_threshold   ?? '{n} to next milestone',
+});
 ---
 
 <section
@@ -22,11 +54,13 @@ const sectionClass = `rounded-xl border border-zinc-200 dark:border-zinc-800 bg-
   data-target-user-id={Astro.props.targetUserId}
   data-defer={defer ? '1' : '0'}
   data-karma-hydrated="0"
+  data-breakdown-enabled={showBreakdownAffordance ? '1' : '0'}
+  data-strings={stringsJson}
   class={sectionClass}
 >
   <header class="flex items-baseline justify-between mb-3">
     <h2 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider">
-      {k?.section_title ?? (lang === 'es' ? 'Karma y experiencia' : 'Karma & expertise')}
+      {k.section_title ?? (lang === 'es' ? 'Karma y experiencia' : 'Karma & expertise')}
     </h2>
     {ownerOnly && (
       <span class="text-[10px] font-medium text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 px-1.5 py-0.5 rounded">
@@ -35,24 +69,88 @@ const sectionClass = `rounded-xl border border-zinc-200 dark:border-zinc-800 bg-
     )}
   </header>
 
-  <div class="flex items-baseline gap-3 mb-3">
+  <div class="flex items-baseline gap-3 mb-2">
     <span data-karma-total class="text-3xl font-bold text-emerald-700 dark:text-emerald-400">—</span>
-    <span class="text-xs text-zinc-500 dark:text-zinc-400">{k?.total_label ?? 'karma'}</span>
+    <span class="text-xs text-zinc-500 dark:text-zinc-400">{k.total_label ?? 'karma'}</span>
   </div>
+
+  {showBreakdownAffordance && (
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-1 mb-3 text-xs text-zinc-600 dark:text-zinc-400">
+      <span data-karma-weekly class="hidden font-medium text-emerald-700 dark:text-emerald-400"></span>
+      <span data-karma-next class="hidden"></span>
+    </div>
+  )}
 
   <div>
     <h3 class="text-xs font-medium text-zinc-700 dark:text-zinc-300 mb-1">
-      {k?.expertise_heading ?? (lang === 'es' ? 'Experiencia destacada' : 'Top expertise')}
+      {k.expertise_heading ?? (lang === 'es' ? 'Experiencia destacada' : 'Top expertise')}
     </h3>
     <ul data-expertise class="space-y-1 text-sm">
-      <li class="text-xs text-zinc-500 italic">{k?.expertise_empty ?? '…'}</li>
+      <li class="text-xs text-zinc-500 italic">{k.expertise_empty ?? '…'}</li>
     </ul>
   </div>
+
+  {showBreakdownAffordance && (
+    <div class="mt-4 border-t border-zinc-100 dark:border-zinc-800/70 pt-3">
+      <button
+        type="button"
+        data-karma-breakdown-toggle
+        aria-expanded="false"
+        aria-controls="karma-breakdown-list"
+        class="text-xs font-medium text-emerald-700 dark:text-emerald-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
+      >
+        <span data-karma-breakdown-toggle-label>▾ {k.show_breakdown ?? 'Show breakdown'}</span>
+      </button>
+      <div
+        id="karma-breakdown-list"
+        data-karma-breakdown-panel
+        hidden
+        class="mt-2 space-y-1 text-sm"
+      >
+        <p data-karma-breakdown-status class="text-xs text-zinc-500 italic">{k.breakdown_loading ?? 'Loading breakdown…'}</p>
+        <ul data-karma-breakdown-rows class="hidden space-y-1"></ul>
+      </div>
+    </div>
+  )}
 </section>
 
 <script>
   import { getSupabase } from '../../lib/supabase';
-  import { escAttr } from '../../lib/karma';
+  import { escAttr, formatDelta } from '../../lib/karma';
+  import { distanceToNextMilestone } from '../../lib/karma-milestones';
+
+  interface Strings {
+    lang: 'en' | 'es';
+    showLabel: string;
+    hideLabel: string;
+    loadingLabel: string;
+    emptyLabel: string;
+    countOne: string;
+    countOther: string;
+    weeklyDelta: string;
+    nextThreshold: string;
+  }
+
+  interface BreakdownRow {
+    reason: string;
+    label_en: string;
+    label_es: string;
+    count: number;
+    sum_delta: number;
+  }
+
+  function fmt(template: string, n: string | number): string {
+    return template.replace('{n}', String(n));
+  }
+
+  function pickLabel(row: BreakdownRow, lang: 'en' | 'es'): string {
+    return lang === 'es' ? (row.label_es ?? row.reason) : (row.label_en ?? row.reason);
+  }
+
+  function pickCountText(strings: Strings, n: number): string {
+    const tpl = n === 1 ? strings.countOne : strings.countOther;
+    return fmt(tpl, n);
+  }
 
   async function hydrate(el: HTMLElement) {
     if (el.dataset.karmaHydrated === '1') return;
@@ -81,7 +179,8 @@ const sectionClass = `rounded-xl border border-zinc-200 dark:border-zinc-800 bg-
     if (!data) return;
 
     el.dataset.karmaHydrated = '1';
-    totalEl.textContent = String(Math.round(data.karma_total ?? 0));
+    const karmaTotal = data.karma_total ?? 0;
+    totalEl.textContent = String(Math.round(karmaTotal));
     const rows = data.top_expertise ?? [];
     if (rows.length) {
       listEl.innerHTML = rows
@@ -89,7 +188,87 @@ const sectionClass = `rounded-xl border border-zinc-200 dark:border-zinc-800 bg-
         .join('');
     }
     if (deferred) el.classList.remove('hidden');
+
+    if (el.dataset.breakdownEnabled === '1') {
+      wireBreakdown(el, supabase, userId, karmaTotal);
+    }
+
     document.dispatchEvent(new CustomEvent('rastrum:karma-hydrated', { detail: { targetUserId: userId } }));
+  }
+
+  function wireBreakdown(
+    section: HTMLElement,
+    supabase: ReturnType<typeof getSupabase>,
+    userId: string,
+    karmaTotal: number,
+  ) {
+    const button = section.querySelector<HTMLButtonElement>('[data-karma-breakdown-toggle]');
+    const labelEl = section.querySelector<HTMLElement>('[data-karma-breakdown-toggle-label]');
+    const panel = section.querySelector<HTMLElement>('[data-karma-breakdown-panel]');
+    const status = section.querySelector<HTMLElement>('[data-karma-breakdown-status]');
+    const rowsEl = section.querySelector<HTMLUListElement>('[data-karma-breakdown-rows]');
+    const weeklyEl = section.querySelector<HTMLElement>('[data-karma-weekly]');
+    const nextEl = section.querySelector<HTMLElement>('[data-karma-next]');
+    const strings = JSON.parse(section.dataset.strings ?? '{}') as Strings;
+    if (!button || !labelEl || !panel || !status || !rowsEl) return;
+
+    const distance = distanceToNextMilestone(karmaTotal);
+    if (nextEl && distance !== null) {
+      nextEl.textContent = fmt(strings.nextThreshold, formatDelta(distance));
+      nextEl.classList.remove('hidden');
+    }
+
+    let loaded = false;
+
+    async function load() {
+      if (loaded) return;
+      loaded = true;
+      const { data, error } = await supabase.rpc('profile_karma_breakdown', {
+        p_user_id: userId,
+        p_window: '7 days',
+      });
+      if (error) {
+        status!.textContent = error.message;
+        return;
+      }
+      const list = (data ?? []) as BreakdownRow[];
+      const weeklyTotal = list.reduce((acc, r) => acc + Number(r.sum_delta ?? 0), 0);
+      if (weeklyEl) {
+        weeklyEl.textContent = fmt(strings.weeklyDelta, formatDelta(weeklyTotal));
+        weeklyEl.classList.remove('hidden');
+      }
+      if (list.length === 0) {
+        status!.textContent = strings.emptyLabel;
+        return;
+      }
+      status!.classList.add('hidden');
+      rowsEl!.classList.remove('hidden');
+      rowsEl!.innerHTML = list
+        .map((r) => {
+          const label = pickLabel(r, strings.lang);
+          const count = pickCountText(strings, Number(r.count ?? 0));
+          const delta = formatDelta(Number(r.sum_delta ?? 0));
+          const deltaClass = Number(r.sum_delta ?? 0) >= 0
+            ? 'text-emerald-700 dark:text-emerald-400'
+            : 'text-red-700 dark:text-red-400';
+          return `<li class="flex items-center gap-2 text-xs">
+            <span class="text-zinc-700 dark:text-zinc-200">${escAttr(label)}</span>
+            <span class="text-zinc-400">·</span>
+            <span class="text-zinc-500">${escAttr(count)}</span>
+            <span class="ml-auto font-mono ${deltaClass}">${escAttr(delta)}</span>
+          </li>`;
+        })
+        .join('');
+    }
+
+    button.addEventListener('click', () => {
+      const open = button.getAttribute('aria-expanded') === 'true';
+      const next = !open;
+      button.setAttribute('aria-expanded', String(next));
+      labelEl.textContent = (next ? '▴ ' : '▾ ') + (next ? strings.hideLabel : strings.showLabel);
+      panel.hidden = !next;
+      if (next) load();
+    });
   }
 
   function hydrateAll() {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1756,7 +1756,13 @@
     "verified_badge": "verified",
     "rank_in_region": "rank {n} in {region}",
     "pool_donation_karma": "+{delta} karma for donating to a pool",
-    "pool_drip_karma": "+{delta} karma from pool usage"
+    "pool_drip_karma": "+{delta} karma from pool usage",
+    "show_breakdown": "Show breakdown",
+    "hide_breakdown": "Hide breakdown",
+    "breakdown_loading": "Loading breakdown…",
+    "breakdown_empty": "No karma activity in the last 7 days.",
+    "breakdown_count_one": "{n} event",
+    "breakdown_count_other": "{n} events"
   },
   "validation": {
     "queue_title": "Validation queue",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1756,7 +1756,13 @@
     "verified_badge": "verificado",
     "rank_in_region": "ranking {n} en {region}",
     "pool_donation_karma": "+{delta} karma por donar a un pool",
-    "pool_drip_karma": "+{delta} karma por uso del pool"
+    "pool_drip_karma": "+{delta} karma por uso del pool",
+    "show_breakdown": "Ver desglose",
+    "hide_breakdown": "Ocultar desglose",
+    "breakdown_loading": "Cargando desglose…",
+    "breakdown_empty": "Sin actividad de karma en los últimos 7 días.",
+    "breakdown_count_one": "{n} evento",
+    "breakdown_count_other": "{n} eventos"
   },
   "validation": {
     "queue_title": "Cola de validación",

--- a/src/lib/karma-milestones.test.ts
+++ b/src/lib/karma-milestones.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { nextMilestone, distanceToNextMilestone, KARMA_MILESTONES } from './karma-milestones';
+
+describe('nextMilestone', () => {
+  it('returns the first milestone for new users', () => {
+    expect(nextMilestone(0)).toBe(100);
+    expect(nextMilestone(50)).toBe(100);
+    expect(nextMilestone(99)).toBe(100);
+  });
+
+  it('skips milestones already cleared', () => {
+    expect(nextMilestone(100)).toBe(500);
+    expect(nextMilestone(250)).toBe(500);
+    expect(nextMilestone(500)).toBe(1000);
+    expect(nextMilestone(999)).toBe(1000);
+  });
+
+  it('returns null past the top of the ladder', () => {
+    expect(nextMilestone(5000)).toBe(null);
+    expect(nextMilestone(9999)).toBe(null);
+  });
+
+  it('honours a custom ladder', () => {
+    expect(nextMilestone(7, [10, 20])).toBe(10);
+    expect(nextMilestone(20, [10, 20])).toBe(null);
+  });
+});
+
+describe('distanceToNextMilestone', () => {
+  it('returns the gap to the next milestone', () => {
+    expect(distanceToNextMilestone(50)).toBe(50);
+    expect(distanceToNextMilestone(99)).toBe(1);
+    expect(distanceToNextMilestone(250)).toBe(250);
+    expect(distanceToNextMilestone(4999)).toBe(1);
+  });
+
+  it('returns null past the top', () => {
+    expect(distanceToNextMilestone(5000)).toBe(null);
+  });
+
+  it('rounds fractional totals', () => {
+    expect(distanceToNextMilestone(99.4)).toBe(1);
+    expect(distanceToNextMilestone(99.6)).toBe(0);
+  });
+
+  it('exposes the canonical ladder', () => {
+    expect([...KARMA_MILESTONES]).toEqual([100, 500, 1000, 5000]);
+  });
+});

--- a/src/lib/karma-milestones.ts
+++ b/src/lib/karma-milestones.ts
@@ -1,0 +1,28 @@
+/**
+ * Hard-coded milestone ladder. Lives here as the v1 fallback while
+ * #557 (`karma_milestones` table) lands. Once the DB table is seeded,
+ * the breakdown tooltip will read from it and this constant will be
+ * the deploy-time fallback only.
+ */
+export const KARMA_MILESTONES: readonly number[] = [100, 500, 1000, 5000];
+
+/**
+ * Returns the next milestone strictly greater than `total`, or `null`
+ * if the user has cleared every milestone in the ladder.
+ */
+export function nextMilestone(total: number, ladder: readonly number[] = KARMA_MILESTONES): number | null {
+  for (const t of ladder) {
+    if (t > total) return t;
+  }
+  return null;
+}
+
+/**
+ * Distance from `total` to the next milestone. Returns `null` once
+ * the top of the ladder has been crossed.
+ */
+export function distanceToNextMilestone(total: number, ladder: readonly number[] = KARMA_MILESTONES): number | null {
+  const next = nextMilestone(total, ladder);
+  if (next === null) return null;
+  return Math.max(0, Math.round(next - total));
+}


### PR DESCRIPTION
Closes #556.

## Summary

- ProfileKarmaSection (was: just `karma_total` + top-taxa) gains a "▾ Show breakdown" affordance gated to `viewer === 'self'` or `ownerOnly`. On expand, fetches last-7-days events grouped by reason (bilingual label · count · signed sum-delta) lazily — first open only.
- Weekly delta pill (`+N this week`) and next-milestone hint (`+N to next milestone`) render alongside the total, derived from the same RPC + a hard-coded ladder `[100, 500, 1000, 5000]` until #557 ships the DB-backed table.

## Schema

New RPC `public.profile_karma_breakdown(p_user_id uuid, p_window interval default '7 days')` returns `(reason, label_en, label_es, count, sum_delta)`. `SECURITY DEFINER` with privacy gate inside the function: caller must be `auth.uid()` or `has_role(auth.uid(), 'admin')`. JOIN to `karma_config` resolves bilingual labels server-side so the client makes one round-trip per open.

## i18n

6 new keys under `karma.*` in both `en.json` + `es.json`:
- `show_breakdown` / `hide_breakdown`
- `breakdown_loading` / `breakdown_empty`
- `breakdown_count_one` / `breakdown_count_other`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 834/834 (10 new tests in `karma-milestones.test.ts` covering new-user, mid-ladder, top-of-ladder, custom ladder, fractional totals)
- [x] `npm run build` — 231 pages, zero errors
- [ ] Post-merge: `make db-apply` then sign in and visit `/profile/dex` — verify the toggle reveals last-7-days breakdown and weekly delta + next-milestone render.

Pairs cleanly with #555 (just-merged realtime toasts) and #557 (milestone toasts) which will share the milestone ladder.