### PR TITLE
fix(sponsorships): return null body for 204 to stop DELETE 500s

### DIFF
--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -15,6 +15,13 @@ const CORS_HEADERS = {
 };
 
 function jsonResponse(status: number, body: unknown): Response {
+  // Per Fetch spec, statuses 101/103/204/205/304 are "null body status" —
+  // constructing `new Response(JSON.stringify(...), { status: 204 })` throws
+  // "Response with null body status cannot have body", which the outer
+  // try/catch then surfaces as a 500. Drop the body for those statuses.
+  if (status === 204 || status === 205 || status === 304 || status === 101 || status === 103) {
+    return new Response(null, { status, headers: CORS_HEADERS });
+  }
   return new Response(JSON.stringify(body), {
     status,
     headers: { 'content-type': 'application/json', ...CORS_HEADERS },


### PR DESCRIPTION
## Summary

Production was returning `500 Internal Server Error` from `DELETE /sponsorships/credentials/<id>` (and three other 204 paths) on /perfil/patrocinios.

```json
{ "error": "internal_error", "detail": "Response with null body status cannot have body" }
```

**Root cause.** `jsonResponse(204, {})` constructed `new Response(JSON.stringify({}), { status: 204 })`. Per the Fetch spec, status 204 (and 101/103/205/304) is a "null body status" — Deno throws `TypeError: Response with null body status cannot have body`, which the wrapper's outer `try/catch` then surfaces as the 500 above.

**Fix.** Helper-level: when the status is one of the null-body statuses, return `new Response(null, { status, headers: CORS_HEADERS })`. This silently fixes all four 204 call sites in the file:

- `DELETE /credentials/:id` (the user-visible bug)
- `POST /sponsorships/:id` with method override (revoke)
- `DELETE /requests/:id` (withdraw request)
- One that already passed `null` and worked (now uniform with the rest)

Every other Edge Function (`identify`, `delete-observation`, `delete-photo`, etc.) already uses the correct `new Response(null, { status: 204 })` pattern — only `sponsorships/index.ts` had this anti-pattern. No regression to those.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run sponsorships` — 13/13 pass
- [ ] After deploy: in /perfil/patrocinios, delete a credential and confirm the row disappears with no 500 in the network tab
- [ ] Confirm `revokeSponsorship()` and `withdrawRequest()` likewise return 204 without throwing

## Deploy

The auto-deploy workflow on push to `main` will pick this up because `supabase/functions/sponsorships/**` changed. Manual fallback:

```bash
gh workflow run deploy-functions.yml --ref main -f function=sponsorships
```