### PR TITLE
fix(ai-pipeline): Sprint 1 — sponsorship gate, isPlantLike, EfficientNet quarantine, claude.isAvailable

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7611,3 +7611,39 @@ EXCEPTION WHEN OTHERS THEN
   -- A pre-existing concurrent refresh from cron may collide; ignore.
   NULL;
 END $$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #595 — has_active_sponsorship(provider): cheap metadata read for the
+-- client to gate Claude isAvailable() on whether the signed-in user has
+-- coverage. SECURITY DEFINER, no decryption, no JOIN to vault. Returns
+-- true if the user has either:
+--   (a) an active personal sponsorship for this provider, OR
+--   (b) an active platform pool with capacity (total_cap > used).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.has_active_sponsorship(p_provider public.ai_provider)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT auth.uid() IS NOT NULL AND (
+    EXISTS (
+      SELECT 1 FROM public.sponsorships s
+      JOIN public.sponsor_credentials c ON c.id = s.credential_id
+      WHERE s.beneficiary_id = auth.uid()
+        AND s.provider       = p_provider
+        AND s.status         = 'active'
+        AND c.revoked_at IS NULL
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.sponsor_pools p
+      JOIN public.sponsor_credentials c ON c.id = p.credential_id
+      WHERE c.provider       = p_provider
+        AND p.status         = 'active'
+        AND p.used < p.total_cap
+        AND c.revoked_at IS NULL
+    )
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.has_active_sponsorship(public.ai_provider) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.has_active_sponsorship(public.ai_provider) TO authenticated;

--- a/src/lib/identifiers/claude.ts
+++ b/src/lib/identifiers/claude.ts
@@ -1,15 +1,45 @@
 /**
  * Claude Haiku 4.5 plugin (server-side via the identify Edge Function).
  *
- * Anthropic key is either:
- *  - The server's ANTHROPIC_API_KEY secret (operator pays), or
- *  - The user's BYO key (passed via byo_keys.anthropic).
+ * Credential resolution at the EF (post-M27 sponsorship migration):
+ *  1. BYO key forwarded via `client_keys.anthropic`.
+ *  2. Active sponsorship for the signed-in user (Vault-backed).
+ *  3. Platform pool slot (atomic via consume_pool_slot RPC).
+ *  4. None — runner skipped, EF returns no_id_engine_available.
+ *
+ * The operator-key fallback (Deno.env.ANTHROPIC_API_KEY) was removed
+ * intentionally — see supabase/functions/identify/index.ts file header.
  */
 import { getSupabase } from '../supabase';
 import { getKey } from '../byo-keys';
 import type { Identifier, IDResult, IdentifyInput } from './types';
 
 const PLUGIN_ID = 'claude_haiku';
+
+const SPONSOR_CACHE_KEY = 'rastrum.has_anthropic_sponsorship';
+const SPONSOR_CACHE_TTL_MS = 30_000;
+
+function readSponsorshipCache(): boolean | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(SPONSOR_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { ts: number; value: boolean };
+    if (Date.now() - parsed.ts > SPONSOR_CACHE_TTL_MS) return null;
+    return parsed.value;
+  } catch {
+    return null;
+  }
+}
+
+function writeSponsorshipCache(value: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(SPONSOR_CACHE_KEY, JSON.stringify({ ts: Date.now(), value }));
+  } catch {
+    // localStorage full or denied — fail open, just skip caching
+  }
+}
 
 export const claudeIdentifier: Identifier = {
   id: PLUGIN_ID,
@@ -40,7 +70,27 @@ export const claudeIdentifier: Identifier = {
   ],
   async isAvailable() {
     if (getKey(PLUGIN_ID, 'anthropic')) return { ready: true };
-    return { ready: true };  // server fallback may exist
+    const cached = readSponsorshipCache();
+    if (cached !== null) {
+      return cached ? { ready: true } : { ready: false, reason: 'needs_key' };
+    }
+    try {
+      const supabase = getSupabase();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        writeSponsorshipCache(false);
+        return { ready: false, reason: 'needs_key' };
+      }
+      const { data, error } = await supabase.rpc('has_active_sponsorship', { p_provider: 'anthropic' });
+      if (error || !data) {
+        writeSponsorshipCache(false);
+        return { ready: false, reason: 'needs_key' };
+      }
+      writeSponsorshipCache(true);
+      return { ready: true };
+    } catch {
+      return { ready: false, reason: 'needs_key' };
+    }
   },
   async testConnection() {
     const key = getKey(PLUGIN_ID, 'anthropic');

--- a/src/lib/identifiers/onnx-base-capabilities.test.ts
+++ b/src/lib/identifiers/onnx-base-capabilities.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./onnx-base-cache', () => ({
+  getOnnxBaseCacheStatus: vi.fn(async () => ({ modelCached: false, labelsCached: false })),
+  getCachedModelBuffer: vi.fn(async () => null),
+  getCachedLabels: vi.fn(async () => null),
+  getOnnxBaseWeightsBaseUrl: vi.fn(() => null),
+}));
+
+import { onnxBaseIdentifier } from './onnx-base';
+
+describe('onnxBaseIdentifier capabilities (#582)', () => {
+  it('confidence_ceiling capped at 0.4 so EfficientNet never crosses ACCEPT_THRESHOLD', () => {
+    expect(onnxBaseIdentifier.capabilities.confidence_ceiling).toBe(0.4);
+  });
+
+  it('keeps free license + zero cost (no behavioral regression)', () => {
+    expect(onnxBaseIdentifier.capabilities.license).toBe('free');
+    expect(onnxBaseIdentifier.capabilities.cost_per_id_usd).toBe(0);
+  });
+});

--- a/src/lib/identifiers/onnx-base.ts
+++ b/src/lib/identifiers/onnx-base.ts
@@ -138,6 +138,11 @@ export const onnxBaseIdentifier: Identifier = {
     runtime: 'client',
     license: 'free',
     cost_per_id_usd: 0,
+    // Capped at 0.4 (#582) so EfficientNet never crosses ACCEPT_THRESHOLD
+    // (0.7) on its own. ImageNet labels are English common names, not
+    // scientific binomials, so this plugin is hint-only — surfaces top-k
+    // alternates in the UI but never wins the cascade.
+    confidence_ceiling: 0.4,
   },
   async isAvailable() {
     if (!getOnnxBaseWeightsBaseUrl()) {

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -194,7 +194,14 @@ async function syncOne(record: ObservationRecord): Promise<void> {
   //      scientificName is still empty (partial results with common names).
   const clientId = obs.identification;
   const hasIdentification = clientId.scientificName || (clientId.confidence > 0 && clientId.source !== 'human');
-  if (hasIdentification && (clientId.status === 'accepted' || clientId.status === 'needs_review')) {
+  // #582: never persist identifications whose source produces non-binomial
+  // scientific names. EfficientNet writes English ImageNet labels into
+  // scientific_name which corrupts taxa rows + DwC exports. Treat as a
+  // hint only — fall through to the server cascade for a real ID.
+  const NON_BINOMIAL_SOURCES = new Set(['onnx_efficientnet_lite0']);
+  if (hasIdentification && NON_BINOMIAL_SOURCES.has(clientId.source ?? '')) {
+    console.warn('[rastrum] skipping non-binomial source persist:', clientId.source);
+  } else if (hasIdentification && (clientId.status === 'accepted' || clientId.status === 'needs_review')) {
     const supabase = getSupabase();
 
     // Upsert taxa row so observations.primary_taxon_id can be resolved by
@@ -391,6 +398,20 @@ async function triggerIdentify(observationId: string): Promise<void> {
   // sync_primary_id_trigger then materialises denormalised columns on
   // the observation row (primary_taxon_id, obscure_level, location_obscured).
   const r = cascadeResult.best;
+
+  // #582: skip non-binomial sources — they produce English ImageNet labels
+  // that pollute taxa.scientific_name and DwC exports. Cascade can still
+  // surface them as alternates in the UI, but never as the primary ID.
+  const NON_BINOMIAL_SOURCES_ID = new Set(['onnx_efficientnet_lite0']);
+  if (NON_BINOMIAL_SOURCES_ID.has(r.source)) {
+    console.warn('[rastrum] cascade winner is non-binomial source, not persisting:', r.source);
+    await db.idQueue.update(observationId, {
+      attempts: ((await db.idQueue.get(observationId))?.attempts ?? 0) + 1,
+      last_error: 'non-binomial source: ' + r.source,
+    });
+    return;
+  }
+
   // Apply taxonomy synonym correction for known outdated names (#345)
   const { correctIdentificationName } = await import('./taxonomy-synonyms');
   const correctedName = correctIdentificationName(r.scientific_name);

--- a/supabase/functions/identify/_helpers.ts
+++ b/supabase/functions/identify/_helpers.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure helpers for the identify EF — extracted so Vitest (Node runtime)
+ * can import them without resolving Deno URL specifiers in `index.ts`.
+ */
+
+/**
+ * Unified gate for whether to attempt the PlantNet runner. Single source of
+ * truth — both the cascade and default-race paths must agree, otherwise
+ * identical input produces different runner sets depending on which client
+ * path called the EF (#580).
+ *
+ * `unknown` is treated as plant-like since it's the safe default for users
+ * who don't tag their photo. PlantNet returns nothing for animal photos
+ * (no harm) but catches plant cases the user didn't classify.
+ */
+export function isPlantLikeHint(hint?: string): boolean {
+  return !hint || hint === 'plant' || hint === 'fungi' || hint === 'unknown';
+}

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -611,10 +611,13 @@ serve(async (req) => {
     result = cascaded.result;
   }
 
-  // If Claude won and a sponsorship paid for it, record usage + threshold notify.
+  // If a sponsorship paid for the winning ID, record usage + threshold notify.
+  // Gate on source !== 'plantnet' so we cover Anthropic-direct, Bedrock, Vertex,
+  // OpenAI, Azure, Gemini — anything that consumed the sponsored credential.
+  // PlantNet has its own quota and never pulls from sponsorship.
   if (
     result
-    && result.source === 'claude_haiku'
+    && result.source !== 'plantnet'
     && sponsorshipCtx
     && beneficiaryId
   ) {

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -108,6 +108,8 @@ type CascadeAttempt = {
   error?: string;
 };
 
+import { isPlantLikeHint } from './_helpers.ts';
+
 const CONFIDENCE_THRESHOLD = 0.7;
 const RACE_TIMEOUT_MS = 30_000;
 
@@ -546,7 +548,7 @@ serve(async (req) => {
     // apply excluded_providers filter, then preferred_providers ordering.
     // Mirrors the client-side cascade from src/lib/identifiers/cascade.ts.
     const allRunners: Record<string, ServerRunner> = {};
-    const isPlantLike = body.user_hint === 'plant' || body.user_hint === 'fungi' || body.user_hint === 'unknown' || !body.user_hint;
+    const isPlantLike = isPlantLikeHint(body.user_hint);
     if (isPlantLike) {
       allRunners.plantnet = (signal) => callPlantNet(imageBytes, byoPlantnet, signal);
     }
@@ -593,7 +595,7 @@ serve(async (req) => {
     // are aborted. user_hint is used to bias the threshold slightly later
     // (today it just gates which runners we even start).
     const runners: Record<string, ServerRunner> = {};
-    const isPlantLike = body.user_hint === 'plant' || body.user_hint === 'fungi' || !body.user_hint;
+    const isPlantLike = isPlantLikeHint(body.user_hint);
     if (isPlantLike) {
       runners.plantnet = (signal) => callPlantNet(imageBytes, byoPlantnet, signal);
     }

--- a/tests/lib/claude-isavailable.test.ts
+++ b/tests/lib/claude-isavailable.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const store = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+    get length() { return store.size; },
+    key: (i: number) => [...store.keys()][i] ?? null,
+  },
+  writable: true,
+  configurable: true,
+});
+
+const mockSession = vi.fn();
+const mockRpc = vi.fn();
+
+vi.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => ({
+    auth: { getSession: () => mockSession() },
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  }),
+}));
+
+vi.mock('../../src/lib/byo-keys', () => ({
+  getKey: vi.fn(() => null),
+}));
+
+import { claudeIdentifier } from '../../src/lib/identifiers/claude';
+import { getKey } from '../../src/lib/byo-keys';
+
+const getKeyMock = getKey as ReturnType<typeof vi.fn>;
+
+describe('claudeIdentifier.isAvailable (#595)', () => {
+  beforeEach(() => {
+    store.clear();
+    getKeyMock.mockReset().mockReturnValue(null);
+    mockSession.mockReset();
+    mockRpc.mockReset();
+  });
+
+  it('ready when BYO key is set (skips RPC entirely)', async () => {
+    getKeyMock.mockReturnValueOnce('sk-ant-test');
+    const result = await claudeIdentifier.isAvailable();
+    expect(result).toEqual({ ready: true });
+    expect(mockSession).not.toHaveBeenCalled();
+  });
+
+  it('not ready when no key + no session', async () => {
+    mockSession.mockResolvedValueOnce({ data: { session: null } });
+    const result = await claudeIdentifier.isAvailable();
+    expect(result.ready).toBe(false);
+    expect((result as { reason: string }).reason).toBe('needs_key');
+  });
+
+  it('not ready when no key + session but RPC returns false', async () => {
+    mockSession.mockResolvedValueOnce({ data: { session: { user: { id: 'u1' } } } });
+    mockRpc.mockResolvedValueOnce({ data: false, error: null });
+    const result = await claudeIdentifier.isAvailable();
+    expect(result.ready).toBe(false);
+  });
+
+  it('ready when no key but RPC reports active sponsorship', async () => {
+    mockSession.mockResolvedValueOnce({ data: { session: { user: { id: 'u1' } } } });
+    mockRpc.mockResolvedValueOnce({ data: true, error: null });
+    const result = await claudeIdentifier.isAvailable();
+    expect(result).toEqual({ ready: true });
+  });
+
+  it('hits cache on second call within TTL window', async () => {
+    mockSession.mockResolvedValueOnce({ data: { session: { user: { id: 'u1' } } } });
+    mockRpc.mockResolvedValueOnce({ data: true, error: null });
+    await claudeIdentifier.isAvailable();
+    const result2 = await claudeIdentifier.isAvailable();
+    expect(result2).toEqual({ ready: true });
+    expect(mockSession).toHaveBeenCalledTimes(1);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/identify-isplantlike.test.ts
+++ b/tests/unit/identify-isplantlike.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { isPlantLikeHint } from '../../supabase/functions/identify/_helpers';
+
+describe('isPlantLikeHint (#580)', () => {
+  it.each([
+    [undefined, true],
+    ['', true],
+    ['plant', true],
+    ['fungi', true],
+    ['unknown', true],
+    ['animal', false],
+  ])('isPlantLikeHint(%j) === %s', (hint, expected) => {
+    expect(isPlantLikeHint(hint as string | undefined)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 1 of the AI identification pipeline audit (epic #596). Bundles four bug fixes:

- **#579** — sponsorship usage tracking now fires for all non-PlantNet provider kinds (Bedrock, Vertex, OpenAI, Azure, Gemini), not just \`claude_haiku\`. Single-line gate change.
- **#580** — \`isPlantLikeHint\` extracted to \`_helpers.ts\`, used by both cascade and default-race branches in the identify EF. Resolves silent inconsistency where \`user_hint='unknown'\` produced different runner sets per code path.
- **#582** — EfficientNet capped at \`confidence_ceiling: 0.4\` so it never crosses ACCEPT_THRESHOLD. Plus persist-boundary filter in \`sync.ts\` (both step 4.5 and triggerIdentify) drops non-binomial sources before \`identifications.insert\`. Stops English ImageNet labels (\"jaguar\", \"flamingo\") from polluting taxa rows + DwC exports.
- **#595** — \`claude.isAvailable()\` now does a real check: BYO key OR session+\`has_active_sponsorship\` RPC. New SECURITY DEFINER SQL function \`has_active_sponsorship(provider)\` performs cheap metadata read joined through \`sponsor_credentials\`. 30s localStorage cache to avoid RPC spam.

## Changes

- \`supabase/functions/identify/index.ts\` — sponsorship gate (#579), isPlantLike helper import (#580)
- \`supabase/functions/identify/_helpers.ts\` (new) — \`isPlantLikeHint\` shared with vitest
- \`src/lib/identifiers/onnx-base.ts\` — \`confidence_ceiling: 0.4\` (#582)
- \`src/lib/sync.ts\` — non-binomial source filter at both persist sites (#582)
- \`src/lib/identifiers/claude.ts\` — sponsorship-aware isAvailable + 30s cache (#595)
- \`docs/specs/infra/supabase-schema.sql\` — \`has_active_sponsorship\` SECURITY DEFINER RPC (#595)
- 3 new test files under \`tests/unit/\` and \`src/lib/identifiers/\`

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm run test\` — 882 tests passing, no regressions
- [ ] After merge: deploy \`identify\` EF via \`gh workflow run deploy-functions.yml -f function=identify\`
- [ ] After merge: \`make db-apply\` to install \`has_active_sponsorship\` RPC
- [ ] Smoke: identify a photo as a sponsored Bedrock beneficiary, confirm \`sponsorship_usage\` row appears (#579)
- [ ] Smoke: \`/profile/settings/ai/\` Claude card shows \"Needs key\" when no key + no sponsorship (#595)

## Closes

- Closes #579
- Closes #580
- Closes #582
- Closes #595

Part of #596. Sprint 2 (refactors) and Sprint 3 (UX) follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)