### PR TITLE
feat(community): active-observers micro-banner on /observe

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -8683,3 +8683,32 @@ $$;
 
 REVOKE ALL ON FUNCTION public.nearby_similar_species(uuid, numeric, int, int) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.nearby_similar_species(uuid, numeric, int, int) TO anon, authenticated;
+
+-- =====================================================================
+-- M28 — Active observers today (issue #743)
+--
+-- Returns the number of distinct observers in the given country who
+-- have at least one synced observation since the start of the current
+-- UTC day. Drives the "Hoy N personas observan en <region>" micro-banner
+-- on /observe. Anon callers can read it (the count is non-PII), but the
+-- function is SECURITY INVOKER so RLS on `observations` (public-read)
+-- and `users` (hide_from_leaderboards = false) still applies. The
+-- caller passes an ISO-3166 alpha-2 country code; NULL collapses to
+-- a global count.
+-- =====================================================================
+CREATE OR REPLACE FUNCTION public.community_active_observers_today(
+  p_country text DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT COUNT(DISTINCT o.observer_id)::int
+    FROM public.observations o
+    JOIN public.users u ON u.id = o.observer_id
+   WHERE o.sync_status = 'synced'
+     AND o.observed_at >= date_trunc('day', now() AT TIME ZONE 'UTC')
+     AND u.hide_from_leaderboards = false
+     AND (p_country IS NULL OR u.country_code = p_country);
+$$;
+
+REVOKE ALL ON FUNCTION public.community_active_observers_today(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.community_active_observers_today(text) TO anon, authenticated;

--- a/src/components/ActiveObserversBanner.astro
+++ b/src/components/ActiveObserversBanner.astro
@@ -1,0 +1,92 @@
+---
+/**
+ * Active observers micro-banner — issue #743.
+ *
+ * Mounts at the top of /observe. After hydrate, fetches the viewer's
+ * country + region via `loadViewerRegion()` and the count of distinct
+ * observers in that country who logged at least one synced observation
+ * since the start of the current UTC day.
+ *
+ * Privacy invariants:
+ *   - Reads `community_active_observers_today(p_country)` RPC, which
+ *     joins observations + users under their existing RLS. The count
+ *     is a non-PII aggregate; no observer IDs leave the server.
+ *   - Anon visitors (no auth user) and signed-in users without a
+ *     `region_primary` get no banner — never shows "in NULL".
+ *
+ * Singular / plural / empty copy lives in three distinct keys under
+ * `observe.active_banner.*` so each locale picks the right grammatical
+ * form.
+ */
+import { t } from '../i18n/utils';
+
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+const tr = t(lang);
+const banner = (tr.observe as Record<string, unknown>).active_banner as {
+  today_n: string;
+  today_one: string;
+  empty: string;
+  aria_label: string;
+};
+const observersHref = isEs ? '/es/comunidad/observadores' : '/en/community/observers';
+---
+
+<a
+  id="active-observers-banner"
+  href={observersHref}
+  aria-label={banner.aria_label}
+  class="hidden rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 px-3 py-1.5 text-xs text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 transition-colors w-fit"
+  data-lang={lang}
+  data-copy-today-n={banner.today_n}
+  data-copy-today-one={banner.today_one}
+  data-copy-empty={banner.empty}
+>
+  <span id="active-observers-banner-text">{banner.empty.replace('{region}', '')}</span>
+</a>
+
+<script>
+  import { loadViewerRegion, loadActiveObserversToday } from '../lib/community';
+  import { formatActiveObserversBanner } from '../lib/active-observers';
+  import { serializeFilters, DEFAULT_FILTERS } from '../lib/community-url';
+
+  async function hydrate(): Promise<void> {
+    const el = document.getElementById('active-observers-banner') as HTMLAnchorElement | null;
+    if (!el) return;
+
+    const copyTodayN = el.dataset.copyTodayN ?? '';
+    const copyTodayOne = el.dataset.copyTodayOne ?? '';
+    const copyEmpty = el.dataset.copyEmpty ?? '';
+
+    let region: { countryCode: string | null; regionPrimary: string | null };
+    try {
+      region = await loadViewerRegion();
+    } catch {
+      return;
+    }
+
+    if (!region.regionPrimary || !region.countryCode) {
+      // Anon visitor or user without a region set — graceful no-banner
+      // fallback so we never display "in NULL".
+      return;
+    }
+
+    const count = await loadActiveObserversToday(region.countryCode);
+    const result = formatActiveObserversBanner(
+      { count, region: region.regionPrimary },
+      { today_n: copyTodayN, today_one: copyTodayOne, empty: copyEmpty },
+    );
+
+    if (!result.text) return;
+
+    const textEl = document.getElementById('active-observers-banner-text');
+    if (textEl) textEl.textContent = result.text;
+
+    const qs = serializeFilters({ ...DEFAULT_FILTERS, country: region.countryCode });
+    el.href = `${el.pathname}${qs}`;
+    el.classList.remove('hidden');
+  }
+
+  hydrate();
+</script>

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -3,6 +3,7 @@ import DropZone from "./DropZone.astro";
 import PipelineGraph from "./PipelineGraph.astro";
 import MapPicker from "./MapPicker.astro";
 import TaxonAutocomplete from "./TaxonAutocomplete.astro";
+import ActiveObserversBanner from "./ActiveObserversBanner.astro";
 import { t } from "../i18n/utils";
 import { HABITATS, WEATHERS } from "../lib/observation-enums";
 
@@ -17,6 +18,10 @@ const weathers = WEATHERS;
 ---
 
 <div class="max-w-2xl mx-auto space-y-6">
+  <!-- Active observers micro-banner (issue #743) — at the top so the
+       social-presence cue lands before the form. -->
+  <ActiveObserversBanner lang={lang} />
+
   <!-- Header -->
   <div class="flex items-start justify-between gap-4">
     <h1 class="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -572,6 +572,14 @@
     }
   },
   "observe": {
+    "active_banner": {
+      "today_n": "Today {count} people are observing in {region} · join in",
+      "today_one": "Today 1 person is observing in {region} · join in",
+      "empty": "No observations in {region} yet today — open the season",
+      "aria_label": "Active observers today",
+      "cta_join": "Join in",
+      "cta_open": "Open the season"
+    },
     "title": "New observation",
     "photo_label": "Photos",
     "photo_hint": "Tap to take a photo or choose one or more from your gallery",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -572,6 +572,14 @@
     }
   },
   "observe": {
+    "active_banner": {
+      "today_n": "Hoy {count} personas observan en {region} · únete",
+      "today_one": "Hoy 1 persona observa en {region} · únete",
+      "empty": "Todavía no hay obs en {region} hoy — abre la temporada",
+      "aria_label": "Observadores activos hoy",
+      "cta_join": "Únete",
+      "cta_open": "Abre la temporada"
+    },
     "title": "Nueva observación",
     "photo_label": "Fotos",
     "photo_hint": "Toca para tomar una foto o elegir una o varias de la galería",

--- a/src/lib/active-observers.ts
+++ b/src/lib/active-observers.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure formatter for the active-observers micro-banner (issue #743).
+ *
+ * Decoupled from the DOM and the Supabase client so the messaging
+ * logic — including the NULL-region fallback and the singular/plural
+ * branch — can be unit-tested in isolation.
+ */
+
+export interface BannerCopy {
+  today_n: string;
+  today_one: string;
+  empty: string;
+}
+
+export interface ActiveObserversInput {
+  /** Distinct observer count for the user's country today. >= 0. */
+  count: number;
+  /** Free-text region label ("Oaxaca"). Null if user has no region. */
+  region: string | null;
+}
+
+export interface ActiveObserversOutput {
+  /** Rendered text. Null = do NOT render the banner. */
+  text: string | null;
+  /** True when the banner should advertise the empty-state CTA. */
+  isEmpty: boolean;
+}
+
+/**
+ * Compute the banner text for a (count, region) pair.
+ *
+ * Returns `{ text: null }` when the region is missing — the banner
+ * MUST NOT render copy like "today X people are observing in NULL".
+ *
+ * Singular / plural / empty branches use distinct copy keys so each
+ * locale can pick the right grammatical form rather than relying on a
+ * single string with a `count` placeholder.
+ */
+export function formatActiveObserversBanner(
+  input: ActiveObserversInput,
+  copy: BannerCopy,
+): ActiveObserversOutput {
+  const region = (input.region ?? '').trim();
+  if (!region) return { text: null, isEmpty: false };
+
+  const count = Math.max(0, Math.trunc(input.count));
+
+  if (count === 0) {
+    return {
+      text: copy.empty.replace('{region}', region),
+      isEmpty: true,
+    };
+  }
+
+  const template = count === 1 ? copy.today_one : copy.today_n;
+  const text = template
+    .replace('{count}', String(count))
+    .replace('{region}', region);
+  return { text, isEmpty: false };
+}

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -175,6 +175,68 @@ export async function loadViewerCommunityMeta(): Promise<ViewerCommunityMeta> {
   }
 }
 
+/**
+ * Viewer "home region" used by the active-observers micro-banner on
+ * /observe (issue #743). region_primary is the free-text label the
+ * banner displays ("Oaxaca"); country_code is the ISO-3166 alpha-2
+ * we filter by — the only column the M28 community page understands.
+ *
+ * Returns nulls for anon visitors or users who haven't picked a region.
+ * Callers MUST gracefully fall back to "no banner" when either field
+ * is null — the banner never displays raw NULL.
+ */
+export interface ViewerRegion {
+  countryCode: string | null;
+  regionPrimary: string | null;
+}
+
+export async function loadViewerRegion(): Promise<ViewerRegion> {
+  try {
+    const supabase = getSupabase();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { countryCode: null, regionPrimary: null };
+    const { data } = await supabase
+      .from('users')
+      .select('country_code, region_primary')
+      .eq('id', user.id)
+      .maybeSingle();
+    return {
+      countryCode: (data?.country_code as string | null | undefined) ?? null,
+      regionPrimary: (data?.region_primary as string | null | undefined) ?? null,
+    };
+  } catch {
+    return { countryCode: null, regionPrimary: null };
+  }
+}
+
+/**
+ * Count distinct observers with at least one synced observation since
+ * the start of the current UTC day, scoped to a country. Uses the
+ * `community_active_observers_today(p_country)` SQL RPC, which reads
+ * RLS-protected tables (`observations` public-read + `users` with
+ * hide_from_leaderboards = false) — no PII leaks via the count alone.
+ *
+ * Returns 0 on any error so the banner gracefully falls back to the
+ * empty-state copy rather than showing a stale or broken UI.
+ */
+export async function loadActiveObserversToday(countryCode: string | null): Promise<number> {
+  try {
+    const supabase = getSupabase();
+    const { data, error } = await supabase.rpc('community_active_observers_today', {
+      p_country: countryCode,
+    });
+    if (error) return 0;
+    if (typeof data === 'number') return data;
+    if (typeof data === 'string') {
+      const n = parseInt(data, 10);
+      return Number.isFinite(n) ? n : 0;
+    }
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
 export interface IsoCountry {
   code: string;
   name: string;

--- a/tests/unit/active-observers.test.ts
+++ b/tests/unit/active-observers.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { formatActiveObserversBanner } from '../../src/lib/active-observers';
+
+const COPY_EN = {
+  today_n: 'Today {count} people are observing in {region} · join in',
+  today_one: 'Today 1 person is observing in {region} · join in',
+  empty: 'No observations in {region} yet today — open the season',
+};
+
+const COPY_ES = {
+  today_n: 'Hoy {count} personas observan en {region} · únete',
+  today_one: 'Hoy 1 persona observa en {region} · únete',
+  empty: 'Todavía no hay obs en {region} hoy — abre la temporada',
+};
+
+describe('formatActiveObserversBanner', () => {
+  it('renders the plural copy with count + region (EN)', () => {
+    const out = formatActiveObserversBanner({ count: 7, region: 'Oaxaca' }, COPY_EN);
+    expect(out).toEqual({
+      text: 'Today 7 people are observing in Oaxaca · join in',
+      isEmpty: false,
+    });
+  });
+
+  it('renders the plural copy with count + region (ES)', () => {
+    const out = formatActiveObserversBanner({ count: 7, region: 'Oaxaca' }, COPY_ES);
+    expect(out.text).toBe('Hoy 7 personas observan en Oaxaca · únete');
+    expect(out.isEmpty).toBe(false);
+  });
+
+  it('uses the singular branch for count = 1 (EN)', () => {
+    const out = formatActiveObserversBanner({ count: 1, region: 'Oaxaca' }, COPY_EN);
+    expect(out.text).toBe('Today 1 person is observing in Oaxaca · join in');
+    expect(out.isEmpty).toBe(false);
+  });
+
+  it('uses the singular branch for count = 1 (ES)', () => {
+    const out = formatActiveObserversBanner({ count: 1, region: 'Oaxaca' }, COPY_ES);
+    expect(out.text).toBe('Hoy 1 persona observa en Oaxaca · únete');
+  });
+
+  it('renders the empty-state copy when count = 0 (EN)', () => {
+    const out = formatActiveObserversBanner({ count: 0, region: 'Oaxaca' }, COPY_EN);
+    expect(out).toEqual({
+      text: 'No observations in Oaxaca yet today — open the season',
+      isEmpty: true,
+    });
+  });
+
+  it('renders the empty-state copy when count = 0 (ES)', () => {
+    const out = formatActiveObserversBanner({ count: 0, region: 'Oaxaca' }, COPY_ES);
+    expect(out.text).toBe('Todavía no hay obs en Oaxaca hoy — abre la temporada');
+    expect(out.isEmpty).toBe(true);
+  });
+
+  it('returns text=null when region is null — graceful no-banner fallback', () => {
+    const out = formatActiveObserversBanner({ count: 7, region: null }, COPY_EN);
+    expect(out).toEqual({ text: null, isEmpty: false });
+  });
+
+  it('returns text=null when region is empty / whitespace-only', () => {
+    expect(formatActiveObserversBanner({ count: 7, region: '' }, COPY_EN).text).toBeNull();
+    expect(formatActiveObserversBanner({ count: 7, region: '   ' }, COPY_EN).text).toBeNull();
+  });
+
+  it('NEVER renders raw "NULL" / placeholder leakage', () => {
+    const out = formatActiveObserversBanner({ count: 0, region: null }, COPY_EN);
+    expect(out.text).toBeNull();
+    // Belt-and-suspenders: the empty template still has a placeholder; we
+    // must not emit it as visible copy.
+    expect(out.text ?? '').not.toMatch(/\{region\}/);
+    expect(out.text ?? '').not.toMatch(/null/i);
+  });
+
+  it('clamps negative counts to 0 (treats as empty)', () => {
+    const out = formatActiveObserversBanner({ count: -3, region: 'Oaxaca' }, COPY_EN);
+    expect(out.isEmpty).toBe(true);
+    expect(out.text).toContain('open the season');
+  });
+
+  it('truncates fractional counts to int', () => {
+    const out = formatActiveObserversBanner({ count: 7.9, region: 'Oaxaca' }, COPY_EN);
+    expect(out.text).toBe('Today 7 people are observing in Oaxaca · join in');
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces ambient activity ("Hoy 7 personas observan en Oaxaca · únete") at the top of `/observe` so users feel they are not alone — applies Fogg's *Principle of Social Facilitation* as called out in the issue. The empty-state copy ("todavía no hay obs en <region> hoy — abre la temporada") flips into a low-pressure invitation to be the seed observer.

Closes #743 (good first issue, ~3 days).

## How it works

1. **Component** — `<ActiveObserversBanner />` (Astro, hydrate via inline `<script>`) mounts at the very top of `ObserveView2`. Starts with `display:none` and reveals only after the count + region resolve, so there is no SSR flash.
2. **SQL RPC** — `community_active_observers_today(p_country text DEFAULT NULL) → integer`. Counts distinct `observer_id` from `observations` where `sync_status='synced'` AND `observed_at >= date_trunc('day', now() AT TIME ZONE 'UTC')`, joined to `users` filtered by `hide_from_leaderboards = false` and the supplied country code. SECURITY INVOKER (default for sql functions), executable by `anon` + `authenticated`. Reads RLS-protected tables — no PII leaks via the aggregate.
3. **Privacy** — uses the anon-safe data path (the `community_observers` view's same eligibility predicate, applied directly inside the RPC); never reads `community_observers_with_centroid`. Mirrors the M28 invariant in CLAUDE.md.
4. **NULL-region fallback** — anon visitors and signed-in users without a `region_primary` simply get **no banner** (graceful path; the formatter returns `text=null`). Regression-tested by `tests/unit/active-observers.test.ts` ("NEVER renders raw NULL / placeholder leakage").
5. **Click target** — the M28 `/community/observers/` page already understands `?country=<ISO alpha-2>` via the existing `serializeFilters()`. The component uses that serializer (no new URL helpers, no leaks).

## Files

- `docs/specs/infra/supabase-schema.sql` — adds the RPC (idempotent `CREATE OR REPLACE FUNCTION`).
- `src/lib/community.ts` — `loadViewerRegion()` + `loadActiveObserversToday()` helpers.
- `src/lib/active-observers.ts` — pure formatter (singular / plural / empty / null-region branches), unit-testable without a DOM.
- `src/components/ActiveObserversBanner.astro` — the component.
- `src/components/ObserveView2.astro` — mounts the banner above the form header.
- `src/i18n/{en,es}.json` — copy under `observe.active_banner.*` (today_n / today_one / empty / aria_label / cta_join / cta_open).
- `tests/unit/active-observers.test.ts` — 11 cases: plural EN+ES, singular EN+ES, empty EN+ES, null-region, empty-string region, no NULL leakage, negative count clamp, fractional truncation.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1238 / 1238 pass (109 files)
- [x] `npm run build` — 231 pages, both `/en/observe/` and `/es/observar/` include the banner
- [ ] After `make db-apply` lands the RPC, manual smoke at `/en/observe`: signed-in user with country → banner appears with count + region; anon → no banner; user without `region_primary` → no banner; count = 0 → empty-state copy renders

## Out of scope (per issue)

- Real-time presence / live counters
- Per-user activity attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)