### PR TITLE
fix(console): 300 on /consola/observaciones + /consola/banderas (#629)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3222,6 +3222,15 @@ DROP POLICY IF EXISTS reports_owner_write ON public.reports;
 CREATE POLICY reports_owner_write ON public.reports FOR INSERT
   WITH CHECK (reporter_id = auth.uid());
 
+-- Admins and moderators can read all reports (powers the /consola/banderas/ view).
+DROP POLICY IF EXISTS reports_admin_read ON public.reports;
+CREATE POLICY reports_admin_read ON public.reports FOR SELECT
+  TO authenticated
+  USING (
+    public.has_role(auth.uid(), 'admin')
+    OR public.has_role(auth.uid(), 'moderator')
+  );
+
 -- 12) notifications
 CREATE TABLE IF NOT EXISTS public.notifications (
   id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/src/components/ConsoleFlagsView.astro
+++ b/src/components/ConsoleFlagsView.astro
@@ -131,10 +131,6 @@ const isEs = lang === 'es';
           isEs ? 'es' : 'en',
           { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' },
         );
-        const statusColor = flag.status === 'open' || flag.status === 'triaged'
-          ? 'text-amber-600'
-          : 'text-emerald-600';
-
         const row = document.createElement('div');
         row.className = 'rounded-lg border border-zinc-200 dark:border-zinc-800 p-3 flex items-start justify-between gap-3';
         row.innerHTML = `

--- a/src/components/ConsoleFlagsView.astro
+++ b/src/components/ConsoleFlagsView.astro
@@ -20,8 +20,10 @@ const isEs = lang === 'es';
       </h2>
       <div class="flex items-center gap-2">
         <select id="flags-status-filter" class="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1.5 text-sm">
-          <option value="pending">{isEs ? 'Pendientes' : 'Pending'}</option>
+          <option value="open">{isEs ? 'Abiertos' : 'Open'}</option>
+          <option value="triaged">{isEs ? 'En revisión' : 'Triaged'}</option>
           <option value="resolved">{isEs ? 'Resueltos' : 'Resolved'}</option>
+          <option value="dismissed">{isEs ? 'Descartados' : 'Dismissed'}</option>
           <option value="all">{isEs ? 'Todos' : 'All'}</option>
         </select>
         <button id="flags-refresh" type="button" class="rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:hover:bg-zinc-800/40">
@@ -80,8 +82,10 @@ const isEs = lang === 'es';
 
   function statusPill(s: string): string {
     const cls: Record<string, string> = {
-      pending: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
-      resolved: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+      open:      'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+      triaged:   'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+      resolved:  'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+      dismissed: 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300',
     };
     return `<span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded ${cls[s] ?? 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'}">${escapeHtml(s)}</span>`;
   }
@@ -97,7 +101,7 @@ const isEs = lang === 'es';
     try {
       const supabase = getSupabase();
       let query = supabase
-        .from('flags')
+        .from('reports')
         .select('*, users!reporter_id(display_name, username)', { count: 'exact' })
         .order('created_at', { ascending: false })
         .range(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE - 1);
@@ -127,7 +131,7 @@ const isEs = lang === 'es';
           isEs ? 'es' : 'en',
           { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' },
         );
-        const statusColor = flag.status === 'pending'
+        const statusColor = flag.status === 'open' || flag.status === 'triaged'
           ? 'text-amber-600'
           : 'text-emerald-600';
 
@@ -188,7 +192,7 @@ const isEs = lang === 'es';
     if (!myRoles.has('admin')) { show('flags-not-auth'); return; }
     shell?.classList.remove('hidden');
     const params = new URLSearchParams(window.location.search);
-    if (filterEl && params.has('status')) filterEl.value = params.get('status') ?? 'pending';
+    if (filterEl && params.has('status')) filterEl.value = params.get('status') ?? 'open';
     await loadFlags();
   })().catch(() => { show('flags-not-auth'); });
 </script>

--- a/src/components/ConsoleObservationsView.astro
+++ b/src/components/ConsoleObservationsView.astro
@@ -237,7 +237,7 @@ const tr = t(lang);
 
     let query = supabase
       .from('observations')
-      .select('id, observer_id, observed_at, primary_taxon_id, obscure_level, location_obscured, hidden, hidden_reason, hidden_at, hidden_by, sync_status, created_at, taxa(scientific_name), users:observer_id(username, display_name, observer_license)')
+      .select('id, observer_id, observed_at, primary_taxon_id, obscure_level, location_obscured, hidden, hidden_reason, hidden_at, hidden_by, sync_status, created_at, taxa(scientific_name), users!observer_id(username, display_name, observer_license)')
       .order('created_at', { ascending: false })
       .limit(50);
 


### PR DESCRIPTION
## Problems

### /consola/observaciones → GET /rest/v1/observations → 300
`users:observer_id(...)` — PostgREST returned 300 Multiple Choices (ambiguous FK). Fixed to `users!observer_id(...)` (explicit FK hint).

### /consola/banderas → GET /rest/v1/flags → 300
`.from('flags')` — table doesn't exist. The DB table is `reports`. Also fixed:
- Status filter options matched non-existent `pending` enum value; updated to real values: `open / triaged / resolved / dismissed`
- `statusPill()` only had `pending` and `resolved`; added all 4 real statuses with appropriate colors
- URL param default fallback `'pending'` → `'open'`