### PR TITLE
feat(praise): contextual photo praise on upload (EXIF-driven, not content)

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -83,6 +83,14 @@ const cameraStationPlaceholder = observeStrings.camera_station_placeholder ?? (i
 const cameraStationHint        = observeStrings.camera_station_hint        ?? (isEs ? 'Vincula esta observación a una estación de cámara de tus proyectos.' : 'Tag this observation to a camera station from your projects.');
 const cameraStationNone        = observeStrings.camera_station_none        ?? (isEs ? 'Ninguna' : 'None');
 const cameraStationLoading     = observeStrings.camera_station_loading     ?? (isEs ? 'Cargando estaciones…' : 'Loading stations…');
+
+const uploadTree = (tr as unknown as { upload?: { praise?: Record<string, string> } }).upload;
+const praiseStrings: Record<string, string> = uploadTree?.praise ?? {};
+const praiseGoodLight        = praiseStrings.good_light        ?? (isEs ? 'Buena luz' : 'Good light');
+const praisePortraitAperture = praiseStrings.portrait_aperture ?? (isEs ? 'Profundidad de retrato' : 'Portrait depth');
+const praiseSharpAction      = praiseStrings.sharp_action      ?? (isEs ? 'Captura nítida' : 'Sharp action');
+const praiseBalancedExposure = praiseStrings.balanced_exposure ?? (isEs ? 'Exposición equilibrada' : 'Balanced exposure');
+const praiseLongLens         = praiseStrings.long_lens         ?? (isEs ? 'Detalle con teleobjetivo' : 'Long-lens detail');
 ---
 
 <div class="max-w-xl mx-auto">
@@ -129,7 +137,15 @@ const cameraStationLoading     = observeStrings.camera_station_loading     ?? (i
     <!-- Photos (multi) -->
     <div>
       <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">{tr.observe.photo_label}</label>
-      <div id="photo-grid" class="hidden mb-3 grid grid-cols-3 gap-2"></div>
+      <div
+        id="photo-grid"
+        class="hidden mb-3 grid grid-cols-3 gap-2"
+        data-praise-good-light={praiseGoodLight}
+        data-praise-portrait-aperture={praisePortraitAperture}
+        data-praise-sharp-action={praiseSharpAction}
+        data-praise-balanced-exposure={praiseBalancedExposure}
+        data-praise-long-lens={praiseLongLens}
+      ></div>
 
       <!-- Primary camera row -->
       <div class="flex gap-2 flex-wrap">
@@ -635,6 +651,7 @@ const cameraStationLoading     = observeStrings.camera_station_loading     ?? (i
     VIDEO_THUMB_PARAMS,
     computeThumbDims,
   } from '../lib/media-helpers';
+  import { pickPraise, type PraiseKey } from '../lib/photo-praise';
 
   const form         = document.getElementById('obs-form') as HTMLFormElement | null;
 
@@ -717,7 +734,7 @@ const cameraStationLoading     = observeStrings.camera_station_loading     ?? (i
     capturedFrom: 'gps' | 'exif' | 'manual';
   } | null;
 
-  type PhotoEntry = { file: File; blobId: string };
+  type PhotoEntry = { file: File; blobId: string; praiseKey: PraiseKey | null };
   type AudioEntry = { blob: Blob; blobId: string; mimeType: string; durationSec: number };
   type VideoEntry = {
     blob: Blob;
@@ -746,16 +763,36 @@ const cameraStationLoading     = observeStrings.camera_station_loading     ?? (i
     gpsStatus.className = 'text-zinc-900 dark:text-zinc-100 font-mono text-xs';
   }
 
+  const PRAISE_DATA_KEY: Record<PraiseKey, string> = {
+    good_light: 'praiseGoodLight',
+    portrait_aperture: 'praisePortraitAperture',
+    sharp_action: 'praiseSharpAction',
+    balanced_exposure: 'praiseBalancedExposure',
+    long_lens: 'praiseLongLens',
+  };
+
+  function praiseLabel(key: PraiseKey): string {
+    const grid = photoGrid as HTMLElement | null;
+    return grid?.dataset[PRAISE_DATA_KEY[key]] ?? '';
+  }
+
   function repaintGrid() {
     if (!photoGrid) return;
     photoGrid.classList.toggle('hidden', photos.length === 0);
-    photoGrid.innerHTML = photos.map((p, i) => `
+    photoGrid.innerHTML = photos.map((p, i) => {
+      const praiseText = p.praiseKey ? praiseLabel(p.praiseKey) : '';
+      const praise = praiseText
+        ? `<span data-praise class="absolute bottom-1 left-1 right-1 text-[10px] px-1.5 py-0.5 rounded bg-black/60 text-white truncate text-center">${escapeHtml(praiseText)}</span>`
+        : '';
+      return `
       <div class="relative aspect-square rounded-lg overflow-hidden border border-zinc-200 dark:border-zinc-800">
         <img src="${URL.createObjectURL(p.file)}" alt="" class="w-full h-full object-cover" />
         ${i === 0 ? '<span class="absolute top-1 left-1 text-[10px] px-1.5 py-0.5 rounded bg-emerald-600 text-white">primary</span>' : ''}
         <button data-rm="${i}" type="button" class="absolute top-1 right-1 w-5 h-5 rounded-full bg-black/60 text-white text-xs flex items-center justify-center" aria-label="remove">×</button>
+        ${praise}
       </div>
-    `).join('');
+    `;
+    }).join('');
     photoGrid.querySelectorAll<HTMLButtonElement>('button[data-rm]').forEach(btn => {
       btn.addEventListener('click', () => {
         const idx = Number(btn.dataset.rm);
@@ -1549,10 +1586,37 @@ const cameraStationLoading     = observeStrings.camera_station_loading     ?? (i
     }
 
     for (const file of compressed) {
-      photos.push({ file, blobId: crypto.randomUUID() });
+      photos.push({ file, blobId: crypto.randomUUID(), praiseKey: null });
       if (photos.length === 1) triggerClientIdentify(file);
     }
     repaintGrid();
+
+    // Compute EXIF-driven praise per photo. Async (decodes the JPEG
+    // header), so we paint the grid first and update praise badges as
+    // they resolve. Empty/missing EXIF → praiseKey stays null and
+    // nothing is shown — see acceptance criteria on issue #733.
+    void resolvePraiseForRecentlyAdded(compressed.length);
+  }
+
+  async function resolvePraiseForRecentlyAdded(addedCount: number): Promise<void> {
+    const startIdx = photos.length - addedCount;
+    if (startIdx < 0) return;
+    let changed = false;
+    for (let i = startIdx; i < photos.length; i++) {
+      const entry = photos[i];
+      if (!entry || entry.praiseKey !== null) continue;
+      try {
+        const exif = await parseExif(entry.file, { tiff: true, exif: true });
+        const key = pickPraise(exif as Record<string, unknown> | undefined);
+        if (key && photos[i] === entry) {
+          entry.praiseKey = key;
+          changed = true;
+        }
+      } catch {
+        // EXIF parse failed (HEIC without lib, no metadata, etc.) — silent.
+      }
+    }
+    if (changed) repaintGrid();
   }
 
   // ── Perceptual-hash dedupe (ux-photo-dedupe) ─────────────────────────
@@ -1721,8 +1785,9 @@ const cameraStationLoading     = observeStrings.camera_station_loading     ?? (i
 
       if (pending.kind === 'photo') {
         const file = new File([blob], filename, { type: pending.mime_type });
-        photos.push({ file, blobId: crypto.randomUUID() });
+        photos.push({ file, blobId: crypto.randomUUID(), praiseKey: null });
         repaintGrid();
+        void resolvePraiseForRecentlyAdded(1);
         await fillFromExif(file).catch(() => {});
       } else {
         audios.push({

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1711,6 +1711,15 @@
     "tip_camera_trap": "Camera trap deployment? Use the camera trap importer →",
     "tip_camera_trap_link": "Open camera-trap importer"
   },
+  "upload": {
+    "praise": {
+      "good_light": "Good light",
+      "portrait_aperture": "Portrait depth",
+      "sharp_action": "Sharp action",
+      "balanced_exposure": "Balanced exposure",
+      "long_lens": "Long-lens detail"
+    }
+  },
   "camera_trap": {
     "title": "Camera trap import",
     "subtitle": "All photos in one deployment share a single GPS. We pull the timestamp per-photo from EXIF.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1711,6 +1711,15 @@
     "tip_camera_trap": "¿Es un despliegue de cámara trampa? Usa el importador específico →",
     "tip_camera_trap_link": "Abrir importador de cámara trampa"
   },
+  "upload": {
+    "praise": {
+      "good_light": "Buena luz",
+      "portrait_aperture": "Profundidad de retrato",
+      "sharp_action": "Captura nítida",
+      "balanced_exposure": "Exposición equilibrada",
+      "long_lens": "Detalle con teleobjetivo"
+    }
+  },
   "camera_trap": {
     "title": "Importación de cámara trampa",
     "subtitle": "Todas las fotos del despliegue comparten un GPS. Tomamos la fecha por foto del EXIF.",

--- a/src/lib/photo-praise.ts
+++ b/src/lib/photo-praise.ts
@@ -1,0 +1,74 @@
+/**
+ * Contextual photo praise — EXIF-driven, not content-driven.
+ *
+ * The PWA reads EXIF on upload (already, for GPS + datetime). This helper
+ * picks a single praise key from the camera-settings tags so the UI can
+ * show a small, honest compliment next to the thumbnail.
+ *
+ * Hard rules:
+ *  • If EXIF is empty / missing — return `null`. We never lie.
+ *  • Praise is technical (lighting, depth-of-field, shutter, focal length),
+ *    never aesthetic. ML aesthetic scoring is explicitly out of scope.
+ *  • One praise message at most — pick the highest-priority match.
+ */
+
+export type PraiseKey =
+  | 'good_light'
+  | 'portrait_aperture'
+  | 'sharp_action'
+  | 'balanced_exposure'
+  | 'long_lens';
+
+export interface PhotoExifSubset {
+  ISO?: unknown;
+  FNumber?: unknown;
+  ExposureTime?: unknown;
+  FocalLength?: unknown;
+}
+
+function num(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  return null;
+}
+
+/**
+ * Return the praise key for a parsed EXIF object, or `null` if the EXIF
+ * payload is empty / has no actionable camera-settings tags.
+ *
+ * Priority order (first match wins):
+ *  1. `sharp_action`        — fast shutter (ExposureTime ≤ 1/500s)
+ *  2. `portrait_aperture`   — wide aperture (FNumber ≤ 2.8)
+ *  3. `long_lens`           — telephoto (FocalLength ≥ 200mm)
+ *  4. `good_light`          — low ISO (< 400)
+ *  5. `balanced_exposure`   — moderate ISO (400 ≤ ISO < 800)
+ */
+export function pickPraise(exif: PhotoExifSubset | null | undefined): PraiseKey | null {
+  if (!exif) return null;
+
+  const iso = num(exif.ISO);
+  const fNumber = num(exif.FNumber);
+  const exposureSec = num(exif.ExposureTime);
+  const focalMm = num(exif.FocalLength);
+
+  if (iso == null && fNumber == null && exposureSec == null && focalMm == null) {
+    return null;
+  }
+
+  if (exposureSec != null && exposureSec > 0 && exposureSec <= 1 / 500) {
+    return 'sharp_action';
+  }
+  if (fNumber != null && fNumber > 0 && fNumber <= 2.8) {
+    return 'portrait_aperture';
+  }
+  if (focalMm != null && focalMm >= 200) {
+    return 'long_lens';
+  }
+  if (iso != null && iso > 0 && iso < 400) {
+    return 'good_light';
+  }
+  if (iso != null && iso >= 400 && iso < 800) {
+    return 'balanced_exposure';
+  }
+
+  return null;
+}

--- a/tests/unit/photo-praise.test.ts
+++ b/tests/unit/photo-praise.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { pickPraise } from '../../src/lib/photo-praise';
+
+describe('pickPraise', () => {
+  it('returns null when EXIF is null', () => {
+    expect(pickPraise(null)).toBeNull();
+  });
+
+  it('returns null when EXIF is undefined', () => {
+    expect(pickPraise(undefined)).toBeNull();
+  });
+
+  it('returns null when EXIF is empty (no actionable camera tags)', () => {
+    expect(pickPraise({})).toBeNull();
+  });
+
+  it('returns null when only non-numeric values are present', () => {
+    expect(pickPraise({ ISO: 'auto', FNumber: null })).toBeNull();
+  });
+
+  it('returns "good_light" for low ISO (< 400)', () => {
+    expect(pickPraise({ ISO: 100 })).toBe('good_light');
+    expect(pickPraise({ ISO: 200 })).toBe('good_light');
+    expect(pickPraise({ ISO: 399 })).toBe('good_light');
+  });
+
+  it('returns "balanced_exposure" for moderate ISO (400-799)', () => {
+    expect(pickPraise({ ISO: 400 })).toBe('balanced_exposure');
+    expect(pickPraise({ ISO: 640 })).toBe('balanced_exposure');
+  });
+
+  it('returns null for high ISO (no praise — do not lie)', () => {
+    expect(pickPraise({ ISO: 800 })).toBeNull();
+    expect(pickPraise({ ISO: 3200 })).toBeNull();
+    expect(pickPraise({ ISO: 12800 })).toBeNull();
+  });
+
+  it('returns "portrait_aperture" for wide aperture (FNumber ≤ 2.8)', () => {
+    expect(pickPraise({ FNumber: 1.4 })).toBe('portrait_aperture');
+    expect(pickPraise({ FNumber: 2.8 })).toBe('portrait_aperture');
+  });
+
+  it('does not return portrait_aperture for narrow aperture', () => {
+    expect(pickPraise({ FNumber: 5.6 })).toBeNull();
+    expect(pickPraise({ FNumber: 11 })).toBeNull();
+  });
+
+  it('returns "sharp_action" for fast shutter (≤ 1/500s)', () => {
+    expect(pickPraise({ ExposureTime: 1 / 1000 })).toBe('sharp_action');
+    expect(pickPraise({ ExposureTime: 1 / 500 })).toBe('sharp_action');
+  });
+
+  it('does not return sharp_action for slow shutter', () => {
+    expect(pickPraise({ ExposureTime: 1 / 60 })).toBeNull();
+    expect(pickPraise({ ExposureTime: 0.5 })).toBeNull();
+  });
+
+  it('returns "long_lens" for telephoto (FocalLength ≥ 200mm)', () => {
+    expect(pickPraise({ FocalLength: 200 })).toBe('long_lens');
+    expect(pickPraise({ FocalLength: 600 })).toBe('long_lens');
+  });
+
+  it('does not return long_lens for short focal length', () => {
+    expect(pickPraise({ FocalLength: 50 })).toBeNull();
+    expect(pickPraise({ FocalLength: 100 })).toBeNull();
+  });
+
+  it('priority — sharp_action wins over portrait_aperture', () => {
+    expect(pickPraise({ ExposureTime: 1 / 1000, FNumber: 1.8 })).toBe('sharp_action');
+  });
+
+  it('priority — portrait_aperture wins over long_lens', () => {
+    expect(pickPraise({ FNumber: 2.8, FocalLength: 400 })).toBe('portrait_aperture');
+  });
+
+  it('priority — long_lens wins over good_light', () => {
+    expect(pickPraise({ FocalLength: 300, ISO: 100 })).toBe('long_lens');
+  });
+
+  it('priority — good_light wins over balanced_exposure (only one fires anyway)', () => {
+    expect(pickPraise({ ISO: 100 })).toBe('good_light');
+    expect(pickPraise({ ISO: 500 })).toBe('balanced_exposure');
+  });
+
+  it('rejects zero/negative numeric noise', () => {
+    expect(pickPraise({ ISO: 0, FNumber: 0, ExposureTime: 0, FocalLength: 0 })).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #733.

## Summary

When a photo is added to the observation form, Rastrum now reads its EXIF camera-settings tags (ISO, FNumber, ExposureTime, FocalLength) and shows a single small praise badge next to the thumbnail. The praise is **technical, not aesthetic** — and it stays silent when EXIF is missing.

## Praise lookup table

Pure function `pickPraise(exif)` in `src/lib/photo-praise.ts`. First match wins:

| Priority | Key | Trigger | EN | ES |
|---|---|---|---|---|
| 1 | `sharp_action` | `ExposureTime ≤ 1/500s` | Sharp action | Captura nítida |
| 2 | `portrait_aperture` | `FNumber ≤ 2.8` | Portrait depth | Profundidad de retrato |
| 3 | `long_lens` | `FocalLength ≥ 200mm` | Long-lens detail | Detalle con teleobjetivo |
| 4 | `good_light` | `ISO < 400` | Good light | Buena luz |
| 5 | `balanced_exposure` | `400 ≤ ISO < 800` | Balanced exposure | Exposición equilibrada |

If none match (high ISO, narrow aperture, slow shutter, short focal length), `pickPraise` returns `null` and no badge renders. Empty EXIF, parse failure, or absence of all four tags also returns `null`.

## Why these thresholds

- `ISO < 400` — well-exposed available light without sensor noise
- `400 ≤ ISO < 800` — still respectable; "balanced" rather than "great"
- `ISO ≥ 800` — explicitly **no praise** (acceptance criterion: don't lie)
- `FNumber ≤ 2.8` — wide enough to imply intentional subject isolation
- `ExposureTime ≤ 1/500s` — fast enough to freeze typical bird/mammal motion
- `FocalLength ≥ 200mm` — telephoto territory, useful for skittish wildlife

Taxon-agnostic for v1 — at upload time the cascade hasn't run yet, so we don't know if it's a bird or a plant. The thresholds work for any subject.

## Out of scope (per issue #733)

- ML-based aesthetic scoring
- Praise on observation count / streaks (already covered by badges)
- Taxon-conditional copy ("portrait of a bird") — possible v1.1

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` — 1219 tests pass (18 new for `pickPraise`)
- [x] `npm run build` — 231 pages build clean
- [ ] Upload a JPEG with rich EXIF (recent DSLR photo) — verify a praise badge appears under the thumbnail
- [ ] Upload a screenshot or compressed photo with stripped EXIF — verify NO praise renders
- [ ] Toggle ES locale (`/es/observar`) — verify the badge text is the Spanish copy
- [ ] Upload a high-ISO low-light photo — verify no badge ("we don't lie")

🤖 Generated with [Claude Code](https://claude.com/claude-code)