### PR TITLE
feat(chat): user_hint inference + kingdom propagation across turns (#593)

### DIFF
--- a/src/components/ChatView.astro
+++ b/src/components/ChatView.astro
@@ -753,7 +753,7 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
   });
 
   // ── Cascade helpers ──
-  async function runAttachmentCascade(att: ChatAttachment): Promise<{
+  async function runAttachmentCascade(att: ChatAttachment, currentTurnText: string): Promise<{
     best: CascadeCandidate | null;
     alternates: CascadeCandidate[];
   }> {
@@ -764,7 +764,11 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
     // Phi-vision exclusion — Phi is surfaced via the slower "looking
     // more carefully" step below, not the primary pass.
     const { buildCascadeOptions } = await import('../lib/identify-options');
-    const opts = await buildCascadeOptions({ mediaKind });
+    // #593: derive user_hint from conversation context (current turn
+    // keywords + propagated kingdom from prior winning IDs).
+    const { deriveHintFromConversation } = await import('../lib/chat-hint');
+    const userHint = deriveHintFromConversation(currentTurnText, conversation);
+    const opts = await buildCascadeOptions({ mediaKind, userHint });
     const result = await runCascade(
       {
         media: { kind: 'blob', blob: att.blob, mime: att.mimeType },
@@ -944,7 +948,7 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
       const placeholderIdx = conversation.length - 1;
 
       try {
-        const { best, alternates } = await runAttachmentCascade(att);
+        const { best, alternates } = await runAttachmentCascade(att, text);
         const ACCEPT_LOW = 0.4;
         const cascadeOk = !!best && best.confidence >= ACCEPT_LOW;
 

--- a/src/lib/chat-hint.ts
+++ b/src/lib/chat-hint.ts
@@ -1,0 +1,80 @@
+/**
+ * Chat user-hint inference (#593).
+ *
+ * Inspects the most recent chat turns for biological keywords and maps
+ * them to identify-EF user_hint values. Also propagates kingdom from the
+ * prior winning identification across turns so a conversation about
+ * birds doesn't keep firing PlantNet.
+ *
+ * Pure helpers — no side effects, easy to test.
+ */
+
+export type UserHint = 'plant' | 'animal' | 'fungi' | 'unknown';
+
+interface TurnLike {
+  role: 'user' | 'assistant';
+  content: string;
+  cascadeResult?: { best?: { kingdom?: string } | null } | null;
+}
+
+const PLANT_PATTERNS = [
+  /\bplant(a|e|s)?\b/i,
+  /\b(árbol|tree|trees|flor|flower|hoja|leaf|hierba|grass|musgo|moss)\b/i,
+];
+const FUNGI_PATTERNS = [
+  /\b(hongo|seta|fungus|mushroom|moho|mold|liquen|lichen)\b/i,
+];
+const ANIMAL_PATTERNS = [
+  /\b(animal|ave|p[aá]jaro|insecto|bird|insect|mammal|mam[íi]fero|reptil|fish|pez|frog|rana|murci[eé]lago|bat)\b/i,
+];
+
+/**
+ * Map a kingdom string back to a UserHint. Used to propagate context
+ * from a prior identification across turns.
+ */
+export function kingdomToHint(kingdom: string | null | undefined): UserHint {
+  if (!kingdom) return 'unknown';
+  switch (kingdom) {
+    case 'Plantae':  return 'plant';
+    case 'Fungi':    return 'fungi';
+    case 'Animalia': return 'animal';
+    default:         return 'unknown';
+  }
+}
+
+/**
+ * Infer the user_hint for the next cascade call based on the current
+ * turn's content + the most recent prior identification (if any).
+ *
+ * Order of precedence:
+ *   1. Explicit keywords in the current turn.
+ *   2. Kingdom from the most recent winning ID in history.
+ *   3. Keywords in the last 3 turns of history.
+ *   4. 'unknown'.
+ */
+export function deriveHintFromConversation(
+  currentTurnText: string,
+  history: TurnLike[],
+): UserHint {
+  if (matchAny(currentTurnText, PLANT_PATTERNS))  return 'plant';
+  if (matchAny(currentTurnText, FUNGI_PATTERNS))  return 'fungi';
+  if (matchAny(currentTurnText, ANIMAL_PATTERNS)) return 'animal';
+
+  for (let i = history.length - 1; i >= 0; i--) {
+    const t = history[i];
+    const k = t.cascadeResult?.best?.kingdom;
+    if (k) return kingdomToHint(k);
+  }
+
+  const recent = history.slice(-3).map(t => t.content).join(' ');
+  if (matchAny(recent, PLANT_PATTERNS))  return 'plant';
+  if (matchAny(recent, FUNGI_PATTERNS))  return 'fungi';
+  if (matchAny(recent, ANIMAL_PATTERNS)) return 'animal';
+
+  return 'unknown';
+}
+
+function matchAny(text: string, patterns: RegExp[]): boolean {
+  for (const re of patterns) if (re.test(text)) return true;
+  return false;
+}

--- a/tests/unit/chat-hint.test.ts
+++ b/tests/unit/chat-hint.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { deriveHintFromConversation, kingdomToHint } from '../../src/lib/chat-hint';
+
+describe('chat-hint (#593)', () => {
+  describe('kingdomToHint', () => {
+    it.each([
+      ['Plantae',  'plant'],
+      ['Fungi',    'fungi'],
+      ['Animalia', 'animal'],
+      ['',         'unknown'],
+      [null,       'unknown'],
+      [undefined,  'unknown'],
+    ])('kingdomToHint(%j) === %s', (k, expected) => {
+      expect(kingdomToHint(k as string | null)).toBe(expected);
+    });
+  });
+
+  describe('deriveHintFromConversation — current turn', () => {
+    it.each([
+      ['what plant is this?', 'plant'],
+      ['¿qué planta es?', 'plant'],
+      ['identify this tree', 'plant'],
+      ['this mushroom', 'fungi'],
+      ['un hongo extraño', 'fungi'],
+      ['this bird', 'animal'],
+      ['un pájaro azul', 'animal'],
+      ['what is this insect?', 'animal'],
+      ['murciélago en el techo', 'animal'],
+      ['hello there', 'unknown'],
+    ])('"%s" → %s', (text, expected) => {
+      expect(deriveHintFromConversation(text, [])).toBe(expected);
+    });
+  });
+
+  describe('deriveHintFromConversation — kingdom propagation', () => {
+    it('propagates kingdom from prior winning id', () => {
+      const hist = [
+        { role: 'user' as const, content: 'identify' },
+        {
+          role: 'assistant' as const,
+          content: 'Quetzal',
+          cascadeResult: { best: { kingdom: 'Animalia' } },
+        },
+      ];
+      expect(deriveHintFromConversation('and this one?', hist)).toBe('animal');
+    });
+
+    it('current-turn keywords override history kingdom', () => {
+      const hist = [
+        {
+          role: 'assistant' as const,
+          content: 'Quetzal',
+          cascadeResult: { best: { kingdom: 'Animalia' } },
+        },
+      ];
+      expect(deriveHintFromConversation('what plant is this?', hist)).toBe('plant');
+    });
+
+    it('falls back to recent history keywords when no kingdom', () => {
+      const hist = [
+        { role: 'user' as const, content: 'this is a plant question' },
+        { role: 'assistant' as const, content: 'sure' },
+      ];
+      expect(deriveHintFromConversation('and this?', hist)).toBe('plant');
+    });
+  });
+});


### PR DESCRIPTION
Closes #593. Part of #596 (Sprint 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)