### PR TITLE
feat(sponsorships): show personal pool consumption today on /perfil/patrocinios

### DIFF
--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -95,6 +95,16 @@ const langJson = JSON.stringify(lang);
         ? 'Dona N llamadas a un pool compartido. Cualquier usuario puede consumirlo (con un cap diario por persona). Tú sólo ves estadísticas agregadas — los beneficiarios son anónimos.'
         : 'Donate N calls to a shared pool. Any user can consume it (with a per-person daily cap). You only see aggregate stats — beneficiaries stay anonymous.'}
     </p>
+
+    <!-- Personal pool consumption today (PR-B): hidden until the RPC resolves -->
+    <div id="pool-self-usage" class="hidden rounded-lg bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-900 px-3 py-2 text-xs text-emerald-800 dark:text-emerald-300 max-w-md">
+      <span class="font-medium">{lang === 'es' ? 'Tu uso del pool hoy:' : 'Your pool usage today:'}</span>
+      <span id="pool-self-usage-value" class="ml-1 font-mono"></span>
+      <span id="pool-self-usage-bar-wrap" class="mt-1.5 block h-1 w-full rounded-full bg-emerald-200 dark:bg-emerald-900/60 overflow-hidden">
+        <span id="pool-self-usage-bar" class="block h-full bg-emerald-600 dark:bg-emerald-500" style="width:0%"></span>
+      </span>
+    </div>
+
     <ul id="pools-list" class="divide-y divide-zinc-200 dark:divide-zinc-800"></ul>
     <p id="pools-empty" class="hidden text-sm text-zinc-500 dark:text-zinc-400">
       {lang === 'es' ? 'Aún no has donado al pool.' : 'You haven’t donated to the pool yet.'}
@@ -807,6 +817,27 @@ const langJson = JSON.stringify(lang);
   });
 
   void refreshPools();
+
+  // PR-B: render "you've used N/M of your daily pool cap today" via the
+  // claude_eligibility RPC. Silent if the user has no pools to draw from
+  // (cap_today === 0) — keeping the section uncluttered for users who
+  // haven't engaged with the pool flow yet.
+  void (async () => {
+    const wrap = document.getElementById('pool-self-usage');
+    const valueEl = document.getElementById('pool-self-usage-value');
+    const barEl = document.getElementById('pool-self-usage-bar') as HTMLElement | null;
+    if (!wrap || !valueEl || !barEl) return;
+    try {
+      const { getClaudeEligibility } = await import('../lib/sponsorships');
+      const elig = await getClaudeEligibility();
+      if (!elig.has_pool || elig.pool_cap_today <= 0) return;  // nothing to show
+      const used = Math.max(0, Math.min(elig.pool_used_today, elig.pool_cap_today));
+      const pct = Math.round((used / elig.pool_cap_today) * 100);
+      valueEl.textContent = `${used} / ${elig.pool_cap_today} (${pct}%)`;
+      barEl.style.width = `${pct}%`;
+      wrap.classList.remove('hidden');
+    } catch { /* not authed or RPC missing — keep hidden */ }
+  })();
 
   document.getElementById('creds-list')?.addEventListener('click', async (e) => {
     const target = e.target as HTMLElement;


### PR DESCRIPTION
## Summary

Stacked on top of #652 (depends on the \`claude_eligibility()\` RPC introduced there).

Adds a small emerald chip + thin progress bar to the "Pool de la plataforma" section showing your personal pool consumption today:

> Tu uso del pool hoy: **3 / 10 (30%)**
> ────────░░░░░░░░░░░░░░

Hidden when the user has no eligibility (\`cap_today === 0\`) so the section stays clean for users who haven't donated yet.

## Why

Closes the second of the two follow-ups requested by the user:

> ¿hay manera de ver cuántas llamadas hay donadas al pool? como puedo usar yo las llamadas que doné al pool?

Combined with #652, the user can now (a) see the pool counts as a sponsor *and* (b) see their daily-cap headroom as a consumer.

## Implementation

- Reuses \`getClaudeEligibility()\` from #652 — no new endpoint, no new schema.
- Pure client-side render in \`SponsoringView.astro\`. Silent on RPC failure (treats as "no pool eligibility").
- The cap shown is \`MIN(daily_user_cap)\` across active pools, matching what \`consume_pool_slot()\` would actually let through.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] After deploy: as a user with an active pool, /perfil/patrocinios shows the chip with 0/N before any consumption
- [ ] After hitting \`/identify\` once via pool resolution, refresh — chip should read 1/N

## Merge order

This must merge **after** #652 (or be rebased onto main once #652 lands).