### PR TITLE
feat(karma): 30-day rolling leaderboard materialized view + tab toggle

### DIFF
--- a/docs/specs/infra/cron-schedules.sql
+++ b/docs/specs/infra/cron-schedules.sql
@@ -370,3 +370,17 @@ SELECT cron.schedule(
    WHERE p.id = s.place_id;
   $$
 );
+
+-- ─────────────────────────────────────────────────────────────────
+-- v12 (2026-05-04): #552 — 'refresh-karma-leaderboard-30d' (every 6h)
+--   Refreshes the karma_leaderboard_30d materialized view that backs
+--   the 30-day rolling tab on /community/leaderboard/. CONCURRENTLY
+--   needs the unique index on user_id (created in supabase-schema.sql).
+-- ─────────────────────────────────────────────────────────────────
+SELECT cron.unschedule('refresh-karma-leaderboard-30d')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'refresh-karma-leaderboard-30d');
+SELECT cron.schedule(
+  'refresh-karma-leaderboard-30d',
+  '0 */6 * * *',
+  $$ REFRESH MATERIALIZED VIEW CONCURRENTLY public.karma_leaderboard_30d $$
+);

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7492,3 +7492,52 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 GRANT EXECUTE ON FUNCTION public.recompute_consensus(uuid) TO service_role;
 GRANT EXECUTE ON FUNCTION public.recompute_consensus(uuid) TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- karma_leaderboard_30d — 30-day rolling karma leaderboard
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Materialized view that aggregates positive karma deltas over the last 30
+-- days per user. The eligibility predicate mirrors community_observers
+-- (`hide_from_leaderboards = false`); MVs don't have RLS, so the privacy
+-- gate is baked into the WHERE clause.
+--
+-- Refreshed every 6h via pg_cron (see cron-schedules.sql). Initial refresh
+-- (non-concurrent, fine on an empty MV) runs at apply time so the view is
+-- queryable immediately. Subsequent refreshes use CONCURRENTLY thanks to
+-- the unique index on user_id.
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.karma_leaderboard_30d AS
+SELECT
+  u.id                                                                AS user_id,
+  u.username,
+  u.display_name,
+  u.avatar_url,
+  u.country_code,
+  u.species_count,
+  COALESCE(SUM(ke.delta) FILTER (WHERE ke.delta > 0), 0)::numeric     AS karma_30d,
+  COUNT(*) FILTER (WHERE ke.reason = 'consensus_win' AND ke.delta > 0)::int AS wins_30d,
+  COUNT(ke.id)::int                                                   AS events_30d
+FROM public.users u
+LEFT JOIN public.karma_events ke
+  ON ke.user_id = u.id
+ AND ke.created_at >= now() - interval '30 days'
+WHERE u.hide_from_leaderboards = false
+GROUP BY u.id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS karma_leaderboard_30d_user_id_uidx
+  ON public.karma_leaderboard_30d (user_id);
+
+CREATE INDEX IF NOT EXISTS karma_leaderboard_30d_karma_idx
+  ON public.karma_leaderboard_30d (karma_30d DESC NULLS LAST);
+
+GRANT SELECT ON public.karma_leaderboard_30d TO anon, authenticated;
+
+-- Initial population. Safe to run on each apply: REFRESH on an MV that's
+-- already been refreshed is just a no-op write. Non-concurrent so it works
+-- on the very first apply when the MV is empty (CONCURRENTLY requires
+-- the MV to be populated at least once).
+DO $$ BEGIN
+  REFRESH MATERIALIZED VIEW public.karma_leaderboard_30d;
+EXCEPTION WHEN OTHERS THEN
+  -- A pre-existing concurrent refresh from cron may collide; ignore.
+  NULL;
+END $$;

--- a/src/components/KarmaLeaderboardView.astro
+++ b/src/components/KarmaLeaderboardView.astro
@@ -2,12 +2,14 @@
 /**
  * KarmaLeaderboardView — shared EN+ES page body for /community/leaderboard/.
  *
- * Shows top 20 users by karma_total (descending). Queries the
- * `community_observers` view which already filters out users with
- * `hide_from_leaderboards = true`.
+ * Two periods, URL-driven via `?period=30d|all`:
+ *   - 30d (default): queries `karma_leaderboard_30d` materialized view.
+ *   - all          : queries `community_observers` for all-time karma_total.
  *
- * Client-rendered (CSR) like CommunityView — the audience is signed-in
- * observers checking their standing.
+ * Both data sources filter `hide_from_leaderboards = false` at the SQL
+ * layer (the MV WHERE clause + the view definition). Client-rendered
+ * (CSR) like CommunityView — the audience is signed-in observers
+ * checking their standing.
  */
 import { t, getLocalizedPath, routes, type Locale } from '../i18n/utils';
 
@@ -26,6 +28,9 @@ interface LeaderboardCopy {
   leaderboard_karma: string;
   leaderboard_species: string;
   leaderboard_empty: string;
+  leaderboard_period_30d: string;
+  leaderboard_period_all: string;
+  leaderboard_period_aria: string;
   loading: string;
 }
 const cm = (tr as unknown as { community: LeaderboardCopy }).community;
@@ -53,6 +58,31 @@ const stringsJson = JSON.stringify({
     <p class="text-sm text-zinc-600 dark:text-zinc-400 mt-1">{cm.leaderboard_subtitle}</p>
   </div>
 
+  <div
+    class="mb-4 inline-flex rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-0.5 text-xs"
+    role="tablist"
+    aria-label={cm.leaderboard_period_aria}
+  >
+    <button
+      type="button"
+      role="tab"
+      data-period-tab="30d"
+      aria-pressed="true"
+      class="px-3 py-1.5 rounded-md font-medium transition"
+    >
+      {cm.leaderboard_period_30d}
+    </button>
+    <button
+      type="button"
+      role="tab"
+      data-period-tab="all"
+      aria-pressed="false"
+      class="px-3 py-1.5 rounded-md font-medium transition"
+    >
+      {cm.leaderboard_period_all}
+    </button>
+  </div>
+
   <div id="leaderboard-loading" class="text-sm text-zinc-500 italic">
     {cm.loading}
   </div>
@@ -78,6 +108,7 @@ const stringsJson = JSON.stringify({
 
 <script>
   import { getSupabase } from '../lib/supabase';
+  import { periodFromSearch, searchForPeriod, type LeaderboardPeriod } from '../lib/leaderboard-url';
 
   interface LeaderboardStrings {
     lang: 'en' | 'es';
@@ -95,10 +126,14 @@ const stringsJson = JSON.stringify({
   const emptyEl = document.getElementById('leaderboard-empty');
   const tableWrap = document.getElementById('leaderboard-table-wrap');
   const tbody = document.getElementById('leaderboard-body');
+  const tabs = root.querySelectorAll<HTMLButtonElement>('[data-period-tab]');
 
   if (!loadingEl || !emptyEl || !tableWrap || !tbody) {
     throw new Error('KarmaLeaderboardView: missing required DOM nodes');
   }
+
+  const ACTIVE_TAB = 'bg-emerald-600 text-white shadow-sm';
+  const INACTIVE_TAB = 'text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800';
 
   function escapeHtml(s: string): string {
     return String(s ?? '').replace(/[&<>"']/g, (c) => ({
@@ -111,8 +146,8 @@ const stringsJson = JSON.stringify({
     username: string | null;
     display_name: string | null;
     avatar_url: string | null;
-    karma_total: number;
-    species_count: number;
+    karma: number;
+    species_count: number | null;
   }
 
   function renderRow(row: LeaderboardRow, rank: number): HTMLTableRowElement {
@@ -140,46 +175,118 @@ const stringsJson = JSON.stringify({
           </div>
         </a>
       </td>
-      <td class="py-3 px-2 text-right font-semibold text-emerald-700 dark:text-emerald-400">${Math.round(row.karma_total)}</td>
-      <td class="py-3 pl-2 text-right text-zinc-600 dark:text-zinc-300">${row.species_count}</td>
+      <td class="py-3 px-2 text-right font-semibold text-emerald-700 dark:text-emerald-400">${Math.round(row.karma)}</td>
+      <td class="py-3 pl-2 text-right text-zinc-600 dark:text-zinc-300">${row.species_count ?? 0}</td>
     `;
     return tr;
   }
 
-  void (async () => {
+  function paintTabs(period: LeaderboardPeriod) {
+    tabs.forEach((tab) => {
+      const own = tab.dataset.periodTab as LeaderboardPeriod;
+      const active = own === period;
+      tab.setAttribute('aria-pressed', active ? 'true' : 'false');
+      tab.className = `px-3 py-1.5 rounded-md font-medium transition ${active ? ACTIVE_TAB : INACTIVE_TAB}`;
+    });
+  }
+
+  function showLoading() {
+    loadingEl!.classList.remove('hidden', 'text-red-600');
+    loadingEl!.classList.add('text-zinc-500');
+    loadingEl!.textContent = STRINGS.loading;
+    emptyEl!.classList.add('hidden');
+    tableWrap!.classList.add('hidden');
+    tbody!.innerHTML = '';
+  }
+
+  async function loadFor(period: LeaderboardPeriod) {
+    showLoading();
     try {
       const supabase = getSupabase();
-      const { data, error } = await supabase
-        .from('community_observers')
-        .select('id, username, display_name, avatar_url, karma_total, species_count')
-        .order('karma_total', { ascending: false, nullsFirst: false })
-        .limit(20);
-
-      loadingEl.classList.add('hidden');
-
-      if (error) {
-        loadingEl.classList.remove('hidden');
-        loadingEl.textContent = error.message;
-        loadingEl.classList.add('text-red-600');
-        loadingEl.classList.remove('text-zinc-500');
-        return;
+      let rows: LeaderboardRow[] = [];
+      if (period === '30d') {
+        const { data, error } = await supabase
+          .from('karma_leaderboard_30d')
+          .select('user_id, username, display_name, avatar_url, karma_30d, species_count')
+          .order('karma_30d', { ascending: false, nullsFirst: false })
+          .limit(20);
+        if (error) throw new Error(error.message);
+        rows = (data ?? []).map((r: {
+          user_id: string;
+          username: string | null;
+          display_name: string | null;
+          avatar_url: string | null;
+          karma_30d: number | null;
+          species_count: number | null;
+        }) => ({
+          id: r.user_id,
+          username: r.username,
+          display_name: r.display_name,
+          avatar_url: r.avatar_url,
+          karma: Number(r.karma_30d ?? 0),
+          species_count: r.species_count,
+        }));
+      } else {
+        const { data, error } = await supabase
+          .from('community_observers')
+          .select('id, username, display_name, avatar_url, karma_total, species_count')
+          .order('karma_total', { ascending: false, nullsFirst: false })
+          .limit(20);
+        if (error) throw new Error(error.message);
+        rows = (data ?? []).map((r: {
+          id: string;
+          username: string | null;
+          display_name: string | null;
+          avatar_url: string | null;
+          karma_total: number | null;
+          species_count: number | null;
+        }) => ({
+          id: r.id,
+          username: r.username,
+          display_name: r.display_name,
+          avatar_url: r.avatar_url,
+          karma: Number(r.karma_total ?? 0),
+          species_count: r.species_count,
+        }));
       }
 
-      const rows = (data ?? []) as LeaderboardRow[];
+      loadingEl!.classList.add('hidden');
       if (rows.length === 0) {
-        emptyEl.classList.remove('hidden');
+        emptyEl!.classList.remove('hidden');
         return;
       }
-
       for (let i = 0; i < rows.length; i++) {
-        tbody.appendChild(renderRow(rows[i], i + 1));
+        tbody!.appendChild(renderRow(rows[i], i + 1));
       }
-      tableWrap.classList.remove('hidden');
+      tableWrap!.classList.remove('hidden');
     } catch (err) {
-      loadingEl.classList.remove('hidden');
-      loadingEl.textContent = err instanceof Error ? err.message : String(err);
-      loadingEl.classList.add('text-red-600');
-      loadingEl.classList.remove('text-zinc-500');
+      loadingEl!.classList.remove('hidden');
+      loadingEl!.textContent = err instanceof Error ? err.message : String(err);
+      loadingEl!.classList.add('text-red-600');
+      loadingEl!.classList.remove('text-zinc-500');
     }
-  })();
+  }
+
+  function applyPeriod(period: LeaderboardPeriod, push: boolean) {
+    paintTabs(period);
+    if (push) {
+      const next = searchForPeriod(window.location.search, period);
+      const url = `${window.location.pathname}${next}${window.location.hash}`;
+      window.history.pushState({ period }, '', url);
+    }
+    void loadFor(period);
+  }
+
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      const period = tab.dataset.periodTab as LeaderboardPeriod;
+      applyPeriod(period, true);
+    });
+  });
+
+  window.addEventListener('popstate', () => {
+    applyPeriod(periodFromSearch(window.location.search), false);
+  });
+
+  applyPeriod(periodFromSearch(window.location.search), false);
 </script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -419,7 +419,10 @@
     "leaderboard_observer": "Observer",
     "leaderboard_karma": "Karma",
     "leaderboard_species": "Species",
-    "leaderboard_empty": "No observers yet. Be the first!"
+    "leaderboard_empty": "No observers yet. Be the first!",
+    "leaderboard_period_30d": "30 days",
+    "leaderboard_period_all": "All time",
+    "leaderboard_period_aria": "Time period"
   },
   "profile": {
     "title": "Profile",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -419,7 +419,10 @@
     "leaderboard_observer": "Observador",
     "leaderboard_karma": "Karma",
     "leaderboard_species": "Especies",
-    "leaderboard_empty": "Aún no hay observadores. ¡Sé el primero!"
+    "leaderboard_empty": "Aún no hay observadores. ¡Sé el primero!",
+    "leaderboard_period_30d": "30 días",
+    "leaderboard_period_all": "Histórico",
+    "leaderboard_period_aria": "Periodo"
   },
   "profile": {
     "title": "Perfil",

--- a/src/lib/leaderboard-url.ts
+++ b/src/lib/leaderboard-url.ts
@@ -1,0 +1,28 @@
+export type LeaderboardPeriod = '30d' | 'all';
+
+const VALID: readonly LeaderboardPeriod[] = ['30d', 'all'] as const;
+
+export function parseLeaderboardPeriod(input: string | null | undefined): LeaderboardPeriod {
+  if (!input) return '30d';
+  return (VALID as readonly string[]).includes(input) ? (input as LeaderboardPeriod) : '30d';
+}
+
+export function periodFromSearch(search: string): LeaderboardPeriod {
+  return parseLeaderboardPeriod(new URLSearchParams(search).get('period'));
+}
+
+/**
+ * Build the next URL search string for a given period. The default period
+ * (`30d`) is rendered as no parameter so the canonical URL stays clean;
+ * `all` is opt-in and shows up explicitly.
+ */
+export function searchForPeriod(currentSearch: string, period: LeaderboardPeriod): string {
+  const params = new URLSearchParams(currentSearch);
+  if (period === '30d') {
+    params.delete('period');
+  } else {
+    params.set('period', period);
+  }
+  const out = params.toString();
+  return out ? `?${out}` : '';
+}

--- a/tests/unit/leaderboard-url.test.ts
+++ b/tests/unit/leaderboard-url.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseLeaderboardPeriod,
+  periodFromSearch,
+  searchForPeriod,
+} from '../../src/lib/leaderboard-url';
+
+describe('parseLeaderboardPeriod', () => {
+  it('defaults to 30d when input is missing', () => {
+    expect(parseLeaderboardPeriod(null)).toBe('30d');
+    expect(parseLeaderboardPeriod(undefined)).toBe('30d');
+    expect(parseLeaderboardPeriod('')).toBe('30d');
+  });
+
+  it('passes through valid periods', () => {
+    expect(parseLeaderboardPeriod('30d')).toBe('30d');
+    expect(parseLeaderboardPeriod('all')).toBe('all');
+  });
+
+  it('falls back to 30d on garbage input', () => {
+    expect(parseLeaderboardPeriod('weekly')).toBe('30d');
+    expect(parseLeaderboardPeriod('30D')).toBe('30d');
+  });
+});
+
+describe('periodFromSearch', () => {
+  it('reads from a search string with leading ?', () => {
+    expect(periodFromSearch('?period=all')).toBe('all');
+    expect(periodFromSearch('?period=30d')).toBe('30d');
+  });
+
+  it('returns 30d when no param is present', () => {
+    expect(periodFromSearch('')).toBe('30d');
+    expect(periodFromSearch('?other=1')).toBe('30d');
+  });
+});
+
+describe('searchForPeriod', () => {
+  it('drops the param entirely for the default 30d', () => {
+    expect(searchForPeriod('?period=all', '30d')).toBe('');
+    expect(searchForPeriod('', '30d')).toBe('');
+  });
+
+  it('sets the param for non-default periods', () => {
+    expect(searchForPeriod('', 'all')).toBe('?period=all');
+    expect(searchForPeriod('?period=30d', 'all')).toBe('?period=all');
+  });
+
+  it('preserves unrelated params', () => {
+    expect(searchForPeriod('?foo=bar', 'all')).toBe('?foo=bar&period=all');
+    expect(searchForPeriod('?period=all&foo=bar', '30d')).toBe('?foo=bar');
+  });
+
+  it('round-trips period across reload (parse → serialise → parse)', () => {
+    const search = searchForPeriod('', 'all');
+    expect(periodFromSearch(search)).toBe('all');
+
+    const reset = searchForPeriod(search, '30d');
+    expect(periodFromSearch(reset)).toBe('30d');
+  });
+});


### PR DESCRIPTION
Closes #552.

## Summary

- All-time `karma_total` ordering favoured veterans; new 30-day rolling tab is now the default on `/community/leaderboard/`. All-time view kept as an opt-in second tab.
- New MV `public.karma_leaderboard_30d` aggregates positive karma deltas over the last 30 days, with denormalised display columns so the page renders in one round-trip. Eligibility predicate (`hide_from_leaderboards = false`) baked into the WHERE clause — MVs don't have RLS, this is the privacy gate.
- pg_cron job `refresh-karma-leaderboard-30d` runs every 6h with CONCURRENTLY against the unique index. Initial non-concurrent REFRESH at apply time so the view is queryable on day one.

## UI

`KarmaLeaderboardView` gains a `role="tablist"` toggle: **30 days** / **All time**. State is URL-driven via `?period=30d|all` — default `30d` drops the param entirely (canonical URLs stay clean), `all` is opt-in and explicit. Uses `history.pushState` on click + `popstate` listener for back/forward.

## i18n

3 new keys under `community.*` in both `en.json` + `es.json`:
- `leaderboard_period_30d` ("30 days" / "30 días")
- `leaderboard_period_all` ("All time" / "Histórico")
- `leaderboard_period_aria` ("Time period" / "Periodo")

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 835/835 (10 new tests in `tests/unit/leaderboard-url.test.ts` covering parse, serialise, default-drops-param, preserves-unrelated-params, survives-reload round-trip)
- [x] `npm run build` — 231 pages, zero errors
- [ ] Post-merge: `make db-apply` populates the MV; `make db-cron-schedule` registers the 6h refresh. Verify on rastrum.org/en/community/leaderboard/ that the default tab shows 30-day data and the All time tab matches the previous behaviour.

Does NOT touch `community_observers` — the column-order trap in `CREATE OR REPLACE VIEW` makes that risky and the all-time tab still queries it directly.