### PR TITLE
feat(profile): cross-link AI settings and sponsorships (#656)

### DIFF
--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -1,5 +1,5 @@
 ---
-import { t } from '../i18n/utils';
+import { t, routes } from '../i18n/utils';
 
 interface Props {
   lang: 'en' | 'es';
@@ -15,6 +15,8 @@ const showSecurity = section === 'all' || section === 'security';
 const pip = (tr as unknown as { pipeline: Record<string, string> }).pipeline;
 const onb = (tr as unknown as { onboarding: Record<string, string> }).onboarding;
 const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } }).privacy;
+const crosslink = (tr as unknown as { ai_sponsor_crosslink: { from_ai_label: string; from_ai_link: string } }).ai_sponsor_crosslink;
+const sponsoringHref = `/${lang}${routes.sponsoring[lang]}/`;
 ---
 
 <div class="max-w-2xl mx-auto">
@@ -252,6 +254,14 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
         <li class="text-sm text-zinc-500 italic">{lang === 'es' ? 'Cargando…' : 'Loading…'}</li>
       </ul>
     </div>
+
+    <!-- Cross-link to sponsorships surface (issue #656) -->
+    <aside class="mb-6 border-l-2 border-emerald-300 dark:border-emerald-700/60 pl-3 py-1 text-xs text-zinc-600 dark:text-zinc-400">
+      {crosslink.from_ai_label}{' '}
+      <a href={sponsoringHref} class="font-medium text-emerald-700 dark:text-emerald-400 hover:underline">
+        {crosslink.from_ai_link} →
+      </a>
+    </aside>
 
     <!-- Legacy hidden field for BYO key migration -->
     <input id="anthropic-key" type="hidden" />

--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -1,10 +1,12 @@
 ---
-import { t } from '../i18n/utils';
+import { t, routes } from '../i18n/utils';
 import { MODEL_COSTS, formatCostBadge } from '../lib/model-costs';
 import PoolDashboardView from './PoolDashboardView.astro';
 interface Props { lang: 'en' | 'es' }
 const { lang } = Astro.props;
 const tr = t(lang);
+const crosslink = (tr as unknown as { ai_sponsor_crosslink: { from_sponsor_label: string; from_sponsor_link: string } }).ai_sponsor_crosslink;
+const profileEditHref = `/${lang}${routes.profileEdit[lang]}/`;
 const cancelLabel = lang === 'es' ? 'Cancelar' : 'Cancel';
 const okLabel = lang === 'es' ? 'Aceptar' : 'OK';
 const statusHeading = lang === 'es' ? 'Estado' : 'Status';
@@ -79,6 +81,13 @@ const langJson = JSON.stringify(lang);
       {tr.sponsoring.add_credential}
     </button>
     <ul id="creds-list" class="divide-y divide-zinc-200 dark:divide-zinc-800"></ul>
+    <!-- Cross-link back to AI Settings, only when no credentials yet (issue #656) -->
+    <aside id="creds-empty-crosslink" class="hidden border-l-2 border-emerald-300 dark:border-emerald-700/60 pl-3 py-1 text-xs text-zinc-600 dark:text-zinc-400">
+      {crosslink.from_sponsor_label}{' '}
+      <a href={profileEditHref} class="font-medium text-emerald-700 dark:text-emerald-400 hover:underline">
+        {crosslink.from_sponsor_link} →
+      </a>
+    </aside>
   </section>
 
   <!-- M32 (#152): donate to platform pool -->
@@ -461,11 +470,14 @@ const langJson = JSON.stringify(lang);
     // must do the same so a Delete click visibly removes the row.
     creds = creds.filter(c => !c.revoked_at);
     credsList.innerHTML = '';
+    const emptyCrosslink = document.getElementById('creds-empty-crosslink');
     if (creds.length === 0) {
       const emptyMsg = (credsSection as HTMLElement).dataset.emptyMsg ?? '';
       credsList.innerHTML = `<li class="py-3 text-sm text-zinc-500">${escHtml(emptyMsg)}</li>`;
+      emptyCrosslink?.classList.remove('hidden');
       return;
     }
+    emptyCrosslink?.classList.add('hidden');
     for (const c of creds) {
       const li = document.createElement('li');
       li.className = 'py-3 flex items-center justify-between';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3241,5 +3241,11 @@
     "in_dex": "in your dex",
     "obs_count_one": "{count} observation",
     "obs_count_other": "{count} observations"
+  },
+  "ai_sponsor_crosslink": {
+    "from_ai_label": "Want your key to sponsor others or feed the community pool?",
+    "from_ai_link": "Sponsorships",
+    "from_sponsor_label": "Just want to use your own key for personal identifications?",
+    "from_sponsor_link": "Configure it in AI Settings (simpler)"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -3241,5 +3241,11 @@
     "in_dex": "ya en tu dex",
     "obs_count_one": "{count} observación",
     "obs_count_other": "{count} observaciones"
+  },
+  "ai_sponsor_crosslink": {
+    "from_ai_label": "¿Quieres que tu llave también pueda patrocinar a otros o usar el pool comunitario?",
+    "from_ai_link": "Patrocinios",
+    "from_sponsor_label": "¿Solo quieres usar tu propia llave para identificar?",
+    "from_sponsor_link": "Configurarla en AI Settings (más simple)"
   }
 }


### PR DESCRIPTION
## Summary
- BYO-key field in profile-edit AI section now links to /perfil/patrocinios
- Sponsorships empty-state links back to /perfil/editar AI section
- New i18n namespace `ai_sponsor_crosslink.*` (EN + ES parity)

## Test plan
- [x] `npx tsc --noEmit` (only pre-existing `@huggingface/transformers` errors, unrelated)
- [x] `npm run test` (only pre-existing 3 failures from same module, unrelated)
- [x] `npm run build` (pre-existing fail from missing `@huggingface/transformers` in node_modules, unrelated; reproduces on clean `origin/main`)
- [ ] Manually verify both surfaces render the callout correctly in EN and ES

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)