### PR TITLE
feat(species): sort chips on the species grid

### DIFF
--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -191,7 +191,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
   import maplibregl from 'maplibre-gl';
   import { getSupabase } from '../lib/supabase';
   import { renderSpeciesCard, type CardLabels } from '../lib/species-card-html';
-  import { parseChips, serializeChips, type ChipsState } from '../lib/species-filters';
+  import { parseChips, parseSort, serializeFilters, type ChipsState, type SortMode } from '../lib/species-filters';
   import { deriveGenus, colorForName, buildTaxonomicTree, taxonomicDepth, type TaxonNode } from '../lib/species-display';
 
   type Lang = 'en' | 'es';
@@ -302,8 +302,11 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     // even when the data fetch below fails (e.g. CI preview with no Supabase
     // keys). applyAllFilters() is a no-op when no cards are rendered yet.
     let currentChips: ChipsState = parseChips(window.location.search);
+    let currentSort: SortMode = parseSort(window.location.search);
     wireChipClicks();
+    wireSortClicks();
     paintChipPressedState();
+    paintSortPressedState();
 
     let supabase;
     try {
@@ -410,12 +413,19 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       }
     }
 
-    const enriched = taxaRows
-      .map(t => ({
-        ...t,
-        count: counts.get(t.id) ?? 0,
-      }))
-      .sort((a, b) => b.count - a.count || a.scientific_name.localeCompare(b.scientific_name));
+    type Enriched = TaxaRow & { count: number };
+    function sortEnriched(rows: Enriched[], mode: SortMode): Enriched[] {
+      if (mode === 'alpha') {
+        return [...rows].sort((a, b) => a.scientific_name.localeCompare(b.scientific_name));
+      }
+      // 'recent' currently falls back to obs count — last_observed_at is added
+      // by the parallel PR feat/mv-taxon-obs-counts; this branch becomes a real
+      // recency sort once that column is available.
+      return [...rows].sort((a, b) => b.count - a.count || a.scientific_name.localeCompare(b.scientific_name));
+    }
+    let cachedEnriched: Enriched[] = taxaRows.map(t => ({ ...t, count: counts.get(t.id) ?? 0 }));
+    const enriched = sortEnriched(cachedEnriched, currentSort);
+    cachedEnriched = enriched;
 
     // M34: expose full taxa list for sunburst + search panels
     // (`deriveGenus` lives in species-display.ts so it's reusable + tested.)
@@ -649,7 +659,31 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
           const k = c.slice('kingdom:'.length);
           currentChips = { ...currentChips, kingdom: currentChips.kingdom === k ? null : k };
         }
-        history.replaceState({}, '', `${window.location.pathname}${serializeChips(currentChips)}`);
+        history.replaceState({}, '', `${window.location.pathname}${serializeFilters(currentChips, currentSort)}`);
+        applyAllFilters();
+      }));
+    }
+
+    function paintSortPressedState() {
+      document.querySelectorAll<HTMLButtonElement>('[data-sort-chips] [data-sort]').forEach((btn) => {
+        const pressed = (btn.dataset.sort ?? '') === currentSort;
+        btn.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+      });
+    }
+
+    function wireSortClicks() {
+      const buttons = document.querySelectorAll<HTMLButtonElement>('[data-sort-chips] [data-sort]');
+      buttons.forEach((btn) => btn.addEventListener('click', () => {
+        const mode = (btn.dataset.sort ?? 'obs') as SortMode;
+        if (mode === currentSort) return;
+        currentSort = mode;
+        history.replaceState({}, '', `${window.location.pathname}${serializeFilters(currentChips, currentSort)}`);
+        if (listEl) {
+          const sorted = sortEnriched(cachedEnriched, currentSort);
+          cachedEnriched = sorted;
+          listEl.innerHTML = sorted.map(cardMarkup).join('');
+        }
+        paintSortPressedState();
         applyAllFilters();
       }));
     }

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -16,7 +16,7 @@ import Skeleton from './Skeleton.astro';
 import EspeciesHero from './species/EspeciesHero.astro';
 import FilterChips from './species/FilterChips.astro';
 import { renderSpeciesCard, type CardLabels } from '../lib/species-card-html';
-import { parseChips, serializeChips, type ChipsState } from '../lib/species-filters';
+import { parseChips, serializeChips, buildSpeciesUrl, type ChipsState } from '../lib/species-filters';
 
 interface Props {
   lang: 'en' | 'es';
@@ -191,7 +191,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
   import maplibregl from 'maplibre-gl';
   import { getSupabase } from '../lib/supabase';
   import { renderSpeciesCard, type CardLabels } from '../lib/species-card-html';
-  import { parseChips, parseSort, serializeFilters, type ChipsState, type SortMode } from '../lib/species-filters';
+  import { parseChips, parseSort, buildSpeciesUrl, type ChipsState, type SortMode } from '../lib/species-filters';
   import { deriveGenus, colorForName, buildTaxonomicTree, taxonomicDepth, type TaxonNode } from '../lib/species-display';
 
   type Lang = 'en' | 'es';
@@ -659,7 +659,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
           const k = c.slice('kingdom:'.length);
           currentChips = { ...currentChips, kingdom: currentChips.kingdom === k ? null : k };
         }
-        history.replaceState({}, '', `${window.location.pathname}${serializeFilters(currentChips, currentSort)}`);
+        history.replaceState({}, '', `${window.location.pathname}${buildSpeciesUrl(currentChips, currentSort)}`);
         applyAllFilters();
       }));
     }
@@ -677,7 +677,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
         const mode = (btn.dataset.sort ?? 'obs') as SortMode;
         if (mode === currentSort) return;
         currentSort = mode;
-        history.replaceState({}, '', `${window.location.pathname}${serializeFilters(currentChips, currentSort)}`);
+        history.replaceState({}, '', `${window.location.pathname}${buildSpeciesUrl(currentChips, currentSort)}`);
         if (listEl) {
           const sorted = sortEnriched(cachedEnriched, currentSort);
           cachedEnriched = sorted;

--- a/src/components/species/FilterChips.astro
+++ b/src/components/species/FilterChips.astro
@@ -7,19 +7,30 @@ const { lang } = Astro.props;
 const tr = t(lang) as unknown as { explore_species_hero: Record<string, string> };
 const eh = tr.explore_species_hero;
 ---
-<div class="flex flex-wrap gap-1.5 mt-2.5" data-filter-chips role="group" aria-label="Filters">
-  <button type="button" class="es-chip" data-chip="all" aria-pressed="true">{eh.chip_all}</button>
-  <button type="button" class="es-chip" data-chip="endemic" aria-pressed="false">🇲🇽 {eh.chip_endemic}</button>
-  <button type="button" class="es-chip" data-chip="nom059" aria-pressed="false">⚠ {eh.chip_nom059}</button>
-  <button type="button" class="es-chip" data-chip="rare" aria-pressed="false">★ {eh.chip_rare}</button>
-  <button type="button" class="es-chip" data-chip="kingdom:Animalia" aria-pressed="false">Animalia</button>
-  <button type="button" class="es-chip" data-chip="kingdom:Plantae" aria-pressed="false">Plantae</button>
-  <button type="button" class="es-chip" data-chip="kingdom:Fungi" aria-pressed="false">Fungi</button>
+<div class="flex flex-wrap items-center gap-3 mt-2.5">
+  <div class="flex flex-wrap gap-1.5" data-filter-chips role="group" aria-label="Filters">
+    <button type="button" class="es-chip" data-chip="all" aria-pressed="true">{eh.chip_all}</button>
+    <button type="button" class="es-chip" data-chip="endemic" aria-pressed="false">🇲🇽 {eh.chip_endemic}</button>
+    <button type="button" class="es-chip" data-chip="nom059" aria-pressed="false">⚠ {eh.chip_nom059}</button>
+    <button type="button" class="es-chip" data-chip="rare" aria-pressed="false">★ {eh.chip_rare}</button>
+    <button type="button" class="es-chip" data-chip="kingdom:Animalia" aria-pressed="false">Animalia</button>
+    <button type="button" class="es-chip" data-chip="kingdom:Plantae" aria-pressed="false">Plantae</button>
+    <button type="button" class="es-chip" data-chip="kingdom:Fungi" aria-pressed="false">Fungi</button>
+  </div>
+  <div class="ml-auto flex flex-wrap items-center gap-1.5" data-sort-chips role="group" aria-label={eh.sort_label ?? 'Sort'}>
+    <button type="button" class="es-chip" data-sort="obs" aria-pressed="true">{eh.sort_obs}</button>
+    <button type="button" class="es-chip" data-sort="recent" aria-pressed="false">{eh.sort_recent}</button>
+    <button type="button" class="es-chip" data-sort="alpha" aria-pressed="false">{eh.sort_alpha}</button>
+  </div>
 </div>
 
 <style>
-  [data-filter-chips] button { padding: 4px 12px; font-size: 12px; border-radius: 9999px; border-width: 1px; cursor: pointer; }
-  [data-filter-chips] button[aria-pressed="false"] { background: #fff; color: #475569; border-color: #e2e8f0; }
-  :global(.dark) [data-filter-chips] button[aria-pressed="false"] { background: #18181b; color: #d4d4d8; border-color: #3f3f46; }
-  [data-filter-chips] button[aria-pressed="true"] { background: #047857; color: #fff; border-color: #047857; }
+  [data-filter-chips] button,
+  [data-sort-chips] button { padding: 4px 12px; font-size: 12px; border-radius: 9999px; border-width: 1px; cursor: pointer; }
+  [data-filter-chips] button[aria-pressed="false"],
+  [data-sort-chips] button[aria-pressed="false"] { background: #fff; color: #475569; border-color: #e2e8f0; }
+  :global(.dark) [data-filter-chips] button[aria-pressed="false"],
+  :global(.dark) [data-sort-chips] button[aria-pressed="false"] { background: #18181b; color: #d4d4d8; border-color: #3f3f46; }
+  [data-filter-chips] button[aria-pressed="true"],
+  [data-sort-chips] button[aria-pressed="true"] { background: #047857; color: #fff; border-color: #047857; }
 </style>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1923,7 +1923,11 @@
     "chip_all": "All",
     "chip_endemic": "Endemic",
     "chip_nom059": "NOM-059",
-    "chip_rare": "Rare"
+    "chip_rare": "Rare",
+    "sort_label": "Sort",
+    "sort_obs": "Most observed",
+    "sort_recent": "Recent",
+    "sort_alpha": "A–Z"
   },
   "commandpalette": {
     "privacy_settings": "Privacy settings",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1923,7 +1923,11 @@
     "chip_all": "Todos",
     "chip_endemic": "Endémicas",
     "chip_nom059": "NOM-059",
-    "chip_rare": "Raras"
+    "chip_rare": "Raras",
+    "sort_label": "Ordenar",
+    "sort_obs": "Más observadas",
+    "sort_recent": "Recientes",
+    "sort_alpha": "A–Z"
   },
   "commandpalette": {
     "privacy_settings": "Configuración de privacidad",

--- a/src/lib/species-filters.ts
+++ b/src/lib/species-filters.ts
@@ -55,7 +55,7 @@ export function parseSort(qs: string): SortMode {
   return DEFAULT_SORT;
 }
 
-export function serializeFilters(s: ChipsState, sort: SortMode): string {
+export function buildSpeciesUrl(s: ChipsState, sort: SortMode): string {
   const chipFrag = serializeChips(s);
   if (sort === DEFAULT_SORT) return chipFrag;
   const sep = chipFrag === '' ? '?' : '&';

--- a/src/lib/species-filters.ts
+++ b/src/lib/species-filters.ts
@@ -44,6 +44,24 @@ export function serializeChips(s: ChipsState): string {
   return out ? `?${out}` : '';
 }
 
+export type SortMode = 'obs' | 'recent' | 'alpha';
+
+export const DEFAULT_SORT: SortMode = 'obs';
+
+export function parseSort(qs: string): SortMode {
+  const p = new URLSearchParams(qs.startsWith('?') ? qs.slice(1) : qs);
+  const v = p.get('sort');
+  if (v === 'recent' || v === 'alpha' || v === 'obs') return v;
+  return DEFAULT_SORT;
+}
+
+export function serializeFilters(s: ChipsState, sort: SortMode): string {
+  const chipFrag = serializeChips(s);
+  if (sort === DEFAULT_SORT) return chipFrag;
+  const sep = chipFrag === '' ? '?' : '&';
+  return `${chipFrag}${sep}sort=${sort}`;
+}
+
 export function filterByChips<T extends SpeciesRow>(rows: T[], s: ChipsState): T[] {
   return rows.filter((r) => {
     if (s.kingdom && r.kingdom !== s.kingdom) return false;

--- a/tests/unit/species-filters.test.ts
+++ b/tests/unit/species-filters.test.ts
@@ -4,7 +4,7 @@ import {
   serializeChips,
   filterByChips,
   parseSort,
-  serializeFilters,
+  buildSpeciesUrl,
   type ChipsState,
   type SpeciesRow,
 } from '../../src/lib/species-filters';
@@ -101,20 +101,20 @@ describe('parseSort', () => {
   });
 });
 
-describe('serializeFilters', () => {
+describe('buildSpeciesUrl', () => {
   it('returns empty string for fully-default state', () => {
     const chips: ChipsState = { endemic: false, nom059: false, rare: false, kingdom: null };
-    expect(serializeFilters(chips, 'obs')).toBe('');
+    expect(buildSpeciesUrl(chips, 'obs')).toBe('');
   });
 
   it('serializes only non-default sort', () => {
     const chips: ChipsState = { endemic: false, nom059: false, rare: false, kingdom: null };
-    expect(serializeFilters(chips, 'recent')).toBe('?sort=recent');
+    expect(buildSpeciesUrl(chips, 'recent')).toBe('?sort=recent');
   });
 
   it('combines chips and sort with &', () => {
     const chips: ChipsState = { endemic: true, nom059: false, rare: false, kingdom: null };
-    const out = serializeFilters(chips, 'alpha');
+    const out = buildSpeciesUrl(chips, 'alpha');
     expect(out).toContain('endemic=1');
     expect(out).toContain('sort=alpha');
     expect(out.startsWith('?')).toBe(true);

--- a/tests/unit/species-filters.test.ts
+++ b/tests/unit/species-filters.test.ts
@@ -3,6 +3,8 @@ import {
   parseChips,
   serializeChips,
   filterByChips,
+  parseSort,
+  serializeFilters,
   type ChipsState,
   type SpeciesRow,
 } from '../../src/lib/species-filters';
@@ -74,5 +76,48 @@ describe('filterByChips', () => {
   it('kingdom filter only', () => {
     const out = filterByChips(rows, { endemic: false, nom059: false, rare: false, kingdom: 'Plantae' });
     expect(out.map(r => r.taxon_id)).toEqual(['b']);
+  });
+});
+
+describe('parseSort', () => {
+  it('returns DEFAULT_SORT for empty search', () => {
+    expect(parseSort('')).toBe('obs');
+  });
+
+  it('parses sort=recent', () => {
+    expect(parseSort('?sort=recent')).toBe('recent');
+  });
+
+  it('parses sort=alpha', () => {
+    expect(parseSort('?sort=alpha')).toBe('alpha');
+  });
+
+  it('rejects unknown values and returns default', () => {
+    expect(parseSort('?sort=bogus')).toBe('obs');
+  });
+
+  it('handles search without leading question mark', () => {
+    expect(parseSort('sort=recent')).toBe('recent');
+  });
+});
+
+describe('serializeFilters', () => {
+  it('returns empty string for fully-default state', () => {
+    const chips: ChipsState = { endemic: false, nom059: false, rare: false, kingdom: null };
+    expect(serializeFilters(chips, 'obs')).toBe('');
+  });
+
+  it('serializes only non-default sort', () => {
+    const chips: ChipsState = { endemic: false, nom059: false, rare: false, kingdom: null };
+    expect(serializeFilters(chips, 'recent')).toBe('?sort=recent');
+  });
+
+  it('combines chips and sort with &', () => {
+    const chips: ChipsState = { endemic: true, nom059: false, rare: false, kingdom: null };
+    const out = serializeFilters(chips, 'alpha');
+    expect(out).toContain('endemic=1');
+    expect(out).toContain('sort=alpha');
+    expect(out.startsWith('?')).toBe(true);
+    expect((out.match(/&/g) ?? []).length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

The species grid had a fixed sort (most observed first, alphabetical tie-break). This PR adds three sort chips so users can choose: **Most observed** / **Recent** / **A–Z**.

State lives in the URL (`?sort=recent`, `?sort=alpha`; default omitted). Composable with the existing filter chips via a new `serializeFilters` helper that handles both URL fragments cleanly.

## Changes

- `src/lib/species-filters.ts` — new `SortMode` type, `parseSort`, `serializeFilters` composer
- `src/components/species/FilterChips.astro` — three new chips on the same row
- `src/components/ExploreSpeciesView.astro` — sort handler + state restoration on load
- i18n: 3 new keys × 2 locales (plus a `sort_label` for the aria-label group)
- 8 new unit tests for the parser + composer

The 'recent' chip currently falls back to obs-count ordering — `last_observed_at` will be available once the parallel PR feat/mv-taxon-obs-counts lands. After both merge, swap the fallback for a real recency sort (one-line change).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run test` — 1074 tests pass
- [x] `npm run build` — 231 pages
- [ ] Visual: click each sort chip, confirm grid re-renders with the new order
- [ ] URL state: refresh after sort change, confirm chip stays selected