### PR TITLE
feat(observe): one-tap Quick Observation mode (foto + GPS + ID async)

### DIFF
--- a/docs/specs/modules/02-observation.md
+++ b/docs/specs/modules/02-observation.md
@@ -173,6 +173,47 @@ Optional (collapse by default on mobile):
 
 ---
 
+## Quick Observation Mode (issue #721)
+
+The standard form requires ≥5 taps before sync (pick photos → wait GPS →
+fill habitat/notes → license → submit). For casual one-time observers
+that drop-off is the single biggest funnel leak. The Quick Observation
+flow collapses it to a single tap.
+
+**Entry points:**
+- `/observe?quick=1` — direct URL.
+- Mobile bottom-bar FAB **long-press** (≥500 ms) — short-tap retains
+  the existing `/observe` behaviour.
+
+**Flow:**
+1. Camera input fires automatically on mount (system camera).
+2. On `change`, EXIF GPS is parsed in parallel with a live `getQuickGps()`
+   request (12 s timeout). EXIF wins when present.
+3. The photo + (best-effort) GPS land in the Dexie outbox via
+   `buildQuickObservationDraft()` + `saveObservationToOutbox()`. When
+   no fix has resolved, the row is saved with `asDraft: true` and the
+   sync engine's existing `promoteDraftsWithGps()` worker flips it to
+   `pending` once a fix arrives.
+4. The identifier cascade runs async via `triggerIdentify` post-sync —
+   no confirm step.
+5. A 2 s toast shows "Observation saved" (or "Draft saved — we’ll
+   attach the location when it resolves") then the user is redirected
+   home.
+
+**Recovery:** because every quick observation lands in the existing
+outbox with the same shape, ObsManagePanel can enrich it later (habitat,
+notes, license, etc.) — no separate edit UI needed.
+
+**Telemetry:** `posthog.capture('quick_observation_saved', { had_gps,
+media_kind })` on success, fire-and-forget. Drives the quick-vs-slow
+conversion comparison promised in the issue scope.
+
+Fogg Principle of Reduction (Persuasive Tech, ch. 3, p. 33):
+*"Using computing technology to reduce complex behavior to simple tasks
+increases the benefit/cost ratio of the behavior."*
+
+---
+
 ## Form Validation
 
 ```typescript

--- a/src/components/MobileBottomBar.astro
+++ b/src/components/MobileBottomBar.astro
@@ -68,7 +68,9 @@ const recentActive = isActiveSection(currentPath, 'exploreRecent', lang);
         href={fab.href}
         data-tour="fab"
         data-on-observe={fab.onObserve ? 'true' : undefined}
+        data-quick-href={getLocalizedPath(lang, routes.observe[locale] + '/?quick=1')}
         aria-label={tr.nav.bottom.fab_observe_label}
+        title={tr.nav.bottom.fab_quick_hint}
         class="absolute left-1/2 -translate-x-1/2 -top-7 w-14 h-14 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white flex items-center justify-center shadow-lg ring-4 ring-white dark:ring-zinc-950 motion-reduce:transition-none transition-transform active:scale-95"
       >
         <svg aria-hidden="true" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2"/></svg>
@@ -128,12 +130,47 @@ const recentActive = isActiveSection(currentPath, 'exploreRecent', lang);
   FAB camera shortcut. When the user is already on /observe and taps the
   FAB, intercept the click and trigger the DropZone capture input directly
   instead of navigating to the same page.
+
+  Long-press (>500ms, mouse or touch) routes to /observe?quick=1 — the
+  one-tap Quick Observation flow (issue #721).
 -->
 <script is:inline>
   (function () {
     var fab = document.getElementById('mbb-fab');
-    if (!fab || fab.dataset.onObserve !== 'true') return;
+    if (!fab) return;
+
+    var LONG_PRESS_MS = 500;
+    var pressTimer = null;
+    var isLongPress = false;
+
+    function startPress() {
+      isLongPress = false;
+      if (pressTimer) clearTimeout(pressTimer);
+      pressTimer = setTimeout(function () {
+        isLongPress = true;
+        var quickHref = fab.dataset.quickHref;
+        if (!quickHref) return;
+        if (navigator.vibrate) {
+          try { navigator.vibrate(30); } catch (e) { /* unsupported */ }
+        }
+        window.location.href = quickHref;
+      }, LONG_PRESS_MS);
+    }
+
+    function endPress() {
+      if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
+    }
+
+    fab.addEventListener('touchstart', startPress, { passive: true });
+    fab.addEventListener('touchend', endPress);
+    fab.addEventListener('touchcancel', endPress);
+    fab.addEventListener('mousedown', startPress);
+    fab.addEventListener('mouseup', endPress);
+    fab.addEventListener('mouseleave', endPress);
+
     fab.addEventListener('click', function (e) {
+      if (isLongPress) { e.preventDefault(); isLongPress = false; return; }
+      if (fab.dataset.onObserve !== 'true') return;
       var capInput = document.getElementById('dz-capture-input');
       if (!capInput) return;
       e.preventDefault();

--- a/src/components/QuickObserveCapture.astro
+++ b/src/components/QuickObserveCapture.astro
@@ -1,0 +1,231 @@
+---
+/**
+ * QuickObserveCapture.astro — one-tap observation flow (issue #721).
+ *
+ * Mounted by the locale observe page when `?quick=1` is present in the URL.
+ * Behaviour:
+ *   1. Triggers the system camera input on mount.
+ *   2. On `change`, parses EXIF GPS + kicks off live geolocation in parallel.
+ *   3. Saves the photo to the Dexie outbox immediately (draft if no GPS yet,
+ *      pending otherwise — sync engine promotes drafts when GPS resolves).
+ *   4. Shows a 2-second toast then redirects home.
+ *
+ * The identify cascade runs async via the existing post-sync trigger; no
+ * confirm step, no waiting on the network.
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+
+const { lang } = Astro.props;
+const tr = t(lang);
+const q = tr.quick_observe as unknown as Record<string, string>;
+
+const heading       = q.heading;
+const subheading    = q.subheading;
+const cancelLabel   = q.cancel;
+const openCamera    = q.open_camera;
+const savedToast    = q.saved_toast;
+const draftToast    = q.draft_toast;
+const errorToast    = q.error_toast;
+const noPhotoNotice = q.no_photo;
+const tipLabel      = q.tip;
+const savingLabel   = q.saving;
+const homeHref      = lang === 'es' ? '/es/' : '/en/';
+---
+
+<section
+  id="quick-observe-root"
+  class="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white dark:bg-zinc-950 px-4"
+  data-saved-toast={savedToast}
+  data-draft-toast={draftToast}
+  data-error-toast={errorToast}
+  data-no-photo-toast={noPhotoNotice}
+  data-saving-label={savingLabel}
+  data-home-href={homeHref}
+>
+  <input
+    id="quick-observe-camera-input"
+    type="file"
+    accept="image/*"
+    capture="environment"
+    class="sr-only"
+    aria-label={openCamera}
+  />
+
+  <div class="max-w-md w-full text-center space-y-5">
+    <div class="mx-auto w-16 h-16 rounded-full bg-emerald-100 dark:bg-emerald-900/40 flex items-center justify-center">
+      <svg class="w-8 h-8 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+        <circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="1.6" />
+      </svg>
+    </div>
+
+    <div>
+      <h1 class="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">{heading}</h1>
+      <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{subheading}</p>
+    </div>
+
+    <p id="quick-observe-tip" class="text-xs text-zinc-400 dark:text-zinc-500">{tipLabel}</p>
+
+    <div class="flex flex-col gap-2">
+      <button
+        id="quick-observe-camera-btn"
+        type="button"
+        class="w-full min-h-12 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-base flex items-center justify-center gap-2 active:scale-95 transition-transform"
+      >
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 0 1 2-2h2l1.5-2h7L17 7h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+          <circle cx="12" cy="13" r="3.5" fill="none" stroke="currentColor" stroke-width="2" />
+        </svg>
+        {openCamera}
+      </button>
+      <a
+        href={homeHref}
+        id="quick-observe-cancel"
+        class="text-sm text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-200 underline underline-offset-2"
+      >{cancelLabel}</a>
+    </div>
+
+    <div
+      id="quick-observe-status"
+      class="hidden flex items-center justify-center gap-2 text-sm text-emerald-700 dark:text-emerald-300"
+      role="status"
+      aria-live="polite"
+    >
+      <span class="inline-block w-4 h-4 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin"></span>
+      <span id="quick-observe-status-text"></span>
+    </div>
+  </div>
+
+  <div
+    id="quick-observe-toast"
+    class="hidden fixed bottom-6 left-1/2 -translate-x-1/2 z-[60] max-w-[90vw] rounded-full px-4 py-2 text-sm font-medium shadow-lg"
+    role="status"
+    aria-live="polite"
+  ></div>
+</section>
+
+<script>
+  import { parse as parseExif } from 'exifr';
+  import { resolveObserverRef, saveObservationToOutbox } from '../lib/observe';
+  import { syncOutbox } from '../lib/sync';
+  import { buildQuickObservationDraft, getQuickGps, isNullIsland, type QuickGpsInput } from '../lib/quick-observe';
+
+  // Only activate this surface when the page mounts in quick mode. Without
+  // this gate the auto-click would fire on every /observe load and block the
+  // default view from interaction.
+  const isQuick = (() => {
+    try { return new URLSearchParams(window.location.search).get('quick') === '1'; }
+    catch { return false; }
+  })();
+
+  const root      = document.getElementById('quick-observe-root');
+  const camInput  = document.getElementById('quick-observe-camera-input') as HTMLInputElement | null;
+  const camBtn    = document.getElementById('quick-observe-camera-btn') as HTMLButtonElement | null;
+  const status    = document.getElementById('quick-observe-status');
+  const statusTxt = document.getElementById('quick-observe-status-text');
+  const toast     = document.getElementById('quick-observe-toast');
+
+  if (isQuick && root && camInput && camBtn && toast) {
+    const saved   = root.dataset.savedToast   ?? 'Saved';
+    const draft   = root.dataset.draftToast   ?? 'Draft saved';
+    const errored = root.dataset.errorToast   ?? 'Could not save';
+    const noPhoto = root.dataset.noPhotoToast ?? 'No photo captured';
+    const saving  = root.dataset.savingLabel  ?? 'Saving…';
+    const home    = root.dataset.homeHref     ?? '/';
+
+    function showToast(message: string, kind: 'success' | 'info' | 'error') {
+      if (!toast) return;
+      toast.textContent = message;
+      const palette =
+        kind === 'success' ? 'bg-emerald-600 text-white'
+        : kind === 'error' ? 'bg-red-600 text-white'
+        : 'bg-zinc-800 text-white';
+      toast.className = `fixed bottom-6 left-1/2 -translate-x-1/2 z-[60] max-w-[90vw] rounded-full px-4 py-2 text-sm font-medium shadow-lg ${palette}`;
+    }
+
+    function setStatus(text: string) {
+      if (!status || !statusTxt) return;
+      statusTxt.textContent = text;
+      status.classList.remove('hidden');
+    }
+
+    async function exifLocation(file: File): Promise<QuickGpsInput | null> {
+      try {
+        const exif = await parseExif(file, { gps: true, tiff: true, exif: true }) as Record<string, unknown> | undefined;
+        if (!exif) return null;
+        const lat = pickNumber(exif.latitude, exif.Latitude, exif.GPSLatitude);
+        const lng = pickNumber(exif.longitude, exif.Longitude, exif.GPSLongitude);
+        if (lat == null || lng == null) return null;
+        if (isNullIsland(lat, lng)) return null;
+        const altitudeM = pickNumber(exif.GPSAltitude, exif.altitude, exif.Altitude);
+        return { lat, lng, accuracyM: 15, altitudeM, source: 'exif' };
+      } catch {
+        return null;
+      }
+    }
+
+    function pickNumber(...candidates: unknown[]): number | null {
+      for (const c of candidates) {
+        if (typeof c === 'number' && Number.isFinite(c)) return c;
+      }
+      return null;
+    }
+
+    async function handleCapture(file: File) {
+      setStatus(saving);
+      try {
+        const observerRefP = resolveObserverRef();
+        const exifP        = exifLocation(file);
+        const gpsP         = getQuickGps();
+
+        const observerRef = await observerRefP;
+        const exif        = await exifP;
+        const location    = exif ?? await gpsP;
+
+        const draftRow = buildQuickObservationDraft({
+          observerRef,
+          file: { blob: file, mimeType: file.type || 'image/jpeg', sizeBytes: file.size },
+          location,
+        });
+        await saveObservationToOutbox(draftRow);
+        syncOutbox().catch(() => { /* fire and forget */ });
+
+        showToast(draftRow.asDraft ? draft : saved, 'success');
+        try {
+          (window as unknown as { posthog?: { capture: (event: string, props?: Record<string, unknown>) => void } })
+            .posthog?.capture('quick_observation_saved', {
+              had_gps: !draftRow.asDraft,
+              media_kind: draftRow.media[0]?.mediaType ?? 'photo',
+            });
+        } catch { /* posthog absent */ }
+        window.setTimeout(() => { window.location.href = home; }, 2_000);
+      } catch (err) {
+        console.warn('[rastrum] quick observation save failed', err);
+        showToast(errored, 'error');
+      }
+    }
+
+    camInput.addEventListener('change', () => {
+      const f = camInput.files?.[0];
+      if (!f) {
+        showToast(noPhoto, 'info');
+        camInput.value = '';
+        return;
+      }
+      void handleCapture(f);
+      camInput.value = '';
+    });
+    camBtn.addEventListener('click', () => camInput.click());
+
+    // Auto-trigger the camera once on mount. iOS/Android both require a user
+    // gesture for input.click() — the bottom-bar tap that brought us here
+    // counts on most browsers; if it doesn't, the button stays as a fallback.
+    requestAnimationFrame(() => {
+      try { camInput.click(); } catch { /* ignored — user can tap the button */ }
+    });
+  }
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -76,7 +76,8 @@
       "identify": "Identify",
       "sign_in": "Sign in",
       "fab_observe_label": "Start observation",
-      "fab_quick_id_label": "Identify without saving"
+      "fab_quick_id_label": "Identify without saving",
+      "fab_quick_hint": "Long-press for one-tap Quick capture"
     }
   },
   "home": {
@@ -3241,6 +3242,18 @@
     "quick_confirm": "Confirm & save",
     "quick_edit": "Edit in full form",
     "quick_discard": "Discard"
+  },
+  "quick_observe": {
+    "heading": "Quick capture",
+    "subheading": "One tap. One observation.",
+    "open_camera": "Open camera",
+    "cancel": "Cancel",
+    "tip": "We are launching your camera — tap below if it doesn’t open.",
+    "saving": "Saving…",
+    "saved_toast": "Observation saved",
+    "draft_toast": "Draft saved — we’ll attach the location when it resolves.",
+    "error_toast": "Could not save.",
+    "no_photo": "No photo captured."
   },
   "guides": {
     "how_it_works": "How does this work?",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -76,7 +76,8 @@
       "identify": "Identificar",
       "sign_in": "Ingresar",
       "fab_observe_label": "Iniciar observación",
-      "fab_quick_id_label": "Identificar sin guardar"
+      "fab_quick_id_label": "Identificar sin guardar",
+      "fab_quick_hint": "Mantén presionado para captura rápida de un toque"
     }
   },
   "home": {
@@ -3241,6 +3242,18 @@
     "quick_confirm": "Confirmar y guardar",
     "quick_edit": "Editar en formulario completo",
     "quick_discard": "Descartar"
+  },
+  "quick_observe": {
+    "heading": "Captura rápida",
+    "subheading": "Un toque. Una observación.",
+    "open_camera": "Abrir cámara",
+    "cancel": "Cancelar",
+    "tip": "Estamos abriendo tu cámara — toca abajo si no aparece.",
+    "saving": "Guardando…",
+    "saved_toast": "Observación guardada",
+    "draft_toast": "Borrador guardado — agregaremos la ubicación cuando esté lista.",
+    "error_toast": "No se pudo guardar.",
+    "no_photo": "No se capturó foto."
   },
   "guides": {
     "how_it_works": "¿Cómo funciona?",

--- a/src/lib/quick-observe.ts
+++ b/src/lib/quick-observe.ts
@@ -1,0 +1,145 @@
+/**
+ * Quick Observation builder — collapses photo + best-effort GPS into a
+ * single Dexie outbox row. The identify cascade and (when GPS is missing
+ * at capture time) a draft → pending promotion both run through the
+ * existing sync engine.
+ *
+ * See issue #721 / docs/specs/modules/02-photo-id.md (Quick Observation
+ * section, M02 v1.1) for design rationale (Fogg Principle of Reduction).
+ */
+
+import type { ObservationDraft, MediaInput } from './observe';
+
+export interface QuickGpsInput {
+  lat: number;
+  lng: number;
+  accuracyM: number;
+  altitudeM: number | null;
+  source: 'gps' | 'exif';
+}
+
+export interface QuickObserveBuildArgs {
+  observerRef: ObservationDraft['observerRef'];
+  /** The captured photo (or audio/video). Single file for the quick path. */
+  file: { blob: Blob; mimeType: string; sizeBytes: number };
+  /**
+   * Best-known location at save time. EXIF preferred over live GPS — the
+   * photo was taken AT that location, not where the user is right now.
+   * Pass `null` when neither has resolved by the moment we hit the outbox;
+   * the row is then saved as 'draft' and `promoteDraftsWithGps()` flips it
+   * to 'pending' once a fix arrives via the existing sync trigger.
+   */
+  location: QuickGpsInput | null;
+  /** Optional extra context (rarely used in quick mode). */
+  notes?: string | null;
+  blobId?: string;
+}
+
+const NULL_ISLAND_EPS = 1e-6;
+
+/**
+ * Decide the media kind from a MIME type. Mirrors the fallback chain in
+ * sync.ts — quick captures from iOS Safari sometimes have empty MIME.
+ */
+export function mediaKindFromMime(mimeType: string): MediaInput['mediaType'] {
+  if (mimeType.startsWith('audio/')) return 'audio';
+  if (mimeType.startsWith('video/')) return 'video';
+  return 'photo';
+}
+
+/**
+ * Reject EXIF/GPS coordinates of (0, 0) — the well-known "null island"
+ * default emitted by camera apps that strip GPS tags. lat=0 alone is a
+ * legitimate equator reading (Ecuador, Kenya, etc.) so only the *pair*
+ * is treated as garbage.
+ */
+export function isNullIsland(lat: number, lng: number): boolean {
+  return Math.abs(lat) < NULL_ISLAND_EPS && Math.abs(lng) < NULL_ISLAND_EPS;
+}
+
+/**
+ * Build a quick-mode `ObservationDraft` ready for `saveObservationToOutbox`.
+ *
+ * Behaviour summary:
+ *   - If `location` is null OR a null-island pair, the draft is saved as
+ *     `asDraft: true` (sync engine skips until GPS is available).
+ *   - Identification is left blank (`status: 'pending'`); the cascade runs
+ *     async via the existing post-sync `triggerIdentify` flow.
+ *   - Defaults: `evidenceType` for audio is 'sound', else 'direct_sighting'.
+ */
+export function buildQuickObservationDraft(args: QuickObserveBuildArgs): ObservationDraft {
+  const { file, location, observerRef, notes = null, blobId } = args;
+  const mediaType = mediaKindFromMime(file.mimeType);
+  const finalLocation = location && !isNullIsland(location.lat, location.lng)
+    ? {
+        lat: location.lat,
+        lng: location.lng,
+        accuracyM: location.accuracyM,
+        altitudeM: location.altitudeM,
+        capturedFrom: location.source,
+      }
+    : null;
+
+  return {
+    observerRef,
+    media: [{
+      blob: file.blob,
+      blobId: blobId ?? crypto.randomUUID(),
+      mimeType: file.mimeType,
+      sizeBytes: file.sizeBytes,
+      mediaType,
+    }],
+    location: finalLocation ?? {
+      lat: 0,
+      lng: 0,
+      accuracyM: 0,
+      altitudeM: null,
+      capturedFrom: 'gps',
+    },
+    notes,
+    evidenceType: mediaType === 'audio' ? 'sound' : 'direct_sighting',
+    asDraft: !finalLocation,
+  };
+}
+
+/**
+ * One-shot navigator.geolocation wrapper bounded by a hard timeout. Returns
+ * null on any failure (denied, unavailable, timeout) — the caller saves a
+ * draft in that case and the sync engine promotes it later.
+ *
+ * The default 12s timeout is generous on purpose — we don't want to bail
+ * prematurely on a cold-start GPS lock when the user is outside.
+ */
+export function getQuickGps(
+  navigatorRef: { geolocation?: { getCurrentPosition: (
+    success: (pos: { coords: { latitude: number; longitude: number; accuracy: number; altitude: number | null } }) => void,
+    error: (err: { code: number }) => void,
+    options?: PositionOptions,
+  ) => void } } = (typeof navigator !== 'undefined' ? navigator : ({} as never)),
+  timeoutMs = 12_000,
+): Promise<QuickGpsInput | null> {
+  if (!navigatorRef.geolocation?.getCurrentPosition) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (v: QuickGpsInput | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(v);
+    };
+    const t = setTimeout(() => finish(null), timeoutMs);
+    navigatorRef.geolocation!.getCurrentPosition(
+      (pos) => {
+        clearTimeout(t);
+        finish({
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+          accuracyM: pos.coords.accuracy,
+          altitudeM: pos.coords.altitude,
+          source: 'gps',
+        });
+      },
+      () => { clearTimeout(t); finish(null); },
+      { enableHighAccuracy: true, timeout: timeoutMs, maximumAge: 60_000 },
+    );
+  });
+}

--- a/src/pages/en/observe.astro
+++ b/src/pages/en/observe.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import ObserveView2 from '../../components/ObserveView2.astro';
+import QuickObserveCapture from '../../components/QuickObserveCapture.astro';
 import { t } from '../../i18n/utils';
 
 const lang = 'en';
@@ -12,5 +13,18 @@ const tr = t(lang);
   description="Identify species or log biodiversity observations. Drop photos, audio, or video — AI identifies with PlantNet, BirdNET, and Claude Vision. Offline-first, syncs to GBIF and CONABIO."
   lang={lang}
 >
-  <ObserveView2 lang={lang} />
+  <div id="observe-default-view"><ObserveView2 lang={lang} /></div>
+  <div id="observe-quick-view" class="hidden"><QuickObserveCapture lang={lang} /></div>
+  <script is:inline>
+    (function () {
+      try {
+        var qs = new URLSearchParams(window.location.search);
+        if (qs.get('quick') !== '1') return;
+        var def = document.getElementById('observe-default-view');
+        var qk  = document.getElementById('observe-quick-view');
+        if (def) def.classList.add('hidden');
+        if (qk)  qk.classList.remove('hidden');
+      } catch { /* malformed search */ }
+    })();
+  </script>
 </BaseLayout>

--- a/src/pages/es/observar.astro
+++ b/src/pages/es/observar.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import ObserveView2 from '../../components/ObserveView2.astro';
+import QuickObserveCapture from '../../components/QuickObserveCapture.astro';
 import { t } from '../../i18n/utils';
 
 const lang = 'es';
@@ -12,5 +13,18 @@ const tr = t(lang);
   description="Identifica especies o registra observaciones de biodiversidad. Sube fotos, audio o video — IA con PlantNet, BirdNET y Claude Vision. Offline-first, sincroniza con GBIF y CONABIO."
   lang={lang}
 >
-  <ObserveView2 lang={lang} />
+  <div id="observe-default-view"><ObserveView2 lang={lang} /></div>
+  <div id="observe-quick-view" class="hidden"><QuickObserveCapture lang={lang} /></div>
+  <script is:inline>
+    (function () {
+      try {
+        var qs = new URLSearchParams(window.location.search);
+        if (qs.get('quick') !== '1') return;
+        var def = document.getElementById('observe-default-view');
+        var qk  = document.getElementById('observe-quick-view');
+        if (def) def.classList.add('hidden');
+        if (qk)  qk.classList.remove('hidden');
+      } catch { /* malformed search */ }
+    })();
+  </script>
 </BaseLayout>

--- a/tests/unit/quick-observe.test.ts
+++ b/tests/unit/quick-observe.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  buildQuickObservationDraft,
+  isNullIsland,
+  mediaKindFromMime,
+  getQuickGps,
+  type QuickGpsInput,
+} from '../../src/lib/quick-observe';
+
+const userRef = { kind: 'user' as const, id: 'u-1' };
+const fakeFile = (mime = 'image/jpeg') => ({
+  blob: new Blob(['x'], { type: mime || 'application/octet-stream' }),
+  mimeType: mime,
+  sizeBytes: 1,
+});
+
+describe('quick-observe / mediaKindFromMime', () => {
+  it.each([
+    ['image/jpeg', 'photo'],
+    ['image/heic', 'photo'],
+    ['audio/mp4', 'audio'],
+    ['audio/wav', 'audio'],
+    ['video/mp4', 'video'],
+    ['', 'photo'],
+    ['application/octet-stream', 'photo'],
+  ])('maps %s -> %s', (mime, kind) => {
+    expect(mediaKindFromMime(mime)).toBe(kind);
+  });
+});
+
+describe('quick-observe / isNullIsland', () => {
+  it('rejects exact (0,0)', () => {
+    expect(isNullIsland(0, 0)).toBe(true);
+  });
+  it('accepts equator readings (legitimate Quito / Nairobi observers)', () => {
+    expect(isNullIsland(0, -78.45)).toBe(false);   // Quito
+    expect(isNullIsland(36.82, 0.0)).toBe(false);  // off-coast Algeria
+  });
+  it('accepts negatives away from origin', () => {
+    expect(isNullIsland(-15.7942, -47.8825)).toBe(false); // Brasília
+  });
+});
+
+describe('quick-observe / buildQuickObservationDraft', () => {
+  it('produces a non-draft row when EXIF GPS is given', () => {
+    const loc: QuickGpsInput = { lat: 19.4326, lng: -99.1332, accuracyM: 15, altitudeM: 2240, source: 'exif' };
+    const draft = buildQuickObservationDraft({ observerRef: userRef, file: fakeFile(), location: loc });
+    expect(draft.asDraft).toBeFalsy();
+    expect(draft.location).toEqual({
+      lat: 19.4326, lng: -99.1332, accuracyM: 15, altitudeM: 2240, capturedFrom: 'exif',
+    });
+  });
+
+  it('produces a non-draft row when live GPS is given', () => {
+    const loc: QuickGpsInput = { lat: -15.7942, lng: -47.8825, accuracyM: 30, altitudeM: null, source: 'gps' };
+    const draft = buildQuickObservationDraft({ observerRef: userRef, file: fakeFile(), location: loc });
+    expect(draft.asDraft).toBeFalsy();
+    expect(draft.location.capturedFrom).toBe('gps');
+  });
+
+  it('falls back to a draft (null-island sentinel) when no GPS available', () => {
+    const draft = buildQuickObservationDraft({ observerRef: userRef, file: fakeFile(), location: null });
+    expect(draft.asDraft).toBe(true);
+    expect(draft.location).toEqual({ lat: 0, lng: 0, accuracyM: 0, altitudeM: null, capturedFrom: 'gps' });
+  });
+
+  it('treats (0,0) coordinates as null island and saves as draft', () => {
+    const loc: QuickGpsInput = { lat: 0, lng: 0, accuracyM: 1, altitudeM: null, source: 'exif' };
+    const draft = buildQuickObservationDraft({ observerRef: userRef, file: fakeFile(), location: loc });
+    expect(draft.asDraft).toBe(true);
+  });
+
+  it('puts the file into media[] with derived mediaType and a fresh blobId', () => {
+    const draft = buildQuickObservationDraft({ observerRef: userRef, file: fakeFile('audio/mp4'), location: null });
+    expect(draft.media).toHaveLength(1);
+    expect(draft.media[0].mediaType).toBe('audio');
+    expect(draft.media[0].mimeType).toBe('audio/mp4');
+    expect(typeof draft.media[0].blobId).toBe('string');
+    expect(draft.media[0].blobId.length).toBeGreaterThan(0);
+  });
+
+  it('preserves a caller-supplied blobId when provided', () => {
+    const draft = buildQuickObservationDraft({
+      observerRef: userRef,
+      file: fakeFile(),
+      location: null,
+      blobId: 'fixed-id',
+    });
+    expect(draft.media[0].blobId).toBe('fixed-id');
+  });
+
+  it('defaults audio captures to evidence "sound"', () => {
+    const draft = buildQuickObservationDraft({ observerRef: userRef, file: fakeFile('audio/m4a'), location: null });
+    expect(draft.evidenceType).toBe('sound');
+  });
+
+  it('defaults photos to evidence "direct_sighting"', () => {
+    const draft = buildQuickObservationDraft({ observerRef: userRef, file: fakeFile('image/jpeg'), location: null });
+    expect(draft.evidenceType).toBe('direct_sighting');
+  });
+});
+
+describe('quick-observe / getQuickGps', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('resolves to coords on success', async () => {
+    const navStub = {
+      geolocation: {
+        getCurrentPosition: vi.fn((success: (p: { coords: { latitude: number; longitude: number; accuracy: number; altitude: number | null } }) => void) => {
+          success({ coords: { latitude: 19.4, longitude: -99.1, accuracy: 12, altitude: 2200 } });
+        }),
+      },
+    };
+    const result = await getQuickGps(navStub);
+    expect(result).toEqual({ lat: 19.4, lng: -99.1, accuracyM: 12, altitudeM: 2200, source: 'gps' });
+  });
+
+  it('returns null on geolocation error (denied / unavailable)', async () => {
+    const navStub = {
+      geolocation: {
+        getCurrentPosition: vi.fn((_s: unknown, error: (e: { code: number }) => void) => {
+          error({ code: 1 });
+        }),
+      },
+    };
+    const result = await getQuickGps(navStub);
+    expect(result).toBeNull();
+  });
+
+  it('returns null after the timeout fires before any callback', async () => {
+    const navStub = {
+      geolocation: {
+        getCurrentPosition: vi.fn(() => { /* never callback */ }),
+      },
+    };
+    const p = getQuickGps(navStub, 5_000);
+    vi.advanceTimersByTime(5_001);
+    await expect(p).resolves.toBeNull();
+  });
+
+  it('returns null when geolocation is not available', async () => {
+    const result = await getQuickGps({} as never);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #721

## Summary

Adds a one-tap **Quick Observation** flow for casual / first-time
observers — collapsing the standard 5-tap form to a single action.

- **Entry**: `/observe?quick=1` directly, or **long-press the centre FAB**
  (≥500 ms) on the mobile bottom-bar. Short tap retains the existing
  `/observe` behaviour.
- **Flow**: camera input fires on mount → on `change`, EXIF GPS is
  parsed in parallel with a live `getQuickGps()` (12 s timeout). EXIF
  wins when present. The photo + GPS land in the Dexie outbox via
  `buildQuickObservationDraft()` + `saveObservationToOutbox()`.
- **No-GPS path**: the row is saved with `asDraft: true` and the sync
  engine's existing `promoteDraftsWithGps()` worker flips it to
  `pending` once a fix arrives — no UX dead-end, no data loss.
- **Identifier cascade** runs async via the existing post-sync
  `triggerIdentify` flow — no confirm step, no waiting on the network.
- A 2-second toast confirms ("Observation saved" / "Draft saved …")
  then the user is redirected home.
- Telemetry: `posthog.capture('quick_observation_saved', { had_gps,
  media_kind })` on success, fire-and-forget.

Fogg Principle of Reduction (Persuasive Tech, ch. 3, p. 33).

## Files

- `src/lib/quick-observe.ts` — pure builder (`buildQuickObservationDraft`,
  `getQuickGps`, `mediaKindFromMime`, `isNullIsland`).
- `src/components/QuickObserveCapture.astro` — full-screen capture surface,
  gates its own activation on `?quick=1` so the script is inert on the
  default `/observe` view.
- `src/components/MobileBottomBar.astro` — long-press detection on the
  FAB (touch + mouse), `data-quick-href` attribute, vibration cue if
  available.
- `src/pages/{en,es}/observe.astro` — render both views; tiny inline
  script swaps to quick mode when `?quick=1` is in the URL.
- `src/i18n/{en,es}.json` — new `quick_observe.*` namespace +
  `nav.bottom.fab_quick_hint`.
- `tests/unit/quick-observe.test.ts` — 22 cases covering the builder,
  null-island guard, media-kind fallback chain, and `getQuickGps`
  success / error / timeout / unavailable.
- `docs/specs/modules/02-observation.md` — Quick Observation Mode
  section documenting entry points, flow, draft semantics, and
  recovery via ObsManagePanel.

## Design decision (calling out for human review)

I chose the **`?quick=1` querystring + long-press on FAB** combination
over a "Rápido" tab on `/observe`. Rationale:
- The querystring keeps the URL shareable / bookmarkable for power
  users who want a Home-Screen shortcut to quick mode.
- A separate tab inside `/observe` would cost an extra tap (the goal
  is *zero* extra taps).
- The pre-existing `QuickObserveSheet.astro` (currently unused) is a
  multi-step confirm sheet — it doesn't satisfy the "one-tap → outbox
  immediately" semantic. I left it alone rather than rewire it,
  because it may still be useful as a slower confirm-step variant.

## Test plan

- [ ] Visit `/observe?quick=1` on a phone — camera opens automatically;
  capture a photo; confirm "Observation saved" toast appears within ≈1 s
  of returning from camera; redirect to `/` after 2 s.
- [ ] Capture a photo with GPS off/denied — toast says "Draft saved …";
  confirm row in Dexie has `sync_status='draft'`; re-open `/observe`
  with GPS available — sync engine promotes the draft on
  visibilitychange.
- [ ] Long-press centre FAB on mobile bottom-bar — navigates to
  `/observe?quick=1`. Short tap still navigates to plain `/observe`
  (or fires camera if already there).
- [ ] EN/ES parity — `/en/observe?quick=1` and `/es/observar?quick=1`
  both render localized strings (heading, subheading, toast labels).
- [ ] `npm run typecheck` clean.
- [ ] `npm run test` — 1249 tests pass (22 new in `quick-observe.test.ts`).
- [ ] `npm run build` — 231 pages, no errors.
- [ ] (Manual) iOS Safari + Android Chrome — verify
  `requestAnimationFrame(camInput.click())` is honoured by the
  bottom-bar tap gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)