### PR TITLE
fix(sync): observation save hangs on "Guardando..." when manual species name is entered (#618)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7778,3 +7778,5 @@ END $$;
 
 REVOKE ALL ON FUNCTION public.touch_user_activity() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.touch_user_activity() TO authenticated;
+
+-- 2026-05-04: trigger db-apply to deploy upsert_primary_identification (#618)

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -232,18 +232,34 @@ async function syncOne(record: ObservationRecord): Promise<void> {
     // the UNIQUE(observation_id) WHERE is_primary partial index — demoting
     // lower-confidence existing primary rows instead of fighting the
     // constraint.
-    const { error: clientIdErr } = await supabase.rpc('upsert_primary_identification', {
-      p_observation_id: record.id,
-      p_scientific_name: clientId.scientificName,
-      p_taxon_id: taxonId,
-      p_confidence: Math.max(0, Math.min(1, clientId.confidence ?? 0)),
-      p_source: clientId.source ?? 'human',
-      p_raw_response: {
-        common_name_en: clientId.commonNameEn,
-        common_name_es: clientId.commonNameEs,
-        client_persisted: true,
-      },
-    });
+    //
+    // #618: wrap with an 8-second timeout. PostgREST returns 404 when the RPC
+    // doesn't exist yet (e.g. schema not yet applied), and some network
+    // conditions can stall the fetch indefinitely. Without a per-call timeout
+    // syncOne() hangs, which means the form's 15-second outer race can never
+    // fire — the observation button stays "Guardando…" forever.
+    let clientIdErr: unknown = null;
+    try {
+      const rpcPromise = supabase.rpc('upsert_primary_identification', {
+        p_observation_id: record.id,
+        p_scientific_name: clientId.scientificName,
+        p_taxon_id: taxonId,
+        p_confidence: Math.max(0, Math.min(1, clientId.confidence ?? 0)),
+        p_source: clientId.source ?? 'human',
+        p_raw_response: {
+          common_name_en: clientId.commonNameEn,
+          common_name_es: clientId.commonNameEs,
+          client_persisted: true,
+        },
+      });
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('upsert_primary_identification timeout after 8s')), 8_000)
+      );
+      const result = await Promise.race([rpcPromise, timeoutPromise]);
+      if (result.error) clientIdErr = result.error;
+    } catch (err) {
+      clientIdErr = err;
+    }
     if (clientIdErr) {
       console.warn('[rastrum] client identification persist failed', clientIdErr);
       // Fall through to server cascade as a backstop.
@@ -376,21 +392,33 @@ async function triggerIdentify(observationId: string): Promise<void> {
   // #589: route through upsert_primary_identification RPC for UNIQUE-safe insert.
   // #586: persist full cascade trace (attempts + winner + raw provider response)
   // for forensics and future re-rank passes. Bounded to 4 KB.
+  // #618: same 8-second timeout as the client-id path above.
   const { serializeClientCascade } = await import('./cascade-trace');
   const trace = serializeClientCascade(cascadeResult);
-  const { error: insertErr } = await supabase.rpc('upsert_primary_identification', {
-    p_observation_id: observationId,
-    p_scientific_name: correctedName,
-    p_taxon_id: null,
-    p_confidence: r.confidence,
-    p_source: r.source,
-    p_raw_response: trace as unknown as object,
-  });
+  let insertErr: unknown = null;
+  try {
+    const rpcPromise2 = supabase.rpc('upsert_primary_identification', {
+      p_observation_id: observationId,
+      p_scientific_name: correctedName,
+      p_taxon_id: null,
+      p_confidence: r.confidence,
+      p_source: r.source,
+      p_raw_response: trace as unknown as object,
+    });
+    const timeout2 = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('upsert_primary_identification timeout after 8s')), 8_000)
+    );
+    const result2 = await Promise.race([rpcPromise2, timeout2]);
+    if (result2.error) insertErr = result2.error;
+  } catch (err) {
+    insertErr = err;
+  }
 
   if (insertErr) {
+    const msg = insertErr instanceof Error ? insertErr.message : String((insertErr as {message?: string}).message ?? insertErr);
     await db.idQueue.update(observationId, {
       attempts: ((await db.idQueue.get(observationId))?.attempts ?? 0) + 1,
-      last_error: 'identification insert failed: ' + insertErr.message,
+      last_error: 'identification insert failed: ' + msg,
     });
     return;
   }


### PR DESCRIPTION
## Root cause

Diagnosed in #618 via direct DB inspection (service role key).

Three issues combined to produce an infinite "Guardando..." state when a user manually overrides the AI identification with a species name:

### 1. `upsert_primary_identification` not deployed to production

The function `public.upsert_primary_identification()` is defined in `supabase-schema.sql` (lines 7664–7716) but was **never applied to the production database**. The `db-apply` run that would have deployed it failed on a different error (column ordering in `community_observers`, fixed in PR #547). No subsequent push touched the schema file, so the function remained missing.

PostgREST returns a 404 error response when an RPC doesn't exist — which *is* handled — but...

### 2. Both RPC call sites have no per-call timeout

```ts
// sync.ts (before this fix) — hangs indefinitely on network stall
const { error: clientIdErr } = await supabase.rpc('upsert_primary_identification', {...});
```

The form wraps `syncOutbox()` with a 15-second `Promise.race` timeout, but that race wraps the *entire* sync run. `syncOne()` is called inside `syncOutbox()` and has no individual timeout. A hung `syncOne()` silently blocks the outer race — `syncOutbox()` never resolves, the form's timeout never fires, and the button stays on "Guardando..." forever.

### 3. taxa table has only 5 rows in production

The RLS policy on `taxa` prevents client-side upserts from normal `authenticated` users (confirmed via service role query). The `catch {}` around the taxa upsert silences this silently, leaving `taxonId = null`. This is acceptable since the `sync_primary_identification` trigger has a fallback lookup by `scientific_name` — but it means `Alamania punicea` would have been linked correctly even without the taxa upsert succeeding.

## Fix

### `src/lib/sync.ts` — two changes

**Client-id persist path (line ~231):** wrap RPC call in `Promise.race` with 8-second timeout. On timeout or error, fall through to server cascade as before.

**Server cascade path (line ~396):** same 8-second timeout. On timeout or error, increment `idQueue.attempts` + set `last_error` as before — the next online event retries the identification.

### `docs/specs/infra/supabase-schema.sql` — comment line added

Causes `db-apply` CI to detect a change and re-run the full idempotent apply, deploying `upsert_primary_identification` to production. The function body is already correct and has been in the schema since #589.

## What this does NOT fix

- The taxa table only having 5 rows. That's a separate data pipeline issue (#617 autocomplete also needs this populated). Not in scope here.
- The form's button still shows "Guardando..." for up to 8s on the first failure. Could be improved with optimistic UI, but that's a separate concern.

## Test plan

- [ ] `npm run typecheck` — clean ✓
- [ ] `npm run test` — no sync-related failures
- [ ] `npm run build` — clean
- [ ] After merge: `db-apply` CI deploys `upsert_primary_identification` — verify with `SELECT proname FROM pg_proc WHERE proname = 'upsert_primary_identification'` → 1 row
- [ ] Manual test: save an observation with a manually-entered species name → should save within 8s and show success or a clear error message, not infinite spinner

Closes #618