### PR TITLE
fix(report-btn): restore FAB positioning broken by relative class

### DIFF
--- a/src/components/ReportIssueButton.astro
+++ b/src/components/ReportIssueButton.astro
@@ -12,25 +12,27 @@ const appVersion = import.meta.env.PUBLIC_VERSION || 'dev';
 const repoSlug = 'ArtemioPadilla/rastrum';
 ---
 
-<button
-  id="report-issue-btn"
-  type="button"
-  aria-label={tr.report.button_label}
-  title={tr.report.button_label}
-  class="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] sm:bottom-4 right-4 z-40 w-14 h-14 rounded-full relative flex items-center justify-center shadow-lg bg-white text-emerald-700 ring-1 ring-emerald-600/20 hover:bg-emerald-50 hover:ring-emerald-600/40 dark:bg-zinc-900 dark:text-emerald-400 dark:ring-emerald-500/30 dark:hover:bg-zinc-800 dark:hover:ring-emerald-500/50 transition-all hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-emerald-500"
->
-  <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-    <path stroke-linecap="round" stroke-linejoin="round"
-      d="M7.5 8.25h9m-9 3.75h6m-7.5 4.5L4.5 19V5.25A1.25 1.25 0 0 1 5.75 4h12.5A1.25 1.25 0 0 1 19.5 5.25v9.5A1.25 1.25 0 0 1 18.25 16h-9.5L6 18l-1.5-1.5z" />
-  </svg>
-  <span class="sr-only">{tr.report.button_label}</span>
-  <!-- Error badge: shown automatically when console errors or failed requests are captured -->
-  <span
-    id="report-fab-badge"
-    aria-label={tr.report.badge_errors_label ?? 'errors detected'}
-    class="hidden absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full bg-red-600 text-white text-[10px] font-bold flex items-center justify-center ring-2 ring-white dark:ring-zinc-900 pointer-events-none"
-  ></span>
-</button>
+<div class="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] sm:bottom-4 right-4 z-40 w-14 h-14">
+  <button
+    id="report-issue-btn"
+    type="button"
+    aria-label={tr.report.button_label}
+    title={tr.report.button_label}
+    class="relative w-14 h-14 rounded-full flex items-center justify-center shadow-lg bg-white text-emerald-700 ring-1 ring-emerald-600/20 hover:bg-emerald-50 hover:ring-emerald-600/40 dark:bg-zinc-900 dark:text-emerald-400 dark:ring-emerald-500/30 dark:hover:bg-zinc-800 dark:hover:ring-emerald-500/50 transition-all hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-emerald-500"
+  >
+    <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round"
+        d="M7.5 8.25h9m-9 3.75h6m-7.5 4.5L4.5 19V5.25A1.25 1.25 0 0 1 5.75 4h12.5A1.25 1.25 0 0 1 19.5 5.25v9.5A1.25 1.25 0 0 1 18.25 16h-9.5L6 18l-1.5-1.5z" />
+    </svg>
+    <span class="sr-only">{tr.report.button_label}</span>
+    <!-- Error badge: shown automatically when console errors or failed requests are captured -->
+    <span
+      id="report-fab-badge"
+      aria-label={tr.report.badge_errors_label ?? 'errors detected'}
+      class="hidden absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full bg-red-600 text-white text-[10px] font-bold flex items-center justify-center ring-2 ring-white dark:ring-zinc-900 pointer-events-none"
+    ></span>
+  </button>
+</div>
 
 <dialog
   id="report-issue-modal"


### PR DESCRIPTION
Adding `relative` directly to the `fixed` button in #624 caused the button to lose its viewport-anchored position — on some browsers/contexts `relative` creates a stacking context that converts `fixed` to behave like `absolute`, making the FAB scroll with the page instead of staying bottom-right.

Fix: move the `fixed` positioning to a wrapper `<div>`, keep `relative` only on the `<button>` so the badge span positions correctly against it.

Fixes the regression introduced in #624.