### PR TITLE
fix(sponsorships): hide revoked credentials from sponsor list + pool dropdown

### DIFF
--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -446,6 +446,10 @@ const langJson = JSON.stringify(lang);
     if (!credsList || !credsSection) return;
     let creds: Awaited<ReturnType<typeof listCredentials>> = [];
     try { creds = await listCredentials(); } catch { /* not authed or fn unavailable */ }
+    // The API returns revoked credentials too (audit-friendly). The sponsor-add
+    // and approve-request selects already filter `!revoked_at`; the main list
+    // must do the same so a Delete click visibly removes the row.
+    creds = creds.filter(c => !c.revoked_at);
     credsList.innerHTML = '';
     if (creds.length === 0) {
       const emptyMsg = (credsSection as HTMLElement).dataset.emptyMsg ?? '';
@@ -701,6 +705,7 @@ const langJson = JSON.stringify(lang);
     // Populate the credential dropdown with the sponsor's active creds.
     let creds: Awaited<ReturnType<typeof listCredentials>> = [];
     try { creds = await listCredentials(); } catch { alert('Could not load credentials.'); return; }
+    creds = creds.filter(c => !c.revoked_at);
     const sel = document.getElementById('pool-cred-select') as HTMLSelectElement | null;
     if (!sel) return;
     sel.innerHTML = creds.map((c) => `<option value="${escHtml(c.id)}" data-model="${escHtml(c.preferred_model ?? '')}" data-kind="${escHtml(c.kind ?? '')}">${escHtml(c.label)}</option>`).join('');


### PR DESCRIPTION
## Summary

Follow-up to #649. After that PR, the DELETE call returns 204 cleanly — but the user reported that clicking "Delete" still left the row visible:

> ya no veo errores pero no pasa nada

**Root cause.** `DELETE /credentials/:id` is a soft-delete (sets `revoked_at`); the GET returns revoked rows so the audit/heartbeat flows can see them. Two callsites in `SponsoringView.astro` already filtered `!revoked_at` (the sponsor-add modal and the approve-request modal) — but the main `refreshCreds()` render loop and the pool-creation dropdown didn't, so revoked credentials kept showing as if undeleted.

**Fix.** Add `creds.filter(c => !c.revoked_at)` in the two leftover spots:
- `refreshCreds()` (line ~449) — the visible "Your credentials" list
- Pool-create credential dropdown (line ~707) — also prevents picking a revoked cred for a new pool

## Test plan

- [x] `npx vitest run sponsorships` — 13/13 pass (no regressions)
- [ ] After deploy: in /perfil/patrocinios, click Delete on a credential and confirm the row disappears immediately
- [ ] Click "Add pool" and confirm the credential dropdown only shows non-revoked rows

Closes the user-visible regression from #649's silent-success path.