### PR TITLE
feat(species): precompute per-taxon obs counts

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -8170,6 +8170,36 @@ SELECT cron.unschedule('refresh-platform-stats')
 SELECT cron.schedule('refresh-platform-stats', '0 * * * *',
   $$REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_platform_stats$$);
 
+-- ─────────────────────────────────────────────────────────────────────────
+-- mv_taxon_obs_counts — per-species observation counts.
+-- Lets /explore/species/ render the index without scanning the full
+-- observations table client-side. Refreshed hourly via pg_cron.
+-- Single-row-per-taxon MV; UNIQUE index on taxon_id lets us
+-- REFRESH CONCURRENTLY.
+-- ─────────────────────────────────────────────────────────────────────────
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_taxon_obs_counts AS
+SELECT
+  o.primary_taxon_id                      AS taxon_id,
+  COUNT(*)::bigint                        AS obs_count,
+  MAX(o.observed_at)                      AS last_observed_at
+FROM public.observations o
+WHERE o.sync_status = 'synced'
+  AND o.primary_taxon_id IS NOT NULL
+GROUP BY o.primary_taxon_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_taxon_obs_counts_unique
+  ON public.mv_taxon_obs_counts (taxon_id);
+
+GRANT SELECT ON public.mv_taxon_obs_counts TO anon, authenticated;
+
+-- Refresh hourly (offset 5 minutes from mv_platform_stats so the two
+-- aren't competing for write locks on the same minute). Idempotent —
+-- unschedule first.
+SELECT cron.unschedule('refresh-taxon-obs-counts')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'refresh-taxon-obs-counts');
+SELECT cron.schedule('refresh-taxon-obs-counts', '5 * * * *',
+  $$REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_taxon_obs_counts$$);
+
 
 -- suggest_pokedex_target(viewer_id): pick one species the viewer hasn't
 -- observed yet, preferring their most-active kingdom, common rarity, with

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -317,17 +317,16 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       return;
     }
 
-    type ObsBucketRow = { primary_taxon_id: string | null };
-    let obsRows: ObsBucketRow[] = [];
+    type MvRow = { taxon_id: string; obs_count: number | string };
+    let mvRows: MvRow[] = [];
     try {
       const { data, error } = await supabase
-        .from('observations')
-        .select('primary_taxon_id')
-        .eq('sync_status', 'synced')
-        .not('primary_taxon_id', 'is', null)
-        .limit(2000);
+        .from('mv_taxon_obs_counts')
+        .select('taxon_id, obs_count')
+        .order('obs_count', { ascending: false })
+        .limit(500);
       if (error) throw error;
-      obsRows = (data ?? []) as unknown as ObsBucketRow[];
+      mvRows = (data ?? []) as unknown as MvRow[];
     } catch (e) {
       hideSkeleton();
       if (errEl) {
@@ -338,11 +337,11 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     }
 
     const counts = new Map<string, number>();
-    for (const r of obsRows) {
-      if (!r.primary_taxon_id) continue;
-      counts.set(r.primary_taxon_id, (counts.get(r.primary_taxon_id) ?? 0) + 1);
+    for (const r of mvRows) {
+      if (!r.taxon_id) continue;
+      counts.set(r.taxon_id, Number(r.obs_count));
     }
-    const taxonIds = Array.from(counts.keys());
+    const taxonIds = mvRows.map(r => r.taxon_id).filter((id): id is string => !!id);
 
     if (taxonIds.length === 0) {
       hideSkeleton();

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -296,6 +296,11 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     const otherTpl = root.dataset.labelObsCountOther ?? '{count} obs';
     const errLabel = root.dataset.labelError ?? 'Failed to load';
 
+    // Cap the species grid at the most-observed N taxa. The MV itself has
+    // no upper bound; this limit is purely about how many cards the page
+    // renders. Bumped if the catalog outgrows it OR if we add pagination.
+    const SPECIES_GRID_LIMIT = 500;
+
     const hideSkeleton = () => skeletonEl?.classList.add('hidden');
 
     // Wire filter chips eagerly — they're pure URL-state and must respond
@@ -324,7 +329,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
         .from('mv_taxon_obs_counts')
         .select('taxon_id, obs_count')
         .order('obs_count', { ascending: false })
-        .limit(500);
+        .limit(SPECIES_GRID_LIMIT);
       if (error) throw error;
       mvRows = (data ?? []) as unknown as MvRow[];
     } catch (e) {


### PR DESCRIPTION
## Summary

Per-species observation counts on /explore/species/ were computed client-side: the page scanned up to **2000 rows** of `observations` (with a hard `limit(2000)` cap that biases the ranking once we cross that threshold) and aggregated in JS. Hero counters are precomputed via `mv_platform_stats` — this gives the species ranking the same treatment.

## Changes

- **New MV `mv_taxon_obs_counts`** — `(taxon_id, obs_count, last_observed_at)`, refreshed hourly via pg_cron at `5 * * * *` (offset 5 min from `mv_platform_stats` to avoid lock contention). Patterned exactly on the existing `mv_platform_stats` block, including UNIQUE index for `REFRESH CONCURRENTLY` and `GRANT SELECT TO anon, authenticated`.
- **Client swap** — `ExploreSpeciesView` now reads from the MV directly (`SELECT taxon_id, obs_count FROM mv_taxon_obs_counts ORDER BY obs_count DESC LIMIT 500`) instead of scanning observations. Bandwidth shrinks from O(observations) to O(species).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run test`
- [x] `npm run build` — 231 pages
- [ ] After merge, `make db-apply` (or wait for `db-apply.yml` to fire on push)
- [ ] After db-apply, verify in `make db-psql`:
      ```
      SELECT count(*) FROM mv_taxon_obs_counts;
      SELECT * FROM mv_taxon_obs_counts ORDER BY obs_count DESC LIMIT 5;
      ```
- [ ] Visual check on `/{en,es}/explore/species/`: grid renders normally, obs counts on cards match what the old code showed