### PR TITLE
fix(species): chips were double-bound, sunburst was tiny + all-grey

### DIFF
--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -178,6 +178,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
   import { getSupabase } from '../lib/supabase';
   import { renderSpeciesCard, type CardLabels } from '../lib/species-card-html';
   import { parseChips, serializeChips, type ChipsState } from '../lib/species-filters';
+  import { deriveGenus, colorForName } from '../lib/species-display';
 
   type Lang = 'en' | 'es';
 
@@ -402,17 +403,8 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       }))
       .sort((a, b) => b.count - a.count || a.scientific_name.localeCompare(b.scientific_name));
 
-    // Derive genus from `Genus species` binomial when the column is null —
-    // most existing taxa rows lack lineage because the identify EF only
-    // writes kingdom/family. This keeps the sunburst groupable by genus.
-    function deriveGenus(name: string): string | null {
-      const first = name.trim().split(/\s+/)[0];
-      if (!first || first.length < 2) return null;
-      if (!/^[A-Z][a-z]+$/.test(first)) return null;
-      return first;
-    }
-
     // M34: expose full taxa list for sunburst + search panels
+    // (`deriveGenus` lives in species-display.ts so it's reusable + tested.)
     allTaxa = enriched.map(t => {
       const rawGenus = (t as Record<string,unknown>).genus as string | null ?? null;
       return {
@@ -478,19 +470,21 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       listEl.innerHTML = enriched.map(cardMarkup).join('');
     }
 
-    // Hide kingdom chips that match zero loaded taxa — when the DB lacks
-    // lineage data they're noise that can't filter anything.
-    {
+    // Show kingdom chips iff at least one loaded taxon carries that
+    // kingdom — when the DB lacks lineage data they're noise that can't
+    // filter anything. Idempotent + data-driven: safe to re-run if
+    // `allTaxa` ever changes (pagination, search refetch, etc.).
+    function refreshKingdomChipVisibility() {
       const kingdomCounts = new Map<string, number>();
-      for (const t of enriched) {
-        const k = (t as Record<string, unknown>).kingdom as string | null;
-        if (k) kingdomCounts.set(k, (kingdomCounts.get(k) ?? 0) + 1);
+      for (const t of allTaxa) {
+        if (t.kingdom) kingdomCounts.set(t.kingdom, (kingdomCounts.get(t.kingdom) ?? 0) + 1);
       }
       document.querySelectorAll<HTMLButtonElement>('[data-filter-chips] [data-chip^="kingdom:"]').forEach((btn) => {
         const k = (btn.dataset.chip ?? '').slice('kingdom:'.length);
-        if ((kingdomCounts.get(k) ?? 0) === 0) btn.classList.add('hidden');
+        btn.classList.toggle('hidden', (kingdomCounts.get(k) ?? 0) === 0);
       });
     }
+    refreshKingdomChipVisibility();
 
     if (searchEl) {
       let timer: number | null = null;
@@ -659,17 +653,6 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
         'Animalia': '#2563eb', 'Plantae': '#16a34a', 'Fungi': '#ea580c',
         'Chromista': '#7c3aed', 'Bacteria': '#dc2626', 'Protozoa': '#0891b2',
       };
-      // Used when a node has no recognised kingdom — picks a stable colour
-      // from a palette so the chart isn't a wall of grey.
-      const FALLBACK_PALETTE = [
-        '#0ea5e9', '#10b981', '#f59e0b', '#a855f7', '#ef4444',
-        '#06b6d4', '#ec4899', '#84cc16', '#6366f1', '#f97316',
-      ];
-      function hashName(s: string): number {
-        let h = 0;
-        for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
-        return Math.abs(h);
-      }
 
       const INNER_HOLE = 0.30;
       const OUTER_LIMIT = 0.95;
@@ -736,14 +719,13 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
         const r0 = INNER_HOLE + (depth - 1) * ringWidth;
         const r1 = r0 + ringWidth;
         let angle = startAngle;
-        node.children.forEach((child, idx) => {
+        node.children.forEach((child) => {
           const frac = node.count > 0 ? child.count / node.count : 0;
           const sweep = (endAngle - startAngle) * frac;
           if (sweep < 0.01) { angle += sweep; return; }
           const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
           const kingdomKey = child.kingdom ?? child.name;
-          const color = KINGDOM_COLORS[kingdomKey]
-            ?? FALLBACK_PALETTE[hashName(child.name || String(idx)) % FALLBACK_PALETTE.length];
+          const color = KINGDOM_COLORS[kingdomKey] ?? colorForName(child.name);
           path.setAttribute('d', arcPath(r0, r1, angle, angle + sweep));
           path.setAttribute('fill', color);
           path.setAttribute('fill-opacity', String(Math.max(0.55, 0.95 - (depth - 1) * 0.08)));

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -90,7 +90,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       <p class="text-xs text-zinc-500 dark:text-zinc-400 mb-2">
         {lang === 'es' ? 'Toca un segmento para explorar. Doble toque en especie para ver su perfil.' : 'Tap a segment to explore. Double-tap a species to view its profile.'}
       </p>
-      <div id="es-sunburst-container" class="relative w-full" style="aspect-ratio: 1;">
+      <div id="es-sunburst-container" class="relative w-full max-w-md mx-auto" style="aspect-ratio: 1;">
         <svg id="es-sunburst" width="100%" height="100%" viewBox="-1 -1 2 2" style="display:block;"></svg>
         <div id="es-sunburst-center" class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
           <p id="es-sunburst-name" class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 text-center px-8"></p>
@@ -402,21 +402,34 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       }))
       .sort((a, b) => b.count - a.count || a.scientific_name.localeCompare(b.scientific_name));
 
+    // Derive genus from `Genus species` binomial when the column is null —
+    // most existing taxa rows lack lineage because the identify EF only
+    // writes kingdom/family. This keeps the sunburst groupable by genus.
+    function deriveGenus(name: string): string | null {
+      const first = name.trim().split(/\s+/)[0];
+      if (!first || first.length < 2) return null;
+      if (!/^[A-Z][a-z]+$/.test(first)) return null;
+      return first;
+    }
+
     // M34: expose full taxa list for sunburst + search panels
-    allTaxa = enriched.map(t => ({
-      id: t.id,
-      scientific_name: t.scientific_name,
-      common_name_es: t.common_name_es,
-      common_name_en: t.common_name_en,
-      kingdom: (t as Record<string,unknown>).kingdom as string | null ?? null,
-      phylum: (t as Record<string,unknown>).phylum as string | null ?? null,
-      class: (t as Record<string,unknown>).class as string | null ?? null,
-      order: (t as Record<string,unknown>).order as string | null ?? null,
-      family: (t as Record<string,unknown>).family as string | null ?? null,
-      genus: (t as Record<string,unknown>).genus as string | null ?? null,
-      slug: (t as Record<string,unknown>).slug as string | null ?? null,
-      observation_count: t.count,
-    }));
+    allTaxa = enriched.map(t => {
+      const rawGenus = (t as Record<string,unknown>).genus as string | null ?? null;
+      return {
+        id: t.id,
+        scientific_name: t.scientific_name,
+        common_name_es: t.common_name_es,
+        common_name_en: t.common_name_en,
+        kingdom: (t as Record<string,unknown>).kingdom as string | null ?? null,
+        phylum: (t as Record<string,unknown>).phylum as string | null ?? null,
+        class: (t as Record<string,unknown>).class as string | null ?? null,
+        order: (t as Record<string,unknown>).order as string | null ?? null,
+        family: (t as Record<string,unknown>).family as string | null ?? null,
+        genus: rawGenus ?? deriveGenus(t.scientific_name),
+        slug: (t as Record<string,unknown>).slug as string | null ?? null,
+        observation_count: t.count,
+      };
+    });
 
     hideSkeleton();
     if (enriched.length === 0) {
@@ -463,6 +476,20 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
 
     if (listEl) {
       listEl.innerHTML = enriched.map(cardMarkup).join('');
+    }
+
+    // Hide kingdom chips that match zero loaded taxa — when the DB lacks
+    // lineage data they're noise that can't filter anything.
+    {
+      const kingdomCounts = new Map<string, number>();
+      for (const t of enriched) {
+        const k = (t as Record<string, unknown>).kingdom as string | null;
+        if (k) kingdomCounts.set(k, (kingdomCounts.get(k) ?? 0) + 1);
+      }
+      document.querySelectorAll<HTMLButtonElement>('[data-filter-chips] [data-chip^="kingdom:"]').forEach((btn) => {
+        const k = (btn.dataset.chip ?? '').slice('kingdom:'.length);
+        if ((kingdomCounts.get(k) ?? 0) === 0) btn.classList.add('hidden');
+      });
     }
 
     if (searchEl) {
@@ -616,7 +643,6 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       }));
     }
 
-    wireChipClicks();
     applyAllFilters();
 
     // ── M34: Sunburst ──────────────────────────────────────────
@@ -633,7 +659,20 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
         'Animalia': '#2563eb', 'Plantae': '#16a34a', 'Fungi': '#ea580c',
         'Chromista': '#7c3aed', 'Bacteria': '#dc2626', 'Protozoa': '#0891b2',
       };
-      const DEFAULT_COLOR = '#71717a';
+      // Used when a node has no recognised kingdom — picks a stable colour
+      // from a palette so the chart isn't a wall of grey.
+      const FALLBACK_PALETTE = [
+        '#0ea5e9', '#10b981', '#f59e0b', '#a855f7', '#ef4444',
+        '#06b6d4', '#ec4899', '#84cc16', '#6366f1', '#f97316',
+      ];
+      function hashName(s: string): number {
+        let h = 0;
+        for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+        return Math.abs(h);
+      }
+
+      const INNER_HOLE = 0.30;
+      const OUTER_LIMIT = 0.95;
 
       type SunNode = { name: string; rank: string; count: number; slug?: string; taxonId?: string; kingdom?: string; children: SunNode[] };
 
@@ -681,27 +720,40 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
 
       const treeData = buildTree(allTaxa);
 
-      function renderLevel(node: SunNode, depth: number, startAngle: number, endAngle: number, maxDepth = 4) {
+      // Real tree depth (1 if only species-level, up to 7 with full lineage).
+      // Used to size rings so they fill the chart instead of leaving a void.
+      function treeDepth(node: SunNode): number {
+        if (!node.children.length) return 0;
+        let m = 0;
+        for (const c of node.children) m = Math.max(m, treeDepth(c));
+        return 1 + m;
+      }
+      const actualDepth = Math.max(1, treeDepth(treeData));
+      const ringWidth = (OUTER_LIMIT - INNER_HOLE) / actualDepth;
+
+      function renderLevel(node: SunNode, depth: number, startAngle: number, endAngle: number, maxDepth = actualDepth) {
         if (depth > maxDepth || node.children.length === 0) return;
-        const r0 = depth * 0.18;
-        const r1 = r0 + 0.17;
+        const r0 = INNER_HOLE + (depth - 1) * ringWidth;
+        const r1 = r0 + ringWidth;
         let angle = startAngle;
-        node.children.forEach(child => {
+        node.children.forEach((child, idx) => {
           const frac = node.count > 0 ? child.count / node.count : 0;
           const sweep = (endAngle - startAngle) * frac;
           if (sweep < 0.01) { angle += sweep; return; }
           const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-          const color = KINGDOM_COLORS[child.kingdom ?? child.name] ?? DEFAULT_COLOR;
+          const kingdomKey = child.kingdom ?? child.name;
+          const color = KINGDOM_COLORS[kingdomKey]
+            ?? FALLBACK_PALETTE[hashName(child.name || String(idx)) % FALLBACK_PALETTE.length];
           path.setAttribute('d', arcPath(r0, r1, angle, angle + sweep));
           path.setAttribute('fill', color);
-          path.setAttribute('fill-opacity', String(0.9 - depth * 0.1));
+          path.setAttribute('fill-opacity', String(Math.max(0.55, 0.95 - (depth - 1) * 0.08)));
           path.setAttribute('stroke', '#fff');
           path.setAttribute('stroke-width', '0.005');
           // Only leaf nodes (species) navigate to the detail page.
           // Intermediate nodes (kingdom → genus) update the center label only
           // so the user can explore the hierarchy without accidental navigation.
           const isLeaf = child.children.length === 0;
-          path.style.cursor = isLeaf ? 'pointer' : 'default';
+          path.style.cursor = 'pointer';
           path.addEventListener('click', () => {
             if (nameEl) nameEl.textContent = child.name;
             if (countEl) countEl.textContent = `${child.count} obs`;
@@ -716,9 +768,10 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       svg.innerHTML = '';
       renderLevel(treeData, 1, -Math.PI / 2, 3 * Math.PI / 2);
 
-      // Center circle
+      // Center circle (matches inner-hole radius).
       const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-      circle.setAttribute('cx', '0'); circle.setAttribute('cy', '0'); circle.setAttribute('r', '0.17');
+      circle.setAttribute('cx', '0'); circle.setAttribute('cy', '0');
+      circle.setAttribute('r', String(INNER_HOLE - 0.01));
       circle.setAttribute('fill', 'transparent');
       svg.appendChild(circle);
 

--- a/src/lib/species-display.ts
+++ b/src/lib/species-display.ts
@@ -35,3 +35,32 @@ export function pillForSpecies(input: SpeciesPillInput): Pill | null {
   }
   return null;
 }
+
+// Most existing taxa rows lack a populated `genus` column because the
+// identify EF only writes kingdom/family at insert. Derive it from the
+// `Genus species` binomial as a safe client-side fallback.
+//
+// Conservative regex: only accepts a Capitalised followed by lowercase
+// (`Aratinga`, `Canis`). Rejects abbreviations (`sp.`), hybrids
+// (`×Genus`), parenthesised subgenera, and noise. Returns null when in
+// doubt — callers treat null as "no genus information".
+export function deriveGenus(name: string): string | null {
+  const first = name.trim().split(/\s+/)[0];
+  if (!first || first.length < 2) return null;
+  if (!/^[A-Z][a-z]+$/.test(first)) return null;
+  return first;
+}
+
+// Stable colour for arbitrary taxon names when no known kingdom mapping
+// applies. Uses golden-ratio hue stepping over HSL so distinct names get
+// distinct hues regardless of how many appear (no collisions on a tiny
+// fixed palette). Saturation/lightness are tuned for legibility on both
+// light and dark sunburst backgrounds.
+//
+// Stable: same input → same output across sessions and rebuilds.
+export function colorForName(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+  const hue = ((Math.abs(h) * 137) % 360);
+  return `hsl(${hue}, 62%, 52%)`;
+}

--- a/tests/unit/species-display.test.ts
+++ b/tests/unit/species-display.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { pillForSpecies, type SpeciesPillInput, type Pill } from '../../src/lib/species-display';
+import {
+  pillForSpecies,
+  deriveGenus,
+  colorForName,
+  type SpeciesPillInput,
+  type Pill,
+} from '../../src/lib/species-display';
 
 describe('pillForSpecies', () => {
   it('returns rarity pill when rarity_bucket >= 4', () => {
@@ -35,5 +41,64 @@ describe('pillForSpecies', () => {
 
   it('rarity beats endemic and nom059', () => {
     expect(pillForSpecies({ rarity_bucket: 5, endemic_mx: true, nom059_status: 'E' })?.kind).toBe('rarity-rare');
+  });
+});
+
+describe('deriveGenus', () => {
+  it('extracts genus from a standard binomial', () => {
+    expect(deriveGenus('Aratinga canicularis')).toBe('Aratinga');
+    expect(deriveGenus('Canis familiaris')).toBe('Canis');
+    expect(deriveGenus('Heliocarpus terebinthinaceus')).toBe('Heliocarpus');
+  });
+
+  it('handles single-word genus-only entries', () => {
+    expect(deriveGenus('Quercus')).toBe('Quercus');
+  });
+
+  it('rejects abbreviations and noise', () => {
+    expect(deriveGenus('sp.')).toBeNull();
+    expect(deriveGenus('Gerbera spp.')).toBe('Gerbera');
+    expect(deriveGenus('cf. Aratinga')).toBeNull();
+  });
+
+  it('rejects hybrids with × prefix', () => {
+    expect(deriveGenus('×Citrofortunella mitis')).toBeNull();
+  });
+
+  it('rejects all-lowercase or all-uppercase', () => {
+    expect(deriveGenus('aratinga canicularis')).toBeNull();
+    expect(deriveGenus('ARATINGA canicularis')).toBeNull();
+  });
+
+  it('handles whitespace gracefully', () => {
+    expect(deriveGenus('   Aratinga canicularis  ')).toBe('Aratinga');
+    expect(deriveGenus('')).toBeNull();
+    expect(deriveGenus('   ')).toBeNull();
+  });
+
+  it('rejects 1-letter "names"', () => {
+    expect(deriveGenus('A canicularis')).toBeNull();
+  });
+});
+
+describe('colorForName', () => {
+  it('returns a parseable HSL string', () => {
+    expect(colorForName('Aratinga')).toMatch(/^hsl\(\d+, 62%, 52%\)$/);
+  });
+
+  it('is stable for the same input', () => {
+    expect(colorForName('Canis')).toBe(colorForName('Canis'));
+  });
+
+  it('produces different hues for different inputs (most of the time)', () => {
+    const names = ['Aratinga', 'Canis', 'Quercus', 'Gerbera', 'Heliocarpus', 'Eysenhardtia', 'Columbina', 'Alamania'];
+    const hues = new Set(names.map(colorForName));
+    // 8 distinct names → expect at least 6 distinct hues (golden-ratio
+    // distribution makes collisions on small sets very unlikely).
+    expect(hues.size).toBeGreaterThanOrEqual(6);
+  });
+
+  it('handles empty string without crashing', () => {
+    expect(colorForName('')).toMatch(/^hsl\(0, 62%, 52%\)$/);
   });
 });


### PR DESCRIPTION
## Summary

Two bugs on `/en/explore/species/` (and `/es/explorar/especies/`):

- **Filter chips did nothing.** `wireChipClicks()` was called twice — once eagerly for the no-Supabase fallback path, then again after data loaded. Every chip had two click listeners, so toggling fired twice and net-zeroed.
- **Tree view "looked like shit."** Container was `w-full` aspect-ratio:1 → ~1000px square on desktop. Rings were hard-coded at radius 0.18→0.35, so the sunburst rendered as a thin band ~17% of the viewport. And every segment was grey because most taxa rows have `NULL` kingdom (the identify EF only ever wrote kingdom/family at insert; most cascades return `'Unknown'`).

## What changed

- Removed the duplicate `wireChipClicks()` call after data load.
- Container is now `max-w-md mx-auto` so the chart caps at ~28rem.
- Ring radii adapt to the actual taxonomic depth present in the data (`[0.30, 0.95]` divided by the deepest path), so sparse data fills the chart.
- Segments without a known kingdom pick a stable colour from a 10-entry palette via name-hash.
- All wedges are now clickable (not just leaves) — clicking a non-leaf updates the centre label, leaves still navigate.
- **Sparse-data fallbacks:**
  - Derive genus from `Genus species` binomial when the column is null, so the sunburst can group by genus when kingdom is missing.
  - Hide kingdom chips with zero matching taxa — they couldn't filter anything anyway.

Backend lineage backfill (populate `kingdom`/`phylum`/`genus` properly via GBIF or similar) is a separate, larger piece of work — out of scope here.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 1004 tests pass
- [x] `npm run build` — 231 pages, no errors
- [ ] Visual check on `/en/explore/species/` and `/es/explorar/especies/`:
  - Click "★ Rare" — chip toggles, list filters to rarity ≥ 4
  - Click "Tree" tab — sunburst is reasonably sized, segments are coloured
  - On a DB with sparse taxonomy, kingdom chips (Animalia/Plantae/Fungi) are hidden
  - On a DB with full lineage, kingdom chips work and segments are kingdom-coloured

🤖 Generated with [Claude Code](https://claude.com/claude-code)