### PR TITLE
fix(console-flags): wrong table name, stale status values, missing admin RLS

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3222,6 +3222,15 @@ DROP POLICY IF EXISTS reports_owner_write ON public.reports;
 CREATE POLICY reports_owner_write ON public.reports FOR INSERT
   WITH CHECK (reporter_id = auth.uid());
 
+-- Admins and moderators can read all reports (powers the /consola/banderas/ view).
+DROP POLICY IF EXISTS reports_admin_read ON public.reports;
+CREATE POLICY reports_admin_read ON public.reports FOR SELECT
+  TO authenticated
+  USING (
+    public.has_role(auth.uid(), 'admin')
+    OR public.has_role(auth.uid(), 'moderator')
+  );
+
 -- 12) notifications
 CREATE TABLE IF NOT EXISTS public.notifications (
   id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/src/components/ConsoleFlagsView.astro
+++ b/src/components/ConsoleFlagsView.astro
@@ -20,8 +20,10 @@ const isEs = lang === 'es';
       </h2>
       <div class="flex items-center gap-2">
         <select id="flags-status-filter" class="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1.5 text-sm">
-          <option value="pending">{isEs ? 'Pendientes' : 'Pending'}</option>
+          <option value="open">{isEs ? 'Abiertos' : 'Open'}</option>
+          <option value="triaged">{isEs ? 'Revisados' : 'Triaged'}</option>
           <option value="resolved">{isEs ? 'Resueltos' : 'Resolved'}</option>
+          <option value="dismissed">{isEs ? 'Descartados' : 'Dismissed'}</option>
           <option value="all">{isEs ? 'Todos' : 'All'}</option>
         </select>
         <button id="flags-refresh" type="button" class="rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-1.5 text-sm hover:bg-zinc-50 dark:hover:bg-zinc-800/40">
@@ -61,7 +63,7 @@ const isEs = lang === 'es';
 
   const PAGE_SIZE = 20;
   let currentPage = 0;
-  let currentFilter = 'pending';
+  let currentFilter = 'open';
 
   const isEs = document.documentElement.lang === 'es';
   const shell = document.getElementById('flags-shell');
@@ -80,8 +82,10 @@ const isEs = lang === 'es';
 
   function statusPill(s: string): string {
     const cls: Record<string, string> = {
-      pending: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+      open: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+      triaged: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
       resolved: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+      dismissed: 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400',
     };
     return `<span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded ${cls[s] ?? 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'}">${escapeHtml(s)}</span>`;
   }
@@ -96,8 +100,9 @@ const isEs = lang === 'es';
 
     try {
       const supabase = getSupabase();
+      // Table is "reports" (not "flags"); FK hint uses reporter_id → users
       let query = supabase
-        .from('flags')
+        .from('reports')
         .select('*, users!reporter_id(display_name, username)', { count: 'exact' })
         .order('created_at', { ascending: false })
         .range(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE - 1);
@@ -127,9 +132,6 @@ const isEs = lang === 'es';
           isEs ? 'es' : 'en',
           { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' },
         );
-        const statusColor = flag.status === 'pending'
-          ? 'text-amber-600'
-          : 'text-emerald-600';
 
         const row = document.createElement('div');
         row.className = 'rounded-lg border border-zinc-200 dark:border-zinc-800 p-3 flex items-start justify-between gap-3';
@@ -188,7 +190,7 @@ const isEs = lang === 'es';
     if (!myRoles.has('admin')) { show('flags-not-auth'); return; }
     shell?.classList.remove('hidden');
     const params = new URLSearchParams(window.location.search);
-    if (filterEl && params.has('status')) filterEl.value = params.get('status') ?? 'pending';
+    if (filterEl && params.has('status')) filterEl.value = params.get('status') ?? 'open';
     await loadFlags();
   })().catch(() => { show('flags-not-auth'); });
 </script>


### PR DESCRIPTION
## Problem

The `/es/consola/banderas/` page failed on every load.

Reported: `2026-05-07T04:58:35Z` — `GET /rest/v1/flags` → error (table does not exist).

Three bugs in `ConsoleFlagsView.astro`:

### 1. Wrong table name
```diff
- .from('flags')
+ .from('reports')
```
The table is `reports`. `flags` does not exist → PostgREST 404, component renders nothing.

### 2. Stale status values
Schema defines: `open | triaged | resolved | dismissed`
Component filtered by: `pending | resolved | all`

`pending` never matched any row → default view always empty even with a correct table name.

Fixed: default filter is now `open`; dropdown exposes all four real values with proper labels.

### 3. Missing admin RLS policy
`reports` only had `reports_owner_read` (`reporter_id = auth.uid()`).
An admin querying the full table got an empty result set. Added:
```sql
CREATE POLICY reports_admin_read ON public.reports FOR SELECT
  TO authenticated
  USING (
    public.has_role(auth.uid(), 'admin')
    OR public.has_role(auth.uid(), 'moderator')
  );
```

### Bonus: dead code removed
`statusColor` variable was declared but never used in the template (colors handled by `statusPill()`). Removed. `statusPill()` now maps all 4 real statuses to distinct colors.

## Changes
- `src/components/ConsoleFlagsView.astro` — table name, default filter, status options, statusPill colours, dead code removed
- `docs/specs/infra/supabase-schema.sql` — `reports_admin_read` RLS policy

## Schema migration required
The `reports_admin_read` policy needs to be applied to the live DB via `db-apply` before the UI works end-to-end.

## Companion
#633 — fixes the same 300 error on `/consola/observaciones/` (`users!observer_id` FK hint in `ConsoleObservationsView`). Both should land together.