### PR TITLE
feat(og): wire share button to share-card edge fn + runtime OG tag rewrite (#714)

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -30,6 +30,11 @@ let client: SupabaseClient | null = null;
  * (hydrated islands or <script> blocks) — Astro SSG pages themselves never
  * need this at build time.
  */
+/** Returns the Supabase project URL — safe to call from client-side scripts. */
+export function getSupabaseUrl(): string {
+  return url ?? '';
+}
+
 export function getSupabase(): SupabaseClient {
   if (client) return client;
   // No `lock` option: supabase-js auto-selects its proper `navigatorLock`

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -5,6 +5,22 @@ import ShareObsView from '../../../components/ShareObsView.astro';
 // SSG: query string is unknown at build time. Components read observation_id
 // from data attributes set by the load() script below. Page is locale-neutral
 // (CLAUDE.md regression note: there is no /en/share/obs/ or /es/share/obs/).
+//
+// OG / social unfurl strategy (#714):
+// Social crawlers (WhatsApp, Twitter, Slack, iMessage) do not execute JS, so
+// they see the generic static og:image/title baked at build time.  The
+// share-card Edge Function at /functions/v1/share-card?obs_id=<uuid> returns
+// a server-rendered HTML page with dynamic OG tags AND an SVG card image — it
+// is the correct URL to share for rich link previews.
+//
+// We solve this client-side:
+//   1. The share button is wired to the share-card URL (not window.location)
+//      so the URL a user copies/pastes IS the share-card URL.
+//   2. An inline <script> in <head> rewrites og:image / og:title / og:url at
+//      runtime so that if the raw /share/obs/?id=… URL IS shared, at least
+//      apps that render JS (Notion, Discord desktop, etc.) get the right meta.
+//      Pure HTTP crawlers (WhatsApp) still see the static fallback — full fix
+//      requires either Cloudflare Worker routing or SSR (tracked in #714).
 const lang: 'en' | 'es' = 'en';
 ---
 
@@ -12,7 +28,7 @@ const lang: 'en' | 'es' = 'en';
   <ShareObsView lang={lang} />
 
   <script>
-    import { getSupabase } from '../../../lib/supabase';
+    import { getSupabase, getSupabaseUrl } from '../../../lib/supabase';
     import { labelFor } from '../../../lib/observation-enums';
     import { wireManagePanelDetails, wireManagePanelLocation, wireManagePanelPhotos } from '../../../lib/manage-panel';
     import { t } from '../../../i18n/utils';
@@ -117,12 +133,33 @@ const lang: 'en' | 'es' = 'en';
 
       const shareBtn = document.getElementById('obs-share-btn');
       if (shareBtn) {
-        shareBtn.dataset.shareTitle = speciesName + ' — Rastrum';
         const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
+        shareBtn.dataset.shareTitle = speciesName + ' — Rastrum';
         shareBtn.dataset.shareText  = lang === 'es'
           ? `Observación de ${speciesName} en Rastrum`
           : `Observation of ${speciesName} on Rastrum`;
-        shareBtn.dataset.shareUrl   = window.location.href;
+        // #714: point the share URL at the share-card Edge Function so that
+        // social crawlers receive server-rendered OG meta + SVG card image
+        // instead of the generic static fallback served by GitHub Pages.
+        const supabaseUrl = getSupabaseUrl();
+        const shareCardUrl = supabaseUrl
+          ? `${supabaseUrl}/functions/v1/share-card?obs_id=${encodeURIComponent(id)}`
+          : window.location.href;
+        shareBtn.dataset.shareUrl = shareCardUrl;
+
+        // Also rewrite the og: tags in <head> at runtime so JS-capable
+        // previewers (Notion, Discord desktop) see the dynamic card.
+        const imgUrl = supabaseUrl
+          ? `${supabaseUrl}/functions/v1/share-card?obs_id=${encodeURIComponent(id)}&format=svg`
+          : null;
+        if (imgUrl) {
+          document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.setAttribute('content', imgUrl);
+          document.querySelector<HTMLMetaElement>('meta[name="twitter:image"]')?.setAttribute('content', imgUrl);
+          document.querySelector<HTMLMetaElement>('meta[property="og:title"]')?.setAttribute('content', speciesName + ' — Rastrum');
+          document.querySelector<HTMLMetaElement>('meta[name="twitter:title"]')?.setAttribute('content', speciesName + ' — Rastrum');
+          document.querySelector<HTMLMetaElement>('meta[property="og:url"]')?.setAttribute('content', shareCardUrl);
+          document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.setAttribute('href', shareCardUrl);
+        }
       }
       const date = new Date(obs.observed_at as string);
       document.getElementById('date')!.textContent = date.toLocaleDateString();

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -157,8 +157,11 @@ const lang: 'en' | 'es' = 'en';
           document.querySelector<HTMLMetaElement>('meta[name="twitter:image"]')?.setAttribute('content', imgUrl);
           document.querySelector<HTMLMetaElement>('meta[property="og:title"]')?.setAttribute('content', speciesName + ' — Rastrum');
           document.querySelector<HTMLMetaElement>('meta[name="twitter:title"]')?.setAttribute('content', speciesName + ' — Rastrum');
+          // og:url → share-card URL (social previewers use this to unfurl the right page)
           document.querySelector<HTMLMetaElement>('meta[property="og:url"]')?.setAttribute('content', shareCardUrl);
-          document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.setAttribute('href', shareCardUrl);
+          // canonical stays pointing to rastrum.org — canonical is for Google,
+          // not social previewers. Changing it to the edge-function URL would
+          // confuse Search crawlers. (Nyx review note on PR #715)
         }
       }
       const date = new Date(obs.observed_at as string);


### PR DESCRIPTION
## Problem

When sharing `/share/obs/?id=<uuid>` on WhatsApp, iMessage, Twitter, etc., social crawlers receive static HTML with generic OG tags — they never execute JS so they see the Rastrum logo instead of the actual observation photo and species name.

The **share-card Edge Function** already exists and already generates server-rendered HTML with dynamic `og:title`, `og:image` (SVG card), and `og:description` per observation. It just wasn't being used as the share URL.

## Changes

### `src/lib/supabase.ts`
- Export `getSupabaseUrl()` — lets client scripts build edge-function URLs without duplicating `import.meta.env.PUBLIC_SUPABASE_URL` access.

### `src/pages/share/obs/index.astro`
1. **Share button URL** → now points to `${SUPABASE_URL}/functions/v1/share-card?obs_id=${id}` instead of `window.location.href`. The URL the native share sheet hands to WhatsApp/iMessage **is** the share-card URL, which returns server-rendered OG meta that HTTP crawlers can read without JS.

2. **Runtime OG tag rewrite** → once species data loads, also rewrites `og:image`, `og:title`, `og:url`, `canonical` in `<head>` at runtime. Covers JS-capable previewers (Notion, Discord desktop) even when the raw `/share/obs/?id=` URL is what gets shared.

## What this fixes

| Surface | Before | After |
|---------|--------|-------|
| WhatsApp (share button) | Generic logo | ✅ Species SVG card + name |
| iMessage (share button) | Generic logo | ✅ Species SVG card + name |
| Twitter/X (share button) | Generic logo | ✅ Species SVG card + name |
| Notion / Discord desktop (any URL) | Generic logo | ✅ Runtime-rewritten meta |
| WhatsApp (raw URL pasted) | Generic logo | ⚠️ Still generic (needs Cloudflare Worker) |

## Limitation

Pure HTTP crawlers (WhatsApp, Slack bots) still see the static fallback when someone pastes the raw `/share/obs/?id=` URL directly (i.e., didn't use the share button). Full fix requires a Cloudflare Worker intercepting social crawler UAs and proxying through the edge function — noted in #714.

## Testing

1. Open any observation: `/share/obs/?id=<uuid>`
2. Tap the share button → the URL in the share sheet should be `https://reppvlqejgoqvitturxp.supabase.co/functions/v1/share-card?obs_id=<uuid>`
3. Share to WhatsApp — preview should show the species SVG card with name, date, region
4. Inspect `<meta property="og:image">` in DevTools after page load — should point to the share-card `?format=svg` URL

Closes #714