### PR TITLE
fix(auth): remove broken custom gotrue lock — deadlocked getSession()

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -32,17 +32,10 @@ let client: SupabaseClient | null = null;
  */
 export function getSupabase(): SupabaseClient {
   if (client) return client;
-  // Use the browser's native Web Locks API for the gotrue mutex (instead
-  // of the library's default async-mutex polyfill). Native locks are
-  // automatically released when the holder tab/page closes, eliminating
-  // the "Lock 'lock:rastrum-auth-v1' was not released within 5000ms"
-  // warnings on every page nav.
-  const lock = (typeof navigator !== 'undefined' && navigator.locks)
-    ? async <T>(name: string, acquireTimeout: number, fn: () => Promise<T>): Promise<T> => {
-        return navigator.locks.request(name, { mode: 'exclusive' }, async () => fn());
-      }
-    : undefined;
-
+  // No `lock` option: supabase-js auto-selects its proper `navigatorLock`
+  // in browsers when persistSession=true. Passing a custom lock that
+  // ignores `acquireTimeout` deadlocks getSession() if a previous holder
+  // (e.g. an interrupted token refresh) doesn't release.
   client = createClient(url ?? '', anonKey ?? '', {
     auth: {
       persistSession: true,
@@ -50,7 +43,6 @@ export function getSupabase(): SupabaseClient {
       detectSessionInUrl: true,
       flowType: 'pkce',
       storageKey: 'rastrum-auth-v1',
-      ...(lock ? { lock } : {}),
     },
   });
   return client;


### PR DESCRIPTION
## Summary

Saving an API key on the AI-sponsoring page left the Save button stuck on **"Saving…" disabled** with no Network request, no console error, and no warning. The submit handler started, awaited `createCredential()` → `authedFetch()` → `getSession()`, and the promise never resolved → `finally` never re-enabled the button.

## Root cause

`src/lib/supabase.ts` passed a custom `lock` option to `createClient` that:

- ignored the `acquireTimeout` parameter
- never stole an orphan lock

When a previous holder (e.g. an interrupted auto-refresh, or a racing concurrent call) didn't release the gotrue mutex, every subsequent `getSession()` awaited a `navigator.locks.request` with no timeout / no abort signal and **hung forever**.

`@supabase/auth-js@2.104.x` already auto-selects its proper `navigatorLock` (with timeout + steal-on-orphan recovery) when `persistSession=true` and `navigator.locks` is available — exactly when our wrapper used to apply. Passing our own lock **disabled that auto-selection** and replaced it with a strictly worse implementation.

The override existed to silence the old `"Lock not released within 5000ms"` warning from the `processLock` polyfill. That warning no longer applies because supabase-js now picks `navigatorLock` by default in browsers.

## Fix

Drop the custom lock. Trust the library default. Net change: **+4 / −12**.

## How to test

1. Sign in.
2. Open `/profile/sponsoring/` (or wherever the AI-sponsoring credential dialog lives).
3. Click **Add credential**, paste any API key (OpenAI / Anthropic / Gemini), click **Save**.
4. Save completes (or returns a clean error from the EF) instead of hanging on "Saving…".

If you still saw a hang on the buggy version, **reload the tab once** after deploy to release any orphaned native Web Lock — the proper `navigatorLock` will steal future orphans automatically.

## Verification

- `npx tsc --noEmit` ✓
- `npm run test` ✓ (962/962)

🤖 Generated with [Claude Code](https://claude.com/claude-code)