### PR TITLE
feat(audio): radial centerpiece on detail page (PR2 of 4)

### DIFF
--- a/src/components/AudioPlayer.astro
+++ b/src/components/AudioPlayer.astro
@@ -1,16 +1,14 @@
 ---
 /**
- * AudioPlayer — waveform + spectrogram + radial visualizer for audio observations.
+ * AudioPlayer — thin Astro wrapper around `mountAudioPlayer({size:'lg'})`.
  *
- * Uses wavesurfer.js (v7) with the Spectrogram plugin.
- * Renders client-side only (the `<script>` block). The HTML shell is
- * lightweight and accessible without JS (falls back to a native <audio> tag).
+ * The actual player (waveform + spectrogram + radial centerpiece + volume)
+ * lives in `src/lib/audio-player.ts`. This component renders an empty mount
+ * point with config in `data-*` attributes; the inline `<script>` reads them
+ * and calls the mount function.
  *
- * Visualization versions:
- *   v1: waveform + lazy spectrogram (inferno colormap)
- *   v2: BirdNET detection overlay on spectrogram with interactive tooltips
- *   v3: frequency zoom, export spectrogram as PNG
- *   v4: real-time radial frequency visualizer with BirdNET species coloring
+ * Render-time props are intentionally minimal: anything that can be
+ * configured per-call (autoExpand, lang, obsId) flows through dataset.
  */
 
 interface Props {
@@ -18,10 +16,10 @@ interface Props {
   mimeType?: string;
   lang: 'en' | 'es';
   obsId: string;
-  label?: string;
-  showSpectrogram?: boolean;
-  /** When true, the spectrogram panel starts expanded (useful for audio-only observations). */
+  /** When true, treat as the centerpiece player (audio-only observations). */
   autoExpand?: boolean;
+  /** Kept for API parity with the previous component; ignored — lg always shows the spectrogram + radial. */
+  showSpectrogram?: boolean;
 }
 
 const {
@@ -29,648 +27,63 @@ const {
   mimeType = 'audio/mpeg',
   lang,
   obsId,
-  label = '',
-  showSpectrogram = true,
   autoExpand = false,
 } = Astro.props;
-
-const isEs = lang === 'es';
-const playLabel    = isEs ? 'Reproducir' : 'Play';
-const pauseLabel   = isEs ? 'Pausar' : 'Pause';
-const spectroLabel = isEs ? 'Ver espectrograma' : 'Show spectrogram';
-const spectroHide  = isEs ? 'Ocultar espectrograma' : 'Hide spectrogram';
-const loadingLabel = isEs ? 'Cargando audio…' : 'Loading audio…';
-const errorLabel   = isEs ? 'No se pudo cargar el audio.' : 'Could not load audio.';
-const freqLabel    = isEs ? 'Frecuencia (kHz)' : 'Frequency (kHz)';
-const timeLabel    = isEs ? 'Tiempo (s)' : 'Time (s)';
-const radialLabel  = isEs ? 'Visualizar' : 'Visualize';
-const radialHide   = isEs ? 'Ocultar' : 'Hide';
 ---
 
 <div
-  class="rastrum-audio-player rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 overflow-hidden"
+  class="rastrum-audio-player-mount"
   data-audio-url={audioUrl}
   data-mime-type={mimeType}
-  data-obs-id={obsId}
-  data-show-spectrogram={showSpectrogram ? 'true' : 'false'}
   data-lang={lang}
-  data-label-play={playLabel}
-  data-label-pause={pauseLabel}
-  data-label-spectro={spectroLabel}
-  data-label-spectro-hide={spectroHide}
-  data-label-freq={freqLabel}
-  data-label-time={timeLabel}
-  data-label-radial={radialLabel}
-  data-label-radial-hide={radialHide}
+  data-obs-id={obsId}
   data-auto-expand={autoExpand ? 'true' : 'false'}
 >
-  <!-- Waveform container -->
-  <div class="px-3 pt-3">
-    <div id={`ws-wave-${obsId}`} class="w-full" style="min-height: 60px;"></div>
-  </div>
-
-  <!-- Controls bar -->
-  <div class="flex items-center gap-3 px-3 py-2">
-    <button
-      id={`ws-play-${obsId}`}
-      type="button"
-      aria-label={playLabel}
-      class="w-9 h-9 rounded-full bg-emerald-600 hover:bg-emerald-700 active:bg-emerald-800 text-white flex items-center justify-center shrink-0 transition-colors disabled:opacity-40"
-      disabled
-    >
-      <svg class="play-icon w-4 h-4 ml-0.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
-      <svg class="pause-icon hidden w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>
-    </button>
-    <span id={`ws-time-${obsId}`} class="text-xs font-mono text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">0:00</span>
-    <span class="loading-label text-xs text-zinc-400 dark:text-zinc-500">{loadingLabel}</span>
-    <span class="error-label hidden text-xs text-red-500">{errorLabel}</span>
-    <div class="flex-1"></div>
-    {showSpectrogram && (
-      <button id={`ws-toggle-radial-${obsId}`} type="button" aria-expanded="false"
-        class="text-xs text-sky-600 dark:text-sky-400 underline underline-offset-2 hover:no-underline transition-all shrink-0">{radialLabel}</button>
-    )}
-    {showSpectrogram && (
-      <button id={`ws-toggle-spec-${obsId}`} type="button" aria-expanded="false"
-        class="text-xs text-emerald-700 dark:text-emerald-400 underline underline-offset-2 hover:no-underline transition-all shrink-0">{spectroLabel}</button>
-    )}
-  </div>
-
-  <!-- v4: Radial visualizer panel -->
-  {showSpectrogram && (
-    <div id={`ws-radial-${obsId}`} class="hidden px-3 pb-3">
-      <div class="relative flex items-center justify-center rounded-xl bg-zinc-950 overflow-hidden" style="height: 280px;">
-        <canvas id={`ws-radial-canvas-${obsId}`} class="w-full h-full" aria-hidden="true"></canvas>
-        <div id={`ws-radial-label-${obsId}`} class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none select-none">
-          <span id={`ws-radial-species-${obsId}`} class="text-sm font-semibold italic text-white/80 drop-shadow-lg transition-all duration-300"></span>
-          <span id={`ws-radial-common-${obsId}`} class="text-[11px] text-white/50 mt-0.5 transition-all duration-300"></span>
-        </div>
-      </div>
-    </div>
-  )}
-
-  <!-- Spectrogram panel (lazy, collapsed by default) -->
-  {showSpectrogram && (
-    <div id={`ws-spec-${obsId}`} class="hidden px-3 pb-2">
-      <div class="flex items-center gap-2 mb-2 flex-wrap">
-        <div class="flex items-center gap-1 text-[10px] text-zinc-500 dark:text-zinc-400">
-          <span>{isEs ? 'Rango:' : 'Range:'}</span>
-          <select id={`ws-freq-range-${obsId}`} class="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-[10px] px-1 py-0.5" aria-label={isEs ? 'Rango de frecuencias' : 'Frequency range'}>
-            <option value="12000">0 – 12 kHz</option>
-            <option value="8000">0 – 8 kHz</option>
-            <option value="4000">0 – 4 kHz</option>
-            <option value="2000">0 – 2 kHz</option>
-          </select>
-        </div>
-        <div class="flex-1"></div>
-        <button id={`ws-export-${obsId}`} type="button" class="flex items-center gap-1 text-[10px] text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors" title={isEs ? 'Descargar espectrograma como imagen' : 'Download spectrogram as image'}>
-          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
-          {isEs ? 'Exportar PNG' : 'Export PNG'}
-        </button>
-        <button id={`ws-info-btn-${obsId}`} type="button" class="w-5 h-5 rounded-full border border-zinc-300 dark:border-zinc-700 text-[10px] text-zinc-500 dark:text-zinc-400 hover:border-emerald-500 hover:text-emerald-500 transition-colors flex items-center justify-center font-bold" aria-label={isEs ? '¿Qué estoy viendo?' : 'What am I looking at?'} title={isEs ? '¿Qué estoy viendo?' : 'What am I looking at?'}>?</button>
-      </div>
-      <div id={`ws-info-panel-${obsId}`} class="hidden mb-2 rounded-lg border border-emerald-200 dark:border-emerald-900/40 bg-emerald-50 dark:bg-emerald-950/30 p-3 text-xs text-zinc-700 dark:text-zinc-300 space-y-1.5">
-        <p class="font-semibold text-emerald-800 dark:text-emerald-300">{isEs ? '¿Qué es un espectrograma?' : 'What is a spectrogram?'}</p>
-        <p>{isEs ? 'Muestra cómo cambian las frecuencias del sonido a lo largo del tiempo. El eje horizontal es el tiempo, el vertical es la frecuencia (tono), y el color indica la intensidad (más brillante = más fuerte).' : 'Shows how the frequencies in a sound change over time. The horizontal axis is time, the vertical axis is frequency (pitch), and the color shows intensity — brighter = louder.'}</p>
-        <p>{isEs ? '🌈 Colormap inferno: negro = silencio, morado/azul = débil, naranja = moderado, amarillo/blanco = muy fuerte.' : '🌈 Inferno colormap: black = silence, purple/blue = faint, orange = moderate, yellow/white = very loud.'}</p>
-        <p>{isEs ? '🐦 Los cantos de aves suelen aparecer entre 1–8 kHz. Patrones horizontales = tonos sostenidos; patrones verticales = clics o golpes.' : '🐦 Bird songs typically appear between 1–8 kHz. Horizontal streaks = sustained tones; vertical streaks = clicks or percussive sounds.'}</p>
-        <p id={`ws-birdnet-info-${obsId}`} class="hidden font-medium text-emerald-700 dark:text-emerald-400">{isEs ? '✅ Las bandas verdes/coloreadas muestran segmentos donde BirdNET detectó una especie. Toca una banda para ver detalles.' : '✅ Colored bands show segments where BirdNET detected a species. Tap a band for details.'}</p>
-      </div>
-      <div class="flex items-end justify-between mb-1 text-[10px] text-zinc-400 dark:text-zinc-500 select-none">
-        <span id={`ws-freq-top-${obsId}`}>12 kHz</span>
-        <span class="italic">{freqLabel}</span>
-        <span>0 Hz</span>
-      </div>
-      <div class="relative">
-        <div id={`ws-spec-host-${obsId}`} class="ws-spectrogram-host w-full rounded overflow-hidden bg-zinc-950" style="height: 140px;" aria-hidden="true"></div>
-        <div id={`ws-detections-${obsId}`} class="absolute inset-0 pointer-events-none" aria-hidden="true"></div>
-        <div id={`ws-tooltip-${obsId}`} class="hidden absolute z-10 rounded-lg border border-emerald-300 dark:border-emerald-700 bg-white/95 dark:bg-zinc-900/95 shadow-lg p-2.5 text-xs max-w-[200px] pointer-events-none" role="tooltip"></div>
-      </div>
-      <div class="mt-1 text-[10px] text-zinc-400 dark:text-zinc-500 text-right select-none italic">{timeLabel}</div>
-      <div id={`ws-legend-${obsId}`} class="hidden mt-2 space-y-1"></div>
-    </div>
-  )}
-
   <noscript>
-    <div class="px-3 pb-3">
-      <audio controls src={audioUrl} class="w-full"><track kind="captions" /></audio>
-    </div>
+    <audio controls src={audioUrl} class="w-full"><track kind="captions" /></audio>
   </noscript>
 </div>
 
 <script>
-/**
- * AudioPlayer client-side init — v1 through v4.
- * v1: waveform + lazy spectrogram (inferno colormap)
- * v2: BirdNET detection overlay on spectrogram with interactive tooltips
- * v3: frequency zoom, export spectrogram as PNG
- * v4: real-time radial frequency visualizer with BirdNET species coloring
- */
-(function () {
+  import { mountAudioPlayer } from '../lib/audio-player';
+
+  type MountedEl = HTMLElement & { __rastrumPlayerCleanup?: () => void };
+
+  function initOne(el: HTMLElement): void {
+    const mounted = el as MountedEl;
+    if (mounted.__rastrumPlayerCleanup) return;
+    const audioUrl = el.dataset.audioUrl ?? '';
+    if (!audioUrl) return;
+    mounted.__rastrumPlayerCleanup = mountAudioPlayer(el, audioUrl, {
+      size: 'lg',
+      lang: (el.dataset.lang as 'en' | 'es') ?? 'en',
+      obsId: el.dataset.obsId,
+      mimeType: el.dataset.mimeType,
+      autoExpand: el.dataset.autoExpand === 'true',
+    });
+  }
+
+  function initAll(): void {
+    document.querySelectorAll<HTMLElement>('.rastrum-audio-player-mount').forEach(initOne);
+  }
+
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initAll);
   } else {
     initAll();
   }
 
-  function initAll() {
-    document.querySelectorAll<HTMLElement>('.rastrum-audio-player').forEach(el => {
-      if (el.dataset.wsReady) return;
-      el.dataset.wsReady = '1';
-      initPlayer(el);
-    });
-  }
-
-  document.addEventListener('rastrum:audio-players-ready', () => {
-    document.querySelectorAll<HTMLElement>('.rastrum-audio-player').forEach(el => {
-      if (el.dataset.wsReady) return;
-      el.dataset.wsReady = '1';
-      initPlayer(el);
-    });
-  });
+  document.addEventListener('rastrum:audio-players-ready', initAll);
 
   document.addEventListener('rastrum:audio-birdnet-ready', (e: Event) => {
-    const ev = e as CustomEvent<{ obsId: string; segments: BirdNetSegment[]; durationSec: number }>;
+    const ev = e as CustomEvent<{ obsId: string; segments: unknown[]; durationSec: number }>;
     const { obsId, segments, durationSec } = ev.detail;
-    const container = document.querySelector<HTMLElement>(`[data-obs-id="${obsId}"]`);
-    if (!container) return;
-    renderDetectionOverlay(container, obsId, segments, durationSec);
-    // Store segments on the container for the radial visualizer to pick up
-    (container as HTMLElement & { __birdnetSegments?: BirdNetSegment[]; __birdnetDuration?: number }).__birdnetSegments = segments;
-    (container as HTMLElement & { __birdnetDuration?: number }).__birdnetDuration = durationSec;
+    const target = document.querySelector<HTMLElement>(
+      `.rastrum-audio-player-mount[data-obs-id="${CSS.escape(obsId)}"]`,
+    );
+    if (!target) return;
+    const ext = target as HTMLElement & { __birdnetSegments?: unknown[]; __birdnetDuration?: number };
+    ext.__birdnetSegments = segments;
+    ext.__birdnetDuration = durationSec;
   });
-
-  // ── Types ──────────────────────────────────────────────────────────────
-  interface BirdNetCandidate { scientific_name: string; common_name_en: string | null; score: number; }
-  interface BirdNetSegment { startSec: number; endSec: number; top: BirdNetCandidate[]; }
-
-  // ── Species color palette (shared v2 + v4) ────────────────────────────
-  const SPECIES_COLORS = [
-    { bg: 'rgba(16,185,129,0.25)',  border: '#10b981', text: '#6ee7b7', rgb: [16,185,129] },
-    { bg: 'rgba(251,191,36,0.25)',  border: '#fbbf24', text: '#fde68a', rgb: [251,191,36] },
-    { bg: 'rgba(167,139,250,0.25)', border: '#a78bfa', text: '#c4b5fd', rgb: [167,139,250] },
-    { bg: 'rgba(251,113,133,0.25)', border: '#fb7185', text: '#fda4af', rgb: [251,113,133] },
-    { bg: 'rgba(56,189,248,0.25)',  border: '#38bdf8', text: '#7dd3fc', rgb: [56,189,248] },
-    { bg: 'rgba(52,211,153,0.25)',  border: '#34d399', text: '#6ee7b7', rgb: [52,211,153] },
-    { bg: 'rgba(249,115,22,0.25)',  border: '#f97316', text: '#fdba74', rgb: [249,115,22] },
-    { bg: 'rgba(232,121,249,0.25)', border: '#e879f9', text: '#f0abfc', rgb: [232,121,249] },
-  ];
-  const DEFAULT_COLOR_RGB = [16, 185, 129]; // emerald when no BirdNET data
-
-  // ── Inferno colormap (256 RGBA entries) ───────────────────────────────
-  function buildInfernoColormap(): [number, number, number, number][] {
-    const stops: [number, [number, number, number]][] = [
-      [0, [0,0,4]], [0.13, [31,12,72]], [0.25, [85,15,109]], [0.38, [139,34,82]],
-      [0.50, [188,55,84]], [0.63, [229,107,54]], [0.75, [246,163,10]], [0.88, [250,213,43]], [1.0, [252,255,164]],
-    ];
-    const out: [number, number, number, number][] = [];
-    for (let i = 0; i < 256; i++) {
-      const t = i / 255;
-      let lo = stops[0], hi = stops[stops.length - 1];
-      for (let j = 0; j < stops.length - 1; j++) {
-        if (t >= stops[j][0] && t <= stops[j + 1][0]) { lo = stops[j]; hi = stops[j + 1]; break; }
-      }
-      const span = hi[0] - lo[0];
-      const f = span > 0 ? (t - lo[0]) / span : 0;
-      out.push([
-        Math.round(lo[1][0] + f * (hi[1][0] - lo[1][0])) / 255,
-        Math.round(lo[1][1] + f * (hi[1][1] - lo[1][1])) / 255,
-        Math.round(lo[1][2] + f * (hi[1][2] - lo[1][2])) / 255, 1,
-      ]);
-    }
-    return out;
-  }
-
-  // ── Detection overlay (v2) ─────────────────────────────────────────────
-  function renderDetectionOverlay(container: HTMLElement, obsId: string, segments: BirdNetSegment[], durationSec: number) {
-    const overlayEl  = document.getElementById(`ws-detections-${obsId}`);
-    const tooltipEl  = document.getElementById(`ws-tooltip-${obsId}`);
-    const legendEl   = document.getElementById(`ws-legend-${obsId}`);
-    const birdInfoEl = document.getElementById(`ws-birdnet-info-${obsId}`);
-    const lang       = container.dataset.lang ?? 'en';
-    const isEs       = lang === 'es';
-    if (!overlayEl || !durationSec) return;
-
-    const CONF_THRESHOLD = 0.3;
-    const filtered = segments.filter(seg => seg.top[0]?.score >= CONF_THRESHOLD).map(seg => ({ ...seg, best: seg.top[0]! }));
-    if (filtered.length === 0) return;
-
-    const speciesOrder: string[] = [];
-    for (const seg of filtered) { if (!speciesOrder.includes(seg.best.scientific_name)) speciesOrder.push(seg.best.scientific_name); }
-    const colorMap = new Map<string, typeof SPECIES_COLORS[0]>();
-    speciesOrder.forEach((sp, i) => colorMap.set(sp, SPECIES_COLORS[i % SPECIES_COLORS.length]!));
-
-    for (const seg of filtered) {
-      const color = colorMap.get(seg.best.scientific_name)!;
-      const leftPct  = (seg.startSec / durationSec) * 100;
-      const widthPct = ((seg.endSec - seg.startSec) / durationSec) * 100;
-      const band = document.createElement('div');
-      band.style.cssText = `position:absolute;top:0;bottom:0;left:${leftPct}%;width:${widthPct}%;background:${color.bg};border-left:2px solid ${color.border};border-right:1px solid ${color.border}40;cursor:pointer;pointer-events:auto;transition:background 0.15s;`;
-      band.setAttribute('role', 'button');
-      band.setAttribute('tabindex', '0');
-      const confPct = Math.round(seg.best.score * 100);
-      const spName = seg.best.scientific_name;
-      const commonName = seg.best.common_name_en ?? spName;
-      const timeRange = `${seg.startSec.toFixed(1)}s – ${seg.endSec.toFixed(1)}s`;
-      band.setAttribute('aria-label', `${spName} ${confPct}%`);
-
-      const showTip = () => {
-        if (!tooltipEl) return;
-        const confBar = Math.round(seg.best.score * 10);
-        const confBarFill = '\u2588'.repeat(confBar) + '\u2591'.repeat(10 - confBar);
-        tooltipEl.innerHTML = `<div class="font-semibold italic text-zinc-900 dark:text-zinc-100" style="color:${color.border}">${spName}</div><div class="text-zinc-500 dark:text-zinc-400">${commonName}</div><div class="mt-1 font-mono text-[10px]" style="color:${color.text}">${confBarFill} ${confPct}%</div><div class="text-zinc-500 dark:text-zinc-400 mt-0.5">\u23F1 ${timeRange}</div>`;
-        const rect = band.getBoundingClientRect();
-        const containerRect = overlayEl.getBoundingClientRect();
-        let left = rect.left - containerRect.left;
-        if (left + 200 > containerRect.width) left = containerRect.width - 204;
-        tooltipEl.style.left = `${Math.max(0, left)}px`;
-        tooltipEl.style.top = '-8px';
-        tooltipEl.style.transform = 'translateY(-100%)';
-        tooltipEl.classList.remove('hidden');
-      };
-      const hideTip = () => tooltipEl?.classList.add('hidden');
-      band.addEventListener('mouseenter', showTip);
-      band.addEventListener('focusin', showTip);
-      band.addEventListener('mouseleave', hideTip);
-      band.addEventListener('focusout', hideTip);
-
-      if (widthPct > 8) {
-        const lbl = document.createElement('div');
-        lbl.style.cssText = `position:absolute;top:4px;left:4px;font-size:9px;font-weight:600;white-space:nowrap;overflow:hidden;color:${color.text};text-shadow:0 0 4px rgba(0,0,0,0.9);pointer-events:none;`;
-        lbl.textContent = `${spName.split(' ')[0]} ${confPct}%`;
-        band.appendChild(lbl);
-      }
-      overlayEl.appendChild(band);
-    }
-
-    if (legendEl) {
-      legendEl.classList.remove('hidden');
-      legendEl.innerHTML = `<div class="text-[10px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1">${isEs ? 'Especies detectadas' : 'Detected species'}</div>${speciesOrder.map(sp => {
-        const color = colorMap.get(sp)!;
-        const maxConf = Math.round(Math.max(...filtered.filter(s => s.best.scientific_name === sp).map(s => s.best.score)) * 100);
-        const common = filtered.find(s => s.best.scientific_name === sp)?.best.common_name_en ?? sp;
-        const segs = filtered.filter(s => s.best.scientific_name === sp).length;
-        return `<div class="flex items-center gap-2 text-xs rounded-lg p-2 border" style="border-color:${color.border}40;background:${color.bg}"><div class="w-3 h-3 rounded-sm shrink-0 border" style="background:${color.bg};border-color:${color.border}"></div><div class="min-w-0"><div class="font-semibold italic text-zinc-900 dark:text-zinc-100 truncate">${sp}</div><div class="text-zinc-500 dark:text-zinc-400 text-[10px]">${common}</div></div><div class="ml-auto text-right shrink-0"><div class="font-mono text-[10px]" style="color:${color.text}">${maxConf}%</div><div class="text-zinc-500 text-[9px]">${segs} ${isEs ? 'seg' : 'seg'}</div></div></div>`;
-      }).join('')}`;
-    }
-    birdInfoEl?.classList.remove('hidden');
-  }
-
-  // ── v4: Radial frequency visualizer ───────────────────────────────────
-  function initRadialVisualizer(
-    container: HTMLElement,
-    obsId: string,
-    getMediaElement: () => HTMLMediaElement,
-    isPlayingFn: () => boolean,
-    getCurrentTimeFn: () => number,
-  ) {
-    const canvas = document.getElementById(`ws-radial-canvas-${obsId}`) as HTMLCanvasElement | null;
-    const speciesEl = document.getElementById(`ws-radial-species-${obsId}`);
-    const commonEl = document.getElementById(`ws-radial-common-${obsId}`);
-    if (!canvas) return { start() {}, stop() {} };
-
-    const ctx = canvas.getContext('2d')!;
-    let audioCtx: AudioContext | null = null;
-    let analyser: AnalyserNode | null = null;
-    let source: MediaElementAudioSourceNode | null = null;
-    let animId = 0;
-    let connected = false;
-
-    // Build species color map from BirdNET data stored on the container
-    type ContainerWithBirdnet = HTMLElement & { __birdnetSegments?: BirdNetSegment[]; __birdnetDuration?: number };
-    function getSpeciesAtTime(timeSec: number): { scientific: string; common: string; color: number[] } | null {
-      const ext = container as ContainerWithBirdnet;
-      const segments = ext.__birdnetSegments;
-      if (!segments) return null;
-      const CONF_THRESHOLD = 0.3;
-      for (const seg of segments) {
-        if (timeSec >= seg.startSec && timeSec <= seg.endSec && seg.top[0]?.score >= CONF_THRESHOLD) {
-          const speciesOrder: string[] = [];
-          for (const s of segments) {
-            if (s.top[0]?.score >= CONF_THRESHOLD && !speciesOrder.includes(s.top[0].scientific_name)) {
-              speciesOrder.push(s.top[0].scientific_name);
-            }
-          }
-          const idx = speciesOrder.indexOf(seg.top[0].scientific_name);
-          const c = SPECIES_COLORS[idx % SPECIES_COLORS.length];
-          return { scientific: seg.top[0].scientific_name, common: seg.top[0].common_name_en ?? '', color: c.rgb };
-        }
-      }
-      return null;
-    }
-
-    function connectAnalyser() {
-      if (connected) return;
-      try {
-        const media = getMediaElement();
-        audioCtx = new AudioContext();
-        analyser = audioCtx.createAnalyser();
-        analyser.fftSize = 256;
-        source = audioCtx.createMediaElementSource(media);
-        source.connect(analyser);
-        analyser.connect(audioCtx.destination);
-        connected = true;
-      } catch {
-        // createMediaElementSource can only be called once per element;
-        // if it fails the visualizer degrades to the idle animation.
-      }
-    }
-
-    function draw() {
-      const dpr = window.devicePixelRatio || 1;
-      const rect = canvas!.getBoundingClientRect();
-      const w = rect.width;
-      const h = rect.height;
-      canvas!.width = w * dpr;
-      canvas!.height = h * dpr;
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-      ctx.fillStyle = '#09090b';
-      ctx.fillRect(0, 0, w, h);
-
-      const cx = w / 2;
-      const cy = h / 2;
-      const innerR = Math.min(w, h) * 0.18;
-      const maxBarH = Math.min(w, h) * 0.28;
-
-      const playing = isPlayingFn();
-      const currentTime = getCurrentTimeFn();
-
-      // Get frequency data
-      let dataArray: Uint8Array;
-      if (analyser && connected) {
-        dataArray = new Uint8Array(analyser.frequencyBinCount);
-        analyser.getByteFrequencyData(dataArray);
-      } else {
-        // Idle: gentle sine breathing
-        const t = Date.now() / 1000;
-        dataArray = new Uint8Array(64);
-        for (let i = 0; i < 64; i++) {
-          const base = playing ? 40 : 15;
-          dataArray[i] = base + Math.sin(t * 1.5 + i * 0.3) * (playing ? 20 : 8);
-        }
-      }
-
-      // Determine color from BirdNET species at current time
-      const species = playing ? getSpeciesAtTime(currentTime) : null;
-      const baseColor = species ? species.color : DEFAULT_COLOR_RGB;
-
-      // Update species label
-      if (speciesEl && commonEl) {
-        speciesEl.textContent = species?.scientific ?? '';
-        commonEl.textContent = species?.common ?? '';
-      }
-
-      const barCount = dataArray.length;
-      const angleStep = (Math.PI * 2) / barCount;
-
-      for (let i = 0; i < barCount; i++) {
-        const val = dataArray[i] / 255;
-        const barH = val * maxBarH + 2;
-        const angle = i * angleStep - Math.PI / 2;
-
-        const x1 = cx + Math.cos(angle) * innerR;
-        const y1 = cy + Math.sin(angle) * innerR;
-        const x2 = cx + Math.cos(angle) * (innerR + barH);
-        const y2 = cy + Math.sin(angle) * (innerR + barH);
-
-        // Color intensity based on amplitude
-        const alpha = 0.3 + val * 0.7;
-        const bright = 0.7 + val * 0.3;
-        const r = Math.round(baseColor[0] * bright);
-        const g = Math.round(baseColor[1] * bright);
-        const b = Math.round(baseColor[2] * bright);
-
-        ctx.beginPath();
-        ctx.moveTo(x1, y1);
-        ctx.lineTo(x2, y2);
-        ctx.strokeStyle = `rgba(${r},${g},${b},${alpha})`;
-        ctx.lineWidth = Math.max(2, (w / barCount) * 0.6);
-        ctx.lineCap = 'round';
-        ctx.stroke();
-      }
-
-      // Inner glow circle
-      const glowAlpha = playing ? 0.15 + (dataArray[0] / 255) * 0.15 : 0.08;
-      const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, innerR);
-      gradient.addColorStop(0, `rgba(${baseColor[0]},${baseColor[1]},${baseColor[2]},${glowAlpha})`);
-      gradient.addColorStop(1, 'rgba(0,0,0,0)');
-      ctx.fillStyle = gradient;
-      ctx.beginPath();
-      ctx.arc(cx, cy, innerR, 0, Math.PI * 2);
-      ctx.fill();
-
-      animId = requestAnimationFrame(draw);
-    }
-
-    return {
-      start() {
-        connectAnalyser();
-        if (audioCtx?.state === 'suspended') audioCtx.resume();
-        if (!animId) animId = requestAnimationFrame(draw);
-      },
-      stop() {
-        if (animId) { cancelAnimationFrame(animId); animId = 0; }
-      },
-    };
-  }
-
-  // ── Main player init ──────────────────────────────────────────────────
-  async function initPlayer(container: HTMLElement) {
-    if (!container.dataset.wsReady) container.dataset.wsReady = '1';
-    const audioUrl   = container.dataset.audioUrl ?? '';
-    const obsId      = container.dataset.obsId ?? '';
-    const showSpec   = container.dataset.showSpectrogram === 'true';
-    const autoExpand = container.dataset.autoExpand === 'true';
-    const labelPause = container.dataset.labelPause ?? 'Pause';
-    const labelPlay  = container.dataset.labelPlay  ?? 'Play';
-    const labelSpec  = container.dataset.labelSpectro ?? 'Show spectrogram';
-    const labelSpecH = container.dataset.labelSpectroHide ?? 'Hide spectrogram';
-    const labelRadial  = container.dataset.labelRadial ?? 'Visualize';
-    const labelRadialH = container.dataset.labelRadialHide ?? 'Hide';
-
-    if (!audioUrl) return;
-
-    const waveEl       = document.getElementById(`ws-wave-${obsId}`);
-    const playBtn      = document.getElementById(`ws-play-${obsId}`) as HTMLButtonElement | null;
-    const toggleBtn    = document.getElementById(`ws-toggle-spec-${obsId}`) as HTMLButtonElement | null;
-    const spectroPanel = document.getElementById(`ws-spec-${obsId}`);
-    const specHost     = document.getElementById(`ws-spec-host-${obsId}`);
-    const timeEl       = document.getElementById(`ws-time-${obsId}`);
-    const loadingEl    = container.querySelector<HTMLElement>('.loading-label');
-    const errorEl      = container.querySelector<HTMLElement>('.error-label');
-    const freqSelect   = document.getElementById(`ws-freq-range-${obsId}`) as HTMLSelectElement | null;
-    const exportBtn    = document.getElementById(`ws-export-${obsId}`) as HTMLButtonElement | null;
-    const infoBtn      = document.getElementById(`ws-info-btn-${obsId}`) as HTMLButtonElement | null;
-    const infoPanel    = document.getElementById(`ws-info-panel-${obsId}`);
-    const radialToggle = document.getElementById(`ws-toggle-radial-${obsId}`) as HTMLButtonElement | null;
-    const radialPanel  = document.getElementById(`ws-radial-${obsId}`);
-
-    if (!waveEl) return;
-
-    function formatTime(sec: number): string {
-      const m = Math.floor(sec / 60);
-      const s = Math.floor(sec % 60);
-      return `${m}:${s.toString().padStart(2, '0')}`;
-    }
-
-    infoBtn?.addEventListener('click', () => {
-      const hidden = infoPanel?.classList.toggle('hidden');
-      infoBtn.setAttribute('aria-expanded', hidden ? 'false' : 'true');
-    });
-
-    try {
-      const WaveSurfer = (await import('wavesurfer.js')).default;
-      const ws = WaveSurfer.create({
-        container: waveEl,
-        waveColor: '#10b981',
-        progressColor: '#047857',
-        cursorColor: '#6ee7b7',
-        barWidth: 2, barGap: 1, barRadius: 2,
-        height: 60, normalize: true, url: audioUrl,
-      });
-
-      ws.on('ready', () => {
-        loadingEl?.classList.add('hidden');
-        if (playBtn) { playBtn.disabled = false; playBtn.setAttribute('aria-label', labelPlay); }
-        if (timeEl) timeEl.textContent = `0:00 / ${formatTime(ws.getDuration())}`;
-      });
-      ws.on('error', () => { loadingEl?.classList.add('hidden'); errorEl?.classList.remove('hidden'); });
-      ws.on('play', () => {
-        playBtn?.querySelector('.play-icon')?.classList.add('hidden');
-        playBtn?.querySelector('.pause-icon')?.classList.remove('hidden');
-        playBtn?.setAttribute('aria-label', labelPause);
-      });
-      ws.on('pause', () => {
-        playBtn?.querySelector('.pause-icon')?.classList.add('hidden');
-        playBtn?.querySelector('.play-icon')?.classList.remove('hidden');
-        playBtn?.setAttribute('aria-label', labelPlay);
-      });
-      ws.on('finish', () => {
-        playBtn?.querySelector('.pause-icon')?.classList.add('hidden');
-        playBtn?.querySelector('.play-icon')?.classList.remove('hidden');
-        playBtn?.setAttribute('aria-label', labelPlay);
-      });
-      ws.on('timeupdate', (t: number) => {
-        if (timeEl) timeEl.textContent = `${formatTime(t)} / ${formatTime(ws.getDuration())}`;
-      });
-
-      playBtn?.addEventListener('click', () => ws.playPause());
-
-      // ── v4: Radial visualizer ─────────────────────────────────────────
-      let radialViz: { start(): void; stop(): void } | null = null;
-      let radialActive = false;
-
-      if (showSpec && radialToggle && radialPanel) {
-        radialToggle.addEventListener('click', () => {
-          const expanded = radialToggle.getAttribute('aria-expanded') === 'true';
-          if (!expanded) {
-            radialPanel.classList.remove('hidden');
-            radialToggle.setAttribute('aria-expanded', 'true');
-            radialToggle.textContent = labelRadialH;
-            if (!radialViz) {
-              radialViz = initRadialVisualizer(
-                container, obsId,
-                () => (ws as unknown as { getMediaElement(): HTMLMediaElement }).getMediaElement(),
-                () => ws.isPlaying(),
-                () => ws.getCurrentTime(),
-              );
-            }
-            radialViz.start();
-            radialActive = true;
-          } else {
-            radialPanel.classList.add('hidden');
-            radialToggle.setAttribute('aria-expanded', 'false');
-            radialToggle.textContent = labelRadial;
-            radialViz?.stop();
-            radialActive = false;
-          }
-        });
-      }
-
-      // ── Lazy spectrogram (v1 + v2 + v3) ──────────────────────────────
-      if (showSpec && toggleBtn && spectroPanel) {
-        let spectroLoaded = false;
-        let spectroPlugin: unknown = null;
-        let currentFreqMax = 12000;
-        const COLORMAP = buildInfernoColormap();
-
-        async function loadSpectrogram(freqMax = 12000) {
-          if (!specHost) return null;
-          try {
-            const SpectrogramPlugin = (await import('wavesurfer.js/plugins/spectrogram')).default;
-            const plugin = SpectrogramPlugin.create({
-              container: specHost, labels: true,
-              labelsBackground: 'rgba(9,9,11,0.7)', labelsColor: '#a1a1aa', labelsHzColor: '#a1a1aa',
-              height: 140, frequencyMax: freqMax, frequencyMin: 0, fftSamples: 512, colorMap: COLORMAP,
-            });
-            ws.registerPlugin(plugin);
-            return plugin;
-          } catch (e) { console.warn('[rastrum] spectrogram failed:', e); return null; }
-        }
-
-        toggleBtn.addEventListener('click', async () => {
-          const expanded = toggleBtn.getAttribute('aria-expanded') === 'true';
-          if (!expanded) {
-            spectroPanel.classList.remove('hidden');
-            toggleBtn.setAttribute('aria-expanded', 'true');
-            toggleBtn.textContent = labelSpecH;
-            if (!spectroLoaded) { spectroLoaded = true; spectroPlugin = await loadSpectrogram(currentFreqMax); }
-          } else {
-            spectroPanel.classList.add('hidden');
-            toggleBtn.setAttribute('aria-expanded', 'false');
-            toggleBtn.textContent = labelSpec;
-          }
-        });
-
-        // Auto-expand spectrogram when requested (audio-only observations)
-        if (autoExpand) {
-          ws.on('ready', async () => {
-            spectroPanel.classList.remove('hidden');
-            toggleBtn.setAttribute('aria-expanded', 'true');
-            toggleBtn.textContent = labelSpecH;
-            if (!spectroLoaded) { spectroLoaded = true; spectroPlugin = await loadSpectrogram(currentFreqMax); }
-          });
-        }
-
-        freqSelect?.addEventListener('change', async () => {
-          const newFreq = parseInt(freqSelect.value, 10);
-          if (newFreq === currentFreqMax || !spectroLoaded) { currentFreqMax = newFreq; return; }
-          currentFreqMax = newFreq;
-          const topLabel = document.getElementById(`ws-freq-top-${obsId}`);
-          if (topLabel) topLabel.textContent = `${newFreq / 1000} kHz`;
-          if (specHost) specHost.innerHTML = '';
-          spectroPlugin = await loadSpectrogram(newFreq);
-        });
-
-        exportBtn?.addEventListener('click', async () => {
-          const canvas = specHost?.querySelector('canvas');
-          if (!canvas) {
-            exportBtn.textContent = container.dataset.lang === 'es' ? '(Abre el espectrograma primero)' : '(Open spectrogram first)';
-            setTimeout(() => exportBtn.innerHTML = `<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg> Export PNG`, 2000);
-            return;
-          }
-          try {
-            const dataUrl = canvas.toDataURL('image/png');
-            const res = await fetch(dataUrl);
-            const blob = await res.blob();
-            const blobUrl = URL.createObjectURL(blob);
-            const link = document.createElement('a');
-            link.download = `spectrogram-${obsId}.png`;
-            link.href = blobUrl;
-            link.click();
-            setTimeout(() => URL.revokeObjectURL(blobUrl), 10000);
-          } catch {
-            const dataUrl = canvas.toDataURL('image/png');
-            window.open(dataUrl, '_blank');
-          }
-        });
-      }
-
-    } catch (err) {
-      loadingEl?.classList.add('hidden');
-      errorEl?.classList.remove('hidden');
-      console.warn('[rastrum] WaveSurfer init failed:', err);
-    }
-  }
-})();
 </script>

--- a/src/components/ShareObsView.astro
+++ b/src/components/ShareObsView.astro
@@ -91,16 +91,13 @@ const labels = {
           >{labels.editLocation}</button>
         </div>
 
-        <!-- Audio player mount — populated dynamically when audio media_files exist -->
-        <!-- The page script replaces innerHTML when audios are found.
-             The div stays hidden until then. -->
+        <!-- Audio player mount — populated dynamically when audio media_files exist.
+             The page script injects `.rastrum-audio-player-mount` nodes; the
+             hidden `<AudioPlayer>` below ensures Astro bundles the lib so
+             those mounts have something to attach to. -->
         <div id="obs-audio-players" class="hidden space-y-3"></div>
-        <!-- Hidden AudioPlayer instance so Astro bundles the <script> that
-             listens for `rastrum:audio-players-ready`. The dynamic HTML
-             injected by the page script creates `.rastrum-audio-player`
-             nodes, but without this anchor the init JS is tree-shaken. -->
         <div class="hidden" aria-hidden="true">
-          <AudioPlayer audioUrl="" lang={lang} obsId="__anchor" showSpectrogram={false} />
+          <AudioPlayer audioUrl="" lang={lang} obsId="__anchor" />
         </div>
       </aside>
 

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -185,105 +185,11 @@ const lang: 'en' | 'es' = 'en';
         if (galleryRoot) galleryRoot.classList.add('hidden');
       }
 
-      // ── Audio players (spectrogram) ──
-      // TODO: when Astro supports SSR hydration in this context, use AudioPlayer.astro directly
-      function buildAudioPlayerHTML(audioUrl: string, mimeType: string, obsIdAttr: string, lang: string, autoExpand = false): string {
-        const isEs = lang === 'es';
-        const playLabel    = isEs ? 'Reproducir' : 'Play';
-        const pauseLabel   = isEs ? 'Pausar' : 'Pause';
-        const spectroLabel = isEs ? 'Ver espectrograma' : 'Show spectrogram';
-        const spectroHide  = isEs ? 'Ocultar espectrograma' : 'Hide spectrogram';
-        const freqLabel    = isEs ? 'Frecuencia (kHz)' : 'Frequency (kHz)';
-        const timeLabel    = isEs ? 'Tiempo (s)' : 'Time (s)';
-        const loadLabel    = isEs ? 'Cargando audio…' : 'Loading audio…';
-        const errLabel     = isEs ? 'No se pudo cargar el audio.' : 'Could not load audio.';
-        const radialLabel  = isEs ? 'Visualizar' : 'Visualize';
-        const radialHide   = isEs ? 'Ocultar' : 'Hide';
-        return `
-            <div
-              class="rastrum-audio-player rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 overflow-hidden"
-              data-audio-url="${audioUrl}"
-              data-mime-type="${mimeType}"
-              data-obs-id="${obsIdAttr}"
-              data-show-spectrogram="true"
-              data-lang="${lang}"
-              data-label-play="${playLabel}"
-              data-label-pause="${pauseLabel}"
-              data-label-spectro="${spectroLabel}"
-              data-label-spectro-hide="${spectroHide}"
-              data-label-freq="${freqLabel}"
-              data-label-time="${timeLabel}"
-              data-label-radial="${radialLabel}"
-              data-label-radial-hide="${radialHide}"
-              data-auto-expand="${autoExpand ? 'true' : 'false'}"
-            >
-              <div class="px-3 pt-3">
-                <div id="ws-wave-${obsIdAttr}" style="min-height:60px;"></div>
-              </div>
-              <div class="flex items-center gap-3 px-3 py-2">
-                <button id="ws-play-${obsIdAttr}" type="button" aria-label="${playLabel}"
-                  class="w-9 h-9 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white flex items-center justify-center shrink-0 transition-colors disabled:opacity-40"
-                  disabled>
-                  <svg class="play-icon w-4 h-4 ml-0.5" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
-                  <svg class="pause-icon hidden w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>
-                </button>
-                <span id="ws-time-${obsIdAttr}" class="text-xs font-mono text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">0:00</span>
-                <span class="loading-label text-xs text-zinc-400 dark:text-zinc-500">${loadLabel}</span>
-                <span class="error-label hidden text-xs text-red-500">${errLabel}</span>
-                <div class="flex-1"></div>
-                <button id="ws-toggle-radial-${obsIdAttr}" type="button" aria-expanded="false"
-                  class="text-xs text-sky-600 dark:text-sky-400 underline underline-offset-2 hover:no-underline shrink-0">${radialLabel}</button>
-                <button id="ws-toggle-spec-${obsIdAttr}" type="button" aria-expanded="false"
-                  class="text-xs text-emerald-700 dark:text-emerald-400 underline underline-offset-2 hover:no-underline shrink-0">
-                  ${spectroLabel}
-                </button>
-              </div>
-              <div id="ws-radial-${obsIdAttr}" class="hidden px-3 pb-3">
-                <div class="relative flex items-center justify-center rounded-xl bg-zinc-950 overflow-hidden" style="height:280px;">
-                  <canvas id="ws-radial-canvas-${obsIdAttr}" class="w-full h-full" aria-hidden="true"></canvas>
-                  <div id="ws-radial-label-${obsIdAttr}" class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none select-none">
-                    <span id="ws-radial-species-${obsIdAttr}" class="text-sm font-semibold italic text-white/80 drop-shadow-lg transition-all duration-300"></span>
-                    <span id="ws-radial-common-${obsIdAttr}" class="text-[11px] text-white/50 mt-0.5 transition-all duration-300"></span>
-                  </div>
-                </div>
-              </div>
-              <div id="ws-spec-${obsIdAttr}" class="hidden px-3 pb-2">
-                <div class="flex items-center gap-2 mb-2">
-                  <span class="text-[10px] text-zinc-500">${isEs ? 'Rango:' : 'Range:'}</span>
-                  <select id="ws-freq-range-${obsIdAttr}" class="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-[10px] px-1 py-0.5">
-                    <option value="12000">0 – 12 kHz</option>
-                    <option value="8000">0 – 8 kHz</option>
-                    <option value="4000">0 – 4 kHz</option>
-                    <option value="2000">0 – 2 kHz</option>
-                  </select>
-                  <div style="flex:1"></div>
-                  <button id="ws-export-${obsIdAttr}" type="button" class="flex items-center gap-1 text-[10px] text-zinc-500 hover:text-zinc-200 transition-colors">
-                    <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
-                    ${isEs ? 'Exportar PNG' : 'Export PNG'}
-                  </button>
-                  <button id="ws-info-btn-${obsIdAttr}" type="button" class="w-5 h-5 rounded-full border border-zinc-700 text-[10px] text-zinc-400 hover:border-emerald-500 hover:text-emerald-500 flex items-center justify-center font-bold">?</button>
-                </div>
-                <div id="ws-info-panel-${obsIdAttr}" class="hidden mb-2 rounded-lg border border-emerald-900/40 bg-emerald-950/30 p-3 text-xs text-zinc-300 space-y-1.5">
-                  <p class="font-semibold text-emerald-300">${isEs ? '¿Qué es un espectrograma?' : 'What is a spectrogram?'}</p>
-                  <p>${isEs ? 'Muestra cómo cambian las frecuencias del sonido a lo largo del tiempo. Horizontal = tiempo, vertical = frecuencia, color = intensidad (más brillante = más fuerte).' : 'Shows how sound frequencies change over time. Horizontal = time, vertical = frequency (pitch), color = intensity — brighter = louder.'}</p>
-                  <p>${isEs ? '🌈 Inferno: negro=silencio, morado=débil, naranja=moderado, amarillo=fuerte.' : '🌈 Inferno: black=silence, purple=faint, orange=moderate, yellow=loud.'}</p>
-                  <p>${isEs ? '🐦 Cantos de aves: 1–8 kHz. Líneas horizontales = tonos sostenidos; verticales = clics.' : '🐦 Bird songs: 1–8 kHz. Horizontal streaks = sustained tones; vertical = clicks.'}</p>
-                  <p id="ws-birdnet-info-${obsIdAttr}" class="hidden font-medium text-emerald-400">${isEs ? '✅ Bandas coloreadas = detecciones BirdNET. Toca para ver detalles.' : '✅ Colored bands = BirdNET detections. Tap for details.'}</p>
-                </div>
-                <div class="flex items-end justify-between mb-1 text-[10px] text-zinc-500 select-none">
-                  <span id="ws-freq-top-${obsIdAttr}">12 kHz</span><span class="italic">${freqLabel}</span><span>0 Hz</span>
-                </div>
-                <div class="relative">
-                  <div id="ws-spec-host-${obsIdAttr}" class="ws-spectrogram-host w-full rounded overflow-hidden bg-zinc-950" style="height:140px;" aria-hidden="true"></div>
-                  <div id="ws-detections-${obsIdAttr}" class="absolute inset-0 pointer-events-none" aria-hidden="true"></div>
-                  <div id="ws-tooltip-${obsIdAttr}" class="hidden absolute z-10 rounded-lg border border-emerald-700 bg-zinc-900/95 shadow-lg p-2.5 text-xs max-w-[200px] pointer-events-none" role="tooltip"></div>
-                </div>
-                <div class="mt-1 text-[10px] text-zinc-500 text-right select-none italic">${timeLabel}</div>
-                <div id="ws-legend-${obsIdAttr}" class="hidden mt-2 space-y-1"></div>
-              </div>
-            </div>`;
-      }
-
+      // ── Audio players ──
+      // The actual player is built by `mountAudioPlayer` (src/lib/audio-player.ts)
+      // which is wired up by AudioPlayer.astro's inline <script>. Here we just
+      // emit empty mount points; AudioPlayer.astro listens for the
+      // `rastrum:audio-players-ready` event and initialises them.
       if (audioFiles.length > 0) {
         const playersEl = document.getElementById('obs-audio-players');
         if (playersEl) {
@@ -292,10 +198,16 @@ const lang: 'en' | 'es' = 'en';
           playersEl.innerHTML = audioFiles.map((af: MediaRow, idx: number) => {
             const obsIdAttr = `obs-detail-audio-${idx}`;
             const mimeType  = af.mime_type ?? 'audio/mpeg';
-            return buildAudioPlayerHTML(af.url, mimeType, obsIdAttr, lang, isAudioOnly);
+            return `<div
+              class="rastrum-audio-player-mount"
+              data-audio-url="${af.url}"
+              data-mime-type="${mimeType}"
+              data-obs-id="${obsIdAttr}"
+              data-lang="${lang}"
+              data-auto-expand="${isAudioOnly ? 'true' : 'false'}"
+            ></div>`;
           }).join('');
 
-          // Re-run AudioPlayer init for the new DOM nodes
           document.dispatchEvent(new CustomEvent('rastrum:audio-players-ready'));
 
           // ── Fetch BirdNET detections from the identifications table ──


### PR DESCRIPTION
## Summary

Rewrites the detail-page audio player to use the new \`mountAudioPlayer({size:'lg'})\` from PR #572. **The radial visualizer is no longer hidden behind a "Visualize" toggle — it is now the player's centerpiece**, with the play button embedded in the inner ring. The species detected by BirdNET appears in real time below the play button.

### What changed

- \`src/components/AudioPlayer.astro\` — collapsed from a 500-line wavesurfer + spectrogram + radial template to a thin Astro wrapper that calls \`mountAudioPlayer({size:'lg'})\` on a data-attribute mount point.
- \`src/pages/share/obs/index.astro\` — deleted the duplicated 100-line \`buildAudioPlayerHTML\` function. The dynamic-fetch path now emits empty \`.rastrum-audio-player-mount\` divs that the wrapper picks up via the existing \`rastrum:audio-players-ready\` event.
- \`src/components/ShareObsView.astro\` — drops the \`showSpectrogram\` prop (\`lg\` always shows it).

Net delta: **+62 / -740 lines**.

### Visible UX delta

| Before | After |
|---|---|
| Play button in a control bar above the waveform | Play button embedded in the radial visualizer's inner ring (64×64, centered) |
| Radial hidden behind a "Visualize / Visualizar" toggle | Radial always visible at the top of the player |
| Spectrogram hidden behind a "Show spectrogram" toggle (still toggleable on photo+audio observations, auto-expanded for audio-only) | Spectrogram **auto-expands** on audio-only observations (\`autoExpand\` flag); placeholder shows for the brief decode window |
| No volume control at all | Inline volume slider in the controls row |

BirdNET detection coloring of the radial bars (per-species at the current playhead) and the inferno-colormap spectrogram with detection-band overlays + tooltips + legend are preserved.

## Stacked on PR #572

This PR's base is \`feat/audio-player-unification\` (PR #572). Once #572 merges, GitHub will rebase this onto main automatically.

## Test plan

- [x] \`npx vitest run\` — 842 tests pass
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npm run build\` — 231 pages built clean
- [ ] Manual smoke on \`/share/obs/?id=<an-audio-obs>\`:
  - Radial visible from first paint, play button inside it
  - Click play → wavesurfer plays, radial bars react in real time
  - Open an observation with BirdNET data → bars colored per species, species name appears below play button when playhead enters detection segment
  - Volume slider drives the engine; volume persists across page loads
  - Click anywhere on the spectrogram → seek (waveform playhead jumps too)