### PR TITLE
fix(edge-fn): wrap serve handlers in try/catch so unhandled throws return CORS headers (#628)

### DIFF
--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -52,6 +52,7 @@ async function verifyToken(
 
 Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  try {
 
   const supabase = createClient(
     Deno.env.get('SUPABASE_URL')!,
@@ -310,6 +311,10 @@ Deno.serve(async (req: Request) => {
   }
 
   return json({ error: 'Not found' }, 404);
+  } catch (e) {
+    console.error('[api] unhandled error', e);
+    return json({ error: 'internal_error', detail: (e as Error).message }, 500);
+  }
 });
 
 function json(body: unknown, status = 200): Response {

--- a/supabase/functions/share-card/index.ts
+++ b/supabase/functions/share-card/index.ts
@@ -35,6 +35,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
+  try {
   const url = new URL(req.url);
   const obsId = url.searchParams.get('obs_id') ?? url.searchParams.get('id');
   const format = url.searchParams.get('format') ?? 'html';   // html | svg
@@ -173,4 +174,11 @@ serve(async (req) => {
       'cache-control': 'public, max-age=300',
     }),
   });
+  } catch (e) {
+    console.error('[share-card] unhandled error', e);
+    return new Response(JSON.stringify({ error: 'internal_error', detail: (e as Error).message }), {
+      status: 500,
+      headers: { 'content-type': 'application/json', ...CORS_HEADERS },
+    });
+  }
 });

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -88,6 +88,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
+  // Wrap the entire handler so unhandled throws still return CORS headers.
+  // Without this, Deno returns a bare 500 with no Access-Control-* headers
+  // and the browser reports a generic "Failed to fetch" instead of the real error.
+  try {
 
   // Support X-HTTP-Method-Override for environments that block DELETE/PUT (mobile carriers)
   const methodOverride = req.headers.get('X-HTTP-Method-Override');
@@ -788,4 +792,10 @@ serve(async (req) => {
   }
 
   return jsonResponse(404, { error: 'not_found', path, method: method });
+  } catch (e) {
+    // Unhandled error — return a CORS-safe 500 so the browser sees the real
+    // status instead of a bare network failure ("Failed to fetch").
+    console.error('[sponsorships] unhandled error', e);
+    return jsonResponse(500, { error: 'internal_error', detail: (e as Error).message });
+  }
 });


### PR DESCRIPTION
## Problem
Any unhandled exception in an Edge Function causes Deno/Supabase to return a bare 500 with **no `Access-Control-Allow-Origin` header**. The browser sees a generic `Failed to fetch` — the actual error is invisible to the user and the bug reporter.

Reproduced via the /profile/sponsoring/ bug report (2026-05-07T04:28): 4x `Failed to fetch` on POST /pools/:id and /credentials/:id.

## Fix
Wrap the `serve()` body in `try/catch` for user-facing functions with CORS:
- `sponsorships` — root cause of this report  
- `api` — public API endpoint  
- `share-card` — OG share cards

Cron/internal functions (award-badges, recompute-*, retry-*, stripe-webhook) are not user-facing and were left unchanged.