### PR TITLE
feat(api/cli/mcp): expose cascade_attempts for trace replay (#591)

### DIFF
--- a/cli/src/api-client.ts
+++ b/cli/src/api-client.ts
@@ -31,9 +31,10 @@ export interface ObserveResponse {
 export class ApiClient {
   constructor(private readonly opts: ApiClientOpts) {}
 
-  private async post<T>(path: string, body: unknown): Promise<T> {
+  private async post<T>(path: string, body: unknown, query?: Record<string, string>): Promise<T> {
     const f = this.opts.fetchImpl ?? fetch;
-    const res = await f(`${this.opts.baseUrl}/api/${path}`, {
+    const qs = query ? '?' + new URLSearchParams(query).toString() : '';
+    const res = await f(`${this.opts.baseUrl}/api/${path}${qs}`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${this.opts.token}`,
@@ -75,8 +76,11 @@ export class ApiClient {
     lat?: number | null;
     lng?: number | null;
     user_hint?: string;
-  }): Promise<unknown> {
-    return this.post('identify', input);
+    /** When true, append ?include_trace=true to receive cascade_attempts (#591). */
+    include_trace?: boolean;
+  }): Promise<{ scientific_name?: string; confidence?: number; source?: string; cascade_attempts?: Array<{ provider: string; confidence: number | null; error?: string }> }> {
+    const { include_trace, ...body } = input;
+    return this.post('identify', body, include_trace ? { include_trace: 'true' } : undefined);
   }
 }
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -31,6 +31,8 @@ export interface RunOpts {
   stationKey?: string;
   /** Print 1-line per file instead of just summary every 10. */
   verbose: boolean;
+  /** Print one line per cascade attempt (provider + confidence + error). #591. */
+  showCascade?: boolean;
 }
 
 export interface RunResult {
@@ -127,11 +129,19 @@ async function processOne(
   // 4. Optional identify pass.
   if (!opts.skipIdentify) {
     try {
-      await client.identify({
+      const id = await client.identify({
         image_url: presigned.public_url,
         lat: exif.lat,
         lng: exif.lng,
+        include_trace: opts.showCascade,
       });
+      if (opts.showCascade && id.cascade_attempts) {
+        for (const a of id.cascade_attempts) {
+          const conf = a.confidence != null ? a.confidence.toFixed(2) : '–';
+          const err = a.error ? ` (${a.error})` : '';
+          logLine(`  ↳ ${a.provider}: ${conf}${err}`);
+        }
+      }
     } catch (err) {
       // Non-fatal — the observation already exists; the user can re-ID later.
       logLine(`WARN   ${entry.path}  (identify failed, continuing: ${(err as Error).message})`);
@@ -214,6 +224,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     projectSlug,
     stationKey,
     verbose: args.verbose === true || args.v === true,
+    showCascade: args['show-cascade'] === true || args.showCascade === true,
   };
 }
 

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -165,6 +165,7 @@ Deno.serve(async (req: Request) => {
         },
         body: JSON.stringify({
           image_url: body.image_url,
+          observation_id: body.observation_id ?? 'cascade-only',
           location: body.lat != null ? { lat: body.lat, lng: body.lng } : undefined,
           user_hint: body.user_hint,
         }),
@@ -172,6 +173,12 @@ Deno.serve(async (req: Request) => {
     );
 
     const result = await identifyRes.json();
+    // #591: opt-in cascade_attempts. Default response stays small (winner
+    // only); pass ?include_trace=true for the full per-provider trace.
+    const includeTrace = url.searchParams.get('include_trace') === 'true';
+    if (!includeTrace && result && typeof result === 'object') {
+      delete (result as Record<string, unknown>).cascade_attempts;
+    }
     return json(result, identifyRes.status);
   }
 

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -731,9 +731,11 @@ serve(async (req) => {
   }
 
   const responsePayload: Record<string, unknown> = { ...result };
-  if (cascadeAttempts) {
-    responsePayload.cascade_attempts = cascadeAttempts;
-  }
+  // #591: always include cascade_attempts for trace replay. Stub a single-
+  // attempt array when the runner didn't go through the cascade path
+  // (force_provider, default-race that didn't track attempts).
+  responsePayload.cascade_attempts = cascadeAttempts
+    ?? [{ provider: result.source, confidence: result.confidence }];
 
   return corsResponse(JSON.stringify(responsePayload), {
     headers: { 'content-type': 'application/json' },

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -78,7 +78,7 @@ const TOOLS: Tool[] = [
   {
     name: 'identify_species',
     description:
-      'Run the Rastrum identification cascade (PlantNet → Claude Haiku 4.5 → on-device fallbacks) on a photo URL. Returns the top scientific-name match with a confidence score and source.',
+      'Run the Rastrum identification cascade (PlantNet → Claude Haiku 4.5 → on-device fallbacks) on a photo URL. Returns the top scientific-name match with a confidence score, source, and a cascade_attempts array showing each provider that tried (#591).',
     scope: 'identify',
     inputSchema: {
       type: 'object',


### PR DESCRIPTION
Closes #591. Part of #596 (Sprint 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)