### PR TITLE
fix(photos): larger touch target for per-photo delete button (#621)

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -441,10 +441,10 @@ export async function wireManagePanelPhotos(obsId: string): Promise<void> {
       const cascadeBadge = p.is_primary
         ? '<span class="absolute top-1 left-1 rounded bg-emerald-700/85 text-white text-[10px] font-semibold px-1.5 py-0.5 uppercase tracking-wide">★</span>'
         : '';
-      return `<div class="relative group">
-        <img src="${srcAt}" alt="" class="aspect-square w-full object-cover rounded-md border border-zinc-200 dark:border-zinc-800" loading="lazy" decoding="async" />
+      return `<div class="relative group overflow-hidden rounded-md">
+        <img src="${srcAt}" alt="" class="aspect-square w-full object-cover border border-zinc-200 dark:border-zinc-800" loading="lazy" decoding="async" />
         ${cascadeBadge}
-        <button type="button" data-delete-photo="${idAt}" aria-label="${aria}" class="absolute top-1 right-1 rounded-full bg-black/60 hover:bg-red-600 text-white w-6 h-6 inline-flex items-center justify-center text-xs leading-none transition-colors">×</button>
+        <button type="button" data-delete-photo="${idAt}" aria-label="${aria}" class="absolute top-1 right-1 rounded-full bg-black/70 hover:bg-red-600 active:bg-red-700 text-white w-10 h-10 inline-flex items-center justify-center text-base leading-none transition-colors touch-manipulation">×</button>
       </div>`;
     }).join('');
     grid!.querySelectorAll<HTMLButtonElement>('[data-delete-photo]').forEach((btn) => {


### PR DESCRIPTION
## Problem
Closes #621.

The per-photo delete button in the observation manage panel was 24×24px and used only `hover:` styling for visual feedback — both invisible on mobile touch screens. Beta tester Eugenio reported it felt impossible to delete a single photo without deleting all of them.

## Changes

`src/lib/manage-panel.ts` — `renderGrid()`:

| Before | After |
|---|---|
| `w-6 h-6` (24px) | `w-10 h-10` (40px) — meets mobile minimum |
| `hover:bg-red-600` only | `hover:bg-red-600 active:bg-red-700` — visible tap feedback |
| No `touch-manipulation` | `touch-manipulation` — removes 300ms tap delay |
| `rounded-md` on `<img>` | moved to wrapper `<div>` with `overflow-hidden` |

## Testing
```
npm run build   # 231 pages, 0 errors
```

No behavior change — only size, feedback, and tap delay.