### PR TITLE
feat(ai-tab): Surface PlantNet daily quota chip on the PlantNet card

### DIFF
--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -1409,6 +1409,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
       { renderPluginCard, renderLocalDataCard },
       { getModelCacheStatus },
       sponsorshipMod,
+      plantnetQuotaMod,
     ] = await Promise.all([
       import('../lib/identifiers'),
       import('../lib/byo-keys'),
@@ -1416,6 +1417,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
       import('../lib/identifier-card-html'),
       import('../lib/local-ai'),
       import('../lib/sponsorships').catch(() => ({ getActiveAnthropicSponsorship: async () => null })),
+      import('../lib/plantnet-quota').catch(() => ({ getPlantNetQuota: () => null })),
     ]);
     runStorageMigration();
 
@@ -1520,6 +1522,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
           cacheStatus: cache,
           byoKeysSet: {},
           sponsorship: p.id === 'claude_haiku' ? (sponsorship as Parameters<typeof renderPluginCard>[0]['sponsorship']) : null,
+          plantnetQuota: p.id === 'plantnet' ? plantnetQuotaMod.getPlantNetQuota() : null,
         });
       }).join('');
       return `

--- a/src/lib/identifier-card-html.ts
+++ b/src/lib/identifier-card-html.ts
@@ -26,6 +26,12 @@ export interface ActiveSponsorship {
   used_today: number | null;
 }
 
+export interface PlantNetQuota {
+  used_today: number;
+  daily_limit: number;
+  reset_at?: string;
+}
+
 export interface PluginCardProps {
   lang: 'en' | 'es';
   plugin: Identifier;
@@ -36,6 +42,8 @@ export interface PluginCardProps {
   byoKeysSet: Record<string, boolean>;
   /** Only meaningful for plugin.id === 'claude_haiku'. */
   sponsorship: ActiveSponsorship | null;
+  /** Only meaningful for plugin.id === 'plantnet'. */
+  plantnetQuota?: PlantNetQuota | null;
 }
 
 function escape(s: string): string {
@@ -195,6 +203,12 @@ function sponsorshipLine(p: PluginCardProps, t: Strings): string {
   return `<span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-violet-100 dark:bg-violet-900/30 text-violet-800 dark:text-violet-300 ml-1">${t.via_sponsorship}</span><div class="text-[10px] text-zinc-500 dark:text-zinc-400 mt-0.5">${t.sponsored_by} ${handle}${usage}</div>`;
 }
 
+function plantnetQuotaChip(p: PluginCardProps, t: Strings): string {
+  if (p.plugin.id !== 'plantnet' || !p.plantnetQuota) return '';
+  const { used_today, daily_limit } = p.plantnetQuota;
+  return `<span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 ml-1">${used_today} / ${daily_limit} ${t.ids_today}</span>`;
+}
+
 export function renderPluginCard(p: PluginCardProps): string {
   const t = STRINGS[p.lang];
   const liClass = p.state.kind === 'disabled'
@@ -214,6 +228,7 @@ export function renderPluginCard(p: PluginCardProps): string {
             <p class="text-sm font-medium text-zinc-900 dark:text-zinc-100">${escape(p.plugin.name)}</p>
             ${pillFor(p.state, t)}
             ${sponsorshipLine(p, t)}
+            ${plantnetQuotaChip(p, t)}
           </div>
           <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">${escape(p.plugin.description)}</p>
           <p class="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1 font-mono">${escape(metaLine(p))}</p>

--- a/src/lib/identifiers/plantnet.ts
+++ b/src/lib/identifiers/plantnet.ts
@@ -8,6 +8,7 @@
  */
 import { getSupabase } from '../supabase';
 import { getKey } from '../byo-keys';
+import { incrementPlantNetQuota } from '../plantnet-quota';
 import type { Identifier, IDResult, IdentifyInput } from './types';
 
 const PLUGIN_ID = 'plantnet';
@@ -74,6 +75,7 @@ export const plantNetIdentifier: Identifier = {
     if (error) throw error;
     const r = data as Partial<IDResult> & { error?: string };
     if (r.error) throw new Error(r.error);
+    incrementPlantNetQuota();
     return {
       scientific_name: r.scientific_name ?? '',
       common_name_en: r.common_name_en ?? null,

--- a/src/lib/plantnet-quota.ts
+++ b/src/lib/plantnet-quota.ts
@@ -1,0 +1,75 @@
+/**
+ * Client-side PlantNet daily usage counter.
+ *
+ * PlantNet's rate-limit headers are not forwarded through the identify
+ * Edge Function (supabase.functions.invoke strips HTTP metadata), so we
+ * track usage locally: increment on each successful call and reset at
+ * midnight UTC. The fixed daily_limit of 500 matches the free-tier quota.
+ *
+ * Storage key: 'rastrum.plantnet.quota'
+ * Shape: { used: number; day: string; }   (day = YYYY-MM-DD UTC)
+ */
+
+export interface PlantNetQuota {
+  used_today: number;
+  daily_limit: number;
+  reset_at?: string;
+}
+
+const KEY = 'rastrum.plantnet.quota';
+const DAILY_LIMIT = 500;
+
+interface Stored {
+  used: number;
+  day: string;
+}
+
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function read(): Stored {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return { used: 0, day: todayUtc() };
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'used' in parsed &&
+      'day' in parsed &&
+      typeof (parsed as Stored).used === 'number' &&
+      typeof (parsed as Stored).day === 'string'
+    ) {
+      return parsed as Stored;
+    }
+  } catch { /* corrupt entry — start fresh */ }
+  return { used: 0, day: todayUtc() };
+}
+
+function write(s: Stored): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(s));
+  } catch { /* storage full — non-blocking */ }
+}
+
+export function getPlantNetQuota(): PlantNetQuota | null {
+  try {
+    const stored = read();
+    const today = todayUtc();
+    const used = stored.day === today ? stored.used : 0;
+    const resetAt = `${today}T23:59:59Z`;
+    return { used_today: used, daily_limit: DAILY_LIMIT, reset_at: resetAt };
+  } catch {
+    return null;
+  }
+}
+
+export function incrementPlantNetQuota(): void {
+  try {
+    const today = todayUtc();
+    const stored = read();
+    const used = stored.day === today ? stored.used + 1 : 1;
+    write({ used, day: today });
+  } catch { /* non-blocking */ }
+}

--- a/tests/unit/identifier-card-html.test.ts
+++ b/tests/unit/identifier-card-html.test.ts
@@ -34,6 +34,22 @@ const claude: Identifier = {
   identify: async () => { throw new Error('not used in tests'); },
 };
 
+const plantnet: Identifier = {
+  id: 'plantnet',
+  name: 'PlantNet',
+  brand: '🌿',
+  description: 'Plant identification by Pl@ntNet.',
+  capabilities: {
+    runtime: 'server',
+    media: ['photo'],
+    taxa: ['Plantae'],
+    license: 'free-quota',
+    cost_per_id_usd: 0,
+  },
+  isAvailable: async () => ({ ready: true }),
+  identify: async () => { throw new Error('not used in tests'); },
+};
+
 function props(overrides: Partial<PluginCardProps> = {}): PluginCardProps {
   return {
     lang: 'en',
@@ -159,6 +175,27 @@ describe('renderPluginCard', () => {
     const html = renderPluginCard(props({ lang: 'es', plugin: claude, state: { kind: 'no-key' }, sponsorship: null }));
     expect(html).toContain('Usar patrocinio');
     expect(html).toMatch(/href="\/es\/perfil\/patrocinado-por\/"/);
+  });
+
+  it('renders PlantNet quota chip when usage is known', () => {
+    const html = renderPluginCard(props({
+      plugin: plantnet,
+      state: { kind: 'active' },
+      cacheStatus: null,
+      plantnetQuota: { used_today: 347, daily_limit: 500 },
+    }));
+    expect(html).toMatch(/347\s*\/\s*500/);
+    expect(html).toContain('IDs today');
+  });
+
+  it('does NOT show quota chip when plantnetQuota is null', () => {
+    const html = renderPluginCard(props({
+      plugin: plantnet,
+      state: { kind: 'active' },
+      cacheStatus: null,
+      plantnetQuota: null,
+    }));
+    expect(html).not.toMatch(/IDs today/);
   });
 
   it('renders Spanish strings when lang=es', () => {

--- a/tests/unit/plantnet-quota.test.ts
+++ b/tests/unit/plantnet-quota.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Map-backed localStorage shim for Node (vitest runs in Node, not browser)
+const store = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+    get length() { return store.size; },
+    key: (i: number) => [...store.keys()][i] ?? null,
+  },
+  writable: true,
+  configurable: true,
+});
+
+import { getPlantNetQuota, incrementPlantNetQuota } from '../../src/lib/plantnet-quota';
+
+describe('plantnet-quota', () => {
+  beforeEach(() => store.clear());
+
+  it('returns 0 used_today and 500 daily_limit when no quota stored', () => {
+    const q = getPlantNetQuota();
+    expect(q).not.toBeNull();
+    expect(q!.used_today).toBe(0);
+    expect(q!.daily_limit).toBe(500);
+  });
+
+  it('increments used_today on each call to incrementPlantNetQuota', () => {
+    incrementPlantNetQuota();
+    incrementPlantNetQuota();
+    incrementPlantNetQuota();
+    const q = getPlantNetQuota();
+    expect(q!.used_today).toBe(3);
+  });
+
+  it('resets counter when stored day differs from today', () => {
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+    store.set('rastrum.plantnet.quota', JSON.stringify({ used: 400, day: yesterday }));
+    const q = getPlantNetQuota();
+    expect(q!.used_today).toBe(0);
+  });
+
+  it('returns null-safe result on corrupt storage', () => {
+    store.set('rastrum.plantnet.quota', 'not-json{{{');
+    const q = getPlantNetQuota();
+    expect(q).not.toBeNull();
+    expect(q!.used_today).toBe(0);
+  });
+
+  it('includes reset_at as an ISO string', () => {
+    const q = getPlantNetQuota();
+    expect(q!.reset_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces a daily usage counter chip on the PlantNet card in the AI settings tab (Profile → Edit → AI), mirroring the existing Claude sponsorship chip pattern.

**What ships:**
- `src/lib/plantnet-quota.ts` — `getPlantNetQuota()` + `incrementPlantNetQuota()`. Persists a local counter to `localStorage` (`rastrum.plantnet.quota`) that increments on each successful PlantNet identify call and resets at UTC midnight. Fixed `daily_limit: 500` matching PlantNet's free-tier quota (rate-limit headers are not forwarded through `supabase.functions.invoke`, so a local counter is the practical fallback).
- `src/lib/identifiers/plantnet.ts` — calls `incrementPlantNetQuota()` after a successful identify response.
- `src/lib/identifier-card-html.ts` — adds `PlantNetQuota` interface, `plantnetQuota?: PlantNetQuota | null` prop to `PluginCardProps`, and a `plantnetQuotaChip()` renderer that appends an amber pill (e.g. `347 / 500 IDs today`) to the pill row next to Active.
- `src/components/ProfileEditForm.astro` — `paintRegistry()` imports `getPlantNetQuota` and passes the result to `renderPluginCard` for the PlantNet card.

**How to test:**
1. Make a successful PlantNet identification.
2. Open Profile → Edit → AI tab — the PlantNet card should show an amber `N / 500 IDs today` chip.
3. Refresh; counter persists across reloads.
4. Check at UTC midnight: counter resets to 0.

Closes #696

## Related Linear tickets, Github issues, and Community forum posts

Closes #696

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included (+7 tests: 2 in `identifier-card-html.test.ts`, 5 in new `plantnet-quota.test.ts`).
- [x] No new external dependencies.
- [x] EN/ES parity: chip label uses the existing `ids_today` string key already present in both locale files.