### PR TITLE
fix(sponsoring): probe with un-dated claude-haiku-4-5 alias + differentiate 401 vs 403

### DIFF
--- a/supabase/functions/_shared/anthropic-validate.ts
+++ b/supabase/functions/_shared/anthropic-validate.ts
@@ -65,12 +65,19 @@ export async function validateAnthropicCredential(
       method: 'POST',
       headers,
       body: JSON.stringify({
-        model: 'claude-haiku-4-5-20251001',
+        // Un-dated alias — Anthropic resolves to the latest patch of
+        // Haiku 4.5. Avoids false 403s when a hard-coded `-YYYYMMDD`
+        // version drops out of the operator's tier.
+        model: 'claude-haiku-4-5',
         max_tokens: 1,
         messages: [{ role: 'user', content: 'hi' }],
       }),
     });
-    if (res.status === 401 || res.status === 403) return { valid: false, error: 'auth_failed' };
+    // 401 = bad key; 403 = key valid but no access to the probe model
+    // (org/tier gating). Surface the distinction so the operator knows
+    // whether to rotate the key or pick a different model.
+    if (res.status === 401) return { valid: false, error: 'auth_failed_401_invalid_key' };
+    if (res.status === 403) return { valid: false, error: 'auth_failed_403_no_model_access' };
     return { valid: true, kind };
   } catch (e) {
     return { valid: false, error: `network: ${(e as Error).message}` };


### PR DESCRIPTION
Follow-up to #597. The prefix-trust fix landed and the validator now successfully reaches Anthropic — but the user's first attempt came back with a generic \`auth_failed\` that doesn't say whether the key is bad or the probe model is gated. Two refinements:

## 1. Un-dated probe model
Probe with \`claude-haiku-4-5\` instead of the hard-coded \`claude-haiku-4-5-20251001\`. Anthropic resolves the alias to the latest patch — removes false 403s if a specific dated version drops out of the operator's tier.

## 2. Differentiate 401 vs 403
- \`auth_failed_401_invalid_key\` → bad / revoked key — rotate it
- \`auth_failed_403_no_model_access\` → key valid, model gated for the org/tier

Old behavior collapsed both into \`auth_failed\` so the operator couldn't tell whether to fix the key or pick a different model.

## Files
- \`supabase/functions/_shared/anthropic-validate.ts\`

## Deploy
Edge Function auto-deploys on merge via deploy-functions.yml.

## Test plan
- [ ] Save & validate with a known-bad key → \`validation_failed | auth_failed_401_invalid_key\`
- [ ] Save & validate with a key that doesn't have Haiku 4.5 access → \`validation_failed | auth_failed_403_no_model_access\`
- [ ] Save & validate with a working key → succeeds (no false 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)