### PR TITLE
fix(ai-tab): inline key form + Anthropic key validation (#691)

### DIFF
--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -1512,13 +1512,17 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
               cacheStatus: cache,
               byoKeysSet: byo.hasKeysForPlugin(p.id),
             });
+        const rawKeys = byo.getAllKeysForPlugin(p.id);
+        const byoKeysSet: Record<string, boolean> = Object.fromEntries(
+          Object.entries(rawKeys).map(([k, v]) => [k, Boolean(v)])
+        );
         return renderPluginCard({
           lang,
           plugin: p,
           state,
           isDisabled,
           cacheStatus: cache,
-          byoKeysSet: {},
+          byoKeysSet,
           sponsorship: p.id === 'claude_haiku' ? (sponsorship as Parameters<typeof renderPluginCard>[0]['sponsorship']) : null,
         });
       }).join('');
@@ -1592,20 +1596,103 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
       });
     });
 
-    // Wire Add key / Edit key buttons (delegated). Uses window.prompt as v1
-    // minimum; richer inline form is a follow-up.
+    // Wire Add key / Edit key buttons — open the inline <details> form.
     list.querySelectorAll<HTMLButtonElement>('[data-add-key], [data-edit-key]').forEach((btn) => {
-      btn.addEventListener('click', async () => {
+      btn.addEventListener('click', () => {
         const id = btn.dataset.addKey ?? btn.dataset.editKey!;
+        const details = list.querySelector<HTMLDetailsElement>(`[data-key-form="${CSS.escape(id)}"]`);
+        if (!details) return;
+        details.open = true;
+        const firstInput = details.querySelector<HTMLInputElement>('[data-key-input]');
+        if (firstInput) {
+          // Pre-fill with the current stored value so the user can see/edit it.
+          const plugin = reg.get(id);
+          if (plugin?.keySpec?.[0]) {
+            firstInput.value = byo.getKey(id, plugin.keySpec[0].name) ?? '';
+          }
+          firstInput.focus();
+        }
+      });
+    });
+
+    // Wire Save buttons for inline key forms.
+    list.querySelectorAll<HTMLButtonElement>('[data-key-save]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.keySave!;
         const plugin = reg.get(id);
         if (!plugin?.keySpec?.length) return;
-        const newKey = window.prompt(plugin.keySpec[0].label, byo.getKey(id, plugin.keySpec[0].name) ?? '');
-        if (newKey == null) return;
-        if (newKey.trim()) {
-          byo.setKey(id, plugin.keySpec[0].name, newKey.trim());
-        } else {
-          byo.clearKey(id, plugin.keySpec[0].name);
+        const statusEl = list.querySelector<HTMLElement>(`[data-key-status="${CSS.escape(id)}"]`);
+        const inputs = list.querySelectorAll<HTMLInputElement>(`[data-key-input][data-plugin="${CSS.escape(id)}"]`);
+        const value = inputs[0]?.value?.trim() ?? '';
+
+        if (!value) {
+          plugin.keySpec.forEach((spec) => byo.clearKey(id, spec.name));
+          if (statusEl) statusEl.textContent = '';
+          await paintRegistry();
+          return;
         }
+
+        // Validate Anthropic keys before persisting.
+        if (id === 'claude_haiku') {
+          if (statusEl) {
+            statusEl.textContent = 'Validating…';
+            statusEl.className = 'text-[10px] text-zinc-500 dark:text-zinc-400';
+          }
+          const { validateAnthropicKey } = await import('../lib/anthropic-key');
+          const result = await validateAnthropicKey(value);
+          if (!result.valid) {
+            if (statusEl) {
+              statusEl.textContent = `✗ ${result.message ?? 'Invalid key'}`;
+              statusEl.className = 'text-[10px] text-red-600 dark:text-red-400';
+            }
+            return;
+          }
+        }
+
+        // Persist all key inputs for this plugin.
+        inputs.forEach((input) => {
+          const name = input.dataset.keyName!;
+          if (input.value.trim()) {
+            byo.setKey(id, name, input.value.trim());
+          }
+        });
+
+        if (statusEl) {
+          statusEl.textContent = '✓ Saved';
+          statusEl.className = 'text-[10px] text-emerald-600 dark:text-emerald-400';
+        }
+        setTimeout(() => paintRegistry(), 800);
+      });
+    });
+
+    // Wire Test buttons for plugins that expose testConnection().
+    list.querySelectorAll<HTMLButtonElement>('[data-key-test]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.keyTest!;
+        const plugin = reg.get(id);
+        if (typeof plugin?.testConnection !== 'function') return;
+        const statusEl = list.querySelector<HTMLElement>(`[data-key-status="${CSS.escape(id)}"]`);
+        if (statusEl) {
+          statusEl.textContent = 'Testing…';
+          statusEl.className = 'text-[10px] text-zinc-500 dark:text-zinc-400';
+        }
+        const result = await plugin.testConnection();
+        if (statusEl) {
+          statusEl.textContent = result.ok ? `✓ ${result.message ?? 'OK'}` : `✗ ${result.message ?? 'Failed'}`;
+          statusEl.className = result.ok
+            ? 'text-[10px] text-emerald-600 dark:text-emerald-400'
+            : 'text-[10px] text-red-600 dark:text-red-400';
+        }
+      });
+    });
+
+    // Wire Clear buttons for inline key forms.
+    list.querySelectorAll<HTMLButtonElement>('[data-key-clear]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.keyClear!;
+        const plugin = reg.get(id);
+        if (!plugin?.keySpec?.length) return;
+        plugin.keySpec.forEach((spec) => byo.clearKey(id, spec.name));
         await paintRegistry();
       });
     });

--- a/src/lib/identifier-card-html.ts
+++ b/src/lib/identifier-card-html.ts
@@ -54,6 +54,8 @@ interface Strings {
   active: string; disabled: string; no_key: string; not_downloaded: string; unsupported: string;
   enable: string; disable: string; download: string; redownload: string; cancel: string; delete: string;
   add_key: string; use_own_key: string; use_sponsorship: string; via_sponsorship: string; sponsored_by: string; ids_today: string;
+  configure: string; configure_edit: string; save: string; test: string; clear: string;
+  validating: string; saved: string; save_anyway: string;
 }
 
 const STRINGS: Record<'en' | 'es', Strings> = {
@@ -64,6 +66,8 @@ const STRINGS: Record<'en' | 'es', Strings> = {
     delete: 'Delete', add_key: 'Add key', use_own_key: 'Use my own key',
     use_sponsorship: 'Use sponsorship',
     via_sponsorship: 'via sponsorship', sponsored_by: 'sponsored by', ids_today: 'IDs today',
+    configure: 'Configure', configure_edit: 'Configure · edit', save: 'Save', test: 'Test',
+    clear: 'Clear', validating: 'Validating…', saved: '✓ Saved', save_anyway: 'Save without testing',
   },
   es: {
     active: 'Activo', disabled: '⏸ Desactivado', no_key: 'Sin API key', not_downloaded: 'Sin descargar',
@@ -72,6 +76,8 @@ const STRINGS: Record<'en' | 'es', Strings> = {
     delete: 'Eliminar', add_key: 'Agregar API key', use_own_key: 'Usar tu propia API key',
     use_sponsorship: 'Usar patrocinio',
     via_sponsorship: 'vía patrocinio', sponsored_by: 'patrocinado por', ids_today: 'IDs hoy',
+    configure: 'Configurar', configure_edit: 'Configurar · editar', save: 'Guardar', test: 'Probar',
+    clear: 'Limpiar', validating: 'Validando…', saved: '✓ Guardado', save_anyway: 'Guardar sin probar',
   },
 };
 
@@ -175,6 +181,79 @@ function actionsFor(p: PluginCardProps, t: Strings): string {
   }
 }
 
+/**
+ * Renders the inline key-configuration form for plugins with keySpec.
+ * The <details> is collapsed by default. The data-add-key / data-edit-key
+ * handler in ProfileEditForm.astro programmatically opens it and focuses
+ * the first input instead of using window.prompt().
+ *
+ * Attributes used by ProfileEditForm.astro's delegated handlers:
+ *   data-key-input[data-plugin]   — password input per key spec
+ *   data-key-save[data-plugin]    — Save button (runs validation + persist)
+ *   data-key-test[data-plugin]    — Test button (only when testConnection exists)
+ *   data-key-clear[data-plugin]   — Clear / remove stored key
+ *   data-key-status[data-plugin]  — Status pill updated by handlers
+ *   data-key-form[data-plugin]    — The <details> element itself
+ */
+function keyForm(p: PluginCardProps, t: Strings, hasKey: boolean): string {
+  if (!p.plugin.keySpec?.length) return '';
+  const id = escape(p.plugin.id);
+  const summaryLabel = hasKey ? escape(t.configure_edit) : escape(t.configure);
+  const hasTestConnection = typeof (p.plugin as { testConnection?: unknown }).testConnection === 'function';
+
+  const inputs = p.plugin.keySpec.map((spec) => {
+    const current = ''; // value is always empty on render — filled by JS after open
+    const hintHtml = spec.hint
+      ? `<p class="text-[10px] text-zinc-500 dark:text-zinc-400 mt-0.5">${escape(spec.hint)}</p>`
+      : '';
+    const setupLink = p.plugin.setupSteps?.find((s) => s.link)?.link ?? '';
+    const linkHtml = setupLink
+      ? `<a href="${escape(setupLink)}" target="_blank" rel="noopener noreferrer" class="text-[10px] text-emerald-600 dark:text-emerald-400 underline hover:no-underline">Get key ↗</a>`
+      : '';
+    return `
+      <div class="flex flex-col gap-1">
+        <label class="text-[11px] font-medium text-zinc-600 dark:text-zinc-400 flex items-center justify-between">
+          <span>${escape(spec.label)}</span>
+          ${linkHtml}
+        </label>
+        <input
+          type="password"
+          data-key-input
+          data-plugin="${id}"
+          data-key-name="${escape(spec.name)}"
+          value="${escape(current)}"
+          placeholder="${escape(spec.placeholder ?? '')}"
+          autocomplete="off"
+          class="w-full rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2.5 py-1.5 text-sm text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
+        />
+        ${hintHtml}
+      </div>
+    `.trim();
+  }).join('');
+
+  const testBtn = hasTestConnection
+    ? `<button type="button" data-key-test="${id}" class="rounded-lg border border-zinc-300 dark:border-zinc-700 px-2 py-1 text-[10px] font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40">${t.test}</button>`
+    : '';
+
+  return `
+    <details data-key-form="${id}" class="mt-2">
+      <summary class="cursor-pointer text-[11px] font-medium text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 select-none list-none flex items-center gap-1">
+        <svg class="w-3 h-3 transition-transform [[open]_&]:rotate-90" viewBox="0 0 8 12" fill="currentColor" aria-hidden="true"><path d="M2 0L8 6L2 12V0Z"/></svg>
+        ${summaryLabel}
+      </summary>
+      <div class="mt-2 flex flex-col gap-2">
+        ${inputs}
+        <div class="flex items-center gap-2 flex-wrap">
+          <button type="button" data-key-save="${id}" class="rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-1.5 text-xs font-semibold text-white">${escape(t.save)}</button>
+          ${testBtn}
+          <button type="button" data-key-clear="${id}" class="rounded-lg border border-red-300 dark:border-red-900/50 px-2 py-1 text-[10px] font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">${escape(t.clear)}</button>
+          <span data-key-status="${id}" class="text-[10px] text-zinc-500 dark:text-zinc-400"></span>
+        </div>
+      </div>
+    </details>
+  `.trim();
+}
+
 function metaLine(p: PluginCardProps): string {
   const c = p.plugin.capabilities;
   const parts: string[] = [];
@@ -205,6 +284,9 @@ export function renderPluginCard(p: PluginCardProps): string {
     ? `<p class="text-[10px] text-zinc-500 italic mt-1">${escape(p.state.message)}</p>`
     : '';
 
+  const hasKey = p.plugin.keySpec?.some((s) => !!p.byoKeysSet[s.name]) ?? false;
+  const form = keyForm(p, t, hasKey);
+
   return `
     <li class="${liClass}">
       <div class="flex items-start justify-between gap-3 flex-wrap">
@@ -218,6 +300,7 @@ export function renderPluginCard(p: PluginCardProps): string {
           <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">${escape(p.plugin.description)}</p>
           <p class="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1 font-mono">${escape(metaLine(p))}</p>
           ${message}
+          ${form}
         </div>
         <div class="flex flex-wrap gap-2 flex-none">
           ${actionsFor(p, t)}

--- a/tests/unit/identifier-card-html.test.ts
+++ b/tests/unit/identifier-card-html.test.ts
@@ -177,6 +177,109 @@ describe('renderPluginCard', () => {
     const active = renderPluginCard(props({ lang: 'es' }));
     expect(active).toContain('Volver a descargar');
   });
+
+  // Inline key-form tests (issue #691)
+  it('renders Configure details summary and password input for Claude (no-key)', () => {
+    const html = renderPluginCard(props({
+      plugin: claude,
+      state: { kind: 'no-key' },
+      cacheStatus: null,
+      byoKeysSet: {},
+    }));
+    expect(html).toContain('data-key-form="claude_haiku"');
+    expect(html).toMatch(/<summary[^>]*>[\s\S]*Configure[\s\S]*<\/summary>/);
+    expect(html).toContain('data-key-input');
+    expect(html).toContain('data-plugin="claude_haiku"');
+    expect(html).toContain('type="password"');
+    expect(html).toContain('placeholder="sk-ant-…"');
+  });
+
+  it('renders Configure · edit when key is already set (byoKeysSet)', () => {
+    const html = renderPluginCard(props({
+      plugin: claude,
+      state: { kind: 'active' },
+      cacheStatus: null,
+      byoKeysSet: { anthropic: true },
+    }));
+    expect(html).toContain('Configure · edit');
+  });
+
+  it('renders Save and Clear buttons in key form', () => {
+    const html = renderPluginCard(props({
+      plugin: claude,
+      state: { kind: 'no-key' },
+      cacheStatus: null,
+      byoKeysSet: {},
+    }));
+    expect(html).toContain('data-key-save="claude_haiku"');
+    expect(html).toContain('data-key-clear="claude_haiku"');
+    expect(html).toContain('data-key-status="claude_haiku"');
+  });
+
+  it('renders Test button for plugins with testConnection', () => {
+    const claudeWithTest: Identifier = {
+      ...claude,
+      testConnection: async () => ({ ok: true }),
+    };
+    const html = renderPluginCard(props({
+      plugin: claudeWithTest,
+      state: { kind: 'no-key' },
+      cacheStatus: null,
+      byoKeysSet: {},
+    }));
+    expect(html).toContain('data-key-test="claude_haiku"');
+  });
+
+  it('omits Test button for plugins without testConnection', () => {
+    const claudeNoTest: Identifier = { ...claude };
+    delete (claudeNoTest as { testConnection?: unknown }).testConnection;
+    const html = renderPluginCard(props({
+      plugin: claudeNoTest,
+      state: { kind: 'no-key' },
+      cacheStatus: null,
+      byoKeysSet: {},
+    }));
+    expect(html).not.toContain('data-key-test=');
+  });
+
+  it('omits key form for plugins without keySpec', () => {
+    const html = renderPluginCard(props({
+      plugin: phi,
+      state: { kind: 'active' },
+      byoKeysSet: {},
+    }));
+    expect(html).not.toContain('data-key-form=');
+    expect(html).not.toContain('data-key-save=');
+  });
+
+  it('renders Get key link from setupSteps that have a link', () => {
+    const claudeWithSteps: Identifier = {
+      ...claude,
+      setupSteps: [
+        { text: 'Sign in', link: 'https://console.anthropic.com' },
+      ],
+    };
+    const html = renderPluginCard(props({
+      plugin: claudeWithSteps,
+      state: { kind: 'no-key' },
+      cacheStatus: null,
+      byoKeysSet: {},
+    }));
+    expect(html).toContain('Get key ↗');
+    expect(html).toContain('https://console.anthropic.com');
+  });
+
+  it('renders Configure summary in Spanish when lang=es', () => {
+    const html = renderPluginCard(props({
+      lang: 'es',
+      plugin: claude,
+      state: { kind: 'no-key' },
+      cacheStatus: null,
+      byoKeysSet: {},
+    }));
+    expect(html).toContain('Configurar');
+    expect(html).toContain('data-key-save="claude_haiku"');
+  });
 });
 
 describe('renderLocalDataCard', () => {


### PR DESCRIPTION
## Summary

Fixes the Add key flow in the AI tab (Profile → Edit) which was using `window.prompt()` and skipping `validateAnthropicKey()`.

**Changes:**
- Replaced `window.prompt()` with an inline `<details>`-driven key form rendered directly inside each plugin card
- Form opens when the user clicks the "Add key" / "Edit key" / "Use my own key" button — the `<details>` is programmatically set to `open` and the first input is focused
- For `claude_haiku`, calls `validateAnthropicKey()` before persisting — shows "Validating…" pill, then `✗ Invalid key` on failure or proceeds to save on success
- For plugins with `testConnection()` (PlantNet, Claude), renders a **Test** button that fires the probe and updates the status pill
- **Save**, **Test**, **Clear** buttons all use delegated event listeners re-bound on each `paintRegistry()` call
- `byoKeysSet` prop in `renderPluginCard` is now populated from `byo.getAllKeysForPlugin()` instead of `{}` so the "Configure · edit" summary label renders correctly when a key is already set
- Get key ↗ deep-link pulled from the first `setupSteps` entry with a `link`
- Full EN/ES string parity (`configure`, `configure_edit`, `save`, `test`, `clear`, `validating`, `saved`, `save_anyway`)

**Tests:** +8 unit tests in `tests/unit/identifier-card-html.test.ts` asserting the Configure details/summary, password input, Save/Clear/Test buttons, and the "omit form" case for plugins without keySpec.

Closes #691

## Test plan

- [ ] Profile → Edit → AI tab → Claude Haiku card shows "Add key" button
- [ ] Clicking "Add key" opens the inline form (no `window.prompt()`)
- [ ] Entering a valid `sk-ant-…` key → Save persists it and re-paints to "Configure · edit"
- [ ] Entering an invalid key → "✗ Invalid key format" or "✗ HTTP 401" status pill, nothing persisted
- [ ] PlantNet card shows Test button; clicking it fires `testConnection()` and updates pill
- [ ] Clear button removes the stored key and re-paints to "No key" state
- [ ] Form renders correctly in dark mode and at mobile widths
- [ ] `npm run typecheck && npm run test && npm run build` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)