### PR TITLE
fix(profile): add missing Phi Vision opt-in toggle

### DIFF
--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -290,6 +290,14 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
             </div>
           </div>
           <p id="vision-progress" class="hidden mt-2 text-xs text-zinc-600 dark:text-zinc-400 font-mono"></p>
+
+          <label class="mt-3 flex items-start gap-2 cursor-pointer">
+            <input type="checkbox" id="phi-vision-enable" class="mt-0.5" />
+            <div>
+              <p class="text-xs text-zinc-700 dark:text-zinc-300">{tr.auth.phi_vision_enable_label}</p>
+              <p class="text-[11px] text-amber-700 dark:text-amber-400 mt-0.5">{tr.auth.phi_vision_enable_warning}</p>
+            </div>
+          </label>
         </div>
 
         <!-- Text -->
@@ -883,6 +891,22 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
     optinBox.addEventListener('change', () => {
       if (optinBox.checked) localStorage.setItem(LAI_OPTIN, 'true');
       else                  localStorage.removeItem(LAI_OPTIN);
+    });
+  }
+
+  // Phi-3.5-vision is gated behind explicit opt-in. The MLC q4f16_1
+  // build crashes with WebGPU "Binding size 1 isn't a multiple of 4"
+  // errors on certain GPU/driver combos (esp. Apple Silicon Metal,
+  // Chromium 147+). Until MLC ships an alignment-fixed artifact, this
+  // toggle keeps Phi off-by-default; flipping it makes the model
+  // available to ObservationForm + the obs2 capability banner.
+  const PHI_OPTIN = 'rastrum.prefs.usePhiVision';
+  const phiBox = document.getElementById('phi-vision-enable') as HTMLInputElement | null;
+  if (phiBox) {
+    phiBox.checked = localStorage.getItem(PHI_OPTIN) === 'true';
+    phiBox.addEventListener('change', () => {
+      if (phiBox.checked) localStorage.setItem(PHI_OPTIN, 'true');
+      else                localStorage.removeItem(PHI_OPTIN);
     });
   }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -306,6 +306,8 @@
     "local_ai_unsupported": "Your browser does not support WebGPU — on-device AI is unavailable.",
     "local_ai_opt_in": "Allow on-device AI as a fallback when no Claude key is set",
     "local_ai_warning": "Phi-3.5-vision is a general AI without taxonomic training. Results are capped at low confidence and never count toward research-grade.",
+    "phi_vision_enable_label": "Use Phi Vision in the identification cascade",
+    "phi_vision_enable_warning": "Experimental — the current MLC build can crash on Apple Silicon Metal and Chromium 147+. Enable only if you're willing to hit occasional WebGPU errors. Requires the model to be downloaded above.",
     "local_ai_download_vision": "Download vision model (~4 GB)",
     "local_ai_download_text": "Download text helpers (~880 MB)",
     "local_ai_downloading": "Downloading…",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -306,6 +306,8 @@
     "local_ai_unsupported": "Tu navegador no soporta WebGPU — la IA local no está disponible.",
     "local_ai_opt_in": "Permitir IA local como respaldo cuando no haya key de Claude",
     "local_ai_warning": "Phi-3.5-vision es una IA general sin entrenamiento taxonómico. Los resultados se limitan a baja confianza y nunca cuentan para grado-investigación.",
+    "phi_vision_enable_label": "Usar Phi Vision en la cascada de identificación",
+    "phi_vision_enable_warning": "Experimental — la build actual de MLC puede crashear en Apple Silicon Metal y Chromium 147+. Actívalo solo si aceptas errores ocasionales de WebGPU. Requiere que el modelo esté descargado arriba.",
     "local_ai_download_vision": "Descargar modelo de visión (~4 GB)",
     "local_ai_download_text": "Descargar ayudantes de texto (~880 MB)",
     "local_ai_downloading": "Descargando…",


### PR DESCRIPTION
## Summary

- The capability banner on `/observe` reads `localStorage['rastrum.prefs.usePhiVision'] === 'true'` to gate ✅/❌ for Phi Vision (`ObserveView2.astro:555`), and the cascade in `ObservationForm.astro:1132` gates the runner the same way — but **no UI in the codebase ever wrote this key**. Users who downloaded the 4 GB Phi model could never get a green checkmark unless they opened DevTools manually.
- Adds an opt-in checkbox inside the Phi-3.5-vision card in Profile → Edit (the section the banner's "Set up →" link already points to), with a warning about the known MLC q4f16_1 WebGPU alignment crashes on Apple Silicon Metal / Chromium 147+ that motivated the strict opt-in (per the existing comment in `ObservationForm.astro:1121-1129`).
- EN/ES strings (`auth.phi_vision_enable_label`, `auth.phi_vision_enable_warning`).

Same hydration pattern as the adjacent `local-ai-optin` checkbox: read on mount, `setItem`/`removeItem` on change. No new deps, no new tests beyond the existing 962-test suite.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 962/962 passing
- [x] `npm run build` — 231 pages, EN/ES paired
- [ ] Manual: load `/en/profile/edit#on-device-ai-section`, toggle the new checkbox, reload `/en/observe`, confirm "Phi Vision (local)" flips ✅/❌
- [ ] Manual: same flow on `/es/perfil/editar` to confirm ES string renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)