### PR TITLE
fix(sponsoring): trust caller-supplied kind in Anthropic validator + clearer auth-token errors

### DIFF
--- a/src/lib/sponsorships.ts
+++ b/src/lib/sponsorships.ts
@@ -45,11 +45,20 @@ export interface CreateCredentialArgs {
 async function authedFetch(path: string, init?: RequestInit): Promise<Response> {
   const { data: { session } } = await getSupabase().auth.getSession();
   if (!session) throw new Error('not_authenticated');
+  // Belt-and-braces: a corrupted/persisted session can produce a token
+  // with non-ByteString characters which makes fetch() reject at
+  // construction with a cryptic "headers ... not a valid ByteString"
+  // error. Fail loudly with a clearer message + force re-auth.
+  const token = session.access_token;
+  if (typeof token !== 'string' || !/^[\x20-\x7E]+$/.test(token)) {
+    await getSupabase().auth.signOut().catch(() => {});
+    throw new Error('session_token_corrupted_please_sign_in_again');
+  }
   return fetch(`${FN_BASE}${path}`, {
     ...init,
     headers: {
       ...(init?.headers ?? {}),
-      'authorization': `Bearer ${session.access_token}`,
+      'authorization': `Bearer ${token}`,
       'content-type':  'application/json',
     },
   });

--- a/supabase/functions/_shared/anthropic-validate.ts
+++ b/supabase/functions/_shared/anthropic-validate.ts
@@ -43,8 +43,14 @@ export function detectAnyKind(secret: string): AnyCredentialKind | null {
   return null;
 }
 
-export async function validateAnthropicCredential(secret: string): Promise<ValidationResult> {
-  const kind = detectKind(secret);
+export async function validateAnthropicCredential(
+  secret: string,
+  /** Caller-supplied kind. When the operator picked Anthropic from the
+   *  dropdown we trust them — otherwise older / non-`api03` Anthropic
+   *  prefixes get rejected here even though the key is fine. */
+  kindHint?: 'api_key' | 'oauth_token',
+): Promise<ValidationResult> {
+  const kind = kindHint ?? detectKind(secret);
   if (!kind) return { valid: false, error: 'invalid_prefix' };
 
   const headers: HeadersInit = {

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -104,16 +104,17 @@ serve(async (req) => {
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60_000).toISOString();
     const { data: stale } = await supabase
       .from('sponsor_credentials')
-      .select('id, vault_secret_id, user_id, label')
+      .select('id, vault_secret_id, user_id, label, kind')
       .is('revoked_at', null)
       .or(`validated_at.is.null,validated_at.lt.${sevenDaysAgo}`)
+      .in('kind', ['api_key', 'oauth_token'])
       .limit(50);
 
     const results: Array<{ id: string; ok: boolean; error?: string }> = [];
-    for (const cred of (stale ?? []) as Array<{ id: string; vault_secret_id: string }>) {
+    for (const cred of (stale ?? []) as Array<{ id: string; vault_secret_id: string; kind: 'api_key' | 'oauth_token' }>) {
       try {
         const secret = await decryptCredential(supabase, cred.vault_secret_id);
-        const result = await validateAnthropicCredential(secret);
+        const result = await validateAnthropicCredential(secret, cred.kind);
         if (result.valid) {
           await supabase.from('sponsor_credentials')
             .update({ validated_at: new Date().toISOString() })
@@ -166,7 +167,9 @@ serve(async (req) => {
     // Other providers (OpenAI, Gemini, Bedrock, Azure, Vertex) are stored as-is —
     // they'll fail at identify-time if invalid, which gives a clearer error.
     if (kind === 'api_key' || kind === 'oauth_token') {
-      const validation = await validateAnthropicCredential(secret);
+      // Pass kind explicitly — older / non-`sk-ant-api03-` Anthropic
+      // prefixes get rejected by the validator's own detect otherwise.
+      const validation = await validateAnthropicCredential(secret, kind);
       if (!validation.valid) return jsonResponse(400, { error: 'validation_failed', detail: validation.error });
     }
 


### PR DESCRIPTION
Follow-up to #577. Production smoke (build 2026.5.1) on /en/profile/sponsoring/ surfaced two failures:

## 1. Save & validate → 400 \`validation_failed | invalid_prefix\`
The dispatcher correctly routed \`kind='api_key'\` from the dropdown, but \`validateAnthropicCredential\` then re-ran its OWN narrow \`detectKind(secret)\` and bailed for any Anthropic key whose prefix isn't \`sk-ant-api03-\` / \`sk-ant-oat01-\` (legacy keys, OAuth-flow keys, admin keys, etc.).

**Fix:** \`validateAnthropicCredential(secret, kindHint?)\` now accepts an explicit kind from the caller; only falls back to detection when absent. The /credentials POST handler passes the kind it already resolved via \`KIND_TO_PROVIDER\`. The heartbeat cron now selects \`kind\` from the row and filters to Anthropic-only creds (the validator was always Anthropic-specific).

## 2. Test → \"Failed to construct 'Request': 'headers' of 'RequestInit' (Argument 2) is not a valid ByteString\"
Cause inconclusive from static inspection — \`authedFetch\`'s headers are pure ASCII (\`Bearer <jwt>\` + \`application/json\`). Most likely a corrupted/stale persisted Supabase session producing an access_token with a non-ByteString character that fetch() rejects at construction.

**Defensive fix:** \`authedFetch\` validates the access_token is ASCII printable before passing to fetch(). If not, signs out and throws a clear \`session_token_corrupted_please_sign_in_again\` message so the user knows to re-auth.

## Files
- \`supabase/functions/_shared/anthropic-validate.ts\` — kindHint parameter
- \`supabase/functions/sponsorships/index.ts\` — pass kind in /credentials + heartbeat; filter heartbeat to Anthropic-only
- \`src/lib/sponsorships.ts\` — token sanity check in authedFetch

## Deploy
Edge Function auto-deploys on merge via deploy-functions.yml.

## Test plan
- [ ] Save & validate with a legacy Anthropic key (any \`sk-ant-*\` prefix) → succeeds (was 400 before)
- [ ] Save & validate with an obviously bad key → still 400 \`validation_failed | auth_failed\` (server actually pings Anthropic)
- [ ] Test button with valid key → ✓ result
- [ ] If session is corrupted → modal shows \`Failed: session_token_corrupted_please_sign_in_again\` and the user is logged out
- [ ] Heartbeat cron continues running on Anthropic creds only (non-Anthropic kinds skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)