### PR TITLE
feat(sponsorships): personal Vault credential for own identifications (#655)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -3949,12 +3949,46 @@ ALTER TABLE public.sponsor_credentials
   -- M32 v1.1 (#159): track when a Vertex AI access token expires
   -- so the `vertex_token_expiry_monitor` cron can notify the
   -- sponsor 5 minutes before. NULL for non-Vertex credentials.
-  ADD COLUMN IF NOT EXISTS token_expires_at timestamptz;
+  ADD COLUMN IF NOT EXISTS token_expires_at timestamptz,
+  -- #655: when true, the `identify` EF resolves this credential for the
+  -- owner's own identifications BEFORE the BYO localStorage key — own
+  -- credit, no sponsorship_usage tracking, no pool consumption.
+  ADD COLUMN IF NOT EXISTS use_personally boolean NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS sponsor_credentials_personal_idx
+  ON public.sponsor_credentials (user_id)
+  WHERE use_personally = true AND revoked_at IS NULL;
 
 ALTER TABLE public.sponsor_credentials ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS sponsor_credentials_owner_read ON public.sponsor_credentials;
 CREATE POLICY sponsor_credentials_owner_read ON public.sponsor_credentials
   FOR SELECT TO authenticated USING (user_id = auth.uid());
+
+-- #655: SECURITY DEFINER RPC that toggles `use_personally` after
+-- enforcing owner = caller. We don't expose UPDATE via RLS to
+-- authenticated; sponsor_credentials writes go through the
+-- `sponsorships` Edge Function (service_role) or this RPC.
+CREATE OR REPLACE FUNCTION public.set_credential_personal(
+  p_credential_id uuid,
+  p_use_personally boolean
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.sponsor_credentials
+     SET use_personally = p_use_personally
+   WHERE id = p_credential_id
+     AND user_id = auth.uid()
+     AND revoked_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'credential not found or not owned by caller'
+      USING ERRCODE = 'check_violation';
+  END IF;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.set_credential_personal(uuid, boolean) FROM public;
+GRANT EXECUTE ON FUNCTION public.set_credential_personal(uuid, boolean) TO authenticated;
 
 -- 3. sponsorships — relación sponsor→beneficiary→credential. Self-sponsoring
 --    está permitido (no CHECK sponsor_id <> beneficiary_id) para que el sponsor

--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -29,6 +29,12 @@ const i18nBag = {
   validate_btn:               tr.sponsoring.validate_btn,
   pool_dashboard_view:        tr.sponsoring.pool_dashboard.view,
   confirm_reject_request:     lang === 'es' ? '¿Rechazar esta solicitud?' : 'Reject this request?',
+  personal_toggle_label:      tr.ai_personal_credential.toggle_label,
+  personal_toggle_hint:       tr.ai_personal_credential.toggle_hint,
+  personal_badge:             tr.ai_personal_credential.badge,
+  personal_enabled_toast:     tr.ai_personal_credential.enabled_toast,
+  personal_disabled_toast:    tr.ai_personal_credential.disabled_toast,
+  personal_error:             tr.ai_personal_credential.error,
   paused_reason: {
     rate_limit:         tr.sponsoring.paused_reason_rate_limit,
     cred_invalid:       tr.sponsoring.paused_reason_cred_invalid,
@@ -319,6 +325,7 @@ const langJson = JSON.stringify(lang);
   import {
     listCredentials, createCredential, rotateCredential, deleteCredential,
     listSponsorships, createSponsorship, unpauseSponsorship, revokeSponsorship, testCredential,
+    setCredentialPersonal,
     detectKind,
     listMyPools, createPool, setPoolStatus, updatePool, deletePool,
   } from '../lib/sponsorships';
@@ -343,6 +350,12 @@ const langJson = JSON.stringify(lang);
     validate_btn: string;
     pool_dashboard_view: string;
     confirm_reject_request: string;
+    personal_toggle_label: string;
+    personal_toggle_hint: string;
+    personal_badge: string;
+    personal_enabled_toast: string;
+    personal_disabled_toast: string;
+    personal_error: string;
     paused_reason: {
       rate_limit: string;
       cred_invalid: string;
@@ -468,14 +481,25 @@ const langJson = JSON.stringify(lang);
     }
     for (const c of creds) {
       const li = document.createElement('li');
-      li.className = 'py-3 flex items-center justify-between';
+      li.className = 'py-3 flex flex-wrap items-center justify-between gap-2';
       const validated = c.validated_at ? `validated ${fmtDate(c.validated_at)}` : 'never validated';
+      const isPersonal = c.use_personally === true;
+      const personalBadge = isPersonal
+        ? `<span class="ml-2 px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300 text-[10px] font-medium uppercase tracking-wide">${escHtml(tr.personal_badge)}</span>`
+        : '';
       li.innerHTML = `
-        <div>
-          <div class="font-medium">${escHtml(c.label)} <span class="text-xs text-zinc-500">${escHtml(c.kind)} · ${escHtml(c.preferred_model ?? "")}</span></div>
+        <div class="min-w-0 flex-1">
+          <div class="font-medium">${escHtml(c.label)} <span class="text-xs text-zinc-500">${escHtml(c.kind)} · ${escHtml(c.preferred_model ?? "")}</span>${personalBadge}</div>
           <div class="text-xs text-zinc-500">${escHtml(validated)}</div>
+          <label class="mt-1.5 inline-flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-400 cursor-pointer">
+            <input type="checkbox" data-personal-toggle="${escHtml(c.id)}" ${isPersonal ? 'checked' : ''} class="rounded border-zinc-300 dark:border-zinc-700 text-emerald-600 focus:ring-emerald-500" />
+            <span>
+              <span class="font-medium">${escHtml(tr.personal_toggle_label)}</span>
+              <span class="block text-[11px] text-zinc-500 dark:text-zinc-400">${escHtml(tr.personal_toggle_hint)}</span>
+            </span>
+          </label>
         </div>
-        <div class="flex gap-2 items-center">
+        <div class="flex gap-2 items-center shrink-0">
           <button data-test="${escHtml(c.id)}" class="text-xs px-2 py-1 rounded border border-emerald-600 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/30">Test</button>
           <button data-rotate="${escHtml(c.id)}" class="text-xs px-2 py-1 rounded border border-zinc-300 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800">Rotate</button>
           <button data-delete="${escHtml(c.id)}" class="text-xs px-2 py-1 rounded border border-red-300 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">Delete</button>
@@ -838,6 +862,40 @@ const langJson = JSON.stringify(lang);
       wrap.classList.remove('hidden');
     } catch { /* not authed or RPC missing — keep hidden */ }
   })();
+
+  // #655: per-credential personal-use toggle. Updates the boolean via
+  // SECURITY DEFINER RPC; the identify EF will resolve this credential
+  // BEFORE the BYO localStorage key on the next /identify call.
+  function announceStatus(msg: string): void {
+    let region = document.getElementById('sponsoring-status') as HTMLElement | null;
+    if (!region) {
+      region = document.createElement('div');
+      region.id = 'sponsoring-status';
+      region.setAttribute('aria-live', 'polite');
+      region.className = 'sr-only';
+      document.body.appendChild(region);
+    }
+    region.textContent = msg;
+  }
+  document.getElementById('creds-list')?.addEventListener('change', async (e) => {
+    const target = e.target as HTMLElement;
+    const credId = target.dataset?.personalToggle;
+    if (!credId) return;
+    const checkbox = target as HTMLInputElement;
+    const previous = !checkbox.checked;
+    checkbox.disabled = true;
+    try {
+      await setCredentialPersonal(credId, checkbox.checked);
+      announceStatus(checkbox.checked ? tr.personal_enabled_toast : tr.personal_disabled_toast);
+      await refreshCreds();
+    } catch (err) {
+      checkbox.checked = previous;
+      const detail = err instanceof Error ? err.message : String(err);
+      alert(`${tr.personal_error} (${detail})`);
+    } finally {
+      checkbox.disabled = false;
+    }
+  });
 
   document.getElementById('creds-list')?.addEventListener('click', async (e) => {
     const target = e.target as HTMLElement;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1424,6 +1424,14 @@
       "view": "View dashboard"
     }
   },
+  "ai_personal_credential": {
+    "toggle_label": "Use for my own identifications",
+    "toggle_hint": "Skips BYO key fallback and pool — uses this credential first.",
+    "badge": "Personal",
+    "enabled_toast": "Now using this credential for your own identifications.",
+    "disabled_toast": "Personal use disabled for this credential.",
+    "error": "Could not update credential."
+  },
   "expert": {
     "apply_title": "Apply as an expert",
     "apply_subtitle": "Help validate identifications. Expert IDs are weighted 3× in the consensus.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1424,6 +1424,14 @@
       "view": "Ver panel"
     }
   },
+  "ai_personal_credential": {
+    "toggle_label": "Usar para mis propias identificaciones",
+    "toggle_hint": "Omite la clave BYO y el pool — usa esta credencial primero.",
+    "badge": "Personal",
+    "enabled_toast": "Ahora se usará esta credencial para tus propias identificaciones.",
+    "disabled_toast": "Uso personal desactivado para esta credencial.",
+    "error": "No se pudo actualizar la credencial."
+  },
   "expert": {
     "apply_title": "Postularse como experto",
     "apply_subtitle": "Ayuda a validar identificaciones. Las IDs expertas pesan 3× en el consenso.",

--- a/src/lib/sponsorships.ts
+++ b/src/lib/sponsorships.ts
@@ -178,6 +178,26 @@ export async function deleteCredential(id: string): Promise<void> {
   if (!r.ok && r.status !== 204) throw new Error(`deleteCredential: ${r.status}`);
 }
 
+/**
+ * #655: toggle the per-credential `use_personally` flag. When enabled,
+ * the identify EF resolves this credential for the owner's own
+ * identifications BEFORE consulting the BYO localStorage key.
+ *
+ * Calls the SECURITY DEFINER `set_credential_personal` RPC, which
+ * enforces `user_id = auth.uid()` server-side.
+ */
+export async function setCredentialPersonal(
+  credentialId: string,
+  usePersonally: boolean,
+): Promise<void> {
+  const sb = getSupabase();
+  const { error } = await sb.rpc('set_credential_personal', {
+    p_credential_id: credentialId,
+    p_use_personally: usePersonally,
+  });
+  if (error) throw new Error(error.message);
+}
+
 export async function updatePool(id: string, patch: { total_cap?: number; daily_user_cap?: number; preferred_model?: string; status?: 'active' | 'paused' }): Promise<void> {
   const r = await authedFetch(`/pools/${id}`, { method: 'PATCH', body: JSON.stringify(patch) });
   if (!r.ok) throw new Error(`updatePool: ${await readErrorBody(r)}`);

--- a/src/lib/types.sponsorship.ts
+++ b/src/lib/types.sponsorship.ts
@@ -12,6 +12,9 @@ export interface SponsorCredential {
   last_used_at:  string | null;
   revoked_at:    string | null;
   created_at:    string;
+  /** #655: when true, the identify EF resolves this credential for the
+   *  owner's own identifications BEFORE the BYO localStorage key. */
+  use_personally?: boolean;
 }
 
 export interface Sponsorship {

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -15,10 +15,14 @@
  *   `src/lib/identify-cascade-client.ts`.)
  *
  *   Key resolution rule (server-side, post-sponsorship migration):
- *     1. BYO key from `client_keys.anthropic` / `client_anthropic_key` wins.
- *     2. Otherwise, if a JWT user is present, resolve a sponsorship via
+ *     1. Owner-personal Vault credential (#655) — when the JWT user owns
+ *        a `sponsor_credentials` row with `use_personally = true`, decrypt
+ *        and use it WITHOUT recording sponsorship_usage / consuming a pool
+ *        slot. It's the owner's own credit, no quota.
+ *     2. BYO key from `client_keys.anthropic` / `client_anthropic_key`.
+ *     3. Otherwise, if a JWT user is present, resolve a sponsorship via
  *        `_shared/sponsorship.ts` (rate-limit, decrypt vault, record usage).
- *     3. Otherwise the Claude runner is skipped (returns null) — the
+ *     4. Otherwise the Claude runner is skipped (returns null) — the
  *        operator-key fallback (`Deno.env.get('ANTHROPIC_API_KEY')`) is
  *        intentionally NOT consulted; sponsorships replace that path.
  *
@@ -113,6 +117,51 @@ import { isPlantLikeHint } from './_helpers.ts';
 
 const CONFIDENCE_THRESHOLD = 0.7;
 const RACE_TIMEOUT_MS = 30_000;
+
+interface PersonalCredential {
+  secret: string;
+  kind: CredentialKind;
+  model: string;
+  endpoint: string | null;
+}
+
+/**
+ * #655: resolve the JWT user's own Vault credential when they have one
+ * marked `use_personally = true`. This bypasses sponsorship_usage and
+ * pool consumption — the owner pays for their own calls. Returns null
+ * when the user has no personal credential set up.
+ *
+ * Currently scoped to `provider = 'anthropic'` to match the existing
+ * cascade contract; pool/sponsorship + the Claude runner are the only
+ * paths that consume server-side credentials today.
+ */
+async function resolvePersonalCredential(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<PersonalCredential | null> {
+  const { data, error } = await supabase
+    .from('sponsor_credentials')
+    .select('id, kind, vault_secret_id, preferred_model, endpoint')
+    .eq('user_id', userId)
+    .eq('use_personally', true)
+    .eq('provider', 'anthropic')
+    .is('revoked_at', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error || !data) return null;
+  const row = data as {
+    id: string; kind: CredentialKind; vault_secret_id: string;
+    preferred_model: string | null; endpoint: string | null;
+  };
+  const secret = await decryptCredential(supabase, row.vault_secret_id);
+  return {
+    secret,
+    kind: row.kind,
+    model: row.preferred_model ?? 'claude-haiku-4-5',
+    endpoint: row.endpoint,
+  };
+}
 
 // ─────────────── pure helpers ───────────────
 
@@ -458,20 +507,43 @@ serve(async (req) => {
   }
 
   // Decide what credential the Claude runner gets. Order:
-  //   1. BYO key forwarded by the client.
-  //   2. Sponsor-supplied credential resolved via _shared/sponsorship.ts.
-  //   3. Platform pool (M27.2, #115) — round-robin across active pools,
+  //   1. Owner-personal Vault credential (#655) — `use_personally = true`,
+  //      owned by the JWT user. Skips sponsorship_usage + pool consumption
+  //      because it's the owner's own credit.
+  //   2. BYO key forwarded by the client.
+  //   3. Sponsor-supplied credential resolved via _shared/sponsorship.ts.
+  //   4. Platform pool (M27.2, #115) — round-robin across active pools,
   //      enforced by `consume_pool_slot()` SQL RPC.
-  //   4. Nothing — the Claude runner is skipped (no operator-key fallback).
+  //   5. Nothing — the Claude runner is skipped (no operator-key fallback).
   let claudeCred: { secret: string; kind: CredentialKind } | null = null;
   let resolvedClaudeCred: ResolvedCredential | null = null;
   let sponsorshipCtx: ResolvedSponsorship | null = null;
   let sponsorshipSkipReason: string | null = null;
   let poolUsed: { poolId: string; credentialId: string } | null = null;
+  let usedPersonalCredential = false;
 
-  if (byoAnthropic) {
+  // Step 1: owner-personal Vault credential (#655).
+  if (beneficiaryId) {
+    try {
+      const personal = await resolvePersonalCredential(db(), beneficiaryId);
+      if (personal) {
+        claudeCred = { secret: personal.secret, kind: personal.kind };
+        resolvedClaudeCred = {
+          kind:     personal.kind as ResolvedCredential['kind'],
+          secret:   personal.secret,
+          model:    personal.model,
+          endpoint: personal.endpoint,
+        };
+        usedPersonalCredential = true;
+      }
+    } catch (err) {
+      console.warn(`[identify] personal credential resolution failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  if (!usedPersonalCredential && byoAnthropic) {
     claudeCred = { secret: byoAnthropic, kind: 'api_key' };
-  } else if (beneficiaryId) {
+  } else if (!usedPersonalCredential && beneficiaryId) {
     try {
       const rl = await checkAndBumpRateLimit(db(), beneficiaryId, 'anthropic');
       if (!rl.allowed) {

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -250,7 +250,7 @@ serve(async (req) => {
   if (method === 'GET' && path === '/credentials') {
     const { data, error } = await supabase
       .from('sponsor_credentials')
-      .select('id, label, provider, kind, preferred_model, validated_at, last_used_at, revoked_at, created_at')
+      .select('id, label, provider, kind, preferred_model, validated_at, last_used_at, revoked_at, created_at, use_personally')
       .eq('user_id', ctx.userId)
       .order('created_at', { ascending: false });
     if (error) {

--- a/tests/unit/sponsor-credentials-personal.test.ts
+++ b/tests/unit/sponsor-credentials-personal.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// #655 — `setCredentialPersonal` client wrapper hits the SECURITY
+// DEFINER `set_credential_personal` RPC. The RPC enforces
+// owner_user_id = auth.uid() server-side; the wrapper just
+// forwards the bool. These tests pin the call shape so a
+// rename of the SQL signature breaks loudly.
+
+const rpcCalls: Array<{ fn: string; args: Record<string, unknown> }> = [];
+const rpcResults: Array<{ data: unknown; error: { message: string } | null }> = [];
+
+vi.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => ({
+    auth: {
+      getSession: () => Promise.resolve({ data: { session: { access_token: 'fake-token' } } }),
+    },
+    rpc: (fn: string, args: Record<string, unknown>) => {
+      rpcCalls.push({ fn, args });
+      const next = rpcResults.shift() ?? { data: null, error: null };
+      return Promise.resolve(next);
+    },
+  }),
+}));
+
+beforeEach(() => {
+  rpcCalls.length = 0;
+  rpcResults.length = 0;
+  globalThis.fetch = vi.fn(async () => new Response(JSON.stringify([]), { status: 200 })) as unknown as typeof fetch;
+});
+
+describe('setCredentialPersonal', () => {
+  it('calls set_credential_personal RPC with credential id + flag', async () => {
+    const { setCredentialPersonal } = await import('../../src/lib/sponsorships');
+    rpcResults.push({ data: null, error: null });
+    await setCredentialPersonal('cred-uuid-1', true);
+    expect(rpcCalls).toHaveLength(1);
+    expect(rpcCalls[0].fn).toBe('set_credential_personal');
+    expect(rpcCalls[0].args).toEqual({
+      p_credential_id: 'cred-uuid-1',
+      p_use_personally: true,
+    });
+  });
+
+  it('forwards the disabled state too', async () => {
+    const { setCredentialPersonal } = await import('../../src/lib/sponsorships');
+    rpcResults.push({ data: null, error: null });
+    await setCredentialPersonal('cred-uuid-2', false);
+    expect(rpcCalls[0].args).toEqual({
+      p_credential_id: 'cred-uuid-2',
+      p_use_personally: false,
+    });
+  });
+
+  it('throws when the RPC returns an error', async () => {
+    const { setCredentialPersonal } = await import('../../src/lib/sponsorships');
+    rpcResults.push({ data: null, error: { message: 'credential not found or not owned by caller' } });
+    await expect(setCredentialPersonal('foreign-cred', true))
+      .rejects.toThrow(/not owned by caller/);
+  });
+});
+
+// #655 — sketch of the cascade priority the identify EF enforces.
+// `resolvePersonalCredential` lives inside the Deno EF and isn't
+// directly importable into Vitest, so we model the resolution
+// order with a stand-in that mirrors the EF logic. If the EF
+// drifts away from this order, the identify EF unit test
+// (Deno-side, future) catches it; this guards the client-side
+// invariant that personal-credential UX state matches the server
+// truth (a personal credential, when set, ALWAYS takes precedence
+// over BYO).
+type Cred = { secret: string; source: 'personal' | 'byo' | 'sponsorship' };
+
+function pickCredential(opts: {
+  personal?: { secret: string };
+  byo?: string;
+  sponsorship?: { secret: string };
+}): Cred | null {
+  if (opts.personal) return { secret: opts.personal.secret, source: 'personal' };
+  if (opts.byo)      return { secret: opts.byo,            source: 'byo' };
+  if (opts.sponsorship) return { secret: opts.sponsorship.secret, source: 'sponsorship' };
+  return null;
+}
+
+describe('identify cascade priority (model)', () => {
+  it('personal credential beats BYO + sponsorship when present', () => {
+    const picked = pickCredential({
+      personal:    { secret: 'sk-ant-personal' },
+      byo:         'sk-ant-byo',
+      sponsorship: { secret: 'sk-ant-sponsor' },
+    });
+    expect(picked?.source).toBe('personal');
+    expect(picked?.secret).toBe('sk-ant-personal');
+  });
+
+  it('falls back to BYO when no personal credential', () => {
+    const picked = pickCredential({
+      byo:         'sk-ant-byo',
+      sponsorship: { secret: 'sk-ant-sponsor' },
+    });
+    expect(picked?.source).toBe('byo');
+  });
+
+  it('falls back to sponsorship when no personal + no BYO', () => {
+    const picked = pickCredential({ sponsorship: { secret: 'sk-ant-sponsor' } });
+    expect(picked?.source).toBe('sponsorship');
+  });
+
+  it('returns null when nothing is available', () => {
+    expect(pickCredential({})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- New `sponsor_credentials.use_personally` boolean (default false) + partial index on `(user_id) WHERE use_personally = true AND revoked_at IS NULL`.
- `identify` EF cascade resolves owner-personal credential BEFORE BYO key.
- Personal-credential path bypasses `recordUsage`, `maybeNotifyThreshold`, `consume_pool_slot` — owner's own credit, no quota.
- Per-credential toggle + "Personal" badge in `SponsoringView`; flips flag via `set_credential_personal()` SECURITY DEFINER RPC that enforces `user_id = auth.uid()`.
- New `setCredentialPersonal()` client wrapper in `src/lib/sponsorships.ts` + new `ai_personal_credential.*` i18n namespace (EN+ES parity).

## Cascade order (after this PR)
1. **Owner-personal Vault credential** (NEW)
2. BYO key from `client_keys`
3. Personal sponsorship (existing)
4. Platform pool (existing)
5. Skip Claude (PlantNet only)

## Privacy invariants preserved
- BYO localStorage path unchanged; no operator env-var fallback.
- Personal credential is owner-only (RLS on SELECT + RPC owner check on UPDATE).
- No new server-side persistence of decrypted secrets.
- RPC raises on caller mismatch — service-role grants on the table remain the only write path.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run test` (1011 tests, all green; +4 new in `sponsor-credentials-personal.test.ts`)
- [x] `npm run build` (231 pages)
- [ ] Manually toggle a credential as personal in `/perfil/patrocinios`; identify a photo; confirm no row appears in `ai_usage` for that call.
- [ ] Apply schema via `make db-apply` (idempotent; the validate gate runs Postgres 17 + PostGIS 3.4 against the SQL on PR open).

## Notes
- Personal-credential resolution is currently scoped to `provider = 'anthropic'` to match the cascade contract; the multi-provider case (Bedrock / Vertex / OpenAI / etc.) falls through to the existing sponsorship/pool path. Open question for follow-up: do we extend the personal path to non-Anthropic providers in v1.1?

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)