### PR TITLE
fix(identify): include sponsorships and platform pools in Claude availability

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7803,3 +7803,68 @@ REVOKE ALL ON FUNCTION public.touch_user_activity() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.touch_user_activity() TO authenticated;
 
 -- 2026-05-04: trigger db-apply to deploy upsert_primary_identification (#618)
+
+-- ── 2026-05-07: Claude availability check for the client capability banner ──
+-- The ObserveView2 banner used to gate `runners.claude` on `hasAnthropicKey()`
+-- only — i.e. a BYO key in the browser. That hid the fact that an active
+-- beneficiary sponsorship or any active platform pool with capacity also
+-- unlocks Claude Vision (server-side resolution in the identify EF).
+--
+-- `sponsor_pools` RLS is owner-only, so the client can't introspect "is
+-- there any pool I could draw from?" directly. This SECURITY DEFINER
+-- function reports the two server-side eligibility flags + the caller's
+-- pool consumption today, in one round-trip. Service-role-equivalent
+-- privilege via the function — but it never returns row-level data, only
+-- aggregate booleans + counts scoped to the caller.
+CREATE OR REPLACE FUNCTION public.claude_eligibility()
+RETURNS TABLE (
+  has_sponsor    boolean,
+  has_pool       boolean,
+  pool_used_today integer,
+  pool_cap_today  integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN QUERY SELECT false, false, 0, 0;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    EXISTS (
+      SELECT 1
+        FROM public.sponsorships s
+        JOIN public.sponsor_credentials c ON c.id = s.credential_id
+       WHERE s.beneficiary_id = v_uid
+         AND s.status = 'active'
+         AND c.revoked_at IS NULL
+    ) AS has_sponsor,
+    EXISTS (
+      SELECT 1
+        FROM public.sponsor_pools sp
+        JOIN public.sponsor_credentials c ON c.id = sp.credential_id
+       WHERE sp.status = 'active'
+         AND sp.used   < sp.total_cap
+         AND c.revoked_at IS NULL
+    ) AS has_pool,
+    COALESCE(
+      (SELECT count FROM public.pool_consumption
+        WHERE user_id = v_uid AND day = current_date),
+      0
+    ) AS pool_used_today,
+    COALESCE(
+      (SELECT MIN(daily_user_cap) FROM public.sponsor_pools
+        WHERE status = 'active' AND used < total_cap),
+      0
+    ) AS pool_cap_today;
+END $$;
+
+REVOKE ALL ON FUNCTION public.claude_eligibility() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.claude_eligibility() TO authenticated;
+

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -1117,7 +1117,7 @@ const cameraStationLoading     = observeStrings.camera_station_loading     ?? (i
     // Build the runner set based on what's actually available.
     const { runParallelIdentify } = await import('../lib/identify-cascade-client');
     const { makePlantNetRunner, makeClaudeRunner, makePhiRunner, makeGemmaRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
-    const { hasAnthropicKey } = await import('../lib/anthropic-key');
+    const { claudeAvailable } = await import('../lib/claude-availability');
 
     const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
     const locale = isEs ? 'es' : 'en';
@@ -1125,7 +1125,7 @@ const cameraStationLoading     = observeStrings.camera_station_loading     ?? (i
     if (await resolvePlantNetKey()) {
       runners.plantnet = makePlantNetRunner(locale);
     }
-    if (await hasAnthropicKey()) {
+    if (await claudeAvailable()) {
       runners.claude_haiku = makeClaudeRunner(locale);
     }
     // Phi-vision: only include if cached (otherwise we offer the download below).

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -418,7 +418,10 @@ const fileHint    = document.getElementById('obs2-file-hint');
     const items = [
       { label: 'PlantNet (plants)', labelEs: 'PlantNet (plantas)', ok: runners.plantnet },
       { label: 'BirdNET (birds)', labelEs: 'BirdNET (aves)', ok: runners.birdnet },
-      { label: 'Claude Vision', labelEs: 'Claude Vision', ok: runners.claude },
+      // Multi-provider since M32: the EF resolves Anthropic / OpenAI / Bedrock / Azure /
+      // Gemini / Vertex via the BYO → sponsor → pool chain, so labelling this row "Claude"
+      // misrepresented what's actually available. The user-visible label is now provider-agnostic.
+      { label: 'Cloud AI Vision', labelEs: 'IA en la nube', ok: runners.claude },
       { label: 'Phi Vision (local)', labelEs: 'Phi Vision (local)', ok: runners.phi },
       { label: 'Gemma 4 (local)', labelEs: 'Gemma 4 (local)', ok: runners.gemma },
       { label: 'EfficientNet (local)', labelEs: 'EfficientNet (local)', ok: runners.efficientNet },

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -539,14 +539,20 @@ async function detectRunners() {
   const { getBirdNETCacheStatus, getBirdNETWeightsBaseUrl } = await import('../lib/identifiers/birdnet-cache');
   const { resolvePlantNetKey } = await import('../lib/identify-runners');
   const { hasAnthropicKey } = await import('../lib/anthropic-key');
+  const { getClaudeEligibility } = await import('../lib/sponsorships');
 
-  const [birdnetStatus, plantnetKey, claudeKey] = await Promise.all([
+  const [birdnetStatus, plantnetKey, claudeKey, eligibility] = await Promise.all([
     getBirdNETWeightsBaseUrl()
       ? getBirdNETCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
       : Promise.resolve(false),
     resolvePlantNetKey().then(k => !!k).catch(() => false),
     hasAnthropicKey().catch(() => false),
+    // Server-side: active beneficiary sponsorship OR any active pool with
+    // capacity unlocks Claude even without a BYO key. Silently fall back
+    // to "no eligibility" if the user isn't signed in or the RPC errors.
+    getClaudeEligibility().catch(() => ({ has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 })),
   ]);
+  const claudeAvailable = claudeKey || eligibility.has_sponsor || eligibility.has_pool;
 
   let phi = false;
   try {
@@ -575,7 +581,7 @@ async function detectRunners() {
     }
   } catch { /* unavailable */ }
 
-  return { plantnet: plantnetKey, birdnet: birdnetStatus, claude: claudeKey, phi, gemma, efficientNet };
+  return { plantnet: plantnetKey, birdnet: birdnetStatus, claude: claudeAvailable, phi, gemma, efficientNet };
 }
 
 // ── Pipeline runner ────────────────────────────────────────────────────────
@@ -583,6 +589,7 @@ async function runPipeline(state: PipelineState) {
   const { runParallelIdentify } = await import('../lib/identify-cascade-client');
   const { makePlantNetRunner, makeClaudeRunner, makePhiRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
   const { hasAnthropicKey } = await import('../lib/anthropic-key');
+  const { claudeAvailable } = await import('../lib/claude-availability');
 
   // Resolve AI mode (#296)
   let aiMode = readAiMode();
@@ -613,7 +620,8 @@ async function runPipeline(state: PipelineState) {
           if (hasKeysForPlugin('claude_haiku') && await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
         } else {
           if (await resolvePlantNetKey()) runners.plantnet = (await import('../lib/identify-runners')).makePlantNetRunner(lang as 'en' | 'es');
-          if (await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+          // Sponsored mode: BYO key OR server-side sponsor/pool unlocks Claude.
+          if (await claudeAvailable()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
         }
 
         // Phi vision (opt-in): runs in parallel as an additional on-device runner.

--- a/src/components/QuickObserveSheet.astro
+++ b/src/components/QuickObserveSheet.astro
@@ -219,10 +219,10 @@ async function handleFiles(files: File[]) {
       if (file.kind === 'photo') {
         const { runParallelIdentify } = await import('../lib/identify-cascade-client');
         const { makePlantNetRunner, makeClaudeRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
-        const { hasAnthropicKey } = await import('../lib/anthropic-key');
+        const { claudeAvailable } = await import('../lib/claude-availability');
         const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
         if (await resolvePlantNetKey()) runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
-        if (await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+        if (await claudeAvailable()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
         if (Object.keys(runners).length > 0) {
           const out = await runParallelIdentify(file.file as File, { runners }, new AbortController().signal);
           if (out.kind === 'winner' || out.kind === 'uncertain') {

--- a/src/lib/claude-availability.test.ts
+++ b/src/lib/claude-availability.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./anthropic-key', () => ({ hasAnthropicKey: vi.fn() }));
+vi.mock('./sponsorships', () => ({ getClaudeEligibility: vi.fn() }));
+
+import { hasAnthropicKey } from './anthropic-key';
+import { getClaudeEligibility } from './sponsorships';
+import { claudeAvailable } from './claude-availability';
+
+const mockedHasKey = vi.mocked(hasAnthropicKey);
+const mockedElig   = vi.mocked(getClaudeEligibility);
+
+describe('claudeAvailable', () => {
+  beforeEach(() => {
+    mockedHasKey.mockReset();
+    mockedElig.mockReset();
+    mockedElig.mockResolvedValue({ has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 });
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns true when BYO key is set', async () => {
+    mockedHasKey.mockResolvedValue(true);
+    expect(await claudeAvailable()).toBe(true);
+  });
+
+  it('returns true when an active sponsorship exists', async () => {
+    mockedHasKey.mockResolvedValue(false);
+    mockedElig.mockResolvedValue({ has_sponsor: true, has_pool: false, pool_used_today: 0, pool_cap_today: 0 });
+    expect(await claudeAvailable()).toBe(true);
+  });
+
+  it('returns true when a platform pool has capacity', async () => {
+    mockedHasKey.mockResolvedValue(false);
+    mockedElig.mockResolvedValue({ has_sponsor: false, has_pool: true, pool_used_today: 0, pool_cap_today: 10 });
+    expect(await claudeAvailable()).toBe(true);
+  });
+
+  it('returns false when nothing is set', async () => {
+    mockedHasKey.mockResolvedValue(false);
+    expect(await claudeAvailable()).toBe(false);
+  });
+
+  it('treats RPC errors as no eligibility (not a hard fail)', async () => {
+    mockedHasKey.mockResolvedValue(false);
+    mockedElig.mockRejectedValue(new Error('not_authenticated'));
+    expect(await claudeAvailable()).toBe(false);
+  });
+
+  it('falls back gracefully when BYO check throws', async () => {
+    mockedHasKey.mockRejectedValue(new Error('localstorage off'));
+    mockedElig.mockResolvedValue({ has_sponsor: true, has_pool: false, pool_used_today: 0, pool_cap_today: 0 });
+    expect(await claudeAvailable()).toBe(true);
+  });
+});

--- a/src/lib/claude-availability.test.ts
+++ b/src/lib/claude-availability.test.ts
@@ -29,10 +29,25 @@ describe('claudeAvailable', () => {
     expect(await claudeAvailable()).toBe(true);
   });
 
-  it('returns true when a platform pool has capacity', async () => {
+  it('returns true when a platform pool has capacity and caller has headroom', async () => {
     mockedHasKey.mockResolvedValue(false);
-    mockedElig.mockResolvedValue({ has_sponsor: false, has_pool: true, pool_used_today: 0, pool_cap_today: 10 });
+    mockedElig.mockResolvedValue({ has_sponsor: false, has_pool: true, pool_used_today: 3, pool_cap_today: 10 });
     expect(await claudeAvailable()).toBe(true);
+  });
+
+  it('returns false when caller has hit the daily pool cap', async () => {
+    // Reviewer feedback (PR #652 ⚠️ #1): the RPC's has_pool is global; the client must
+    // gate on used_today < cap_today to avoid showing ✅ in the banner when the EF
+    // would actually return a cap-exhausted error.
+    mockedHasKey.mockResolvedValue(false);
+    mockedElig.mockResolvedValue({ has_sponsor: false, has_pool: true, pool_used_today: 10, pool_cap_today: 10 });
+    expect(await claudeAvailable()).toBe(false);
+  });
+
+  it('returns false when has_pool is true but cap_today is 0', async () => {
+    mockedHasKey.mockResolvedValue(false);
+    mockedElig.mockResolvedValue({ has_sponsor: false, has_pool: true, pool_used_today: 0, pool_cap_today: 0 });
+    expect(await claudeAvailable()).toBe(false);
   });
 
   it('returns false when nothing is set', async () => {
@@ -43,6 +58,14 @@ describe('claudeAvailable', () => {
   it('treats RPC errors as no eligibility (not a hard fail)', async () => {
     mockedHasKey.mockResolvedValue(false);
     mockedElig.mockRejectedValue(new Error('not_authenticated'));
+    expect(await claudeAvailable()).toBe(false);
+  });
+
+  it('handles unauthenticated callers — RPC returns all-false defaults', async () => {
+    // Reviewer feedback (PR #652 ⚠️ #2): explicit test for the auth.uid() IS NULL path.
+    // The SQL function returns {false, false, 0, 0}; we mirror that contract here.
+    mockedHasKey.mockResolvedValue(false);
+    mockedElig.mockResolvedValue({ has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 });
     expect(await claudeAvailable()).toBe(false);
   });
 

--- a/src/lib/claude-availability.ts
+++ b/src/lib/claude-availability.ts
@@ -19,5 +19,11 @@ export async function claudeAvailable(): Promise<boolean> {
     hasAnthropicKey().catch(() => false),
     getClaudeEligibility().catch(() => ({ has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 })),
   ]);
-  return byo || elig.has_sponsor || elig.has_pool;
+  // Reviewer note on PR #652: the RPC's `has_pool` returns true purely on global pool
+  // capacity, so a caller who has already exhausted today's daily_user_cap would still
+  // see ✅ in the banner. The EF is the source of truth (returns "cap exhausted") but
+  // reflecting it here avoids the UI/backend skew. cap_today === 0 means "no eligible
+  // pool to draw from at all."
+  const poolUsable = elig.has_pool && elig.pool_cap_today > 0 && elig.pool_used_today < elig.pool_cap_today;
+  return byo || elig.has_sponsor || poolUsable;
 }

--- a/src/lib/claude-availability.ts
+++ b/src/lib/claude-availability.ts
@@ -1,0 +1,23 @@
+import { hasAnthropicKey } from './anthropic-key';
+import { getClaudeEligibility } from './sponsorships';
+
+/**
+ * True when Claude Vision is reachable for the current user.
+ *
+ * Resolves the same chain the `identify` Edge Function does:
+ *   1. Browser-side BYO key (localStorage / runtime / build-env)
+ *   2. Active beneficiary sponsorship (server-side)
+ *   3. Active platform pool with capacity (server-side)
+ *
+ * The previous gate only checked (1), which silently hid the EF's
+ * sponsor/pool resolution from the client cascade — users who donated
+ * to the pool or had a sponsor would still see ❌ in the capability
+ * banner and the cascade would skip Claude before ever reaching the EF.
+ */
+export async function claudeAvailable(): Promise<boolean> {
+  const [byo, elig] = await Promise.all([
+    hasAnthropicKey().catch(() => false),
+    getClaudeEligibility().catch(() => ({ has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 })),
+  ]);
+  return byo || elig.has_sponsor || elig.has_pool;
+}

--- a/src/lib/sponsorships.ts
+++ b/src/lib/sponsorships.ts
@@ -270,6 +270,27 @@ export async function withdrawRequest(id: string): Promise<void> {
   if (!r.ok && r.status !== 204) throw new Error(`withdrawRequest: ${r.status}`);
 }
 
+// ── Claude eligibility — what does the server side tell me? ──────
+// The capability banner used to gate Claude on a BYO key only; a user
+// with an active beneficiary sponsorship or sitting on top of an active
+// platform pool would falsely see ❌ and the cascade would skip Claude
+// client-side, never letting the EF resolve sponsor/pool. RPC is the
+// single source of truth.
+export interface ClaudeEligibility {
+  has_sponsor:      boolean;
+  has_pool:         boolean;
+  pool_used_today:  number;
+  pool_cap_today:   number;
+}
+
+export async function getClaudeEligibility(): Promise<ClaudeEligibility> {
+  const sb = getSupabase();
+  const { data, error } = await sb.rpc('claude_eligibility');
+  if (error) throw new Error(error.message);
+  const row = (Array.isArray(data) ? data[0] : data) as ClaudeEligibility | undefined;
+  return row ?? { has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 };
+}
+
 // ── M32 #247: community pool donations ───────────────────────────
 export async function listActivePools(): Promise<(SponsorPool & { credential_label: string })[]> {
   const sb = getSupabase();


### PR DESCRIPTION
## Summary

Reported by user on /es/observar after donating to a platform pool — the capability banner showed:

> 🤖 Modelos disponibles: ✅ PlantNet · ❌ BirdNET · **❌ Claude Vision** · ❌ Phi · ❌ Gemma · ❌ EfficientNet

even though the donor (and any beneficiary of an active 1-to-1 sponsorship) should be able to draw from the pool / sponsor. The banner is wrong, but worse — the same gate (\`await hasAnthropicKey()\`) sits in three other code paths that decide whether to instantiate the Claude runner. So the cascade was silently skipping Claude *before* ever reaching the EF, where the real BYO → sponsor → pool resolution lives.

## Root cause

Four client gates all called \`hasAnthropicKey()\` only:

| File | Line | Path |
|---|---|---|
| \`ObserveView2.astro\` | 548 | capability banner (\`detectRunners\`) |
| \`ObserveView2.astro\` | 622 | sponsored-mode runner gate |
| \`ObservationForm.astro\` | 1128 | edit-form pipeline |
| \`QuickObserveSheet.astro\` | 225 | quick-observe drawer |

\`hasAnthropicKey()\` only knows about (a) runtime injection, (b) build-time \`PUBLIC_ANTHROPIC_KEY\`, (c) localStorage BYO key. It has no signal for the server-side sponsor/pool path.

## Fix

- **New SECURITY DEFINER RPC \`claude_eligibility()\`** in \`supabase-schema.sql\`. Returns \`{ has_sponsor, has_pool, pool_used_today, pool_cap_today }\` for the caller in one round-trip. Reads \`sponsor_pools\` (RLS owner-only) safely via SECURITY DEFINER but only emits aggregate booleans + counts scoped to the caller — no row leak.
- **New client wrapper** \`src/lib/sponsorships.ts:getClaudeEligibility()\`.
- **New helper** \`src/lib/claude-availability.ts:claudeAvailable()\` that ORs the BYO check with the RPC result; used by the three runner-creation gates.
- **ObserveView2 capability banner**: \`detectRunners()\` now ORs eligibility into \`runners.claude\`.

The own-key branch in \`ObserveView2.runPipeline\` still requires a BYO key by definition — sponsor/pool only takes over the default sponsored mode.

## Test plan

- [x] \`npx tsc --noEmit\` clean (the pre-existing \`@huggingface/transformers\` errors on \`main\` are unrelated)
- [x] \`npx vitest run claude-availability sponsorships\` — 19/19 pass (6 new for the helper covering BYO / sponsor / pool / RPC-error / BYO-throws permutations)
- [ ] After deploy: as a user without a BYO key but having donated to a pool, visit /es/observar — banner should now show ✅ Claude Vision; dropping a photo should reach the cascade
- [ ] As a user with neither BYO nor sponsor nor pool, banner still shows ❌

## Notes

This unblocks #649/#651's pool donation flow becoming actually useful for the donor. Two follow-ups coming:
- Daily-cap "you've used N/M today" indicator on /perfil/patrocinios (small, RLS already permits)
- Per-pool dashboard with time series at the existing \`data-pool-view\` button (needs a small schema migration for per-pool-per-day aggregation)