### PR TITLE
fix(schema): move karma_total to end of community_observers_with_centroid — unblocks db-apply

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -4504,18 +4504,25 @@ GRANT SELECT ON public.community_observers TO anon, authenticated;
 -- feature. Anon callers cannot read centroid via any path; the lack of
 -- a GRANT to anon is the security gate (mirrored in UI by the sign-in
 -- requirement).
+-- Column order note: karma_total is appended LAST (after centroid_lat /
+-- centroid_lng) because Postgres CREATE OR REPLACE VIEW only allows
+-- adding columns at the end. Inserting karma_total mid-list is treated
+-- as a rename of the column at that position and breaks db-apply on
+-- databases that already have centroid_lat/lng but no karma_total
+-- (the production state since 2026-05-04). Same rule as
+-- community_observers above.
 CREATE OR REPLACE VIEW public.community_observers_with_centroid AS
 SELECT
   id, username, display_name, avatar_url, country_code,
   expert_taxa, is_expert,
   observation_count, species_count, obs_count_7d, obs_count_30d,
   centroid_geog, last_observation_at, joined_at,
-  karma_total,
   -- Scalar lat/lng for clients that can't decode the geography WKB
   -- (the /community/map/ heatmap reads these directly). PostGIS
   -- geography → geometry cast is a zero-copy reinterpret for points.
   ST_Y(centroid_geog::geometry) AS centroid_lat,
-  ST_X(centroid_geog::geometry) AS centroid_lng
+  ST_X(centroid_geog::geometry) AS centroid_lng,
+  karma_total
 FROM public.users
 WHERE hide_from_leaderboards = false;
 -- 2026-04-30: same change as community_observers above — M28-only opt-out.


### PR DESCRIPTION
## Summary

- `db-apply` has been failing on every push to `main` since 2026-05-04 04:04 UTC (3+ days, 13 failed runs) with the same error:

  ```
  psql:docs/specs/infra/supabase-schema.sql:4520:
  ERROR: cannot change name of view column "centroid_lat" to "karma_total"
  HINT: Use ALTER VIEW ... RENAME COLUMN ...
  ```

- The block is the `community_observers_with_centroid` view: `karma_total` was inserted mid-list, but the live DB has `centroid_lat` at that position. CREATE OR REPLACE VIEW interprets it as a column rename and refuses.
- This PR moves `karma_total` to the end (after `centroid_lat`/`centroid_lng`), making the change append-only relative to live. Mirrors the same convention already documented on the sister view `community_observers`.

## Why this matters

The `mv_platform_stats` MV is defined at line 7935 of the schema. Apply chain dies at line 4520 before reaching it — so the materialized view doesn't exist in production. PR #650 (M34) just merged the species-page redesign that depends on this MV; the page now hits `/rest/v1/mv_platform_stats` and gets a 404, leaving the hero showing `0/0/0/+0` stats.

Once this PR lands and db-apply unblocks, ~5 days of queued schema changes apply in one go:

- M34: `mv_platform_stats`, `taxa_thumbnails`, `featured_species_current`, `suggest_pokedex_target`, profile_pokedex extension, taxa.slug forward-decl
- Karma: realtime triggers, 30-day rolling leaderboard MV
- Sync: UNIQUE primary identification + upsert RPC
- Sponsoring: vault decrypt SECURITY DEFINER RPC, `has_active_sponsorship`
- Identify-EF: anon rate-limit Postgres-backed
- Console: `/consola/observaciones` + `/consola/banderas` 300 fix

## Verification

- `db-validate` runs on a fresh DB and doesn't expose the column-order trap (no existing view to clash with). It will pass on this PR like every other recent PR. The real signal is the post-merge `db-apply` run on main.
- Both consumers select by column name, so the reorder is invisible to clients:
  - `src/components/CommunityMapView.astro:221` — `.select('id, country_code, is_expert, ..., centroid_lat, centroid_lng')`
  - `src/lib/community.ts:140` — `.select('id')`
- The two RPCs that `RETURN SETOF community_observers_with_centroid` (`community_observers_nearby` / `_at`) pick up the new column order transparently.

## Test plan

- [x] Diff inspection — only `karma_total` reordered + comment added
- [ ] CI `db-validate` green on this PR
- [ ] After merge, watch `db-apply` workflow on main: should turn green for the first time since 2026-05-04
- [ ] Curl `https://reppvlqejgoqvitturxp.supabase.co/rest/v1/mv_platform_stats?select=*&limit=1` — should return 200 with one row
- [ ] Reload `https://rastrum.org/en/explore/species/` — hero card should show non-zero stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)