### PR TITLE
fix(sponsoring): route vault decrypt through SECURITY DEFINER RPC — fixes Test, heartbeat, sponsor cascade

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4130,6 +4130,24 @@ END $$;
 REVOKE ALL ON FUNCTION public.delete_vault_secret(uuid) FROM public;
 GRANT EXECUTE ON FUNCTION public.delete_vault_secret(uuid) TO service_role;
 
+-- 16b. read_vault_secret — companion to create/delete. Edge Functions
+--      can't `.schema('vault')` directly via PostgREST (the vault schema
+--      isn't in the API exposed-schemas list, and surfacing it would
+--      over-expose raw secret rows). This SECURITY DEFINER wrapper is
+--      the only path the EF has to read a decrypted secret. Used by
+--      /credentials/:id/test, the heartbeat cron, and the sponsor
+--      cascade in the identify EF.
+CREATE OR REPLACE FUNCTION public.read_vault_secret(p_secret_id uuid)
+RETURNS text LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_secret text;
+BEGIN
+  EXECUTE 'SELECT decrypted_secret FROM vault.decrypted_secrets WHERE id = $1'
+    INTO v_secret USING p_secret_id;
+  RETURN v_secret;
+END $$;
+REVOKE ALL ON FUNCTION public.read_vault_secret(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.read_vault_secret(uuid) TO service_role;
+
 -- 17. upsert_vault_secret_by_name — used by CI to sync the cron token to
 --     Vault on every db-apply. We can't use psql's `:'var'` substitution
 --     inside dollar-quoted DO blocks (psql skips substitution there),

--- a/supabase/functions/_shared/sponsorship.ts
+++ b/supabase/functions/_shared/sponsorship.ts
@@ -73,14 +73,13 @@ export async function resolveSponsorship(
 export async function decryptCredential(
   supabase: SupabaseClient, vaultSecretId: string
 ): Promise<string> {
-  const { data, error } = await supabase
-    .schema('vault' as never)
-    .from('decrypted_secrets')
-    .select('decrypted_secret')
-    .eq('id', vaultSecretId)
-    .single();
+  // Direct `.schema('vault').from('decrypted_secrets')` access fails
+  // with "Invalid schema: vault" — the vault schema isn't in the API
+  // exposed-schemas list (and surfacing it would over-expose raw
+  // secret rows). Route through the SECURITY DEFINER RPC instead.
+  const { data, error } = await supabase.rpc('read_vault_secret', { p_secret_id: vaultSecretId });
   if (error) throw new Error(`vault decrypt failed: ${error.message}`);
-  const secret = (data as { decrypted_secret?: string } | null)?.decrypted_secret;
+  const secret = data as string | null;
   if (!secret) throw new Error('vault returned empty secret');
   return secret;
 }


### PR DESCRIPTION
Smoke from production (build 2026.5.1) on /en/profile/sponsoring/ — clicking Test on a saved credential flashes:

> ✗ vault decrypt failed: Invalid schema: vault

## Root cause
\`decryptCredential\` used \`.schema('vault').from('decrypted_secrets')\` via PostgREST, but the \`vault\` schema isn't in the API's exposed-schemas list — and surfacing it would over-expose raw secret rows. The query was rejected at the PostgREST layer with \"Invalid schema: vault\".

## Why this is bigger than the Test button
The same helper is used by every code path that decrypts a stored credential:
- \`/credentials/:id/test\` — the Test button (what the user reported)
- \`/heartbeat\` cron — was silently logging failures every 7 days
- The sponsor cascade in the \`identify\` Edge Function — **sponsorships never actually resolved to a real key**; beneficiary requests would have fallen through to BYO or the platform pool, never the sponsor's secret

So this fix unbreaks the whole sponsorship feature, not just the modal smoke test.

## Fix
Add \`public.read_vault_secret(uuid)\` SECURITY DEFINER RPC mirroring the existing \`create_vault_secret\` / \`delete_vault_secret\` pattern (idempotent CREATE OR REPLACE; REVOKE ALL FROM public; GRANT EXECUTE TO service_role only). Route \`decryptCredential\` through the RPC instead of touching the vault schema directly.

## Files
- \`docs/specs/infra/supabase-schema.sql\` — new RPC
- \`supabase/functions/_shared/sponsorship.ts\` — call the RPC

## Deploy
- \`db-apply.yml\` auto-applies the schema on merge (idempotent)
- \`deploy-functions.yml\` auto-redeploys both \`sponsorships\` and \`identify\` (both import the helper from \`_shared/\`)

## Test plan
- [ ] Click Test on the saved \"Claude\" credential → ✓ result with latency, no vault error
- [ ] Click Rotate → succeeds (rotate also touches vault)
- [ ] Run an identify request that should hit the sponsor cascade → succeeds with the sponsor's key (was silently falling through before)

## Out of scope
The earlier \"Failed to fetch\" on Delete/Update — likely a CORS-preflight cache from before #569 deployed. Hard-reload should clear it; if it persists after this lands, share another log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)