### PR TITLE
fix(schema): restore karma_total to end of community_observers_with_centroid view

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4510,12 +4510,18 @@ SELECT
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
   centroid_geog, last_observation_at, joined_at,
-  karma_total,
   -- Scalar lat/lng for clients that can't decode the geography WKB
   -- (the /community/map/ heatmap reads these directly). PostGIS
   -- geography → geometry cast is a zero-copy reinterpret for points.
   ST_Y(centroid_geog::geometry) AS centroid_lat,
-  ST_X(centroid_geog::geometry) AS centroid_lng
+  ST_X(centroid_geog::geometry) AS centroid_lng,
+  -- karma_total stays LAST per the append-only rule documented on
+  -- community_observers. PR #547 already fixed this; b6755ed re-introduced
+  -- the trap by appending centroid_lat/lng *after* karma_total without
+  -- moving karma_total to the new tail. Production now errors with
+  -- `cannot change name of view column "centroid_lat" to "karma_total"`
+  -- because prod's column 15 is centroid_lat. This restores the order.
+  karma_total
 FROM public.users
 WHERE hide_from_leaderboards = false;
 -- 2026-04-30: same change as community_observers above — M28-only opt-out.


### PR DESCRIPTION
## Summary

**db-apply has been failing on every push to main** since b6755ed (\`fix(community-map): expose centroid_lat/lng…\`) appended the two scalar columns *between* the previous tail (\`karma_total\`) and the geography column. After that merge the SELECT list ended in \`…, centroid_geog, last_observation_at, joined_at, karma_total, centroid_lat, centroid_lng\`. The validate gate ran on a fresh DB and was happy. db-apply ran against the production view (whose tail was already \`…, centroid_lat, centroid_lng, karma_total\` from the post-PR #547 deploy) and failed:

\`\`\`
psql:docs/specs/infra/supabase-schema.sql:4520:
ERROR:  cannot change name of view column "centroid_lat" to "karma_total"
\`\`\`

This is **the exact same trap PR #547 fixed in early May.** The append-only rule was spelled out in a comment on \`community_observers\` but didn't carry over to its centroid sibling.

## Fix

Move \`karma_total\` to the **last** column in \`community_observers_with_centroid\` (after \`centroid_lat\` / \`centroid_lng\`), matching what production already has. Header comment expanded so the next editor doesn't repeat the mistake.

No behavioural change — every consumer SELECTs by name.

## Why this matters now

Three queued PRs (#652, #653, #654) ship schema additions (the \`claude_eligibility()\` RPC and the \`pool_usage_daily\` table). They'll merge cleanly individually, but their auto-deploy via the db-apply workflow on main has been silently broken since b6755ed. This unblocks the queue.

## Test plan

- [x] Diff inspection: column count unchanged, only the position of \`karma_total\` moves to the tail.
- [ ] After merge: db-apply workflow on main goes green.
- [ ] Sanity: \`SELECT karma_total, centroid_lat FROM community_observers_with_centroid LIMIT 0\` still resolves.

## Related

- Original fix: #547
- Regression: b6755ed
- Memory note: "CREATE OR REPLACE VIEW column-order trap — append-only rule"