### PR TITLE
refactor(identifiers): Move KNOWN_MODEL_BYTES onto Identifier capabilities

### DIFF
--- a/src/lib/identifier-card-html.ts
+++ b/src/lib/identifier-card-html.ts
@@ -94,15 +94,6 @@ function pillFor(state: CardState, t: Strings): string {
   }
 }
 
-/** Approximate cached/download sizes for on-device plugins (binary units). */
-const KNOWN_MODEL_BYTES: Record<string, number> = {
-  webllm_phi35_vision: 4_294_967_296,    // 4.0 GiB
-  onnx_gemma4_vision: 3_435_973_837,     // ≈ 3.2 GB binary (matches existing UI)
-  birdnet_lite: 52_428_800,              // 50 MiB
-  onnx_efficientnet_lite0: 18_874_368,   // 18 MB (matches existing UI showing 18 MB)
-  camera_trap_megadetector: 140_509_184, // ≈ 134 MB (matches existing UI)
-  speciesnet_distilled: 104_857_600,     // 100 MiB
-};
 
 function actionsFor(p: PluginCardProps, t: Strings): string {
   const id = escape(p.plugin.id);
@@ -161,7 +152,7 @@ function actionsFor(p: PluginCardProps, t: Strings): string {
       return primaryBtn(t.add_key, 'data-add-key', id);
     }
     case 'not-downloaded': {
-      const knownBytes = KNOWN_MODEL_BYTES[p.plugin.id] ?? p.cacheStatus?.approxBytes ?? 0;
+      const knownBytes = p.plugin.capabilities.approxDownloadBytes ?? p.cacheStatus?.approxBytes ?? 0;
       const sizeLabel = bytesHuman(knownBytes) || '?';
       const idBase = dlPrefix ?? '';
       return `<button type="button" id="${idBase}-download" class="rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-1.5 text-xs font-semibold text-white">${t.download} · ${escape(sizeLabel)}</button>`;

--- a/src/lib/identifiers/birdnet.ts
+++ b/src/lib/identifiers/birdnet.ts
@@ -112,6 +112,7 @@ export const birdnetIdentifier: Identifier = {
     runtime: 'client',
     license: 'free-nc',
     cost_per_id_usd: 0,
+    approxDownloadBytes: 52_428_800,
   },
   async isAvailable() {
     if (!getBirdNETWeightsBaseUrl()) {

--- a/src/lib/identifiers/camera-trap-megadetector.ts
+++ b/src/lib/identifiers/camera-trap-megadetector.ts
@@ -161,6 +161,7 @@ export const cameraTrapMegadetectorIdentifier: Identifier = {
     // ceiling so the cascade always tries a downstream species model
     // when an animal IS detected.
     confidence_ceiling: 0.4,
+    approxDownloadBytes: 140_509_184,
   },
 
   async isAvailable() {

--- a/src/lib/identifiers/gemma-vision.ts
+++ b/src/lib/identifiers/gemma-vision.ts
@@ -31,6 +31,7 @@ export const gemmaVisionIdentifier: Identifier = {
     license: 'free',
     confidence_ceiling: 0.35,
     cost_per_id_usd: 0,
+    approxDownloadBytes: 3_435_973_837,
   },
   async isAvailable() {
     const { gemmaSupported } = await import('../onnx-vision');

--- a/src/lib/identifiers/onnx-base.ts
+++ b/src/lib/identifiers/onnx-base.ts
@@ -143,6 +143,7 @@ export const onnxBaseIdentifier: Identifier = {
     // scientific binomials, so this plugin is hint-only — surfaces top-k
     // alternates in the UI but never wins the cascade.
     confidence_ceiling: 0.4,
+    approxDownloadBytes: 18_874_368,
   },
   async isAvailable() {
     if (!getOnnxBaseWeightsBaseUrl()) {

--- a/src/lib/identifiers/phi-vision.ts
+++ b/src/lib/identifiers/phi-vision.ts
@@ -23,6 +23,7 @@ export const phiVisionIdentifier: Identifier = {
     license: 'free',
     confidence_ceiling: 0.35,
     cost_per_id_usd: 0,
+    approxDownloadBytes: 4_294_967_296,
   },
   async isAvailable() {
     const { localAISupported } = await import('../local-ai');

--- a/src/lib/identifiers/speciesnet.ts
+++ b/src/lib/identifiers/speciesnet.ts
@@ -182,6 +182,7 @@ export const speciesnetIdentifier: Identifier = {
     license: 'free',
     confidence_ceiling: 0.85,
     cost_per_id_usd: 0,
+    approxDownloadBytes: 104_857_600,
   },
 
   async isAvailable() {

--- a/src/lib/identifiers/types.ts
+++ b/src/lib/identifiers/types.ts
@@ -86,6 +86,8 @@ export interface IdentifierCapabilities {
   confidence_ceiling?: number;
   /** Approximate $ cost per identification (operator-side). 0 if free. */
   cost_per_id_usd?: number;
+  /** Approximate size of the model artifact in bytes (binary). Used to label download buttons. */
+  approxDownloadBytes?: number;
 }
 
 /** Per-plugin status surfaced to the UI. */

--- a/tests/unit/identifier-card-html.test.ts
+++ b/tests/unit/identifier-card-html.test.ts
@@ -13,6 +13,7 @@ const phi: Identifier = {
     taxa: ['*'],
     license: 'free',
     confidence_ceiling: 0.35,
+    approxDownloadBytes: 4_294_967_296,
   },
   isAvailable: async () => ({ ready: true }),
   identify: async () => { throw new Error('not used in tests'); },


### PR DESCRIPTION
## Summary

Eliminates the `KNOWN_MODEL_BYTES` lookup table in `identifier-card-html.ts` by moving each plugin's approximate download size onto its own `IdentifierCapabilities` shape.

**Before:** size lived in a hardcoded `Record<string, number>` in the renderer, creating a second source of truth that could drift from plugin descriptions.

**After:** each on-device plugin declares `approxDownloadBytes` in its `capabilities` block; the renderer reads `plugin.capabilities.approxDownloadBytes ?? cacheStatus?.approxBytes ?? 0`. One source of truth.

Changes:
- `IdentifierCapabilities` gets optional `approxDownloadBytes?: number`
- Six plugins annotated: phi-vision (4 GiB), gemma-vision (≈3.2 GiB), birdnet (50 MiB), onnx-base (18 MB), megadetector (≈134 MB), speciesnet (100 MiB)
- `KNOWN_MODEL_BYTES` constant deleted from renderer
- Test fixture for `phi` updated with the field; `not-downloaded` assertion still produces "Download · 4.0 GB"

## Related issues

Closes #695

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 1212/1212 passed (no delta)
- [x] `npm run build` — 231 pages, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)