### PR TITLE
feat(retry-unidentified): scope to dormant users + abandon after 30 days (#590)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7736,3 +7736,45 @@ DROP POLICY IF EXISTS anon_rate_limit_service_only ON public.anon_rate_limit;
 CREATE POLICY anon_rate_limit_service_only ON public.anon_rate_limit
   FOR ALL TO service_role
   USING (true) WITH CHECK (true);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- #590 — retry-unidentified scope refactor.
+--
+--   * users.last_active_at: bumped on every authenticated request (or via the
+--     touch_user_activity RPC). The retry-unidentified cron skips obs whose
+--     observer was active < 7 days ago — their browser will retry client-side.
+--   * observations.identification_status: 'pending' (default) | 'abandoned'.
+--     Cron flips to 'abandoned' after 30 days without an ID so the obs can
+--     be flagged for human review in /console/identifications/.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS last_active_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS users_last_active_at_idx
+  ON public.users (last_active_at DESC NULLS LAST);
+
+ALTER TABLE public.observations
+  ADD COLUMN IF NOT EXISTS identification_status text
+  CHECK (identification_status IN ('pending', 'abandoned'))
+  DEFAULT 'pending';
+
+CREATE OR REPLACE FUNCTION public.touch_user_activity()
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RETURN;
+  END IF;
+  -- Debounce: only update if last_active_at is older than 5 minutes.
+  -- Avoids hammering the row on a chatty session.
+  UPDATE public.users
+     SET last_active_at = now()
+   WHERE id = auth.uid()
+     AND (last_active_at IS NULL OR last_active_at < now() - interval '5 minutes');
+END $$;
+
+REVOKE ALL ON FUNCTION public.touch_user_activity() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.touch_user_activity() TO authenticated;

--- a/supabase/functions/retry-unidentified/_helpers.ts
+++ b/supabase/functions/retry-unidentified/_helpers.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure helpers for retry-unidentified — extracted so Vitest (Node runtime)
+ * can import them without resolving Deno URL specifiers in `index.ts`.
+ */
+
+/**
+ * Map observation evidence_type → identify EF user_hint (#590).
+ */
+export function deriveHint(evidenceType: string | null | undefined): 'plant' | 'animal' | 'fungi' | 'unknown' {
+  if (!evidenceType) return 'unknown';
+  if (evidenceType === 'plant_observation') return 'plant';
+  if (evidenceType === 'fungi_observation') return 'fungi';
+  if (evidenceType === 'camera_trap') return 'animal';
+  if (evidenceType === 'direct_sighting') return 'animal';
+  if (evidenceType === 'tracks' || evidenceType === 'scat' || evidenceType === 'sound') return 'animal';
+  return 'unknown';
+}

--- a/supabase/functions/retry-unidentified/index.ts
+++ b/supabase/functions/retry-unidentified/index.ts
@@ -1,32 +1,31 @@
 /**
  * retry-unidentified — cron-triggered Edge Function
  *
- * Finds synced observations that have no identification yet and kicks off
- * the identify cascade for each one. Runs every 30 minutes via pg_cron.
+ * Retries identification for synced observations that don't have a primary
+ * taxon yet. Refactored for #590 to coordinate with the client-side idQueue
+ * retry worker (#588): we now SKIP obs whose observer was recently active —
+ * those will retry client-side with the full plugin cascade (MegaDetector,
+ * BirdNET, on-device EfficientNet, BYO key Claude). The cron's job is to
+ * be a fallback for dormant users only.
  *
- * Design constraints:
- *   - Cost 0 to run: uses the existing identify EF (no extra AI spend here —
- *     identify itself selects the cheapest available provider via cascade).
- *   - Fire-and-forget: calls identify async (no await on each response) so
- *     the cron job completes in < 10 s regardless of batch size.
- *   - Idempotent: only targets observations without ANY identification row.
- *   - Rate-safe: caps at 20 observations per run to avoid thundering herd.
- *   - Requires: SUPABASE_SERVICE_ROLE_KEY (auto-injected by Supabase runtime)
- *
- * Auth: cron-only — no user JWT needed. Deploy with --no-verify-jwt.
+ * Behaviour:
+ *   - Skip when the owner was active in the last 7 days.
+ *   - Cap at MAX_AGE_DAYS (30) — older obs flip to identification_status
+ *     'abandoned' so /console/identifications/ can flag them for human ID.
+ *   - Pass user_hint derived from evidence_type to bias PlantNet vs Claude.
+ *   - Fire-and-forget the identify EF (no await on each call).
  */
 
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
+import { deriveHint } from './_helpers.ts';
 
 const BATCH_SIZE = 20;
-// Only retry observations that have been synced for at least 10 minutes
-// (give the normal identify flow time to complete before we interfere).
 const MIN_AGE_MINUTES = 10;
+const SKIP_ACTIVE_USER_DAYS = 7;
+const MAX_AGE_DAYS = 30;
 
 serve(async (req) => {
-  // Accept cron calls (no auth header needed — deployed --no-verify-jwt).
-  // Reject non-POST for hygiene.
   if (req.method !== 'POST') {
     return new Response('Method Not Allowed', { status: 405 });
   }
@@ -41,15 +40,17 @@ serve(async (req) => {
     auth: { persistSession: false },
   });
 
-  // Find synced observations with no identification, at least MIN_AGE_MINUTES old,
-  // that have at least one media file (can't identify without a photo/audio).
-  const cutoff = new Date(Date.now() - MIN_AGE_MINUTES * 60 * 1000).toISOString();
+  const cutoffMin = new Date(Date.now() - MIN_AGE_MINUTES * 60 * 1000).toISOString();
+  const cutoffMax = new Date(Date.now() - MAX_AGE_DAYS * 86_400_000).toISOString();
+  const activeCutoff = new Date(Date.now() - SKIP_ACTIVE_USER_DAYS * 86_400_000).toISOString();
+
   const { data: obs, error } = await db
     .from('observations')
-    .select('id, observed_at')
+    .select('id, observer_id, evidence_type, observed_at')
     .eq('sync_status', 'synced')
     .is('primary_taxon_id', null)
-    .lt('observed_at', cutoff)
+    .neq('identification_status', 'abandoned')
+    .lt('observed_at', cutoffMin)
     .limit(BATCH_SIZE);
 
   if (error) {
@@ -58,17 +59,37 @@ serve(async (req) => {
   }
 
   if (!obs || obs.length === 0) {
-    return new Response(JSON.stringify({ queued: 0, message: 'nothing to retry' }), {
+    return new Response(JSON.stringify({ queued: 0, abandoned: 0 }), {
       headers: { 'content-type': 'application/json' },
     });
   }
 
-  // For each observation, fetch the primary media URL then kick off identify.
   const identifyUrl = `${supabaseUrl}/functions/v1/identify`;
   let queued = 0;
+  let abandoned = 0;
+  let skippedActive = 0;
 
   for (const o of obs) {
-    // Get primary media file
+    if (o.observed_at < cutoffMax) {
+      await db.from('observations')
+        .update({ identification_status: 'abandoned' })
+        .eq('id', o.id);
+      abandoned++;
+      continue;
+    }
+
+    if (o.observer_id) {
+      const { data: ownerRow } = await db
+        .from('users')
+        .select('last_active_at')
+        .eq('id', o.observer_id)
+        .maybeSingle();
+      if (ownerRow?.last_active_at && ownerRow.last_active_at > activeCutoff) {
+        skippedActive++;
+        continue;
+      }
+    }
+
     const { data: media } = await db
       .from('media_files')
       .select('url, media_type')
@@ -78,12 +99,9 @@ serve(async (req) => {
       .limit(1)
       .maybeSingle();
 
-    if (!media?.url) {
-      console.warn(`[retry-unidentified] obs ${o.id} has no media — skipping`);
-      continue;
-    }
+    if (!media?.url) continue;
 
-    // Fire-and-forget: don't await so we don't block the cron response
+    const hint = deriveHint(o.evidence_type as string | null);
     fetch(identifyUrl, {
       method: 'POST',
       headers: {
@@ -94,6 +112,8 @@ serve(async (req) => {
         observation_id: o.id,
         image_url: media.url,
         cascade: true,
+        user_hint: hint,
+        force_provider: hint === 'plant' ? 'plantnet' : undefined,
       }),
     }).catch(err => {
       console.warn(`[retry-unidentified] identify fire failed for ${o.id}:`, err);
@@ -102,8 +122,8 @@ serve(async (req) => {
     queued++;
   }
 
-  console.log(`[retry-unidentified] queued ${queued}/${obs.length} observations`);
-  return new Response(JSON.stringify({ queued, total_found: obs.length }), {
+  console.log(`[retry-unidentified] queued=${queued} abandoned=${abandoned} skipped_active=${skippedActive}/${obs.length}`);
+  return new Response(JSON.stringify({ queued, abandoned, skipped_active: skippedActive, total_found: obs.length }), {
     headers: { 'content-type': 'application/json' },
   });
 });

--- a/tests/unit/retry-unidentified-hint.test.ts
+++ b/tests/unit/retry-unidentified-hint.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { deriveHint } from '../../supabase/functions/retry-unidentified/_helpers';
+
+describe('retry-unidentified deriveHint (#590)', () => {
+  it.each([
+    [null, 'unknown'],
+    [undefined, 'unknown'],
+    ['', 'unknown'],
+    ['plant_observation', 'plant'],
+    ['fungi_observation', 'fungi'],
+    ['camera_trap', 'animal'],
+    ['direct_sighting', 'animal'],
+    ['tracks', 'animal'],
+    ['scat', 'animal'],
+    ['sound', 'animal'],
+    ['unknown_type', 'unknown'],
+  ])('deriveHint(%j) === %s', (evidenceType, expected) => {
+    expect(deriveHint(evidenceType as string | null | undefined)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Closes #590. Part of #596 (Sprint 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)