### PR TITLE
fix(sponsoring): friendly 409 on duplicate credential label + auto-focus rename

### DIFF
--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -657,8 +657,23 @@ const langJson = JSON.stringify(lang);
       await refreshCreds();
     } catch (err) {
       const msg = (err as Error).message;
-      if (errEl) { errEl.textContent = `Error: ${msg}`; errEl.classList.remove('hidden'); }
-      else alert(`Error: ${msg}`);
+      // 409 label_already_in_use — focus + select the label so the user
+      // can rename in one keystroke. Surface the friendly server detail
+      // instead of the raw "duplicate key value..." Postgres message.
+      if (msg.includes('label_already_in_use')) {
+        if (errEl) {
+          errEl.textContent = msg.split('|').slice(1).join('|').trim() || msg;
+          errEl.classList.remove('hidden');
+        }
+        const labelInput = document.getElementById('cred-label-input') as HTMLInputElement | null;
+        labelInput?.focus();
+        labelInput?.select();
+      } else if (errEl) {
+        errEl.textContent = `Error: ${msg}`;
+        errEl.classList.remove('hidden');
+      } else {
+        alert(`Error: ${msg}`);
+      }
     } finally {
       if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = originalSubmitText; }
       if (testBtn)   { testBtn.disabled = false; }

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -200,6 +200,12 @@ serve(async (req) => {
       .single();
     if (insErr) {
       await supabase.rpc('delete_vault_secret', { p_secret_id: vaultRow });
+      // Postgres unique violation (sponsor_credentials_user_id_label_key)
+      // — surface a friendly 409 so the client can prompt for a rename
+      // instead of dumping the raw "duplicate key value" message.
+      if (insErr.code === '23505') {
+        return jsonResponse(409, { error: 'label_already_in_use', detail: `A credential with the label "${label}" already exists. Pick a different label or delete the existing one from your credentials list.` });
+      }
       return jsonResponse(500, { error: 'credential_insert_failed', detail: insErr.message });
     }
 


### PR DESCRIPTION
Production smoke (build 2026.5.1 / 7a886d0): after #597 + #599 the user successfully validated their key, then hit:

> Error: createCredential: credential_insert_failed | duplicate key value violates unique constraint \"sponsor_credentials_user_id_label_key\"

The \`(user_id, label)\` UNIQUE constraint is doing its job, but the raw Postgres message is the wrong UX. They already have a credential labeled \"Claude\" — they need a clear prompt to rename or delete it.

## Changes
- **Server** (\`sponsorships/index.ts\`): catch \`23505\` on the credential insert, return \`409 { error: 'label_already_in_use', detail: 'A credential with the label \"X\" already exists. Pick a different label or delete the existing one from your credentials list.' }\`. Vault secret is still cleaned up (existing branch).
- **Client** (\`SponsoringView.astro\`): detect \`label_already_in_use\` in the modal's catch path, show the friendly detail instead of the raw message, focus + select the label input so the user can rename in one keystroke.

## Out of scope (separate investigation)
The same session log shows two \"Failed to fetch\" entries on later \`POST /pools/{id}\` and \`POST /credentials/{id}\` (X-HTTP-Method-Override DELETE/PATCH). Looks like CORS preflight or a transient network blip — needs more data before a fix. Not blocking this PR.

## Deploy
Edge Function auto-deploys on merge.

## Test plan
- [ ] Try to add a credential with a label that already exists → modal shows the friendly detail, label input focused + selected, button re-enabled
- [ ] Rename the label → succeeds without further interaction
- [ ] Add with a unique label → succeeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)