### PR TITLE
fix(sync): preserve cascade trace in client-persisted identifications (#586)

### DIFF
--- a/src/lib/cascade-trace.ts
+++ b/src/lib/cascade-trace.ts
@@ -1,0 +1,137 @@
+/**
+ * Cascade trace serializer (#586).
+ *
+ * The client-persist path in sync.ts step 4.5 used to write a minimal
+ * raw_response (just common names + a marker) — losing top-k alternates,
+ * scores, plantnet candidates, claude rationale, etc. The server EF path
+ * stored the full provider response. This asymmetry made forensics
+ * impossible for client-persisted IDs and starved future re-rank passes.
+ *
+ * `serializeClientCascade` produces a bounded summary suitable for
+ * `identifications.raw_response` (jsonb). Cap is 4 KB; we strip pixel-level
+ * data, drop GPS, and truncate large strings.
+ *
+ * Companion to #584 (CascadeTrace UI component) — that issue defines
+ * adapters that consume this same shape from the database row.
+ */
+
+export interface CascadeAttemptSummary {
+  id: string;
+  ok: boolean;
+  confidence?: number;
+  error?: string;
+  duration_ms?: number;
+}
+
+export interface ClientCascadeTrace {
+  client_persisted: true;
+  cascade_attempts: CascadeAttemptSummary[];
+  winner: {
+    source: string;
+    scientific_name: string;
+    confidence: number;
+    common_name_en: string | null;
+    common_name_es: string | null;
+    family: string | null;
+    kingdom: string;
+    raw_provider_response?: unknown;
+  } | null;
+}
+
+const SIZE_CAP_BYTES = 4_096;
+const STRING_TRUNCATE = 200;
+const TOP_K_CAP = 5;
+const PII_KEYS = new Set(['lat', 'lng', 'latitude', 'longitude', 'gps', 'location']);
+
+function truncateStrings(value: unknown, depth = 0): unknown {
+  if (depth > 4) return null;
+  if (typeof value === 'string') {
+    return value.length > STRING_TRUNCATE ? value.slice(0, STRING_TRUNCATE - 1) + '…' : value;
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, TOP_K_CAP).map(v => truncateStrings(v, depth + 1));
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (PII_KEYS.has(k.toLowerCase())) continue;
+      out[k] = truncateStrings(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+interface RunCascadeAttemptLike {
+  id: string;
+  ok: boolean;
+  confidence?: number;
+  error?: string;
+  duration_ms?: number;
+  result?: {
+    scientific_name: string;
+    common_name_en: string | null;
+    common_name_es: string | null;
+    family: string | null;
+    kingdom: string;
+    confidence: number;
+    source: string;
+    raw?: unknown;
+  };
+}
+
+interface RunCascadeResultLike {
+  best: {
+    scientific_name: string;
+    common_name_en: string | null;
+    common_name_es: string | null;
+    family: string | null;
+    kingdom: string;
+    confidence: number;
+    source: string;
+    raw?: unknown;
+  } | null;
+  attempts: RunCascadeAttemptLike[];
+}
+
+export function serializeClientCascade(r: RunCascadeResultLike): ClientCascadeTrace {
+  const attempts: CascadeAttemptSummary[] = r.attempts.map(a => ({
+    id: a.id,
+    ok: a.ok,
+    confidence: a.confidence ?? a.result?.confidence,
+    error: a.error,
+    duration_ms: a.duration_ms,
+  }));
+
+  let winner: ClientCascadeTrace['winner'] = null;
+  if (r.best) {
+    const rawProvider = truncateStrings(r.best.raw ?? null);
+    winner = {
+      source: r.best.source,
+      scientific_name: r.best.scientific_name,
+      confidence: r.best.confidence,
+      common_name_en: r.best.common_name_en,
+      common_name_es: r.best.common_name_es,
+      family: r.best.family,
+      kingdom: r.best.kingdom,
+      raw_provider_response: rawProvider,
+    };
+  }
+
+  let trace: ClientCascadeTrace = {
+    client_persisted: true,
+    cascade_attempts: attempts,
+    winner,
+  };
+
+  // If still over cap, drop raw_provider_response — keep cascade_attempts summary.
+  if (JSON.stringify(trace).length > SIZE_CAP_BYTES && winner) {
+    trace = {
+      client_persisted: true,
+      cascade_attempts: attempts,
+      winner: { ...winner, raw_provider_response: undefined },
+    };
+  }
+
+  return trace;
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -394,12 +394,16 @@ async function triggerIdentify(observationId: string): Promise<void> {
   // Apply taxonomy synonym correction for known outdated names (#345)
   const { correctIdentificationName } = await import('./taxonomy-synonyms');
   const correctedName = correctIdentificationName(r.scientific_name);
+  // #586: persist full cascade trace (attempts + winner + raw provider response)
+  // for forensics and future re-rank passes. Bounded to 4 KB.
+  const { serializeClientCascade } = await import('./cascade-trace');
+  const trace = serializeClientCascade(cascadeResult);
   const { error: insertErr } = await supabase.from('identifications').insert({
     observation_id: observationId,
     scientific_name: correctedName,
     confidence: r.confidence,
     source: r.source,
-    raw_response: r.raw as object,
+    raw_response: trace as unknown as object,
     is_primary: true,
   });
 

--- a/tests/unit/cascade-trace.test.ts
+++ b/tests/unit/cascade-trace.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { serializeClientCascade } from '../../src/lib/cascade-trace';
+
+const baseResult = {
+  scientific_name: 'Panthera onca',
+  common_name_en: 'Jaguar',
+  common_name_es: 'Jaguar',
+  family: 'Felidae',
+  kingdom: 'Animalia',
+  confidence: 0.89,
+  source: 'claude_haiku',
+  raw: { rationale: 'Spotted coat, large head' },
+};
+
+describe('serializeClientCascade (#586)', () => {
+  it('serializes cascade attempts with id/ok/confidence', () => {
+    const trace = serializeClientCascade({
+      best: baseResult,
+      attempts: [
+        { id: 'plantnet', ok: false, confidence: 0.1, error: 'no match' },
+        { id: 'claude_haiku', ok: true, confidence: 0.89, result: baseResult },
+      ],
+    });
+    expect(trace.cascade_attempts).toHaveLength(2);
+    expect(trace.cascade_attempts[0]).toMatchObject({ id: 'plantnet', ok: false });
+    expect(trace.cascade_attempts[1]).toMatchObject({ id: 'claude_haiku', ok: true, confidence: 0.89 });
+  });
+
+  it('marks client_persisted: true', () => {
+    const t = serializeClientCascade({ best: null, attempts: [] });
+    expect(t.client_persisted).toBe(true);
+    expect(t.winner).toBeNull();
+  });
+
+  it('strips PII keys (lat/lng/gps/location) from raw_provider_response', () => {
+    const trace = serializeClientCascade({
+      best: { ...baseResult, raw: { lat: 19.4, lng: -99.1, location: 'Mexico City', confidence: 0.89 } },
+      attempts: [],
+    });
+    const raw = trace.winner?.raw_provider_response as Record<string, unknown>;
+    expect(raw).not.toHaveProperty('lat');
+    expect(raw).not.toHaveProperty('lng');
+    expect(raw).not.toHaveProperty('location');
+    expect(raw.confidence).toBe(0.89);
+  });
+
+  it('truncates long strings to ~200 chars', () => {
+    const longStr = 'x'.repeat(500);
+    const trace = serializeClientCascade({
+      best: { ...baseResult, raw: { description: longStr } },
+      attempts: [],
+    });
+    const raw = trace.winner?.raw_provider_response as Record<string, unknown>;
+    expect((raw.description as string).length).toBeLessThanOrEqual(200);
+  });
+
+  it('caps top-k arrays at 5 entries', () => {
+    const trace = serializeClientCascade({
+      best: { ...baseResult, raw: { results: Array.from({ length: 20 }, (_, i) => ({ rank: i })) } },
+      attempts: [],
+    });
+    const raw = trace.winner?.raw_provider_response as Record<string, unknown>;
+    expect((raw.results as unknown[]).length).toBe(5);
+  });
+
+  it('keeps trace under 4 KB even with verbose raw response', () => {
+    const huge = 'x'.repeat(50_000);
+    const trace = serializeClientCascade({
+      best: { ...baseResult, raw: { dump: huge } },
+      attempts: Array.from({ length: 10 }, (_, i) => ({ id: `p${i}`, ok: true, confidence: 0.5 })),
+    });
+    expect(JSON.stringify(trace).length).toBeLessThan(4_096);
+  });
+});


### PR DESCRIPTION
Closes #586. Part of #596 (Sprint 2). Foundation for #584 CascadeTrace UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)