### PR TITLE
fix(sponsorships): make per-pool daily-usage chart actually work

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7523,22 +7523,19 @@ LANGUAGE sql STABLE SECURITY DEFINER AS $$
   SELECT NULL::text, NULL::bigint WHERE false;
 $$;
 
--- Daily usage for a pool (current month). Pre-2026-05-07 this body was
--- broken: it ignored p_pool_id (returned aggregate consumption across
--- ALL pools, joining pool_consumption — which is keyed by user, not pool —
--- and any caller could query any pool's "shape"). Now reads from the
--- per-pool aggregate table populated by consume_pool_slot, and only
--- returns rows when the caller owns the pool.
+-- Daily usage for a pool. Original broken body — kept here so the schema
+-- replays in order against a fresh DB (pool_usage_daily is declared later
+-- in the file). The FIXED body that joins pool_usage_daily + sponsor_pools
+-- and filters by caller ownership lives at the bottom of the file in the
+-- 2026-05-07 trailer; CREATE OR REPLACE FUNCTION is idempotent and the
+-- last definition wins, so consumers get the corrected behavior.
 CREATE OR REPLACE FUNCTION public.pool_daily_usage(p_pool_id uuid)
 RETURNS TABLE(usage_date date, calls bigint)
 LANGUAGE sql STABLE SECURITY DEFINER AS $$
-  SELECT pud.day AS usage_date, pud.count::bigint AS calls
-    FROM public.pool_usage_daily pud
-    JOIN public.sponsor_pools sp ON sp.id = pud.pool_id
-   WHERE pud.pool_id = p_pool_id
-     AND sp.sponsor_id = auth.uid()
-     AND pud.day >= (current_date - interval '30 days')::date
-   ORDER BY pud.day;
+  SELECT pc.day AS usage_date, pc.count::bigint AS calls
+  FROM public.pool_consumption pc
+  WHERE pc.day >= date_trunc('month', now())::date
+  ORDER BY pc.day;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.pool_top_taxa(uuid) TO authenticated;
@@ -8130,3 +8127,20 @@ AS $$
 $$;
 
 GRANT EXECUTE ON FUNCTION public.suggest_pokedex_target(uuid) TO authenticated;
+
+-- ── 2026-05-07: pool_daily_usage final body (overrides earlier stub) ──
+-- Earlier in this file the function is declared with a placeholder body
+-- so the schema replays top-to-bottom on a fresh DB (pool_usage_daily is
+-- created in this same trailer block). This trailing CREATE OR REPLACE
+-- supplies the real body — same function signature, idempotent.
+CREATE OR REPLACE FUNCTION public.pool_daily_usage(p_pool_id uuid)
+RETURNS TABLE(usage_date date, calls bigint)
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT pud.day AS usage_date, pud.count::bigint AS calls
+    FROM public.pool_usage_daily pud
+    JOIN public.sponsor_pools sp ON sp.id = pud.pool_id
+   WHERE pud.pool_id = p_pool_id
+     AND sp.sponsor_id = auth.uid()
+     AND pud.day >= (current_date - interval '30 days')::date
+   ORDER BY pud.day;
+$$;

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7399,14 +7399,22 @@ LANGUAGE sql STABLE SECURITY DEFINER AS $$
   SELECT NULL::text, NULL::bigint WHERE false;
 $$;
 
--- Daily usage for a pool (current month)
+-- Daily usage for a pool (current month). Pre-2026-05-07 this body was
+-- broken: it ignored p_pool_id (returned aggregate consumption across
+-- ALL pools, joining pool_consumption — which is keyed by user, not pool —
+-- and any caller could query any pool's "shape"). Now reads from the
+-- per-pool aggregate table populated by consume_pool_slot, and only
+-- returns rows when the caller owns the pool.
 CREATE OR REPLACE FUNCTION public.pool_daily_usage(p_pool_id uuid)
 RETURNS TABLE(usage_date date, calls bigint)
 LANGUAGE sql STABLE SECURITY DEFINER AS $$
-  SELECT pc.day AS usage_date, pc.count::bigint AS calls
-  FROM public.pool_consumption pc
-  WHERE pc.day >= date_trunc('month', now())::date
-  ORDER BY pc.day;
+  SELECT pud.day AS usage_date, pud.count::bigint AS calls
+    FROM public.pool_usage_daily pud
+    JOIN public.sponsor_pools sp ON sp.id = pud.pool_id
+   WHERE pud.pool_id = p_pool_id
+     AND sp.sponsor_id = auth.uid()
+     AND pud.day >= (current_date - interval '30 days')::date
+   ORDER BY pud.day;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.pool_top_taxa(uuid) TO authenticated;
@@ -7803,3 +7811,92 @@ REVOKE ALL ON FUNCTION public.touch_user_activity() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.touch_user_activity() TO authenticated;
 
 -- 2026-05-04: trigger db-apply to deploy upsert_primary_identification (#618)
+
+-- ── 2026-05-07: Per-pool daily usage aggregate for the donor dashboard ─────
+-- pool_consumption is keyed by (user_id, day) — used for daily-cap enforcement
+-- and for the consumer-facing "you used N/M today" indicator. It deliberately
+-- has no pool_id because consume_pool_slot can hop between pools as one fills.
+--
+-- Donors need the orthogonal slice: "how is my own pool being used over time?"
+-- This table captures it without leaking consumer identity (no user_id).
+CREATE TABLE IF NOT EXISTS public.pool_usage_daily (
+  pool_id uuid    NOT NULL REFERENCES public.sponsor_pools(id) ON DELETE CASCADE,
+  day     date    NOT NULL,
+  count   integer NOT NULL DEFAULT 0 CHECK (count >= 0),
+  PRIMARY KEY (pool_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pool_usage_daily_pool ON public.pool_usage_daily(pool_id, day DESC);
+
+ALTER TABLE public.pool_usage_daily ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS pool_usage_daily_owner_read ON public.pool_usage_daily;
+CREATE POLICY pool_usage_daily_owner_read ON public.pool_usage_daily
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.sponsor_pools sp
+       WHERE sp.id = pool_usage_daily.pool_id
+         AND sp.sponsor_id = auth.uid()
+    )
+  );
+
+GRANT SELECT                         ON public.pool_usage_daily TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.pool_usage_daily TO service_role;
+
+-- Updated consume_pool_slot: now also bumps the per-pool daily aggregate.
+-- Same return type as before — no DROP needed.
+CREATE OR REPLACE FUNCTION public.consume_pool_slot(p_user_id uuid)
+RETURNS TABLE (pool_id uuid, credential_id uuid, preferred_model text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_today    date := current_date;
+  v_used_today integer;
+  v_pool_id  uuid;
+  v_cred_id  uuid;
+  v_model    text;
+  v_cap      integer;
+BEGIN
+  SELECT sp.id, sp.credential_id, sp.preferred_model, sp.daily_user_cap
+    INTO v_pool_id, v_cred_id, v_model, v_cap
+    FROM public.sponsor_pools sp
+   WHERE sp.status = 'active' AND sp.used < sp.total_cap
+   ORDER BY sp.created_at ASC
+   FOR UPDATE SKIP LOCKED
+   LIMIT 1;
+  IF v_pool_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT COALESCE(count, 0) INTO v_used_today
+    FROM public.pool_consumption
+   WHERE user_id = p_user_id AND day = v_today;
+  IF v_used_today >= v_cap THEN
+    RETURN;
+  END IF;
+
+  UPDATE public.sponsor_pools SET used = used + 1, updated_at = now()
+   WHERE id = v_pool_id;
+
+  INSERT INTO public.pool_consumption (user_id, day, count)
+       VALUES (p_user_id, v_today, 1)
+  ON CONFLICT (user_id, day) DO UPDATE SET count = pool_consumption.count + 1;
+
+  -- Per-pool daily aggregate for the donor dashboard.
+  INSERT INTO public.pool_usage_daily (pool_id, day, count)
+       VALUES (v_pool_id, v_today, 1)
+  ON CONFLICT (pool_id, day) DO UPDATE SET count = pool_usage_daily.count + 1;
+
+  UPDATE public.sponsor_pools SET status = 'exhausted'
+   WHERE id = v_pool_id AND used >= total_cap AND status = 'active';
+
+  RETURN QUERY SELECT v_pool_id, v_cred_id, v_model;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.consume_pool_slot(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.consume_pool_slot(uuid) TO service_role;
+

--- a/src/lib/pool-analytics.test.ts
+++ b/src/lib/pool-analytics.test.ts
@@ -52,6 +52,10 @@ describe('fetchPoolAnalytics', () => {
     expect(result!.topTaxa).toHaveLength(2);
     expect(result!.topTaxa[0].scientific_name).toBe('Quercus robur');
     expect(result!.dailyUsage).toHaveLength(2);
+    // Regression: pre-2026-05-07 the client read `row.date` from a row
+    // shaped `{ usage_date, calls }`, so every chart bar had `date: undefined`.
+    expect(result!.dailyUsage[0].date).toBe('2026-05-01');
+    expect(result!.dailyUsage[0].calls).toBe(3);
   });
 
   it('returns null when pool is not found', async () => {

--- a/src/lib/pool-analytics.ts
+++ b/src/lib/pool-analytics.ts
@@ -18,17 +18,23 @@ export interface PoolAnalytics {
   }>;
 }
 
-/** Shape returned by the pool_top_taxa RPC. */
+/** Shape returned by the pool_top_taxa RPC. The RPC column is
+ *  `call_count` — keep both fields here so the dashboard renders
+ *  whichever the server emits (the stub currently returns nothing,
+ *  so no rows hit either path; future implementation will pick one). */
 interface RpcTaxaRow {
   scientific_name: string;
-  common_name: string | null;
-  kingdom: string;
-  count: number;
+  common_name?: string | null;
+  kingdom?: string;
+  count?: number;
+  call_count?: number;
 }
 
-/** Shape returned by the pool_daily_usage RPC. */
+/** Shape returned by the pool_daily_usage RPC. The RPC column is
+ *  `usage_date`; pre-2026-05-07 the client expected `date` and the
+ *  chart silently rendered with `undefined` x-axis values. */
 interface RpcDailyRow {
-  date: string;
+  usage_date: string;
   calls: number;
 }
 
@@ -76,11 +82,11 @@ export async function fetchPoolAnalytics(
       scientific_name: row.scientific_name,
       common_name: row.common_name ?? null,
       kingdom: row.kingdom ?? '',
-      count: row.count,
+      count: row.count ?? row.call_count ?? 0,
     }));
 
   const dailyUsage: PoolAnalytics['dailyUsage'] = ((daily as RpcDailyRow[] | null) ?? [])
-    .map((row) => ({ date: row.date, calls: row.calls }));
+    .map((row) => ({ date: row.usage_date, calls: row.calls }));
 
   return {
     poolId: typedPool.id,


### PR DESCRIPTION
## Summary

User reported "no veo manera fácil de usar los AI sponsors" — turns out the per-pool dashboard at \`PoolDashboardView.astro\` had two silent bugs since it shipped:

1. **\`pool_daily_usage(p_pool_id)\` ignored its argument.** The body did:
   \`\`\`sql
   SELECT pc.day AS usage_date, pc.count::bigint AS calls
   FROM public.pool_consumption pc
   WHERE pc.day >= date_trunc('month', now())::date
   \`\`\`
   No \`WHERE pc.pool_id = …\` (because \`pool_consumption\` is keyed by user, not pool), and no ownership check — any authenticated user could query the function for any pool ID and get the same result. Every pool's chart looked identical.

2. **TS interface mismatch.** \`pool-analytics.ts\` declared \`RpcDailyRow = { date, calls }\` but the SQL emits \`usage_date\`. So \`dailyUsage[i].date\` was always \`undefined\` and the dashboard chart bars rendered with no x-axis labels.

## Fix

- **New table \`pool_usage_daily(pool_id, day, count)\`** — owner-only RLS via \`EXISTS sponsor_pools WHERE sponsor_id = auth.uid()\`. Tiny aggregate, populated inside \`consume_pool_slot()\` in the same transaction as the other counters.
- **\`consume_pool_slot()\`** updated to bump the new table on every slot consumption.
- **\`pool_daily_usage\` RPC** rewritten to JOIN \`pool_usage_daily\` to \`sponsor_pools\` and filter by \`sp.sponsor_id = auth.uid()\`. Non-owners get an empty result.
- **\`pool-analytics.ts\`** now reads \`row.usage_date\` (matching the actual RPC contract). Regression test added that asserts the date round-trips.

## Out of scope (follow-ups)

- \`pool_top_taxa\` is still a stub — needs \`ai_usage\` to gain \`pool_id\` + \`observation_id\` columns to be implementable. Filed as a separate concern.
- \`pool_unique_users\` is referenced by the client but has no SQL definition. The dashboard already null-paths through it, so the \`uniqueUsers: 0\` display is benign for now.

## Test plan

- [x] \`npx vitest run pool-analytics\` — 8/8 pass, includes new regression assertion on the date column
- [x] \`npx tsc --noEmit\` clean
- [ ] After deploy: as a pool donor, open the dashboard at /perfil/patrocinios — daily-usage chart should render with real dates and per-pool counts (not empty / not all-pools cross-leak)
- [ ] Verify \`pool_daily_usage('<other-users-pool>')\` returns empty rows when called as a non-owner

## Schema migration

Adds one table + one trigger-equivalent inline insert in \`consume_pool_slot()\`. Idempotent (\`CREATE TABLE IF NOT EXISTS\`, \`DROP POLICY … CREATE POLICY\`, \`CREATE OR REPLACE FUNCTION\` with no return-type change).