### PR TITLE
fix(ci): vision-providers-smoke false-fails when no secrets are set

### DIFF
--- a/.github/workflows/vision-providers-smoke.yml
+++ b/.github/workflows/vision-providers-smoke.yml
@@ -65,15 +65,27 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Fail when ALL providers failed
+      - name: Gate — fail only on real provider failures
         if: always()
         run: |
           if [ ! -f smoke-results.txt ]; then
-            echo "no results file — failing"
+            echo "no results file — script never ran"
             exit 1
           fi
-          # The script writes one line per provider: PASS|FAIL <provider> <message>
-          if ! grep -q '^PASS' smoke-results.txt; then
-            echo "all providers failed — abstraction-level regression"
+          # The script writes one line per provider: PASS|FAIL|SKIP <name> [<msg>]
+          # Three cases:
+          #   ≥1 PASS                     → green
+          #   ≥1 FAIL and 0 PASS          → real abstraction regression, fail
+          #   only SKIPs (0 PASS, 0 FAIL) → no secrets configured, no-op,
+          #                                 don't false-fail the workflow
+          if grep -q '^PASS' smoke-results.txt; then
+            echo "at least one provider passed"
+            exit 0
+          fi
+          if grep -q '^FAIL' smoke-results.txt; then
+            echo "providers ran but all failed — abstraction-level regression"
             exit 1
           fi
+          echo "no provider secrets configured — smoke is a no-op."
+          echo "configure VISION_PROVIDERS_TEST_* secrets to enable real probes."
+          exit 0


### PR DESCRIPTION
## Root cause

The \`vision-providers-smoke\` nightly workflow has been failing every run for 3 days (2026-05-06 → 2026-05-08). The cause is a workflow-logic bug, not a code regression.

The probe script outputs one of three states per provider:
- \`PASS <name>\`
- \`FAIL <name> (<reason>)\`
- \`SKIP <name> (env X unset)\` — when the secret isn't configured

The 7 secrets (\`VISION_PROVIDERS_TEST_*\`) have never been configured in this repo, so every probe correctly emits SKIP. **The gate step fires a false positive** because it uses \`grep -q '^PASS'\` and treats "no PASS lines" as "all failed", without distinguishing FAIL from SKIP.

## Fix

Three explicit cases in the gate:

| Output | Verdict |
|---|---|
| ≥1 PASS | green |
| 0 PASS, ≥1 FAIL | real regression — fail |
| 0 PASS, 0 FAIL (only SKIPs) | no-op, don't false-fail |

The third case now exits 0 with a log message nudging the operator to configure secrets if they want real probing.

## Operator note

To make the smoke test actually exercise providers nightly, configure these GH Actions secrets:

\`\`\`
VISION_PROVIDERS_TEST_ANTHROPIC_API_KEY
VISION_PROVIDERS_TEST_ANTHROPIC_OAT          (optional)
VISION_PROVIDERS_TEST_BEDROCK_JSON
VISION_PROVIDERS_TEST_OPENAI_API_KEY
VISION_PROVIDERS_TEST_AZURE_OPENAI_KEY + _ENDPOINT
VISION_PROVIDERS_TEST_GEMINI_API_KEY
VISION_PROVIDERS_TEST_VERTEX_SA_JSON
\`\`\`

Each can use a low-quota dev key; probes are tiny (1x1 black PNG).

## Test plan

- [x] YAML validates
- [x] grep logic verified against the actual smoke-results.txt from the latest failed run (7 SKIP lines → new gate exits 0)
- [ ] Manual workflow_dispatch after merge to confirm green run

🤖 Generated with [Claude Code](https://claude.com/claude-code)