### PR TITLE
fix(console-obs): users!observer_id FK hint — fixes 300 on /consola/observaciones

### DIFF
--- a/src/components/ConsoleObservationsView.astro
+++ b/src/components/ConsoleObservationsView.astro
@@ -237,7 +237,7 @@ const tr = t(lang);
 
     let query = supabase
       .from('observations')
-      .select('id, observer_id, observed_at, primary_taxon_id, obscure_level, location_obscured, hidden, hidden_reason, hidden_at, hidden_by, sync_status, created_at, taxa(scientific_name), users:observer_id(username, display_name, observer_license)')
+      .select('id, observer_id, observed_at, primary_taxon_id, obscure_level, location_obscured, hidden, hidden_reason, hidden_at, hidden_by, sync_status, created_at, taxa(scientific_name), users!observer_id(username, display_name, observer_license)')
       .order('created_at', { ascending: false })
       .limit(50);
 


### PR DESCRIPTION
Companion to #632 (Nyx's flags fix).

`users:observer_id(...)` → `users!observer_id(...)` in `ConsoleObservationsView`.

PostgREST returns 300 when the colon-alias syntax is ambiguous. The `!` form is the explicit FK hint and resolves cleanly.