### PR TITLE
fix(console): drop thenable trap that broke admin filter chains

### DIFF
--- a/docs/runbooks/admin-entity-browsers.md
+++ b/docs/runbooks/admin-entity-browsers.md
@@ -149,12 +149,45 @@ to a single shared key and only the last-clicked row stays open.
 ### Filtering on a baseline predicate
 
 Some browsers need an always-on baseline (e.g. taxon-changes filters
-admin_audit to `op IN ('taxon_conservation_set', …)`). Pattern:
-prepend a synthetic `FilterSpec` with `key: '__op_baseline'` to the
-filters array, and inject a hidden `<input id="<prefix>-f-__op_baseline" value="1" />`
-so `applyFilters()` runs the predicate. The synthetic filter doesn't
-render a form element (the `<ConsoleEntityBrowser>` only enumerates the
-declared `filters` prop).
+admin_audit to `op IN ('taxon_conservation_set', …)`). Pass the
+predicate as `BrowserConfig.baseline`:
+
+```ts
+new EntityBrowser<Row>({
+  // …
+  baseline: (q: SupabaseQuery): SupabaseQuery => q.in('op', TAXON_OPS),
+});
+```
+
+It is applied after `.order()` and before any user filter, runs
+synchronously, and never persists to the URL. The earlier "synthetic
+`__op_baseline` filter + hidden input" workaround is gone — it ran
+through `applyFilters` whose `await f.apply(...)` triggered the
+PostgrestFilterBuilder thenable and stripped `.range()` off the chain.
+
+### The thenable trap (FilterSpec.apply contract)
+
+`PostgrestFilterBuilder` is itself thenable: its `.then()` method
+fires the HTTP request. That means a sync apply that does
+`return q.eq(...)` cannot be naively `await`ed (await would execute
+the query early and return the response body), and an async apply
+that does `return q.eq(...)` is auto-unwrapped by the Promise
+machinery for the same reason.
+
+`applyFilters` handles this for sync apply by inspecting the return
+value (presence of `.range`) and using it without `await`. Async apply
+must wrap its result in `{ q }` so the resolved Promise payload is a
+plain object, not a thenable:
+
+```ts
+apply: async (q, v): Promise<{ q: SupabaseQuery | null }> => {
+  const id = await resolveUserId(v);
+  return { q: id ? q.eq('actor_id', id) : null };
+}
+```
+
+`applyFilters` itself returns `Promise<{ q: SupabaseQuery | null }>`
+for the same reason — callers unpack with `(await applyFilters(…)).q`.
 
 ### Lazy aggregate facets in drill-downs
 

--- a/src/components/ConsoleFollowsView.astro
+++ b/src/components/ConsoleFollowsView.astro
@@ -121,18 +121,18 @@ const labels = {
       key: 'follower',
       label: 'Follower',
       kind: 'autocomplete',
-      apply: async (q: SupabaseQuery, v: string): Promise<SupabaseQuery | null> => {
+      apply: async (q: SupabaseQuery, v: string): Promise<{ q: SupabaseQuery | null }> => {
         const id = await resolveUserId(v);
-        return id ? q.eq('follower_id', id) : null;
+        return { q: id ? q.eq('follower_id', id) : null };
       },
     },
     {
       key: 'followee',
       label: 'Followee',
       kind: 'autocomplete',
-      apply: async (q: SupabaseQuery, v: string): Promise<SupabaseQuery | null> => {
+      apply: async (q: SupabaseQuery, v: string): Promise<{ q: SupabaseQuery | null }> => {
         const id = await resolveUserId(v);
-        return id ? q.eq('followee_id', id) : null;
+        return { q: id ? q.eq('followee_id', id) : null };
       },
     },
     { key: 'status', label: 'Status', kind: 'select', apply: filterPredicates.eq('status') },

--- a/src/components/ConsoleIdentificationsView.astro
+++ b/src/components/ConsoleIdentificationsView.astro
@@ -138,18 +138,18 @@ const labels = {
       key: 'identifier',
       label: 'Identifier',
       kind: 'autocomplete',
-      apply: async (q: SupabaseQuery, v: string): Promise<SupabaseQuery | null> => {
+      apply: async (q: SupabaseQuery, v: string): Promise<{ q: SupabaseQuery | null }> => {
         const id = await resolveUserId(v);
-        return id ? q.eq('validated_by', id) : null;
+        return { q: id ? q.eq('validated_by', id) : null };
       },
     },
     {
       key: 'taxon',
       label: 'Taxon',
       kind: 'autocomplete',
-      apply: async (q: SupabaseQuery, v: string): Promise<SupabaseQuery | null> => {
+      apply: async (q: SupabaseQuery, v: string): Promise<{ q: SupabaseQuery | null }> => {
         const id = await resolveTaxonId(v);
-        return id ? q.eq('taxon_id', id) : null;
+        return { q: id ? q.eq('taxon_id', id) : null };
       },
     },
     {

--- a/src/components/ConsoleNotificationsView.astro
+++ b/src/components/ConsoleNotificationsView.astro
@@ -115,9 +115,9 @@ const labels = {
       key: 'recipient',
       label: 'Recipient',
       kind: 'autocomplete',
-      apply: async (q: SupabaseQuery, v: string): Promise<SupabaseQuery | null> => {
+      apply: async (q: SupabaseQuery, v: string): Promise<{ q: SupabaseQuery | null }> => {
         const id = await resolveUserId(v);
-        return id ? q.eq('user_id', id) : null;
+        return { q: id ? q.eq('user_id', id) : null };
       },
     },
     {

--- a/src/components/ConsoleProjectsView.astro
+++ b/src/components/ConsoleProjectsView.astro
@@ -119,9 +119,9 @@ const labels = {
       key: 'owner',
       label: 'Owner',
       kind: 'autocomplete',
-      apply: async (q: SupabaseQuery, v: string): Promise<SupabaseQuery | null> => {
+      apply: async (q: SupabaseQuery, v: string): Promise<{ q: SupabaseQuery | null }> => {
         const id = await resolveUserId(v);
-        return id ? q.eq('owner_user_id', id) : null;
+        return { q: id ? q.eq('owner_user_id', id) : null };
       },
     },
     { key: 'visibility', label: 'Visibility', kind: 'select', apply: filterPredicates.eq('visibility') },

--- a/src/components/ConsoleTaxonChangesView.astro
+++ b/src/components/ConsoleTaxonChangesView.astro
@@ -126,9 +126,9 @@ const labels = {
       key: 'actor',
       label: 'Actor',
       kind: 'autocomplete',
-      apply: async (q: SupabaseQuery, v: string): Promise<SupabaseQuery | null> => {
+      apply: async (q: SupabaseQuery, v: string): Promise<{ q: SupabaseQuery | null }> => {
         const id = await resolveUserId(v);
-        return id ? q.eq('actor_id', id) : null;
+        return { q: id ? q.eq('actor_id', id) : null };
       },
     },
     { key: 'from', label: 'From', kind: 'date', apply: filterPredicates.gteDate('created_at') },
@@ -211,31 +211,14 @@ const labels = {
     }
     document.getElementById('txc-shell')?.classList.remove('hidden');
 
-    // Pre-baseline filter: limit admin_audit to taxon-related ops. We model
-    // this as a synthetic filter so it shows up in the chain before the
-    // user-selected ones, and it persists across pagination.
-    const taxonOpsFilter: FilterSpec = {
-      key: '__op_baseline',
-      label: '',
-      kind: 'select',
-      apply: (q: SupabaseQuery): SupabaseQuery => q.in('op', TAXON_OPS),
-    };
-    // Always-on baseline: applied via a wrapping filter list whose value is
-    // hard-coded to a non-empty sentinel so applyFilters() runs the
-    // predicate. We don't render the underlying form element.
-    const baselineHidden = document.createElement('input');
-    baselineHidden.type = 'hidden';
-    baselineHidden.id = 'txc-f-__op_baseline';
-    baselineHidden.value = '1';
-    document.getElementById('txc-shell')?.appendChild(baselineHidden);
-
     const browser = new EntityBrowser<Row>({
       prefix: 'txc',
       tableName: 'admin_audit',
       selectClause: 'id, created_at, actor_id, op, target_type, target_id, before, after, reason',
       orderBy: 'created_at',
       columns,
-      filters: [taxonOpsFilter, ...filters],
+      filters,
+      baseline: (q: SupabaseQuery): SupabaseQuery => q.in('op', TAXON_OPS),
       resolveUsersFromRow: r => [r.actor_id],
       resolveTaxaFromRow: r => (r.target_id && isUuid(r.target_id) ? [r.target_id] : []),
       rowIdFromRow: r => String(r.id),

--- a/src/components/ConsoleWatchlistsView.astro
+++ b/src/components/ConsoleWatchlistsView.astro
@@ -103,9 +103,9 @@ const labels = {
       key: 'user',
       label: 'User',
       kind: 'autocomplete',
-      apply: async (q: SupabaseQuery, v: string): Promise<SupabaseQuery | null> => {
+      apply: async (q: SupabaseQuery, v: string): Promise<{ q: SupabaseQuery | null }> => {
         const id = await resolveUserId(v);
-        return id ? q.eq('user_id', id) : null;
+        return { q: id ? q.eq('user_id', id) : null };
       },
     },
     {

--- a/src/lib/entity-browser.ts
+++ b/src/lib/entity-browser.ts
@@ -41,8 +41,21 @@ export interface FilterSpec {
    * supabase-js predicate builder — receives the running query and the
    * current filter value (string), returns the modified query.
    * Predicates short-circuit to an empty rowset by returning null.
+   *
+   * IMPORTANT: PostgrestFilterBuilder is itself thenable (it has a `.then`
+   * method that triggers the HTTP request). That means an `async` apply
+   * that does `return q.eq(...)` will be auto-unwrapped by the Promise
+   * machinery — `await` resolves to the response object, not the builder.
+   * For sync apply functions we read the return value without awaiting,
+   * which is safe; for async apply functions the contract requires
+   * wrapping the result as `{ q }` so the Promise resolution sees a plain
+   * object and does not recurse into the thenable. See `applyFilters`.
    */
-  apply: (query: SupabaseQuery, value: string) => Promise<SupabaseQuery | null> | (SupabaseQuery | null);
+  apply: (query: SupabaseQuery, value: string) =>
+    | SupabaseQuery
+    | null
+    | { q: SupabaseQuery | null }
+    | Promise<{ q: SupabaseQuery | null }>;
 }
 
 /** Render-side type for one column. `render` returns a trusted HTML fragment (escape your inputs). */
@@ -97,6 +110,13 @@ export interface BrowserConfig<Row extends { id?: string; [k: string]: unknown }
   loadingText: string;
   /** Locale (en | es). */
   lang: 'en' | 'es';
+  /**
+   * Always-on baseline predicate applied after `.order()` and before any
+   * user filter. Pure synchronous — must not await. Used by views that
+   * need to scope a shared backing table down to a fixed subset (e.g. the
+   * taxon-changes browser scoping `admin_audit` to taxon-touching ops).
+   */
+  baseline?: (q: SupabaseQuery) => SupabaseQuery;
 }
 
 // Minimal supabase-js PostgrestFilterBuilder slice — typed as `unknown` so this
@@ -119,20 +139,45 @@ export type SupabaseQuery = {
  * Filter-to-supabase-query translator. Pure — takes an empty query, applies
  * each filter that has a non-empty value, returns the resulting query.
  * Used by EntityBrowser internally and exported for unit-testing.
+ *
+ * Thenable trap: PostgrestFilterBuilder has a `.then()` method that fires
+ * the HTTP request, so `await <builder>` would execute the query early and
+ * resolve to a response object stripped of `.range()`. The return value is
+ * therefore wrapped in `{ q }` — plain objects are not thenable, so the
+ * caller's `await` does not recurse into the builder. Inside the loop we
+ * also never blindly await an apply result; we inspect its shape first and
+ * only await real Promises whose payload is a plain `{ q }` wrapper. See
+ * the FilterSpec.apply doc comment for the contract.
  */
 export async function applyFilters(
   query: SupabaseQuery,
   filters: FilterSpec[],
   values: Record<string, string>,
-): Promise<SupabaseQuery | null> {
+): Promise<{ q: SupabaseQuery | null }> {
   let q: SupabaseQuery | null = query;
   for (const f of filters) {
     const v = values[f.key];
     if (!v || v === '') continue;
-    q = await f.apply(q, v);
-    if (q === null) return null;
+    const raw = f.apply(q, v);
+    let next: SupabaseQuery | null;
+    if (raw === null) {
+      next = null;
+    } else if (typeof (raw as { range?: unknown }).range === 'function') {
+      // Sync builder return — taken as-is, never awaited.
+      next = raw as SupabaseQuery;
+    } else {
+      // `{ q }` wrapper, sync or in a Promise. Plain objects are not
+      // thenable, so awaiting the wrapper does not recurse into the
+      // builder it contains.
+      const wrapped = await (raw as
+        | { q: SupabaseQuery | null }
+        | Promise<{ q: SupabaseQuery | null }>);
+      next = wrapped.q;
+    }
+    if (next === null) return { q: null };
+    q = next;
   }
-  return q;
+  return { q };
 }
 
 /** Common filter primitives for use in FilterSpec.apply callbacks. */
@@ -439,7 +484,8 @@ export class EntityBrowser<Row extends { id?: string; [k: string]: unknown }> {
         .select(this.cfg.selectClause, { count: 'exact' });
       q = built as unknown as SupabaseQuery;
       q = q.order(this.cfg.orderBy, { ascending: false });
-      q = await applyFilters(q, this.cfg.filters, values);
+      if (this.cfg.baseline) q = this.cfg.baseline(q);
+      q = (await applyFilters(q, this.cfg.filters, values)).q;
       if (q === null) {
         // Filter resolved to "no possible rows" (e.g. unknown username)
         this.hide('skeleton');
@@ -447,22 +493,12 @@ export class EntityBrowser<Row extends { id?: string; [k: string]: unknown }> {
         this.renderPagination();
         return;
       }
-      // Defensive: a buggy FilterSpec.apply that doesn't return the running
-      // query will silently strip .range() off `q`. Detect it loudly here
-      // instead of throwing the cryptic minified `r.range is not a function`.
-      // TODO(#260): this is a defensive guard, NOT a root-cause fix. PR #258
-      // hit this in production but static analysis of every FilterSpec.apply
-      // showed each one returning the query (or null) correctly. When this
-      // warn fires in production, capture the offending filter keys + the
-      // active view's prefix from the log and trace which apply mutates `q`
-      // into a non-builder shape. Prime suspects: autocomplete-resolved
-      // filters that swap to a different supabase-js builder type, or any
-      // future filter that does an inline `await q.from(...)` (which kills
-      // the chain).
+      // Sanity guard: now that applyFilters never blindly awaits a thenable
+      // builder this should never fire, but keep it as a regression alarm.
       if (typeof (q as { range?: unknown }).range !== 'function') {
         const offendingKeys = Object.keys(values).filter(k => values[k]);
         console.warn(
-          `entity-browser[${this.cfg.prefix}]: a filter.apply returned a non-query value (likely missing return). Active filters:`,
+          `entity-browser[${this.cfg.prefix}]: filter chain lost the builder shape. Active filters:`,
           offendingKeys,
         );
         throw new Error('Filter chain produced an invalid query. Clear filters and retry.');

--- a/tests/lib/entity-browser.test.ts
+++ b/tests/lib/entity-browser.test.ts
@@ -109,7 +109,7 @@ describe('entity-browser: applyFilters', () => {
     expect(calls[1].method).toBe('ilike');
   });
 
-  it('returns null short-circuit when an apply returns null', async () => {
+  it('returns wrapped null short-circuit when an apply returns null', async () => {
     const { q } = mockQuery();
     const shortFilter: FilterSpec[] = [
       {
@@ -120,13 +120,114 @@ describe('entity-browser: applyFilters', () => {
       },
     ];
     const result = await applyFilters(q, shortFilter, { identifier: 'unknown-user' });
-    expect(result).toBeNull();
+    expect(result).toEqual({ q: null });
   });
 
   it('skips filters whose value is undefined', async () => {
     const { q, calls } = mockQuery();
     await applyFilters(q, filters, {});
     expect(calls).toHaveLength(0);
+  });
+
+  /**
+   * Regression for #260 / #275 — PostgrestFilterBuilder is itself thenable
+   * (its `.then()` triggers the HTTP request), so naively `await`ing the
+   * result of an apply that returns a sync builder, or of an `async` apply
+   * that does `return q.eq(...)`, would resolve to the response object and
+   * strip `.range()` off the chain. applyFilters must NOT trigger the
+   * thenable when the apply hands back a builder.
+   */
+  describe('thenable safety', () => {
+    it('does not invoke .then() when a sync apply returns a builder', async () => {
+      // Use a mutable counter the proxy can write to.
+      const counter = { thenCalls: 0 };
+      const calls: Call[] = [];
+      const q: SupabaseQuery = new Proxy({}, {
+        get(_t, prop) {
+          if (prop === 'then') {
+            return (resolve: (v: unknown) => void) => {
+              counter.thenCalls += 1;
+              resolve({ data: 'response', count: 0 });
+            };
+          }
+          if (typeof prop === 'symbol') return undefined;
+          return (...args: unknown[]) => {
+            calls.push({ method: prop as string, args });
+            return q;
+          };
+        },
+      }) as unknown as SupabaseQuery;
+
+      const syncFilter: FilterSpec[] = [
+        { key: 'k', label: 'k', kind: 'select', apply: filterPredicates.eq('col') },
+      ];
+      const result = await applyFilters(q, syncFilter, { k: 'v' });
+
+      expect(counter.thenCalls).toBe(0);
+      expect(result.q).toBe(q);
+      expect(calls).toEqual([{ method: 'eq', args: ['col', 'v'] }]);
+    });
+
+    it('does not invoke .then() when an async apply returns a wrapped builder', async () => {
+      const counter = { thenCalls: 0 };
+      const calls: Call[] = [];
+      const q: SupabaseQuery = new Proxy({}, {
+        get(_t, prop) {
+          if (prop === 'then') {
+            return (resolve: (v: unknown) => void) => {
+              counter.thenCalls += 1;
+              resolve({ data: 'response', count: 0 });
+            };
+          }
+          if (typeof prop === 'symbol') return undefined;
+          return (...args: unknown[]) => {
+            calls.push({ method: prop as string, args });
+            return q;
+          };
+        },
+      }) as unknown as SupabaseQuery;
+
+      const asyncFilter: FilterSpec[] = [
+        {
+          key: 'actor',
+          label: 'actor',
+          kind: 'autocomplete',
+          apply: async (qq, v) => {
+            await Promise.resolve();
+            return { q: qq.eq('actor_id', v) };
+          },
+        },
+      ];
+      const result = await applyFilters(q, asyncFilter, { actor: 'abc' });
+
+      expect(counter.thenCalls).toBe(0);
+      expect(result.q).toBe(q);
+      expect(calls).toEqual([{ method: 'eq', args: ['actor_id', 'abc'] }]);
+    });
+
+    it('short-circuits when wrapped result has q: null', async () => {
+      const calls: Call[] = [];
+      const q: SupabaseQuery = new Proxy({}, {
+        get(_t, prop) {
+          if (prop === 'then' || typeof prop === 'symbol') return undefined;
+          return (...args: unknown[]) => {
+            calls.push({ method: prop as string, args });
+            return q;
+          };
+        },
+      }) as unknown as SupabaseQuery;
+
+      const filterList: FilterSpec[] = [
+        {
+          key: 'actor',
+          label: 'actor',
+          kind: 'autocomplete',
+          apply: async () => ({ q: null }),
+        },
+      ];
+      const result = await applyFilters(q, filterList, { actor: 'unknown' });
+      expect(result.q).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- `PostgrestFilterBuilder` from `@supabase/postgrest-js` is itself thenable — its `.then()` fires the HTTP request. `entity-browser.ts::applyFilters` was doing `q = await f.apply(q, v)`, which on a sync builder return (or an `async` apply that did `return q.eq(...)`) executed the query early and resolved `q` to the response object stripped of `.range()`.
- Fixed by wrapping the apply / applyFilters return values as `{ q }` (plain objects aren't thenable, so the Promise machinery doesn't recurse) and by inspecting sync apply returns without awaiting them.
- Replaced the synthetic ` __op_baseline` filter + hidden input pattern in `ConsoleTaxonChangesView` with a clean `BrowserConfig.baseline` hook that runs after `.order()` and before user filters.

## User-visible impact

This fixes the error _"Filter chain produced an invalid query. Clear filters and retry."_ which was firing:
- **always** on `/consola/cambios-taxon` (and `/console/taxon-changes`) because the synthetic baseline was permanently active;
- **whenever a user typed into a filter** on Identifications, Notifications, Media (sync inline), Follows, Watchlists, Projects, etc. — same root cause, just gated on user input.

## Why static analysis missed it (TODO #260)

PR #258 added a defensive guard for the symptom but couldn't repro from the source. Reason: the test mock in `tests/lib/entity-browser.test.ts` returned `undefined` for `then` (the comment even acknowledged the recursion risk), so vitest never exercised the real thenable contract. New regression tests use a `Proxy` whose `then` is a real function with a counter, asserting it's never invoked when filters return builders.

## Files

- `src/lib/entity-browser.ts` — applyFilters now returns `Promise<{ q }>` and inspects raw apply returns; `FilterSpec.apply` admits a `{ q }` wrapper return; new `BrowserConfig.baseline`.
- `src/components/ConsoleTaxonChangesView.astro` — synthetic filter + hidden input removed; uses `baseline`; async actor wrapped.
- `src/components/Console{Notifications,Watchlists,Projects,Identifications,Follows}View.astro` — 8 async applies wrapped as `{ q: builder }`.
- `tests/lib/entity-browser.test.ts` — existing null-short-circuit test updated; 3 new regression tests with real-thenable mock.
- `docs/runbooks/admin-entity-browsers.md` — runbook updated to document `baseline` + the thenable trap.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 965 tests passing (3 new)
- [x] `npm run build` — 231 pages, ~8s
- [ ] After merge + deploy, verify `/es/consola/cambios-taxon/` loads rows instead of the error banner
- [ ] After merge + deploy, type into the recipient autocomplete on `/console/notifications`, confirm rows filter and no error banner appears
- [ ] Old `?__op_baseline=1` URLs in user history are silently dropped on next filter persistence (no broken state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)