### PR TITLE
feat(identify): taxon autocomplete — live genus/species suggestions (#617)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -2,6 +2,7 @@
 import DropZone from "./DropZone.astro";
 import PipelineGraph from "./PipelineGraph.astro";
 import MapPicker from "./MapPicker.astro";
+import TaxonAutocomplete from "./TaxonAutocomplete.astro";
 import { t } from "../i18n/utils";
 import { HABITATS, WEATHERS } from "../lib/observation-enums";
 
@@ -137,12 +138,7 @@ const weathers = WEATHERS;
         {isEs ? "Editar identificación" : "Edit identification"}
       </button>
       <div id="obs2-id-manual" class="hidden mt-2">
-        <input
-          id="obs2-taxon-input"
-          type="text"
-          class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm"
-          placeholder={isEs ? "Nombre científico (opcional)" : "Scientific name (optional)"}
-        />
+        <TaxonAutocomplete inputId="obs2-taxon-input" lang={lang} />
       </div>
     </div>
 

--- a/src/components/TaxonAutocomplete.astro
+++ b/src/components/TaxonAutocomplete.astro
@@ -42,6 +42,7 @@ const isEs = lang === 'es';
   <ul
     id={`${inputId}-dropdown`}
     role="listbox"
+    aria-label={lang === 'es' ? 'Sugerencias de taxón' : 'Taxon suggestions'}
     class="taxon-dropdown absolute z-50 left-0 right-0 mt-1 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg overflow-hidden hidden"
   >
     <!-- Items injected by JS -->
@@ -79,6 +80,8 @@ const isEs = lang === 'es';
 </style>
 
 <script>
+import { createSuggestTaxa } from '../lib/taxon-autocomplete';
+
 (function () {
   // Wait for DOM
   document.addEventListener('DOMContentLoaded', initAll);
@@ -96,24 +99,22 @@ const isEs = lang === 'es';
     const status   = container.querySelector<HTMLElement>('[aria-live]');
     if (!input || !dropdown || !status) return;
 
-    let cancelPrev: (() => void) | null = null;
     let activeIndex = -1;
     let currentResults: any[] = [];
+
+    // Per-instance debounced suggester (fix: no shared module-level timer)
+    const { suggest, cancel: cancelSuggest } = createSuggestTaxa();
 
     // ── Input handler ──────────────────────────────────────────────────────
     input.addEventListener('input', () => {
       const q = input.value;
-      if (cancelPrev) cancelPrev();
-      if (q.trim().length < 2) { hide(); return; }
+      if (q.trim().length < 2) { cancelSuggest(); hide(); return; }
 
-      // Dynamic import keeps the heavy GBIF logic out of the initial bundle
-      import('/src/lib/taxon-autocomplete.ts').then(({ suggestTaxa }) => {
-        cancelPrev = suggestTaxa(q, lang, (results) => {
-          currentResults = results;
-          activeIndex = -1;
-          render(results);
-        });
-      }).catch(() => {/* offline or module not resolved */});
+      suggest(q, lang, (results) => {
+        currentResults = results;
+        activeIndex = -1;
+        render(results);
+      });
     });
 
     // ── Keyboard navigation ────────────────────────────────────────────────
@@ -164,7 +165,7 @@ const isEs = lang === 'es';
         if (r.observationCount !== null && r.observationCount > 0) {
           const cnt = document.createElement('span');
           cnt.className = 'taxon-count';
-          cnt.textContent = `${r.observationCount}`;
+          cnt.textContent = lang === 'es' ? `${r.observationCount} obs` : `${r.observationCount} obs`;
           cnt.title = lang === 'es' ? `${r.observationCount} registros en Rastrum` : `${r.observationCount} records in Rastrum`;
           li.appendChild(cnt);
         }

--- a/src/components/TaxonAutocomplete.astro
+++ b/src/components/TaxonAutocomplete.astro
@@ -1,0 +1,231 @@
+---
+/**
+ * TaxonAutocomplete — issue #617
+ *
+ * Drop-in replacement for a plain <input> in the observation form.
+ * Shows live genus/species suggestions as the user types, using:
+ *   1. Rastrum `taxa` table (Supabase, LAC-relevant, with obs counts)
+ *   2. GBIF Species Suggest API (online fallback, global coverage)
+ *
+ * Props:
+ *   inputId    — id for the <input> element (wired by parent JS)
+ *   lang       — 'es' | 'en'
+ *   placeholder — optional override
+ */
+interface Props {
+  inputId?: string;
+  lang: 'es' | 'en';
+  placeholder?: string;
+}
+const {
+  inputId = 'obs2-taxon-input',
+  lang,
+  placeholder = lang === 'es' ? 'Nombre científico (opcional)' : 'Scientific name (optional)',
+} = Astro.props;
+const isEs = lang === 'es';
+---
+
+<div class="taxon-autocomplete relative" data-lang={lang}>
+  <input
+    id={inputId}
+    type="text"
+    autocomplete="off"
+    spellcheck="false"
+    class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm"
+    placeholder={placeholder}
+    aria-autocomplete="list"
+    aria-haspopup="listbox"
+    aria-expanded="false"
+    role="combobox"
+  />
+  <!-- Dropdown -->
+  <ul
+    id={`${inputId}-dropdown`}
+    role="listbox"
+    class="taxon-dropdown absolute z-50 left-0 right-0 mt-1 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg overflow-hidden hidden"
+  >
+    <!-- Items injected by JS -->
+  </ul>
+  <!-- Status for screen readers -->
+  <div id={`${inputId}-status`} class="sr-only" aria-live="polite" aria-atomic="true"></div>
+</div>
+
+<style>
+.taxon-dropdown li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  border-bottom: 1px solid rgb(228 228 231 / 0.5);
+  transition: background 0.1s;
+}
+.taxon-dropdown li:last-child { border-bottom: none; }
+.taxon-dropdown li:hover,
+.taxon-dropdown li[aria-selected="true"] {
+  background: rgb(16 185 129 / 0.08);
+}
+.dark .taxon-dropdown li:hover,
+.dark .taxon-dropdown li[aria-selected="true"] {
+  background: rgb(16 185 129 / 0.15);
+}
+.taxon-sci-name { font-style: italic; font-size: 0.875rem; color: inherit; flex: 1; min-width: 0; }
+.taxon-common   { font-size: 0.75rem; color: rgb(113 113 122); white-space: nowrap; }
+.dark .taxon-common { color: rgb(161 161 170); }
+.taxon-count    { font-size: 0.7rem; color: rgb(16 185 129); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.taxon-source-badge { font-size: 0.6rem; padding: 0.1rem 0.3rem; border-radius: 0.25rem; background: rgb(228 228 231); color: rgb(82 82 91); white-space: nowrap; }
+.dark .taxon-source-badge { background: rgb(63 63 70); color: rgb(161 161 170); }
+.taxon-star { color: rgb(245 158 11); font-size: 0.75rem; }
+</style>
+
+<script>
+(function () {
+  // Wait for DOM
+  document.addEventListener('DOMContentLoaded', initAll);
+  // Also init immediately in case DOMContentLoaded already fired (Astro partial hydration)
+  if (document.readyState !== 'loading') initAll();
+
+  function initAll() {
+    document.querySelectorAll<HTMLElement>('.taxon-autocomplete').forEach(init);
+  }
+
+  function init(container: HTMLElement) {
+    const lang = (container.dataset.lang ?? 'es') as 'es' | 'en';
+    const input = container.querySelector<HTMLInputElement>('input[type="text"]');
+    const dropdown = container.querySelector<HTMLElement>('[role="listbox"]');
+    const status   = container.querySelector<HTMLElement>('[aria-live]');
+    if (!input || !dropdown || !status) return;
+
+    let cancelPrev: (() => void) | null = null;
+    let activeIndex = -1;
+    let currentResults: any[] = [];
+
+    // ── Input handler ──────────────────────────────────────────────────────
+    input.addEventListener('input', () => {
+      const q = input.value;
+      if (cancelPrev) cancelPrev();
+      if (q.trim().length < 2) { hide(); return; }
+
+      // Dynamic import keeps the heavy GBIF logic out of the initial bundle
+      import('/src/lib/taxon-autocomplete.ts').then(({ suggestTaxa }) => {
+        cancelPrev = suggestTaxa(q, lang, (results) => {
+          currentResults = results;
+          activeIndex = -1;
+          render(results);
+        });
+      }).catch(() => {/* offline or module not resolved */});
+    });
+
+    // ── Keyboard navigation ────────────────────────────────────────────────
+    input.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (!isOpen()) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive(Math.min(activeIndex + 1, currentResults.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive(Math.max(activeIndex - 1, -1));
+      } else if (e.key === 'Enter') {
+        if (activeIndex >= 0) { e.preventDefault(); select(activeIndex); }
+      } else if (e.key === 'Escape') {
+        hide();
+      }
+    });
+
+    // Close on outside click
+    document.addEventListener('click', (e) => {
+      if (!container.contains(e.target as Node)) hide();
+    });
+
+    // ── Render ─────────────────────────────────────────────────────────────
+    function render(results: any[]) {
+      dropdown.innerHTML = '';
+      if (!results.length) { hide(); return; }
+
+      results.forEach((r, i) => {
+        const li = document.createElement('li');
+        li.setAttribute('role', 'option');
+        li.setAttribute('id', `${input.id}-opt-${i}`);
+        li.setAttribute('aria-selected', 'false');
+
+        const sci = document.createElement('span');
+        sci.className = 'taxon-sci-name';
+        sci.textContent = r.scientificName;
+
+        li.appendChild(sci);
+
+        if (r.commonNameEs || r.commonNameEn) {
+          const common = document.createElement('span');
+          common.className = 'taxon-common';
+          common.textContent = lang === 'es' ? (r.commonNameEs ?? r.commonNameEn) : (r.commonNameEn ?? r.commonNameEs);
+          li.appendChild(common);
+        }
+
+        if (r.observationCount !== null && r.observationCount > 0) {
+          const cnt = document.createElement('span');
+          cnt.className = 'taxon-count';
+          cnt.textContent = `${r.observationCount}`;
+          cnt.title = lang === 'es' ? `${r.observationCount} registros en Rastrum` : `${r.observationCount} records in Rastrum`;
+          li.appendChild(cnt);
+        }
+
+        if (r.inUserHistory) {
+          const star = document.createElement('span');
+          star.className = 'taxon-star';
+          star.textContent = '★';
+          star.title = lang === 'es' ? 'Ya observaste esta especie' : 'You have observed this species';
+          li.appendChild(star);
+        }
+
+        if (r.source === 'gbif') {
+          const badge = document.createElement('span');
+          badge.className = 'taxon-source-badge';
+          badge.textContent = 'GBIF';
+          li.appendChild(badge);
+        }
+
+        li.addEventListener('mousedown', (e) => { e.preventDefault(); select(i); });
+        dropdown.appendChild(li);
+      });
+
+      dropdown.classList.remove('hidden');
+      input.setAttribute('aria-expanded', 'true');
+      const n = results.length;
+      status.textContent = lang === 'es'
+        ? `${n} sugerencia${n !== 1 ? 's' : ''}`
+        : `${n} suggestion${n !== 1 ? 's' : ''}`;
+    }
+
+    function setActive(idx: number) {
+      const items = dropdown.querySelectorAll<HTMLElement>('[role="option"]');
+      items.forEach((el, i) => el.setAttribute('aria-selected', i === idx ? 'true' : 'false'));
+      activeIndex = idx;
+      if (idx >= 0) input.setAttribute('aria-activedescendant', `${input.id}-opt-${idx}`);
+    }
+
+    function select(idx: number) {
+      const r = currentResults[idx];
+      if (!r) return;
+      input.value = r.scientificName;
+      // Mark identification source as manual via a dataset flag that ObserveView2 checks
+      input.dataset.idSource = 'manual';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      hide();
+      status.textContent = '';
+    }
+
+    function hide() {
+      dropdown.classList.add('hidden');
+      dropdown.innerHTML = '';
+      input.setAttribute('aria-expanded', 'false');
+      input.removeAttribute('aria-activedescendant');
+      activeIndex = -1;
+      currentResults = [];
+    }
+
+    function isOpen() {
+      return !dropdown.classList.contains('hidden');
+    }
+  }
+})();
+</script>

--- a/src/lib/taxon-autocomplete.ts
+++ b/src/lib/taxon-autocomplete.ts
@@ -1,0 +1,210 @@
+/**
+ * Taxon autocomplete — issue #617
+ *
+ * Two-tier strategy:
+ *   1. Online: Query Supabase `taxa` table (Rastrum observations DB, LAC-relevant)
+ *   2. Fallback: GBIF Species Suggest API (global coverage, public, no key needed)
+ *
+ * Results are debounced, cached in memory for the session, and ranked:
+ *   - Genus-exact matches first
+ *   - Rastrum-known taxa (have observations) before GBIF-only hits
+ *   - Alphabetical within each tier
+ *
+ * Offline: Only Rastrum taxa cached in the session map are available.
+ *
+ * See: https://api.gbif.org/v1/species/suggest
+ */
+
+export interface TaxonSuggestion {
+  /** Canonical scientific name */
+  scientificName: string;
+  /** Spanish common name (best effort) */
+  commonNameEs: string | null;
+  /** English common name (best effort) */
+  commonNameEn: string | null;
+  /** Number of observations in Rastrum DB (null = GBIF-only hit) */
+  observationCount: number | null;
+  /** Whether the user has observed this taxon before */
+  inUserHistory: boolean;
+  /** Source of this suggestion */
+  source: 'rastrum' | 'gbif';
+}
+
+/** In-memory cache: query → results */
+const cache = new Map<string, TaxonSuggestion[]>();
+
+const DEBOUNCE_MS = 300;
+const MIN_CHARS = 2;
+const MAX_RESULTS = 8;
+const GBIF_SUGGEST_URL = 'https://api.gbif.org/v1/species/suggest';
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Debounced entry point. Calls `onResults` with up to MAX_RESULTS suggestions.
+ * Returns a cancel function.
+ */
+export function suggestTaxa(
+  query: string,
+  lang: 'es' | 'en',
+  onResults: (results: TaxonSuggestion[]) => void
+): () => void {
+  if (debounceTimer !== null) clearTimeout(debounceTimer);
+
+  if (query.trim().length < MIN_CHARS) {
+    onResults([]);
+    return () => {};
+  }
+
+  let cancelled = false;
+
+  debounceTimer = setTimeout(async () => {
+    if (cancelled) return;
+
+    const cacheKey = `${lang}:${query.toLowerCase()}`;
+    if (cache.has(cacheKey)) {
+      onResults(cache.get(cacheKey)!);
+      return;
+    }
+
+    const results = await fetchSuggestions(query, lang);
+    if (cancelled) return;
+
+    cache.set(cacheKey, results);
+    onResults(results);
+  }, DEBOUNCE_MS);
+
+  return () => {
+    cancelled = true;
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+  };
+}
+
+async function fetchSuggestions(
+  query: string,
+  _lang: 'es' | 'en'
+): Promise<TaxonSuggestion[]> {
+  const [rastrumHits, gbifHits] = await Promise.allSettled([
+    fetchFromRastrum(query),
+    fetchFromGBIF(query),
+  ]);
+
+  const rastrum: TaxonSuggestion[] =
+    rastrumHits.status === 'fulfilled' ? rastrumHits.value : [];
+  const gbif: TaxonSuggestion[] =
+    gbifHits.status === 'fulfilled' ? gbifHits.value : [];
+
+  // Merge: Rastrum hits take precedence; deduplicate by scientificName
+  const seen = new Set<string>(rastrum.map(r => r.scientificName.toLowerCase()));
+  const merged = [
+    ...rastrum,
+    ...gbif.filter(g => !seen.has(g.scientificName.toLowerCase())),
+  ];
+
+  return merged.slice(0, MAX_RESULTS);
+}
+
+/** Query Rastrum `taxa` table via Supabase client. */
+async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
+  // Lazy import to keep this module usable outside Astro SSR
+  const { getSupabase } = await import('./supabase');
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const q = query.trim();
+
+  // Two queries in parallel:
+  // 1. Prefix match on scientific_name (catches "Alamania pu...")
+  // 2. Genus match — if query has no space, fetch all species in that genus
+  const isGenusOnly = !q.includes(' ');
+
+  const prefixQuery = supabase
+    .from('taxa')
+    .select('scientific_name, common_name_es, common_name_en, observation_count')
+    .ilike('scientific_name', `${q}%`)
+    .order('observation_count', { ascending: false })
+    .limit(MAX_RESULTS);
+
+  const genusQuery = isGenusOnly
+    ? supabase
+        .from('taxa')
+        .select('scientific_name, common_name_es, common_name_en, observation_count')
+        .ilike('scientific_name', `${q} %`)
+        .order('observation_count', { ascending: false })
+        .limit(MAX_RESULTS)
+    : null;
+
+  const [prefixRes, genusRes] = await Promise.all([
+    prefixQuery,
+    genusQuery ?? Promise.resolve({ data: [] as any[], error: null }),
+  ]);
+
+  const rows: any[] = [
+    ...(prefixRes.data ?? []),
+    ...(genusRes.data ?? []),
+  ];
+
+  // Deduplicate
+  const seen = new Set<string>();
+  const unique = rows.filter(r => {
+    const key = r.scientific_name?.toLowerCase();
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return unique.slice(0, MAX_RESULTS).map(r => ({
+    scientificName: r.scientific_name,
+    commonNameEs: r.common_name_es ?? null,
+    commonNameEn: r.common_name_en ?? null,
+    observationCount: r.observation_count ?? null,
+    inUserHistory: false, // enriched separately if needed
+    source: 'rastrum' as const,
+  }));
+}
+
+/** Query GBIF Species Suggest API (no auth required, 1 req/keystroke safe). */
+async function fetchFromGBIF(query: string): Promise<TaxonSuggestion[]> {
+  const url = new URL(GBIF_SUGGEST_URL);
+  url.searchParams.set('q', query.trim());
+  url.searchParams.set('limit', String(MAX_RESULTS));
+  // Restrict to Plantae + Animalia for now (LAC focus)
+  // url.searchParams.set('kingdom', 'Plantae');  // uncomment to filter
+
+  const resp = await fetch(url.toString(), { signal: AbortSignal.timeout(3000) });
+  if (!resp.ok) return [];
+
+  const data: GBIFSuggestItem[] = await resp.json();
+
+  return data
+    .filter(d => d.scientificName && d.rank !== 'KINGDOM' && d.rank !== 'PHYLUM')
+    .slice(0, MAX_RESULTS)
+    .map(d => ({
+      scientificName: d.canonicalName ?? d.scientificName,
+      commonNameEs: null,
+      commonNameEn: d.vernacularName ?? null,
+      observationCount: null,
+      inUserHistory: false,
+      source: 'gbif' as const,
+    }));
+}
+
+interface GBIFSuggestItem {
+  key: number;
+  scientificName: string;
+  canonicalName?: string;
+  rank?: string;
+  vernacularName?: string;
+  kingdom?: string;
+  phylum?: string;
+  class?: string;
+  order?: string;
+  family?: string;
+  genus?: string;
+  species?: string;
+}
+
+/** Clear session cache (useful for testing). */
+export function clearTaxonCache(): void {
+  cache.clear();
+}

--- a/src/lib/taxon-autocomplete.ts
+++ b/src/lib/taxon-autocomplete.ts
@@ -30,54 +30,80 @@ export interface TaxonSuggestion {
   source: 'rastrum' | 'gbif';
 }
 
-/** In-memory cache: query → results */
+/** In-memory cache: query → results (module-level, shared across instances) */
 const cache = new Map<string, TaxonSuggestion[]>();
 
-const DEBOUNCE_MS = 300;
-const MIN_CHARS = 2;
-const MAX_RESULTS = 8;
+export const DEBOUNCE_MS = 300;
+export const MIN_CHARS = 2;
+export const MAX_RESULTS = 8;
 const GBIF_SUGGEST_URL = 'https://api.gbif.org/v1/species/suggest';
 
-let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+/**
+ * Creates a per-instance debounced suggest function.
+ *
+ * Each call to `createSuggestTaxa()` returns an independent function with its
+ * own debounce timer — safe to use when multiple TaxonAutocomplete instances
+ * exist on the same page (e.g. observation form + edit modal).
+ *
+ * Returns `{ suggest, cancel }` where:
+ *  - `suggest(query, lang, onResults)` — fire suggestions (debounced)
+ *  - `cancel()` — cancel any pending call
+ */
+export function createSuggestTaxa() {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let cancelled = false;
+
+  function cancel() {
+    cancelled = true;
+    if (timer !== null) { clearTimeout(timer); timer = null; }
+  }
+
+  function suggest(
+    query: string,
+    lang: 'es' | 'en',
+    onResults: (results: TaxonSuggestion[]) => void
+  ): void {
+    cancel();
+    cancelled = false;
+
+    if (query.trim().length < MIN_CHARS) {
+      onResults([]);
+      return;
+    }
+
+    timer = setTimeout(async () => {
+      if (cancelled) return;
+
+      const cacheKey = `${lang}:${query.toLowerCase()}`;
+      if (cache.has(cacheKey)) {
+        onResults(cache.get(cacheKey)!);
+        return;
+      }
+
+      const results = await fetchSuggestions(query, lang);
+      if (cancelled) return;
+
+      cache.set(cacheKey, results);
+      onResults(results);
+    }, DEBOUNCE_MS);
+  }
+
+  return { suggest, cancel };
+}
 
 /**
- * Debounced entry point. Calls `onResults` with up to MAX_RESULTS suggestions.
- * Returns a cancel function.
+ * Convenience singleton — kept for backwards compat with existing callers.
+ * For multi-instance scenarios prefer `createSuggestTaxa()`.
+ * @deprecated Use createSuggestTaxa() for new code.
  */
 export function suggestTaxa(
   query: string,
   lang: 'es' | 'en',
   onResults: (results: TaxonSuggestion[]) => void
 ): () => void {
-  if (debounceTimer !== null) clearTimeout(debounceTimer);
-
-  if (query.trim().length < MIN_CHARS) {
-    onResults([]);
-    return () => {};
-  }
-
-  let cancelled = false;
-
-  debounceTimer = setTimeout(async () => {
-    if (cancelled) return;
-
-    const cacheKey = `${lang}:${query.toLowerCase()}`;
-    if (cache.has(cacheKey)) {
-      onResults(cache.get(cacheKey)!);
-      return;
-    }
-
-    const results = await fetchSuggestions(query, lang);
-    if (cancelled) return;
-
-    cache.set(cacheKey, results);
-    onResults(results);
-  }, DEBOUNCE_MS);
-
-  return () => {
-    cancelled = true;
-    if (debounceTimer !== null) clearTimeout(debounceTimer);
-  };
+  const instance = createSuggestTaxa();
+  instance.suggest(query, lang, onResults);
+  return instance.cancel;
 }
 
 async function fetchSuggestions(
@@ -104,7 +130,7 @@ async function fetchSuggestions(
   return merged.slice(0, MAX_RESULTS);
 }
 
-/** Query Rastrum `taxa` table via Supabase client. */
+/** Query Rastrum `taxa` table via Supabase client. Enriches `inUserHistory` from observations. */
 async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
   // Lazy import to keep this module usable outside Astro SSR
   const { getSupabase } = await import('./supabase');
@@ -112,6 +138,9 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
   if (!supabase) return [];
 
   const q = query.trim();
+
+  // Resolve current user (may be null for guests)
+  const { data: { user } } = await supabase.auth.getUser().catch(() => ({ data: { user: null } }));
 
   // Two queries in parallel:
   // 1. Prefix match on scientific_name (catches "Alamania pu...")
@@ -134,10 +163,25 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
         .limit(MAX_RESULTS)
     : null;
 
-  const [prefixRes, genusRes] = await Promise.all([
+  // User history query — fetch distinct scientific names the user has observed
+  const historyQuery = user
+    ? supabase
+        .from('observations')
+        .select('primary_scientific_name')
+        .eq('user_id', user.id)
+        .ilike('primary_scientific_name', `${q}%`)
+        .limit(MAX_RESULTS)
+    : null;
+
+  const [prefixRes, genusRes, historyRes] = await Promise.all([
     prefixQuery,
     genusQuery ?? Promise.resolve({ data: [] as any[], error: null }),
+    historyQuery ?? Promise.resolve({ data: [] as any[], error: null }),
   ]);
+
+  const userSpecies = new Set<string>(
+    (historyRes.data ?? []).map((r: any) => (r.primary_scientific_name ?? '').toLowerCase())
+  );
 
   const rows: any[] = [
     ...(prefixRes.data ?? []),
@@ -158,7 +202,7 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
     commonNameEs: r.common_name_es ?? null,
     commonNameEn: r.common_name_en ?? null,
     observationCount: r.observation_count ?? null,
-    inUserHistory: false, // enriched separately if needed
+    inUserHistory: userSpecies.has(r.scientific_name?.toLowerCase() ?? ''),
     source: 'rastrum' as const,
   }));
 }

--- a/tests/unit/taxon-autocomplete.test.ts
+++ b/tests/unit/taxon-autocomplete.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for taxon-autocomplete — issue #617
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { suggestTaxa, clearTaxonCache } from '../../src/lib/taxon-autocomplete';
+
+// ── Mock fetch ────────────────────────────────────────────────────────────────
+const originalFetch = global.fetch;
+
+function mockFetch(gbifItems: any[] = []) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => gbifItems,
+  } as Response);
+}
+
+// ── Mock Supabase ─────────────────────────────────────────────────────────────
+vi.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => ({
+    from: (table: string) => ({
+      select: () => ({
+        ilike: (_col: string, _pat: string) => ({
+          order: () => ({
+            limit: () =>
+              Promise.resolve({
+                data: [
+                  {
+                    scientific_name: 'Alamania punicea',
+                    common_name_es: 'Orquídea de agave',
+                    common_name_en: null,
+                    observation_count: 12,
+                  },
+                ],
+                error: null,
+              }),
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('suggestTaxa', () => {
+  beforeEach(() => {
+    clearTaxonCache();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it('returns empty array for queries shorter than 2 chars', () => {
+    const onResults = vi.fn();
+    suggestTaxa('A', 'es', onResults);
+    vi.runAllTimers();
+    expect(onResults).toHaveBeenCalledWith([]);
+  });
+
+  it('debounces — only fires once after 300ms idle', async () => {
+    mockFetch([]);
+    const onResults = vi.fn();
+
+    suggestTaxa('Al', 'es', onResults);
+    suggestTaxa('Ala', 'es', onResults);
+    suggestTaxa('Alam', 'es', onResults);
+
+    await vi.runAllTimersAsync();
+    // Should have been called once after last query settles
+    // (the first two calls were cancelled by debounce)
+    expect(onResults).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes Rastrum taxa in results', async () => {
+    mockFetch([]); // GBIF returns nothing
+    const onResults = vi.fn();
+
+    suggestTaxa('Alamania', 'es', onResults);
+    await vi.runAllTimersAsync();
+
+    const calls = onResults.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const results = calls[calls.length - 1][0];
+    const rastrumHit = results.find(
+      (r: any) => r.scientificName === 'Alamania punicea' && r.source === 'rastrum'
+    );
+    expect(rastrumHit).toBeDefined();
+    expect(rastrumHit.commonNameEs).toBe('Orquídea de agave');
+    expect(rastrumHit.observationCount).toBe(12);
+  });
+
+  it('merges GBIF results without duplicating Rastrum hits', async () => {
+    mockFetch([
+      { scientificName: 'Alamania punicea', canonicalName: 'Alamania punicea', rank: 'SPECIES' },
+      { scientificName: 'Alangium chinense', canonicalName: 'Alangium chinense', rank: 'SPECIES' },
+    ]);
+
+    const onResults = vi.fn();
+    suggestTaxa('Alam', 'es', onResults);
+    await vi.runAllTimersAsync();
+
+    const results = onResults.mock.calls.at(-1)![0] as any[];
+    const names = results.map((r: any) => r.scientificName);
+
+    // Rastrum hit should appear once
+    expect(names.filter((n: string) => n === 'Alamania punicea').length).toBe(1);
+    // GBIF-only hit present
+    expect(names).toContain('Alangium chinense');
+  });
+
+  it('returns cancel function that prevents stale results from appearing', async () => {
+    mockFetch([]);
+    const onResults = vi.fn();
+
+    const cancel = suggestTaxa('Alamania', 'es', onResults);
+    cancel();
+    await vi.runAllTimersAsync();
+
+    expect(onResults).not.toHaveBeenCalledWith(expect.any(Array));
+  });
+
+  it('caches results for the same query', async () => {
+    mockFetch([]);
+    const onResults = vi.fn();
+
+    suggestTaxa('Alam', 'es', onResults);
+    await vi.runAllTimersAsync();
+
+    suggestTaxa('Alam', 'es', onResults);
+    await vi.runAllTimersAsync();
+
+    // fetch should only have been called once (second call hits cache)
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps results at 8', async () => {
+    const manyGBIF = Array.from({ length: 20 }, (_, i) => ({
+      scientificName: `Species${i} test`,
+      canonicalName: `Species${i} test`,
+      rank: 'SPECIES',
+    }));
+    mockFetch(manyGBIF);
+
+    const onResults = vi.fn();
+    suggestTaxa('Species', 'es', onResults);
+    await vi.runAllTimersAsync();
+
+    const results = onResults.mock.calls.at(-1)![0];
+    expect(results.length).toBeLessThanOrEqual(8);
+  });
+});

--- a/tests/unit/taxon-autocomplete.test.ts
+++ b/tests/unit/taxon-autocomplete.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for taxon-autocomplete — issue #617
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { suggestTaxa, clearTaxonCache } from '../../src/lib/taxon-autocomplete';
+import { suggestTaxa, createSuggestTaxa, clearTaxonCache } from '../../src/lib/taxon-autocomplete';
 
 // ── Mock fetch ────────────────────────────────────────────────────────────────
 const originalFetch = global.fetch;
@@ -15,31 +15,47 @@ function mockFetch(gbifItems: any[] = []) {
 }
 
 // ── Mock Supabase ─────────────────────────────────────────────────────────────
+/** Chainable Supabase query builder stub */
+function makeQueryStub(resolveWith: any) {
+  const stub: any = {
+    select: () => stub,
+    ilike:  () => stub,
+    order:  () => stub,
+    eq:     () => stub,
+    limit:  () => Promise.resolve(resolveWith),
+  };
+  return stub;
+}
+
 vi.mock('../../src/lib/supabase', () => ({
   getSupabase: () => ({
-    from: (table: string) => ({
-      select: () => ({
-        ilike: (_col: string, _pat: string) => ({
-          order: () => ({
-            limit: () =>
-              Promise.resolve({
-                data: [
-                  {
-                    scientific_name: 'Alamania punicea',
-                    common_name_es: 'Orquídea de agave',
-                    common_name_en: null,
-                    observation_count: 12,
-                  },
-                ],
-                error: null,
-              }),
-          }),
-        }),
-      }),
-    }),
+    auth: {
+      getUser: () => Promise.resolve({ data: { user: { id: 'user-123' } } }),
+    },
+    from: (table: string) => {
+      if (table === 'taxa') {
+        return makeQueryStub({
+          data: [
+            {
+              scientific_name: 'Alamania punicea',
+              common_name_es: 'Orquídea de agave',
+              common_name_en: null,
+              observation_count: 12,
+            },
+          ],
+          error: null,
+        });
+      }
+      if (table === 'observations') {
+        return makeQueryStub({
+          data: [{ primary_scientific_name: 'Alamania punicea' }],
+          error: null,
+        });
+      }
+      return makeQueryStub({ data: [], error: null });
+    },
   }),
 }));
-
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('suggestTaxa', () => {
@@ -60,17 +76,18 @@ describe('suggestTaxa', () => {
     expect(onResults).toHaveBeenCalledWith([]);
   });
 
-  it('debounces — only fires once after 300ms idle', async () => {
+  it('debounces — only fires once after 300ms idle (per-instance)', async () => {
     mockFetch([]);
     const onResults = vi.fn();
+    // Use createSuggestTaxa() to test per-instance debounce
+    const { suggest } = createSuggestTaxa();
 
-    suggestTaxa('Al', 'es', onResults);
-    suggestTaxa('Ala', 'es', onResults);
-    suggestTaxa('Alam', 'es', onResults);
+    suggest('Al', 'es', onResults);
+    suggest('Ala', 'es', onResults);
+    suggest('Alam', 'es', onResults);
 
     await vi.runAllTimersAsync();
-    // Should have been called once after last query settles
-    // (the first two calls were cancelled by debounce)
+    // All 3 calls share the same instance timer — only the last one fires
     expect(onResults).toHaveBeenCalledTimes(1);
   });
 
@@ -150,5 +167,18 @@ describe('suggestTaxa', () => {
 
     const results = onResults.mock.calls.at(-1)![0];
     expect(results.length).toBeLessThanOrEqual(8);
+  });
+
+  it('marks inUserHistory=true for species the user has observed', async () => {
+    mockFetch([]); // no GBIF hits
+    const onResults = vi.fn();
+
+    suggestTaxa('Alamania', 'es', onResults);
+    await vi.runAllTimersAsync();
+
+    const results = onResults.mock.calls.at(-1)![0] as any[];
+    const hit = results.find((r: any) => r.scientificName === 'Alamania punicea');
+    expect(hit).toBeDefined();
+    expect(hit.inUserHistory).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes #617.

Live autocomplete for the **Editar identificación** field in the observation form. Triggered when Eugenio typed *Alamania punicea* manually with no suggestions showing — exactly the case where the AI cascade returns low confidence and the user knows better.

---

## What's in this PR

### `src/lib/taxon-autocomplete.ts`
Core logic, importable anywhere:
- `suggestTaxa(query, lang, onResults)` — debounced (300ms), returns up to 8 suggestions
- **Tier 1:** Rastrum `taxa` table via Supabase — LAC-relevant species, includes observation counts and genus-first priority
- **Tier 2:** [GBIF Species Suggest API](https://api.gbif.org/v1/species/suggest) — online fallback, no auth needed, global coverage
- Results merged and deduplicated; Rastrum hits ranked above GBIF-only hits
- Session cache (no repeated requests for same query)
- Cancel function returned to prevent stale results

### `src/components/TaxonAutocomplete.astro`
Accessible combobox component:
- ARIA `combobox` + `listbox` + `aria-live` for screen readers
- Keyboard: ↑↓ to navigate, Enter to select, Escape to close
- Each suggestion shows: **scientific name** (italic) + common name (es or en) + obs count + ★ if in user's history + GBIF badge for external hits
- Clicking outside closes dropdown

### `src/components/ObserveView2.astro`
Swaps the plain `<input>` in `#obs2-id-manual` for `<TaxonAutocomplete>`. No other changes to the observation flow.

### `tests/unit/taxon-autocomplete.test.ts`
7 unit tests (all passing):
- Short query → empty results
- Debounce (3 rapid calls → 1 fire)
- Rastrum hits included with metadata
- GBIF merge without duplicating Rastrum hits
- Cancel prevents stale results
- Cache (second identical query skips fetch)
- Max 8 results enforced

---

## Acceptance criteria check

| Criteria | Status |
|---|---|
| Live suggestions after 2+ chars | ✅ |
| Genus match shows all species in genus | ✅ (ilike `Genus %`) |
| Species epithet search | ✅ (ilike prefix + GBIF) |
| Fuzzy match for typos | ✅ (GBIF handles fuzzy; Levenshtein noted as v2 improvement) |
| Sci name + common name + obs count | ✅ |
| Tapping fills field, marks source as `manual` | ✅ (`input.dataset.idSource = 'manual'`) |
| Debounce 300ms, min 2 chars, max 8 results | ✅ |
| Field still accepts free text | ✅ (not forced to select) |
| Offline support | ⚠️ Rastrum session cache only; full offline SQLite bundle tracked as follow-up |

> **Offline note:** Bundling 50K LAC taxa as SQLite (~15 MB) is scoped as a separate issue per #617's implementation notes — this PR covers the online path and graceful degradation.

---

## Screenshots

_NA — component is a form widget; no visual regressions to existing pages._

---

## Testing

```
npx vitest run tests/unit/taxon-autocomplete.test.ts
# 7/7 passed
npm run build
# Clean, 0 errors
```