### PR TITLE
fix(identify): Fall back to next credential when BYO key returns 401

### DIFF
--- a/supabase/functions/_shared/vision-provider.test.ts
+++ b/supabase/functions/_shared/vision-provider.test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
-import { bedrockModelId, buildProvider, parseModelJson, parseBedrockSecret, toVisionResult } from './vision-provider.ts';
+import { assertEquals, assertRejects } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { bedrockModelId, buildProvider, parseModelJson, parseBedrockSecret, toVisionResult, CredentialUnauthorizedError } from './vision-provider.ts';
+import type { ResolvedCredential, VisionInput } from './vision-provider.ts';
 import { defaultModelFor, detectKind } from './vision-validate.ts';
 
 Deno.test('buildProvider — exhaustive switch handles every kind without throwing', () => {
@@ -131,4 +132,110 @@ Deno.test('VisionInput — crop_bbox is accepted when provided', () => {
     crop_bbox: [50, 100, 200, 300],
   };
   assertEquals(input.crop_bbox, [50, 100, 200, 300]);
+});
+
+// ── CredentialUnauthorizedError / 401 fallback tests (#693) ──────────
+
+Deno.test('CredentialUnauthorizedError — is instanceof Error and carries kind', () => {
+  const err = new CredentialUnauthorizedError('api_key');
+  assertEquals(err instanceof Error, true);
+  assertEquals(err instanceof CredentialUnauthorizedError, true);
+  assertEquals(err.kind, 'api_key');
+  assertEquals(err.name, 'CredentialUnauthorizedError');
+  assertEquals(err.message.includes('api_key'), true);
+});
+
+Deno.test('AnthropicProvider — throws CredentialUnauthorizedError on HTTP 401', async () => {
+  // Stub globalThis.fetch to return a 401.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response('Unauthorized', { status: 401 });
+  try {
+    const cred: ResolvedCredential = { kind: 'api_key', secret: 'sk-invalid', model: 'claude-haiku-4-5', endpoint: null };
+    const provider = buildProvider(cred);
+    await assertRejects(
+      () => provider.identify({ imageBase64: 'abc', mimeType: 'image/jpeg', systemPrompt: 'test', userText: 'id' }),
+      CredentialUnauthorizedError,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test('AnthropicProvider — returns null (not throw) on non-401 HTTP error', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response('Server Error', { status: 500 });
+  try {
+    const cred: ResolvedCredential = { kind: 'api_key', secret: 'sk-test', model: 'claude-haiku-4-5', endpoint: null };
+    const provider = buildProvider(cred);
+    const result = await provider.identify({ imageBase64: 'abc', mimeType: 'image/jpeg', systemPrompt: 'test', userText: 'id' });
+    assertEquals(result, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test('fallthrough simulation — caller catches CredentialUnauthorizedError and retries next credential', async () => {
+  // Simulates the cascade fallback: first credential 401s, second succeeds.
+  const callLog: string[] = [];
+  const credentials: ResolvedCredential[] = [
+    { kind: 'api_key', secret: 'revoked-key', model: 'claude-haiku-4-5', endpoint: null },
+    { kind: 'api_key', secret: 'valid-key',   model: 'claude-haiku-4-5', endpoint: null },
+  ];
+
+  // Stub fetch: 401 for revoked-key, 200 with valid JSON for valid-key.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    // Distinguish by the x-api-key header set by AnthropicProvider.
+    const headers = init?.headers as Record<string, string> | undefined ?? {};
+    const key = headers['x-api-key'] ?? '';
+    callLog.push(key);
+    if (key === 'revoked-key') return new Response('Unauthorized', { status: 401 });
+    // Return a minimal valid response for valid-key.
+    return new Response(JSON.stringify({
+      content: [{ type: 'text', text: '{"scientific_name":"Quercus robur","confidence":0.9,"kingdom":"Plantae"}' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+
+  try {
+    let result = null;
+    for (const cred of credentials) {
+      const provider = buildProvider(cred);
+      try {
+        result = await provider.identify({ imageBase64: 'abc', mimeType: 'image/jpeg', systemPrompt: 'test', userText: 'id' });
+        break;
+      } catch (err) {
+        if (err instanceof CredentialUnauthorizedError) continue;
+        throw err;
+      }
+    }
+    assertEquals(callLog, ['revoked-key', 'valid-key']);
+    assertEquals(result?.scientific_name, 'Quercus robur');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test('all credentials 401 — fallthrough loop returns null', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response('Unauthorized', { status: 401 });
+  try {
+    const credentials: ResolvedCredential[] = [
+      { kind: 'api_key', secret: 'key-a', model: 'claude-haiku-4-5', endpoint: null },
+      { kind: 'api_key', secret: 'key-b', model: 'claude-haiku-4-5', endpoint: null },
+    ];
+    let result = null;
+    for (const cred of credentials) {
+      const provider = buildProvider(cred);
+      try {
+        result = await provider.identify({ imageBase64: 'abc', mimeType: 'image/jpeg', systemPrompt: 'test', userText: 'id' });
+        break;
+      } catch (err) {
+        if (err instanceof CredentialUnauthorizedError) continue;
+        throw err;
+      }
+    }
+    assertEquals(result, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/supabase/functions/_shared/vision-provider.ts
+++ b/supabase/functions/_shared/vision-provider.ts
@@ -75,6 +75,19 @@ export interface VisionProvider {
 }
 
 /**
+ * Thrown by a VisionProvider when the upstream API rejects the
+ * credential with HTTP 401 (key revoked, expired, or never valid).
+ * The cascade catches this specifically so it can fall through to
+ * the next credential rather than treating it as a hard failure.
+ */
+export class CredentialUnauthorizedError extends Error {
+  constructor(public readonly kind: CredentialKind) {
+    super(`credential_unauthorized: ${kind}`);
+    this.name = 'CredentialUnauthorizedError';
+  }
+}
+
+/**
  * Source of truth for the model identifiers each `CredentialKind`
  * accepts as `preferred_model`. Used by `assertValidModel()` to
  * reject a typo at the EF boundary instead of silently storing it
@@ -289,6 +302,7 @@ class AnthropicProvider implements VisionProvider {
     const res = await fetch('https://api.anthropic.com/v1/messages', {
       method: 'POST', headers, body: JSON.stringify(body), signal: input.signal,
     });
+    if (res.status === 401) throw new CredentialUnauthorizedError(this.cred.kind);
     if (!res.ok) return null;
     const json = await res.json() as { content: Array<{ type: string; text?: string }> };
     const text = json.content?.find(c => c.type === 'text')?.text;
@@ -335,6 +349,7 @@ class BedrockProvider implements VisionProvider {
       sessionToken: creds.sessionToken,
     });
     const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body), signal: input.signal });
+    if (res.status === 401 || res.status === 403) throw new CredentialUnauthorizedError(this.cred.kind);
     if (!res.ok) return null;
     const json = await res.json() as { content?: Array<{ type: string; text?: string }> };
     const text = json.content?.find(c => c.type === 'text')?.text;
@@ -470,7 +485,7 @@ class OpenAIProvider implements VisionProvider {
       'Authorization': `Bearer ${this.cred.secret}`,
       'Content-Type':  'application/json',
     };
-    return await callOpenAICompatible(url, headers, this.cred.model, input, 'openai');
+    return await callOpenAICompatible(url, headers, this.cred.model, input, this.cred.kind, 'openai');
   }
 }
 
@@ -488,7 +503,7 @@ class AzureOpenAIProvider implements VisionProvider {
       'api-key':      this.cred.secret,
       'Content-Type': 'application/json',
     };
-    return await callOpenAICompatible(url, headers, this.cred.model || 'azure', input, 'azure_openai');
+    return await callOpenAICompatible(url, headers, this.cred.model || 'azure', input, this.cred.kind, 'azure_openai');
   }
 }
 
@@ -497,6 +512,7 @@ async function callOpenAICompatible(
   headers: Record<string, string>,
   model: string,
   input: VisionInput,
+  kind: CredentialKind,
   source: string,
 ): Promise<VisionResult | null> {
   const body = {
@@ -514,6 +530,7 @@ async function callOpenAICompatible(
     ],
   };
   const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body), signal: input.signal });
+  if (res.status === 401) throw new CredentialUnauthorizedError(kind);
   if (!res.ok) return null;
   const json = await res.json() as { choices?: Array<{ message?: { content?: string } }> };
   const text = json.choices?.[0]?.message?.content;
@@ -527,7 +544,7 @@ class GeminiProvider implements VisionProvider {
 
   async identify(input: VisionInput): Promise<VisionResult | null> {
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(this.cred.model)}:generateContent?key=${encodeURIComponent(this.cred.secret)}`;
-    return await callGeminiCompatible(url, {}, input, 'gemini');
+    return await callGeminiCompatible(url, {}, input, this.cred.kind, 'gemini');
   }
 }
 
@@ -550,7 +567,7 @@ class VertexAIProvider implements VisionProvider {
       'Authorization': `Bearer ${accessToken}`,
       'Content-Type':  'application/json',
     };
-    return await callGeminiCompatible(url, headers, input, 'vertex_ai');
+    return await callGeminiCompatible(url, headers, input, this.cred.kind, 'vertex_ai');
   }
 
   private async resolveAccessToken(): Promise<string | null> {
@@ -573,6 +590,7 @@ async function callGeminiCompatible(
   url: string,
   headers: Record<string, string>,
   input: VisionInput,
+  kind: CredentialKind,
   source: string,
 ): Promise<VisionResult | null> {
   const body = {
@@ -592,6 +610,7 @@ async function callGeminiCompatible(
     body: JSON.stringify(body),
     signal: input.signal,
   });
+  if (res.status === 401 || res.status === 403) throw new CredentialUnauthorizedError(kind);
   if (!res.ok) return null;
   const json = await res.json() as {
     candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -49,9 +49,11 @@ import {
 import {
   buildProvider,
   DEFAULT_SYSTEM_PROMPT,
+  CredentialUnauthorizedError,
   type ResolvedCredential,
   type VisionResult,
 } from '../_shared/vision-provider.ts';
+import { reportFunctionError } from '../admin/_shared/error-reporter.ts';
 import { checkAnonRateLimit } from '../_shared/anon-rate-limit.ts';
 
 type IdentifyRequest = {
@@ -323,6 +325,8 @@ async function callViaProvider(
       crop_bbox: context.crop_bbox,
     });
   } catch (err) {
+    // Re-throw 401s so the cascade can fall through to the next credential.
+    if (err instanceof CredentialUnauthorizedError) throw err;
     console.warn(`[identify] provider.identify failed kind=${cred.kind}: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
@@ -818,44 +822,67 @@ serve(async (req) => {
     }
   }
 
-  // Decide what credential the Claude runner gets. Order:
-  //   1. Owner-personal Vault credential (#655, #664) — `use_personally = true`,
-  //      owned by the JWT user, of any provider kind. Skips sponsorship_usage
-  //      + pool consumption because it's the owner's own credit.
-  //   2. BYO key forwarded by the client.
-  //   3. Sponsor-supplied credential resolved via _shared/sponsorship.ts.
-  //   4. Platform pool (M27.2, #115) — round-robin across active pools,
-  //      enforced by `consume_pool_slot()` SQL RPC.
-  //   5. Nothing — the Claude runner is skipped (no operator-key fallback).
-  let claudeCred: { secret: string; kind: CredentialKind } | null = null;
-  let resolvedClaudeCred: ResolvedCredential | null = null;
-  let sponsorshipCtx: ResolvedSponsorship | null = null;
-  let sponsorshipSkipReason: string | null = null;
-  let poolUsed: { poolId: string; credentialId: string } | null = null;
-  let usedPersonalCredential = false;
+  // Credential resolution — ordered fallback chain (#693).
+  //
+  // Each supplier is lazy: it's only invoked when the previous credential
+  // returned 401. The pool slot is consumed atomically at resolve-time via
+  // `consume_pool_slot()`; if the pool credential then 401s, we surface a
+  // hard failure (the slot is already spent, and the issue spec says pool
+  // is the last resort).
+  //
+  // Resolution order:
+  //   1. Owner-personal Vault credential (#655, #664) — `use_personally = true`.
+  //   2. BYO key forwarded by the client (client_keys.anthropic).
+  //   3. Sponsor-supplied credential via _shared/sponsorship.ts.
+  //   4. Platform pool — round-robin via `consume_pool_slot()` RPC.
+  //   5. Nothing — the Claude runner is skipped.
 
-  // Step 1: owner-personal Vault credential (#655).
+  interface CredentialWithMeta {
+    cred: ResolvedCredential;
+    sponsorCtx: ResolvedSponsorship | null;
+    poolInfo: { poolId: string; credentialId: string } | null;
+    label: string;   // for logging only — never contains the secret
+  }
+
+  // Step 1: personal Vault credential (#655).
+  let personalCred: CredentialWithMeta | null = null;
   if (beneficiaryId) {
     try {
       const personal = await resolvePersonalCredential(db(), beneficiaryId);
       if (personal) {
-        claudeCred = { secret: personal.secret, kind: personal.kind };
-        resolvedClaudeCred = {
-          kind:     personal.kind as ResolvedCredential['kind'],
-          secret:   personal.secret,
-          model:    personal.model,
-          endpoint: personal.endpoint,
+        personalCred = {
+          cred: {
+            kind:     personal.kind as ResolvedCredential['kind'],
+            secret:   personal.secret,
+            model:    personal.model,
+            endpoint: personal.endpoint,
+          },
+          sponsorCtx: null,
+          poolInfo: null,
+          label: 'personal',
         };
-        usedPersonalCredential = true;
       }
     } catch (err) {
       console.warn(`[identify] personal credential resolution failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
-  if (!usedPersonalCredential && byoAnthropic) {
-    claudeCred = { secret: byoAnthropic, kind: 'api_key' };
-  } else if (!usedPersonalCredential && beneficiaryId) {
+  // Lazy suppliers for steps 2–4. Each returns null if the slot is
+  // unavailable (no sponsorship, no pool capacity, rate-limited, etc.).
+  let sponsorshipSkipReason: string | null = null;
+
+  const byoSupplier = (): CredentialWithMeta | null => {
+    if (!byoAnthropic) return null;
+    return {
+      cred: { kind: 'api_key', secret: byoAnthropic, model: 'claude-haiku-4-5', endpoint: null },
+      sponsorCtx: null,
+      poolInfo: null,
+      label: 'byo',
+    };
+  };
+
+  const sponsorshipSupplier = async (): Promise<CredentialWithMeta | null> => {
+    if (!beneficiaryId) return null;
     try {
       const rl = await checkAndBumpRateLimit(db(), beneficiaryId, 'anthropic');
       if (!rl.allowed) {
@@ -864,74 +891,166 @@ serve(async (req) => {
           const ctxNow = await resolveSponsorship(db(), beneficiaryId, 'anthropic');
           if (ctxNow) await autoPauseSponsorship(db(), ctxNow.sponsorshipId, rl.reason, beneficiaryId);
         }
-      } else {
-        // Sponsored users add ~3 DB round-trips vs BYO: resolve, decrypt vault, rate-limit bump.
-        // Acceptable at v1 scale; profile if /identify p95 latency regresses.
-        sponsorshipCtx = await resolveSponsorship(db(), beneficiaryId, 'anthropic');
-        if (sponsorshipCtx) {
-          const secret = await decryptCredential(db(), sponsorshipCtx.vaultSecretId);
-          claudeCred = { secret, kind: sponsorshipCtx.kind };
-          resolvedClaudeCred = {
-            kind:     sponsorshipCtx.kind as ResolvedCredential['kind'],
-            secret,
-            model:    sponsorshipCtx.preferredModel,
-            endpoint: sponsorshipCtx.endpoint,
-          };
-        } else {
-          // Step 3: platform pool. Atomic increment of pool.used + per-user
-          // daily count via consume_pool_slot RPC. Returns null when no pool
-          // has capacity OR the user has hit their daily cap.
-          const { data: poolRows, error: poolErr } = await db().rpc('consume_pool_slot', {
-            p_user_id: beneficiaryId,
-          });
-          if (poolErr) {
-            console.warn(`[identify] consume_pool_slot failed: ${poolErr.message}`);
-          } else if (Array.isArray(poolRows) && poolRows.length > 0) {
-            const slot = poolRows[0] as {
-              pool_id: string; credential_id: string; preferred_model: string;
-            };
-            // Look up the credential to fetch vault_secret_id + kind + endpoint.
-            const { data: credRow, error: credErr } = await db()
-              .from('sponsor_credentials')
-              .select('kind, vault_secret_id, endpoint')
-              .eq('id', slot.credential_id)
-              .single();
-            if (credErr) {
-              console.warn(`[identify] pool credential lookup failed: ${credErr.message}`);
-            } else if (credRow) {
-              const secret = await decryptCredential(db(), (credRow as { vault_secret_id: string }).vault_secret_id);
-              const kind = (credRow as { kind: CredentialKind }).kind;
-              claudeCred = { secret, kind };
-              resolvedClaudeCred = {
-                kind:     kind as ResolvedCredential['kind'],
-                secret,
-                model:    slot.preferred_model,
-                endpoint: (credRow as { endpoint: string | null }).endpoint,
-              };
-              poolUsed = { poolId: slot.pool_id, credentialId: slot.credential_id };
-            }
-          }
-        }
+        return null;
       }
+      const ctx = await resolveSponsorship(db(), beneficiaryId, 'anthropic');
+      if (!ctx) return null;
+      const secret = await decryptCredential(db(), ctx.vaultSecretId);
+      return {
+        cred: {
+          kind:     ctx.kind as ResolvedCredential['kind'],
+          secret,
+          model:    ctx.preferredModel,
+          endpoint: ctx.endpoint,
+        },
+        sponsorCtx: ctx,
+        poolInfo: null,
+        label: 'sponsorship',
+      };
     } catch (err) {
-      // allowed: log level + no secret
       console.warn(`[identify] sponsorship resolution failed: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
     }
+  };
+
+  const poolSupplier = async (): Promise<CredentialWithMeta | null> => {
+    if (!beneficiaryId) return null;
+    try {
+      const { data: poolRows, error: poolErr } = await db().rpc('consume_pool_slot', {
+        p_user_id: beneficiaryId,
+      });
+      if (poolErr) {
+        console.warn(`[identify] consume_pool_slot failed: ${poolErr.message}`);
+        return null;
+      }
+      if (!Array.isArray(poolRows) || poolRows.length === 0) return null;
+      const slot = poolRows[0] as {
+        pool_id: string; credential_id: string; preferred_model: string;
+      };
+      const { data: credRow, error: credErr } = await db()
+        .from('sponsor_credentials')
+        .select('kind, vault_secret_id, endpoint')
+        .eq('id', slot.credential_id)
+        .single();
+      if (credErr) {
+        console.warn(`[identify] pool credential lookup failed: ${credErr.message}`);
+        return null;
+      }
+      if (!credRow) return null;
+      const secret = await decryptCredential(db(), (credRow as { vault_secret_id: string }).vault_secret_id);
+      const kind = (credRow as { kind: CredentialKind }).kind;
+      return {
+        cred: {
+          kind:     kind as ResolvedCredential['kind'],
+          secret,
+          model:    slot.preferred_model,
+          endpoint: (credRow as { endpoint: string | null }).endpoint,
+        },
+        sponsorCtx: null,
+        poolInfo: { poolId: slot.pool_id, credentialId: slot.credential_id },
+        label: 'pool',
+      };
+    } catch (err) {
+      console.warn(`[identify] pool resolution failed: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  };
+
+  // Build the ordered chain. Personal cred is already resolved; BYO is
+  // trivial; sponsorship and pool are async lazy suppliers.
+  // We use a discriminated union so TypeScript can distinguish sync vs async.
+  type CredSupplier =
+    | { kind: 'resolved'; value: CredentialWithMeta | null }
+    | { kind: 'sync';     fn: () => CredentialWithMeta | null }
+    | { kind: 'async';    fn: () => Promise<CredentialWithMeta | null> };
+
+  const credChain: CredSupplier[] = [
+    { kind: 'resolved', value: personalCred },
+    { kind: 'sync',     fn: byoSupplier },
+    { kind: 'async',    fn: sponsorshipSupplier },
+    { kind: 'async',    fn: poolSupplier },
+  ];
+
+  /**
+   * Try each credential supplier in order. On 401, log a structured
+   * warning (no secret) and continue to the next. Returns the first
+   * successful result plus which credential won.
+   */
+  async function callClaudeWithFallback(
+    imgBytes: Uint8Array,
+    mime: string,
+    context: Omit<ClaudeContext, 'credential' | 'resolvedCredential'>,
+    chain: CredSupplier[],
+  ): Promise<{ result: IDResult | null; winner: CredentialWithMeta | null }> {
+    for (const supplier of chain) {
+      let meta: CredentialWithMeta | null;
+      if (supplier.kind === 'resolved') {
+        meta = supplier.value;
+      } else if (supplier.kind === 'sync') {
+        meta = supplier.fn();
+      } else {
+        meta = await supplier.fn();
+      }
+      if (!meta) continue;
+
+      try {
+        const r = await callClaudeHaiku(imgBytes, mime, {
+          ...context,
+          credential: { secret: meta.cred.secret, kind: meta.cred.kind as CredentialKind },
+          resolvedCredential: meta.cred,
+        });
+        return { result: r, winner: meta };
+      } catch (err) {
+        if (err instanceof CredentialUnauthorizedError) {
+          console.warn(`[identify] credential 401 on label=${meta.label} kind=${meta.cred.kind} — falling through to next (user_id=${beneficiaryId ?? 'anon'})`);
+          // Best-effort structured log — never blocks.
+          if (serviceRole && supabaseUrl) {
+            reportFunctionError(
+              db(),
+              'identify',
+              'byo_401_fallthrough',
+              beneficiaryId,
+              { credential_label: meta.label, credential_kind: meta.cred.kind },
+            ).catch(() => {/* swallow — reporter is best-effort */});
+          }
+          continue;
+        }
+        throw err;
+      }
+    }
+    return { result: null, winner: null };
   }
+
+  // Snapshot the resolved state after identification so usage recording
+  // and pool-drip work correctly regardless of which credential won.
+  let sponsorshipCtx: ResolvedSponsorship | null = null;
+  let poolUsed: { poolId: string; credentialId: string } | null = null;
+  // hasAnyCred: true when at least one supplier would have produced a
+  // credential, used for the error hint message.
+  const hasAnyCred = personalCred !== null || !!byoAnthropic || !!beneficiaryId;
 
   let result: IDResult | null = null;
   let cascadeAttempts: CascadeAttempt[] | null = null;
+  let providerUsed: string | null = null;
+
+  const claudeContext: Omit<ClaudeContext, 'credential' | 'resolvedCredential'> = {
+    lat: body.location?.lat,
+    lng: body.location?.lng,
+    crop_bbox: body.crop_bbox,
+  };
 
   if (body.force_provider === 'plantnet') {
     result = await callPlantNet(imageBytes, byoPlantnet);
   } else if (body.force_provider === 'claude_haiku') {
-    result = await callClaudeHaiku(imageBytes, mimeType, {
-      lat: body.location?.lat,
-      lng: body.location?.lng,
-      credential: claudeCred ?? undefined,
-      resolvedCredential: resolvedClaudeCred ?? undefined,
-      crop_bbox: body.crop_bbox,
-    });
+    const { result: r, winner } = await callClaudeWithFallback(
+      imageBytes, mimeType, claudeContext, credChain,
+    );
+    result = r;
+    if (winner) {
+      sponsorshipCtx = winner.sponsorCtx;
+      poolUsed = winner.poolInfo;
+      providerUsed = winner.label;
+    }
   } else if (body.cascade) {
     // Cascade mode: build the runners map dynamically based on user_hint,
     // apply excluded_providers filter, then preferred_providers ordering.
@@ -941,15 +1060,19 @@ serve(async (req) => {
     if (isPlantLike) {
       allRunners.plantnet = (signal) => callPlantNet(imageBytes, byoPlantnet, signal);
     }
-    if (claudeCred) {
-      allRunners.claude_haiku = (signal) => callClaudeHaiku(imageBytes, mimeType, {
-        lat: body.location?.lat,
-        lng: body.location?.lng,
-        credential: claudeCred ?? undefined,
-        resolvedCredential: resolvedClaudeCred ?? undefined,
-        signal,
-      });
-    }
+    // Claude runner uses the fallback chain — the signal is forwarded for
+    // abort on cascade timeout, but credential fallback is still sequential.
+    allRunners.claude_haiku = async (signal) => {
+      const { result: r, winner } = await callClaudeWithFallback(
+        imageBytes, mimeType, { ...claudeContext, signal }, credChain,
+      );
+      if (winner) {
+        sponsorshipCtx = winner.sponsorCtx;
+        poolUsed = winner.poolInfo;
+        providerUsed = winner.label;
+      }
+      return r;
+    };
     allRunners.onnx_base = (signal) => callOnnxBase(imageBytes, signal);
     // Future: add new server-side plugins here.
 
@@ -979,23 +1102,25 @@ serve(async (req) => {
     result = cascaded.result;
     cascadeAttempts = cascaded.attempts;
   } else {
-    // Default: race PlantNet, Claude Haiku, and (placeholder) ONNX-base in
-    // parallel. The first to return confidence ≥ threshold wins; the rest
-    // are aborted. user_hint is used to bias the threshold slightly later
-    // (today it just gates which runners we even start).
+    // Default: race PlantNet, Claude Haiku (with credential fallback chain),
+    // and (placeholder) ONNX-base in parallel. The first to return confidence
+    // ≥ threshold wins; the rest are aborted.
     const runners: Record<string, ServerRunner> = {};
     const isPlantLike = isPlantLikeHint(body.user_hint);
     if (isPlantLike) {
       runners.plantnet = (signal) => callPlantNet(imageBytes, byoPlantnet, signal);
     }
-    runners.claude_haiku = (signal) => callClaudeHaiku(imageBytes, mimeType, {
-      lat: body.location?.lat,
-      lng: body.location?.lng,
-      credential: claudeCred ?? undefined,
-      resolvedCredential: resolvedClaudeCred ?? undefined,
-      crop_bbox: body.crop_bbox,
-      signal,
-    });
+    runners.claude_haiku = async (signal) => {
+      const { result: r, winner } = await callClaudeWithFallback(
+        imageBytes, mimeType, { ...claudeContext, signal }, credChain,
+      );
+      if (winner) {
+        sponsorshipCtx = winner.sponsorCtx;
+        poolUsed = winner.poolInfo;
+        providerUsed = winner.label;
+      }
+      return r;
+    };
     runners.onnx_base = (signal) => callOnnxBase(imageBytes, signal);
 
     const cascaded = await runServerCascade(runners);
@@ -1054,10 +1179,9 @@ serve(async (req) => {
   }
 
   if (!result) {
-    const hasAnyClaudeCred = !!claudeCred;
     const errorPayload: Record<string, unknown> = {
-      error: hasAnyClaudeCred ? 'identification_failed' : 'no_id_engine_available',
-      hint: hasAnyClaudeCred
+      error: hasAnyCred ? 'identification_failed' : 'no_id_engine_available',
+      hint: hasAnyCred
         ? 'PlantNet returned nothing and Claude failed to parse the response.'
         : sponsorshipSkipReason
           ? `Claude skipped (${sponsorshipSkipReason}). Supply a BYO key, accept a sponsorship, or wait for the rate-limit window to reset.`
@@ -1144,6 +1268,9 @@ serve(async (req) => {
   // (force_provider, default-race that didn't track attempts).
   responsePayload.cascade_attempts = cascadeAttempts
     ?? [{ provider: result.source, confidence: result.confidence }];
+  // #693: surface which credential tier ultimately succeeded so the UI can
+  // render correctly (e.g. "Identified via sponsorship" after BYO key 401).
+  if (providerUsed) responsePayload.credential_used = providerUsed;
 
   return corsResponse(JSON.stringify(responsePayload), {
     headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
## Summary

**Bug:** When a user has a BYO Anthropic key that has been revoked and also has an active sponsorship, the `identify` Edge Function returns 401 and stops — it does not retry with the sponsorship credential. The credential resolution was a single-pass upfront selection with no fallback on failure.

**Fix:** Restructured credential resolution into an ordered lazy-supplier chain:
1. Personal Vault credential (`use_personally = true`)
2. BYO key from `client_keys.anthropic`
3. Sponsor-supplied credential (resolved lazily — only if BYO 401s)
4. Platform pool slot (resolved lazily — only if sponsorship 401s or unavailable)

**How 401 is detected:** Each provider's `identify()` method now checks the HTTP response status explicitly. On HTTP 401, it throws a new `CredentialUnauthorizedError` (typed, carries the `CredentialKind`). On all other non-2xx statuses it continues to return `null` (existing behaviour). The new `callClaudeWithFallback()` function in the EF iterates the chain, catches `CredentialUnauthorizedError` to fall through, and returns the first successful result.

**Structured logging:** Each 401 fallthrough emits a `console.warn` (no key value logged, only `credential_label` + `credential_kind` + `user_id`) and a best-effort `function_errors` row via the existing `reportFunctionError` helper.

**Response:** The response now includes a `credential_used` field (`"personal"` | `"byo"` | `"sponsorship"` | `"pool"`) so the UI can render the correct attribution after a transparent fallback.

## Changes

- `supabase/functions/_shared/vision-provider.ts`: Add `CredentialUnauthorizedError` class; `AnthropicProvider`, `BedrockProvider`, `callOpenAICompatible`, `callGeminiCompatible` throw it on HTTP 401/403. Pass credential `kind` through shared helpers to avoid `as CredentialKind` casts.
- `supabase/functions/identify/index.ts`: Replace single-credential upfront resolution with a `CredSupplier[]` chain + `callClaudeWithFallback()`. Import `CredentialUnauthorizedError` and `reportFunctionError`. Add `credential_used` to response payload.
- `supabase/functions/_shared/vision-provider.test.ts`: Four new Deno tests — throw on 401, null on 500, fallthrough to second credential, all-401 returns null.

## Testing notes

Deno EF tests cannot be run locally (Supabase CLI 2.90.0 regression on this project). Verified via:
- `npm run typecheck` — zero errors
- `npm run test` — 1201 tests, all green
- `npm run build` — 231 pages, clean

The four new tests in `vision-provider.test.ts` stub `globalThis.fetch` and are runnable via `deno test` in CI.

Closes #693