### PR TITLE
fix(species): 'recent' sort chip now uses last_observed_at from the MV

### DIFF
--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -330,12 +330,12 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       return;
     }
 
-    type MvRow = { taxon_id: string; obs_count: number | string };
+    type MvRow = { taxon_id: string; obs_count: number | string; last_observed_at: string | null };
     let mvRows: MvRow[] = [];
     try {
       const { data, error } = await supabase
         .from('mv_taxon_obs_counts')
-        .select('taxon_id, obs_count')
+        .select('taxon_id, obs_count, last_observed_at')
         .order('obs_count', { ascending: false })
         .limit(SPECIES_GRID_LIMIT);
       if (error) throw error;
@@ -350,9 +350,18 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     }
 
     const counts = new Map<string, number>();
+    // Most-recent-observation timestamp per taxon, keyed by taxon_id.
+    // Sourced from `mv_taxon_obs_counts.last_observed_at` (refreshed
+    // hourly with the rest of the MV) so the 'recent' sort chip can
+    // sort by actual observation recency, not by obs-count fallback.
+    const recencyMs = new Map<string, number>();
     for (const r of mvRows) {
       if (!r.taxon_id) continue;
       counts.set(r.taxon_id, Number(r.obs_count));
+      if (r.last_observed_at) {
+        const t = Date.parse(r.last_observed_at);
+        if (!Number.isNaN(t)) recencyMs.set(r.taxon_id, t);
+      }
     }
     const taxonIds = mvRows.map(r => r.taxon_id).filter((id): id is string => !!id);
 
@@ -427,9 +436,15 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
       if (mode === 'alpha') {
         return [...rows].sort((a, b) => a.scientific_name.localeCompare(b.scientific_name));
       }
-      // 'recent' currently falls back to obs count — last_observed_at is added
-      // by the parallel PR feat/mv-taxon-obs-counts; this branch becomes a real
-      // recency sort once that column is available.
+      if (mode === 'recent') {
+        // Most-recently observed first; rows missing recency data fall to
+        // the bottom (-Infinity) so the sort is stable and predictable.
+        return [...rows].sort((a, b) => {
+          const ar = recencyMs.get(a.id) ?? -Infinity;
+          const br = recencyMs.get(b.id) ?? -Infinity;
+          return br - ar || a.scientific_name.localeCompare(b.scientific_name);
+        });
+      }
       return [...rows].sort((a, b) => b.count - a.count || a.scientific_name.localeCompare(b.scientific_name));
     }
     let cachedEnriched: Enriched[] = taxaRows.map(t => ({ ...t, count: counts.get(t.id) ?? 0 }));


### PR DESCRIPTION
## Summary

Closes the follow-up #676 left in its body: the 'recent' sort chip was a fallback to obs-count ordering until the MV column landed. The MV from #675 has been live since merge, so this plumbs `last_observed_at` through to the client and sorts by it for real.

## Changes

- `src/components/ExploreSpeciesView.astro`:
  - SELECT extended: `taxon_id, obs_count` → `taxon_id, obs_count, last_observed_at`
  - New `recencyMs: Map<taxon_id, number>` populated alongside `counts`
  - `sortEnriched`'s `'recent'` branch now sorts by `recencyMs` (descending), with rows missing data falling to `-Infinity` so the sort stays stable

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 1118 tests pass
- [x] `npm run build` — 231 pages, no errors
- [ ] Visual: click 'Recent' sort chip on `/explore/species/`, confirm grid reorders by most-recently observed first

🤖 Generated with [Claude Code](https://claude.com/claude-code)