### PR TITLE
refactor(identify): extract buildCascadeOptions helper for unified cascade (#583)

### DIFF
--- a/src/components/ChatView.astro
+++ b/src/components/ChatView.astro
@@ -760,6 +760,11 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
     const { bootstrapIdentifiers, runCascade } = await import('../lib/identifiers');
     bootstrapIdentifiers();
     const mediaKind = att.kind === 'photo' ? 'photo' : 'audio';
+    // Unified cascade options helper (#583); chat keeps its explicit
+    // Phi-vision exclusion — Phi is surfaced via the slower "looking
+    // more carefully" step below, not the primary pass.
+    const { buildCascadeOptions } = await import('../lib/identify-options');
+    const opts = await buildCascadeOptions({ mediaKind });
     const result = await runCascade(
       {
         media: { kind: 'blob', blob: att.blob, mime: att.mimeType },
@@ -768,11 +773,8 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
       },
       {
         media: mediaKind,
-        taxa: mediaKind === 'audio' ? 'Animalia.Aves' : undefined,
-        // Phi-vision is the slow expensive fallback — exclude it from the
-        // primary cascade pass; we surface it explicitly via the "looking
-        // more carefully" step below if the cascade returns nothing.
-        excluded: ['webllm_phi35_vision'],
+        ...opts,
+        excluded: [...opts.excluded, 'webllm_phi35_vision'],
       },
     );
     const best = result.best ? toCandidate(result.best) : null;

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -1287,22 +1287,9 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
 
   refreshPmtiles().catch(() => {});
 
-  // ── Pipeline disabled list (persisted in localStorage) ──
-  const DISABLED_KEY = 'rastrum.pipeline.disabled';
-  function getDisabledPlugins(): string[] {
-    try {
-      return JSON.parse(localStorage.getItem(DISABLED_KEY) ?? '[]');
-    } catch { return []; }
-  }
-  function setDisabledPlugins(ids: string[]): void {
-    try { localStorage.setItem(DISABLED_KEY, JSON.stringify(ids)); } catch { /* ignore */ }
-  }
-  function togglePluginDisabled(id: string): void {
-    const list = getDisabledPlugins();
-    const idx = list.indexOf(id);
-    if (idx >= 0) list.splice(idx, 1); else list.push(id);
-    setDisabledPlugins(list);
-  }
+  // Pipeline disabled list — extracted to src/lib/identifier-prefs.ts (#583)
+  // so every cascade call site honors the toggle uniformly.
+  const { getDisabledPlugins, togglePluginDisabled } = await import('../lib/identifier-prefs');
 
   function updatePipelineFlow(plugins: Array<{ id: string; name: string; brand?: string }>) {
     const flowItems = document.getElementById('pipeline-flow-items');

--- a/src/lib/identifier-prefs.ts
+++ b/src/lib/identifier-prefs.ts
@@ -1,0 +1,37 @@
+/**
+ * Identifier plugin user preferences (#583).
+ *
+ * Single source of truth for which plugins the user has explicitly disabled
+ * in the registry UI (/profile/settings/ai/). Extracted from ProfileEditForm
+ * so every cascade call site can honor the toggle uniformly.
+ *
+ * Storage key kept as `rastrum.pipeline.disabled` for backwards compat with
+ * existing user preferences.
+ */
+
+const STORAGE_KEY = 'rastrum.pipeline.disabled';
+
+export function getDisabledPlugins(): string[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export function setDisabledPlugins(ids: string[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+}
+
+export function togglePluginDisabled(id: string): string[] {
+  const list = getDisabledPlugins();
+  const idx = list.indexOf(id);
+  if (idx >= 0) list.splice(idx, 1); else list.push(id);
+  setDisabledPlugins(list);
+  return list;
+}

--- a/src/lib/identify-options.ts
+++ b/src/lib/identify-options.ts
@@ -1,0 +1,65 @@
+/**
+ * Single source of truth for cascade option-building across all UI
+ * surfaces that call runCascade() (#583).
+ *
+ * Without this helper, sync.ts / share/obs / chat / observe each
+ * re-implemented exclusion + preferred logic divergently — so user
+ * preferences (disabled plugins, BYO key, local-AI opt-out, EfficientNet
+ * cache state) didn't propagate consistently.
+ */
+
+import { getKey } from './byo-keys';
+import { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } from './identifiers/onnx-base-cache';
+import { getDisabledPlugins } from './identifier-prefs';
+import { isLocalAIEnabled } from './local-ai-prefs';
+
+export interface IdentifyContext {
+  mediaKind: 'photo' | 'audio' | 'video';
+  evidenceType?: string;
+  userHint?: 'plant' | 'animal' | 'fungi' | 'unknown';
+}
+
+export interface IdentifyContextResult {
+  excluded: string[];
+  preferred: string[];
+  taxa?: string;
+}
+
+export async function buildCascadeOptions(ctx: IdentifyContext): Promise<IdentifyContextResult> {
+  const excluded: string[] = [];
+
+  // 1. User-disabled plugins (registry UI toggle)
+  for (const id of getDisabledPlugins()) {
+    if (!excluded.includes(id)) excluded.push(id);
+  }
+
+  // 2. WebLLM Phi + BirdNET gated on local-AI bandwidth opt-in
+  if (!isLocalAIEnabled()) {
+    if (!excluded.includes('webllm_phi35_vision')) excluded.push('webllm_phi35_vision');
+    if (!excluded.includes('birdnet_lite')) excluded.push('birdnet_lite');
+  }
+
+  // 3. EfficientNet only when its weights are cached
+  const efficientNetCached = getOnnxBaseWeightsBaseUrl()
+    ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
+    : false;
+  if (!efficientNetCached && !excluded.includes('onnx_efficientnet_lite0')) {
+    excluded.push('onnx_efficientnet_lite0');
+  }
+
+  // 4. Claude needs a BYO key (sponsorship gate happens server-side, see #595)
+  if (!getKey('claude_haiku', 'anthropic') && !excluded.includes('claude_haiku')) {
+    excluded.push('claude_haiku');
+  }
+
+  // 5. Camera-trap evidence biases the cascade toward MegaDetector
+  const preferred: string[] = [];
+  if (ctx.mediaKind === 'photo' && ctx.evidenceType === 'camera_trap') {
+    preferred.push('camera_trap_megadetector');
+  }
+
+  // 6. Audio defaults to Aves until non-bird audio plugins arrive
+  const taxa = ctx.mediaKind === 'audio' ? 'Animalia.Aves' : undefined;
+
+  return { excluded, preferred, taxa };
+}

--- a/src/lib/local-ai-prefs.ts
+++ b/src/lib/local-ai-prefs.ts
@@ -1,0 +1,30 @@
+/**
+ * Local-AI bandwidth opt-in pref (#583).
+ *
+ * Extracted from sync.ts so multiple cascade call sites share the same
+ * gate without duplicating localStorage logic.
+ *
+ * WebLLM (Phi-3.5-vision) is ON by default (issue #12 — privacy-first,
+ * offline-capable). Users can opt OUT in profile settings if bandwidth
+ * is a concern.
+ */
+
+const LOCAL_AI_OPTIN = 'rastrum.localAiOptIn';
+const LOCAL_AI_DOWNLOAD_WARNED = 'rastrum.localAiDownloadWarned';
+
+export function isLocalAIEnabled(): boolean {
+  if (typeof localStorage === 'undefined') return true;
+  if (localStorage.getItem(LOCAL_AI_OPTIN) === 'true') return true;
+  return localStorage.getItem(LOCAL_AI_OPTIN) !== 'false';
+}
+
+export function hasShownLocalAIDownloadWarning(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  return localStorage.getItem(LOCAL_AI_DOWNLOAD_WARNED) === 'true';
+}
+
+export function markLocalAIDownloadWarningShown(): void {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(LOCAL_AI_DOWNLOAD_WARNED, 'true');
+  }
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -269,32 +269,13 @@ async function triggerEnvEnrichment(observationId: string): Promise<void> {
   });
 }
 
-const LOCAL_AI_OPTIN = 'rastrum.localAiOptIn';
-const LOCAL_AI_DOWNLOAD_WARNED = 'rastrum.localAiDownloadWarned';
-
-/**
- * WebLLM is ON by default (issue #12 — privacy-first, offline-capable).
- * Users can opt OUT in profile settings if bandwidth is a concern.
- * On first use, a download warning is shown (see ObservationForm).
- */
-function isLocalAIEnabled(): boolean {
-  if (typeof localStorage === 'undefined') return true; // SSR: default on
-  // Legacy opt-in key still respected for users who explicitly enabled it
-  if (localStorage.getItem(LOCAL_AI_OPTIN) === 'true') return true;
-  // New default: on unless user explicitly opted out
-  return localStorage.getItem(LOCAL_AI_OPTIN) !== 'false';
-}
-
-export function hasShownLocalAIDownloadWarning(): boolean {
-  if (typeof localStorage === 'undefined') return false;
-  return localStorage.getItem(LOCAL_AI_DOWNLOAD_WARNED) === 'true';
-}
-
-export function markLocalAIDownloadWarningShown(): void {
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem(LOCAL_AI_DOWNLOAD_WARNED, 'true');
-  }
-}
+// Local-AI prefs extracted to ./local-ai-prefs.ts (#583). Re-exported for
+// backwards compat with consumers (ObservationForm) importing from sync.ts.
+export {
+  isLocalAIEnabled,
+  hasShownLocalAIDownloadWarning,
+  markLocalAIDownloadWarningShown,
+} from './local-ai-prefs';
 
 /**
  * Run the identifier cascade against the freshly-synced observation.
@@ -333,33 +314,9 @@ async function triggerIdentify(observationId: string): Promise<void> {
   const { bootstrapIdentifiers, runCascade } = await import('./identifiers');
   bootstrapIdentifiers();
 
-  // WebLLM (Phi-3.5-vision) is ON by default — local, private, no key needed.
-  // Exclude it only if user explicitly opted out (bandwidth concern).
-  // Claude is excluded when no BYO key is set — avoids silent crashes.
-  const { getKey } = await import('./byo-keys');
-  const hasAnthropicKey = !!getKey('claude_haiku', 'anthropic');
-  const localAIEnabled = isLocalAIEnabled();
-
-  const excluded: string[] = [];
-  // Large models (Phi-3.5 2.4 GB, BirdNET ~50 MB) gate on localAIEnabled.
-  // EfficientNet-Lite0 is only ~2.8 MB — run it whenever it's downloaded,
-  // regardless of the localAI bandwidth toggle.
-  if (!localAIEnabled) excluded.push('webllm_phi35_vision', 'birdnet_lite');
-  const { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } = await (await import('./identifiers/onnx-base-cache'));
-  const efficientNetCached = getOnnxBaseWeightsBaseUrl()
-    ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
-    : false;
-  if (!efficientNetCached) excluded.push('onnx_efficientnet_lite0');
-  if (!hasAnthropicKey) excluded.push('claude_haiku');
-
-  // Camera-trap photos prefer the MegaDetector + SpeciesNet pipeline.
-  // When PUBLIC_MEGADETECTOR_ENDPOINT is unset the plugin reports
-  // model_not_bundled and the cascade transparently falls through to
-  // the standard cost-sorted race (PlantNet ∥ Claude ∥ on-device).
-  const preferred: string[] = [];
-  if (mediaKind === 'photo' && evidenceType === 'camera_trap') {
-    preferred.push('camera_trap_megadetector');
-  }
+  // Single source of truth for cascade options — see src/lib/identify-options.ts.
+  const { buildCascadeOptions } = await import('./identify-options');
+  const opts = await buildCascadeOptions({ mediaKind, evidenceType });
 
   // Plugins read their own keys from byo-keys.ts at identify-time, so we
   // don't pre-collect them here. Pass an empty byo_keys object as a default.
@@ -373,9 +330,7 @@ async function triggerIdentify(observationId: string): Promise<void> {
     },
     {
       media: mediaKind,
-      taxa: mediaKind === 'audio' ? 'Animalia.Aves' : undefined,
-      excluded,
-      preferred,
+      ...opts,
     },
   );
 

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -88,7 +88,7 @@ const lang: 'en' | 'es' = 'en';
         .from('observations')
         .select(`
           id, observed_at, obscure_level, state_province, habitat, weather, establishment_means, observer_id, notes,
-          last_material_edit_at, location, location_obscured,
+          last_material_edit_at, location, location_obscured, evidence_type,
           places:place_id(id, slug, name, place_type),
           identifications(scientific_name, is_primary, is_research_grade),
           users:observer_id(display_name, username, profile_public)
@@ -107,6 +107,13 @@ const lang: 'en' | 'es' = 'en';
       document.getElementById('obs')?.classList.remove('hidden');
       const speciesName = ident?.scientific_name ?? 'Unknown species';
       document.getElementById('species')!.textContent = speciesName;
+
+      // Expose evidence_type for the Ask-my-AI cascade so buildCascadeOptions
+      // can prefer MegaDetector for camera-trap photos (#583).
+      const askAiBtnInit = document.getElementById('ci-ask-ai-btn');
+      if (askAiBtnInit && obs.evidence_type) {
+        askAiBtnInit.dataset.evidenceType = obs.evidence_type as string;
+      }
 
       const shareBtn = document.getElementById('obs-share-btn');
       if (shareBtn) {
@@ -546,13 +553,17 @@ const lang: 'en' | 'es' = 'en';
               }
             }
 
+            const { buildCascadeOptions } = await import('../../../lib/identify-options');
+            const evidenceType = askAiBtn.dataset.evidenceType;
+            const opts = await buildCascadeOptions({ mediaKind: 'photo', evidenceType });
+
             const result = await runCascade(
               {
                 media: { kind: 'blob', blob, mime: blob.type || 'image/jpeg' },
                 mediaKind: 'photo',
                 byo_keys: byoKeys,
               },
-              { media: 'photo' },
+              { media: 'photo', ...opts },
             );
 
             if (result.best) {

--- a/tests/unit/identify-options.test.ts
+++ b/tests/unit/identify-options.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const store = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+    get length() { return store.size; },
+    key: (i: number) => [...store.keys()][i] ?? null,
+  },
+  writable: true,
+  configurable: true,
+});
+
+vi.mock('../../src/lib/byo-keys', () => ({
+  getKey: vi.fn(() => null),
+}));
+
+vi.mock('../../src/lib/identifiers/onnx-base-cache', () => ({
+  getOnnxBaseWeightsBaseUrl: vi.fn(() => null),
+  getOnnxBaseCacheStatus: vi.fn(async () => ({ modelCached: false, labelsCached: false })),
+}));
+
+import { buildCascadeOptions } from '../../src/lib/identify-options';
+import { getKey } from '../../src/lib/byo-keys';
+import { getOnnxBaseWeightsBaseUrl } from '../../src/lib/identifiers/onnx-base-cache';
+import { setDisabledPlugins } from '../../src/lib/identifier-prefs';
+
+const getKeyMock = getKey as ReturnType<typeof vi.fn>;
+const onnxUrlMock = getOnnxBaseWeightsBaseUrl as ReturnType<typeof vi.fn>;
+
+describe('buildCascadeOptions (#583)', () => {
+  beforeEach(() => {
+    store.clear();
+    getKeyMock.mockReset().mockReturnValue(null);
+    onnxUrlMock.mockReset().mockReturnValue(null);
+  });
+
+  it('excludes Claude when no BYO key is set', async () => {
+    const r = await buildCascadeOptions({ mediaKind: 'photo' });
+    expect(r.excluded).toContain('claude_haiku');
+  });
+
+  it('does NOT exclude Claude when BYO key is set', async () => {
+    getKeyMock.mockReturnValueOnce('sk-ant-test');
+    const r = await buildCascadeOptions({ mediaKind: 'photo' });
+    expect(r.excluded).not.toContain('claude_haiku');
+  });
+
+  it('excludes Phi + BirdNET when localAI is opted out', async () => {
+    localStorage.setItem('rastrum.localAiOptIn', 'false');
+    const r = await buildCascadeOptions({ mediaKind: 'photo' });
+    expect(r.excluded).toContain('webllm_phi35_vision');
+    expect(r.excluded).toContain('birdnet_lite');
+  });
+
+  it('excludes EfficientNet when weights are not cached', async () => {
+    onnxUrlMock.mockReturnValueOnce(null);
+    const r = await buildCascadeOptions({ mediaKind: 'photo' });
+    expect(r.excluded).toContain('onnx_efficientnet_lite0');
+  });
+
+  it('honors user-disabled plugin list from identifier-prefs', async () => {
+    setDisabledPlugins(['plantnet']);
+    const r = await buildCascadeOptions({ mediaKind: 'photo' });
+    expect(r.excluded).toContain('plantnet');
+  });
+
+  it('prefers MegaDetector for camera-trap evidence type', async () => {
+    const r = await buildCascadeOptions({ mediaKind: 'photo', evidenceType: 'camera_trap' });
+    expect(r.preferred).toContain('camera_trap_megadetector');
+  });
+
+  it('does NOT add MegaDetector preference for non camera-trap', async () => {
+    const r = await buildCascadeOptions({ mediaKind: 'photo', evidenceType: 'direct_sighting' });
+    expect(r.preferred).not.toContain('camera_trap_megadetector');
+  });
+
+  it('audio mediaKind sets Animalia.Aves taxa filter', async () => {
+    const r = await buildCascadeOptions({ mediaKind: 'audio' });
+    expect(r.taxa).toBe('Animalia.Aves');
+  });
+
+  it('photo mediaKind has no taxa filter', async () => {
+    const r = await buildCascadeOptions({ mediaKind: 'photo' });
+    expect(r.taxa).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #583. Part of #596 (Sprint 2 — architectural cleanup).

## Summary

Three client-side cascade call sites — `sync.ts` triggerIdentify, share/obs Ask-my-AI, and ChatView attachment cascade — re-implemented exclusion + preferred logic divergently. User prefs (disabled plugins, BYO key, local-AI opt-out, EfficientNet cache state) didn't propagate consistently. Camera-trap photos in /share/obs/ never preferred MegaDetector; Chat ignored disabled-plugins toggle.

- `src/lib/identify-options.ts` — single source of truth for cascade options
- `src/lib/identifier-prefs.ts` — extracted `getDisabledPlugins` from ProfileEditForm
- `src/lib/local-ai-prefs.ts` — extracted `isLocalAIEnabled` (sync.ts re-exports)
- 9 unit tests covering all gating paths

## Test plan
- [x] tsc passes
- [x] vitest 878 tests passing
- [ ] After merge: capture a camera-trap photo in /observe → check /share/obs/ "Ask my AI" prefers MegaDetector
- [ ] Disable a plugin in /profile/settings/ai/ → verify Chat respects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)