### PR TITLE
fix(sponsoring): add has_active_sponsorship RPC (#627)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4021,6 +4021,20 @@ $$;
 REVOKE ALL ON FUNCTION public.resolve_sponsorship(uuid, public.ai_provider) FROM public;
 GRANT EXECUTE ON FUNCTION public.resolve_sponsorship(uuid, public.ai_provider) TO service_role;
 
+-- has_active_sponsorship: lightweight boolean wrapper used by the client-side
+-- claude.ts isAvailable() check. Returns TRUE when at least one active,
+-- non-exhausted sponsorship exists for the calling user and given provider.
+DROP FUNCTION IF EXISTS public.has_active_sponsorship(public.ai_provider);
+CREATE OR REPLACE FUNCTION public.has_active_sponsorship(
+  p_provider public.ai_provider
+) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.resolve_sponsorship(auth.uid(), p_provider) LIMIT 1
+  );
+$$;
+REVOKE ALL ON FUNCTION public.has_active_sponsorship(public.ai_provider) FROM public;
+GRANT EXECUTE ON FUNCTION public.has_active_sponsorship(public.ai_provider) TO authenticated;
+
 -- 10. Extend karma_events.reason CHECK to include sponsorship reasons.
 ALTER TABLE public.karma_events DROP CONSTRAINT IF EXISTS karma_events_reason_check;
 ALTER TABLE public.karma_events ADD CONSTRAINT karma_events_reason_check

--- a/scripts/db-sentinel.sql
+++ b/scripts/db-sentinel.sql
@@ -173,4 +173,9 @@ SELECT
 FROM pg_tables
 WHERE schemaname = 'public';
 
+-- Verify has_active_sponsorship exists (client-side isAvailable check).
+SELECT proname FROM pg_proc
+  JOIN pg_namespace ON pg_namespace.oid = pg_proc.pronamespace
+  WHERE nspname = 'public' AND proname = 'has_active_sponsorship';
+
 SELECT 'sentinel ok' AS status;


### PR DESCRIPTION
## Problem
`claude.ts` calls `supabase.rpc('has_active_sponsorship', { p_provider: 'anthropic' })` but the function never existed in the DB — 404 on every call from `/profile/settings/ai/`.

Reported via bug reporter: Build `12ce7e7`, 2026-05-07T04:12:42Z.

## Fix
- Add `has_active_sponsorship(p_provider ai_provider)` to `supabase-schema.sql` — lightweight boolean wrapper over `resolve_sponsorship()`, callable by `authenticated` role
- Add sentinel assertion so future db-apply regressions surface immediately

## Deploy
Merging to main triggers `db-apply.yml` automatically (schema path filter).