### PR TITLE
docs: surface SW pmtiles caching + persistent-cache invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,6 +577,13 @@ Runbooks: [`docs/runbooks/multi-provider-vision.md`](docs/runbooks/multi-provide
 | E2E test fails after adding doc page to MegaMenu | New link duplicates text in mobile drawer, Playwright strict mode violation | Use `locator('p').filter()` instead of `getByText()` for group headings. |
 | `flowType: 'pkce'` not set | Supabase defaulted to implicit flow with hash fragments | Set `flowType: 'pkce'` in `supabase.ts` — PKCE uses `?code=` (single-use, server-exchanged). |
 
+### Pitfalls discovered 2026-05-06
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Map page hits network for pmtiles even after user clicked "Download offline map" | Cache API entry written by `src/lib/offline-map.ts` was orphaned — MapLibre's pmtiles protocol uses `fetch()` directly, never consults the Cache API; the SW didn't intercept after the `.app → .org` migration | SW now intercepts `media.rastrum.org/maps/*.pmtiles` and slices the cached 200 into 206 Partial Content. Algorithm pinned by `tests/unit/sw-pmtiles-range.test.ts`. Fixed in PR #636. |
+| Downloaded offline map (and in-flight share-target stash) silently wiped on every SW upgrade | `activate` handler deleted any cache whose name wasn't the current `VERSION`; `rastrum/pmtiles` and `rastrum-share-target-v1` are page-managed and got nuked too | `PERSISTENT_CACHES` allowlist in `public/sw.js` now skips those caches when pruning. Fixed in PR #636. |
+
 ---
 
 ## Things you should NOT do without asking

--- a/docs/specs/modules/03-offline.md
+++ b/docs/specs/modules/03-offline.md
@@ -1,8 +1,8 @@
 # Module 03 — Offline-First / PWA / Sync
 
 **Version target:** v0.1
-**Status:** shipped — Dexie outbox + `syncOutbox()` + identify trigger live; service worker shell-cached.
-**Last verified:** 2026-04-26 — `src/lib/db.ts` (RastrumDB), `src/lib/sync.ts`, `public/sw.js` running in production. Workbox-style background sync queue intentionally deferred (visibilitychange + online events suffice).
+**Status:** shipped — Dexie outbox + `syncOutbox()` + identify trigger live; service worker shell-cached; offline pmtiles archive served from page-managed Cache API via SW range-slicing.
+**Last verified:** 2026-05-06 — `src/lib/db.ts` (RastrumDB), `src/lib/sync.ts`, `public/sw.js` running in production. Workbox-style background sync queue intentionally deferred (visibilitychange + online events suffice).
 
 ---
 
@@ -40,7 +40,13 @@ All observations are written to IndexedDB first, synced to Supabase when connect
 
 ## Service Worker
 
-Using Workbox (via `@vite-pwa/astro` or manual):
+The shipped implementation is hand-rolled in [`public/sw.js`](../../../public/sw.js) — a flat classic SW (no Workbox bundle, no build step). Operator runbook at [`docs/runbooks/sw-cache.md`](../../runbooks/sw-cache.md). The Workbox sketch below is historical: it documents the strategy shape we landed on, not the current code. Three implementation details that don't appear in the sketch:
+
+- **Hand-rolled cache buckets per strategy** — `caches.open(VERSION)` for the shell (network-first HTML, cache-first hashed assets, SWR for unhashed paths), versioned via the `VERSION` constant. Bumping `VERSION` invalidates the shell on the next visit.
+- **Page-managed offline-map cache** — `src/lib/offline-map.ts` writes the full ~50 MB Mexico pmtiles archive into `caches.open('rastrum/pmtiles')` as a single 200 Response when the user clicks "Download offline map" in Profile → Edit. The SW intercepts `media.rastrum.org/maps/*.pmtiles` requests and slices the cached body into 206 Partial Content responses to satisfy MapLibre's byte-range fetches; falls through to network on cache miss. The slicing algorithm is pinned by [`tests/unit/sw-pmtiles-range.test.ts`](../../../tests/unit/sw-pmtiles-range.test.ts).
+- **`PERSISTENT_CACHES` allowlist** — `rastrum/pmtiles` and `rastrum-share-target-v1` are page-managed caches that the SW deliberately preserves across `VERSION` upgrades. Without this, every SW upgrade silently wiped a user's downloaded offline map (fixed in PR #636).
+
+Historical Workbox sketch (kept for design context):
 
 ```typescript
 // sw.ts


### PR DESCRIPTION
Closes #640

## Summary

- Adds two pitfall rows under a new "Pitfalls discovered 2026-05-06" section in `CLAUDE.md` for the trap fixed in #636 (orphaned offline-map cache + activate-handler nuking page-managed caches).
- Updates `docs/specs/modules/03-offline.md`'s Service Worker section to describe the actual hand-rolled implementation, the page-managed `rastrum/pmtiles` cache + range-slicing exception, and the `PERSISTENT_CACHES` allowlist. Frames the existing Workbox sketch as historical design context (it's not what shipped).
- Bumps the module's "Last verified" stamp.

Pure documentation — no code change.

## Test plan

- [x] No code touched. `make build` not required for docs-only changes; running it anyway as a sanity check would just confirm the markdown isn't malformed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)