### PR TITLE
feat(profile): falta-dex taxonomic gaps panel

### DIFF
--- a/docs/runbooks/00-index.md
+++ b/docs/runbooks/00-index.md
@@ -53,6 +53,7 @@ high-level system view.
 | Runbook | Covers |
 |---|---|
 | [`karma-phase-1-post-merge-verification.md`](karma-phase-1-post-merge-verification.md) | Phase 1 deploy verification — schema + cache + recompute cron. |
+| [`falta-dex.md`](falta-dex.md) | M08 — taxonomic gaps panel + region pool baseline (Option A: own data) + showMissing localStorage. |
 
 ## Social graph (Module 26)
 

--- a/docs/runbooks/falta-dex.md
+++ b/docs/runbooks/falta-dex.md
@@ -1,0 +1,118 @@
+# Falta-dex (taxonomic gaps panel)
+
+> Operator notes for the Pokédex "missing species" surface introduced
+> by issue [#726](https://github.com/ArtemioPadilla/rastrum/issues/726)
+> (phase-1 of [#561](https://github.com/ArtemioPadilla/rastrum/issues/561)).
+
+## What it is
+
+`/{en,es}/{profile,perfil}/dex` and `/{en,es}/u/dex` (visitor view) now
+support a "Show missing" toggle that appends silhouette cards for
+species the user *has not* observed but that are present in their
+region's pool. Card border is dashed grey, scientific name is revealed
+("?" puzzle is the gameplay, not the secret), star rating reflects
+rarity bucket, and a "Observe this" CTA links to the species page on
+`/explore/species/`.
+
+The toggle is **owner-only** — visitors looking at someone else's
+`/u/<handle>/dex` never see the missing surface (privacy: revealing
+which species someone hasn't observed is more invasive than revealing
+which they have).
+
+## Baseline source — Option A
+
+The "expected pool" for a country is **the set of taxa with at least
+one synced, research-grade, public observation made by an observer
+whose `users.country_code` matches**. We considered two alternatives:
+
+| Option | Pros | Cons | Picked? |
+|---|---|---|---|
+| **A — Rastrum's own community data as proxy** | No ETL, no external dep, refreshes automatically, honest about its limits | Bootstrap problem in low-density regions | yes (v1) |
+| B — Curated GBIF baseline per state/ecoregion | More authoritative, larger pool | Needs a separate ETL job + license review (GBIF DOI per export); overkill for v1 | v1.1 |
+
+The disclaimer copy in both locales says exactly this: *"Estimación
+basada en observaciones de la comunidad de Rastrum en tu región —
+datos incompletos para algunas áreas. (Baseline de GBIF llegará en
+v1.1.)"*
+
+## SQL surface
+
+Two functions in `supabase-schema.sql` (idempotent `CREATE OR REPLACE`):
+
+### `profile_pokedex_with_missing(p_user_id uuid, p_region_country text default null, p_missing_limit int default 60)`
+
+`SECURITY DEFINER` because it joins `users.country_code` (which RLS
+on `users` allows reads of for `profile_public = true` rows but the
+join is cleaner with definer rights) and the missing-pool query
+needs consistent semantics regardless of viewer.
+
+Behaviour:
+1. Gates on `can_see_facet(p_user_id, 'pokedex', auth.uid())`.
+   Anonymous + privacy-blocked viewers get **zero rows**.
+2. Resolves region: `upper(p_region_country)` wins, else
+   `(SELECT country_code FROM users WHERE id = p_user_id)`.
+3. Returns a UNION ALL of `profile_pokedex` rows
+   (`is_missing = false`) and missing rows (`is_missing = true`).
+4. Missing rows are scoped to `taxa.taxon_rank = 'species'` and
+   excluded by `NOT EXISTS` against the user's existing pokedex.
+5. Missing rows ordered `taxon_rarity.bucket DESC NULLS LAST,
+   regional_obs_count ASC` — rarest + scarcest first.
+6. `p_missing_limit` is clamped to `[1, 200]`.
+
+### `region_species_pool_size(p_region_country text)`
+
+Cheap denominator for the "X of Y species in your region" line.
+`STABLE PARALLEL SAFE`. Anonymous-readable (count is non-PII).
+
+## UI contract
+
+- Toggle button + count line live in `#pokedex-missing-toolbar`,
+  rendered between the kingdom pills and the species grid.
+- Toggle preference persisted in `localStorage.rastrum.pokedex.showMissing`.
+  Default = false (off). Helper: `src/lib/pokedex-missing.ts`.
+- Disclaimer (`#pokedex-missing-disclaimer`) only renders when
+  `showMissing && missing.length > 0`.
+- The kingdom-pill filter applies to missing cards too — they have a
+  `data-kingdom` attribute and are toggled by the same handler.
+- Missing cards are **not** rendered for visitor mode.
+
+## Manual verification
+
+```sql
+-- Pick any user, e.g. yourself
+SELECT user_id, scientific_name, rarity_bucket, obs_count, is_missing
+  FROM profile_pokedex_with_missing(
+    p_user_id => '<your-uuid>',
+    p_region_country => 'MX',
+    p_missing_limit => 10
+  )
+ ORDER BY is_missing, rarity_bucket DESC NULLS LAST;
+
+-- Expected: present rows first (is_missing=false, your dex), then up
+-- to 10 missing rows (is_missing=true) sorted rarity DESC.
+
+SELECT region_species_pool_size('MX');
+-- Expected: integer count of distinct species in MX research-grade pool.
+```
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Toggle shows but missing list is empty | Region pool empty (`country_code` not set on user, or no research-grade observations in country) | Set country in Profile → Edit; await community to log RG observations |
+| Disclaimer text missing | New i18n key not synced | Verify `pokedex.missing.disclaimer` exists in both `en.json` and `es.json` |
+| Missing cards reveal scientific name | Working as intended — the card is a "wanted poster", not a quiz | (n/a) |
+| Visitor view shows missing cards | Regression — owner-only invariant broken | Check `runVisitor()` does not call `loadFalta()` |
+
+## v1.1 follow-ups
+
+- GBIF baseline (Option B): seed a `region_taxon_baseline` table from
+  GBIF state-level checklists; query the pool from there instead of
+  Rastrum-internal observations. Need license review + DOI tracking.
+- Missing-by-rank (orders / families): the original [#726](https://github.com/ArtemioPadilla/rastrum/issues/726)
+  framing showed "te faltan 3 órdenes". Ship after the GBIF baseline
+  lands so the totals are meaningful.
+- "Where to find" mini-map per missing card — kernel of the regional
+  observations of that taxon.
+- `?suggested_taxon=<id>` on `/observe` so the CTA pre-fills the
+  identification field.

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -8712,3 +8712,192 @@ $$;
 
 REVOKE ALL ON FUNCTION public.community_active_observers_today(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.community_active_observers_today(text) TO anon, authenticated;
+-- M08 — Falta-dex / taxonomic gaps (issue #726, supersedes #561 phase-1)
+--
+-- Returns the union of (a) species the user has ALREADY observed —
+-- mirroring `profile_pokedex` columns — and (b) species *missing* from
+-- their dex but observed in their region by other Rastrum users at
+-- research grade. Missing rows are ordered by rarity bucket DESC then
+-- regional obs_count ASC (rarest + scarcest first), so the gamification
+-- rewards effort proportional to challenge.
+--
+-- Baseline source (Option A — own observation data as proxy):
+--   The "expected pool" for a country is the set of taxa with at least
+--   one synced, research-grade, public observation made by an observer
+--   whose `country_code` matches. This avoids a GBIF ETL for v1 and is
+--   honest about its limits — the i18n copy says so. Option B (curated
+--   GBIF baseline per state/ecoregion) remains the v1.1 follow-up.
+--
+-- Region resolution: defaults to `users.country_code` of the target
+-- user. If still NULL, the function returns only present rows (no
+-- region pool to draw missing slots from).
+--
+-- The viewer is gated by `can_see_facet(target, 'pokedex', viewer)` —
+-- same predicate as `profile_pokedex`. Public/private profile rules
+-- propagate naturally because the missing-pool excludes hidden
+-- observers' contributions only if they hide their *observations*; the
+-- pool is derived from public observation rows already.
+-- =====================================================================
+CREATE OR REPLACE FUNCTION public.profile_pokedex_with_missing(
+  p_user_id         uuid,
+  p_region_country  text DEFAULT NULL,
+  p_missing_limit   int  DEFAULT 60
+)
+RETURNS TABLE (
+  user_id           uuid,
+  taxon_id          uuid,
+  scientific_name   text,
+  kingdom           text,
+  rarity_bucket     smallint,
+  first_observed_at timestamptz,
+  obs_count         int,
+  common_name_es    text,
+  common_name_en    text,
+  slug              text,
+  endemic_mx        boolean,
+  nom059_status     text,
+  thumbnail_url     text,
+  is_missing        boolean
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_country text;
+  v_can_see boolean;
+BEGIN
+  -- Facet gate — anonymous callers and viewers blocked by privacy
+  -- settings get the same answer as profile_pokedex would: zero rows.
+  SELECT public.can_see_facet(p_user_id, 'pokedex', auth.uid())
+    INTO v_can_see;
+  IF v_can_see IS NOT TRUE THEN
+    RETURN;
+  END IF;
+
+  -- Resolve region: explicit param wins, else derive from the target
+  -- user's stored country_code. Two-letter ISO check mirrors the
+  -- column constraint on users.country_code.
+  v_country := COALESCE(
+    NULLIF(upper(p_region_country), ''),
+    (SELECT u.country_code FROM public.users u WHERE u.id = p_user_id)
+  );
+
+  -- Cap missing-limit defensively — the UI grid is bounded.
+  IF p_missing_limit IS NULL OR p_missing_limit <= 0 THEN
+    p_missing_limit := 60;
+  ELSIF p_missing_limit > 200 THEN
+    p_missing_limit := 200;
+  END IF;
+
+  RETURN QUERY
+  -- Present rows — pulled directly from the existing view so this
+  -- function stays in lock-step with the dex shape.
+  SELECT
+    pp.user_id,
+    pp.taxon_id,
+    pp.scientific_name,
+    pp.kingdom,
+    pp.rarity_bucket,
+    pp.first_observed_at,
+    pp.obs_count,
+    pp.common_name_es,
+    pp.common_name_en,
+    pp.slug,
+    pp.endemic_mx,
+    pp.nom059_status,
+    pp.thumbnail_url,
+    false AS is_missing
+  FROM public.profile_pokedex pp
+  WHERE pp.user_id = p_user_id
+
+  UNION ALL
+
+  -- Missing rows — region-pool species the user has not observed.
+  -- Region pool: synced research-grade public observations with
+  -- a taxon, observed by users whose country_code matches v_country.
+  -- Excludes private observations and rows already in the dex.
+  -- Wrapped in a subquery so ORDER BY + LIMIT scope to the missing
+  -- branch only, not the UNION result.
+  SELECT * FROM (
+    SELECT
+      p_user_id                AS user_id,
+      t.id                     AS taxon_id,
+      t.scientific_name,
+      t.kingdom,
+      tr.bucket                AS rarity_bucket,
+      NULL::timestamptz        AS first_observed_at,
+      region_pool.regional_obs_count::int AS obs_count,
+      t.common_name_es,
+      t.common_name_en,
+      t.slug,
+      t.is_endemic_mexico      AS endemic_mx,
+      t.nom059_status,
+      (SELECT tt.thumbnail_url
+         FROM public.taxa_thumbnails tt
+        WHERE tt.taxon_id = t.id) AS thumbnail_url,
+      true                     AS is_missing
+    FROM (
+      SELECT i.taxon_id, COUNT(*)::bigint AS regional_obs_count
+        FROM public.observations o
+        JOIN public.identifications i
+          ON i.observation_id = o.id AND i.is_primary = true
+        JOIN public.users u
+          ON u.id = o.observer_id
+       WHERE v_country IS NOT NULL
+         AND u.country_code = v_country
+         AND o.sync_status = 'synced'
+         AND o.obscure_level <> 'private'
+         AND i.is_research_grade = true
+         AND i.taxon_id IS NOT NULL
+       GROUP BY i.taxon_id
+    ) AS region_pool
+    JOIN public.taxa t ON t.id = region_pool.taxon_id
+    LEFT JOIN public.taxon_rarity tr ON tr.taxon_id = t.id
+    WHERE v_country IS NOT NULL
+      AND t.taxon_rank = 'species'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.profile_pokedex pp
+         WHERE pp.user_id = p_user_id
+           AND pp.taxon_id = t.id
+      )
+    ORDER BY tr.bucket DESC NULLS LAST,
+             region_pool.regional_obs_count ASC
+    LIMIT p_missing_limit
+  ) AS missing;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.profile_pokedex_with_missing(uuid, text, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.profile_pokedex_with_missing(uuid, text, int)
+  TO anon, authenticated;
+
+-- Companion helper — region pool size (denominator for "X of Y species
+-- in your region"). Cached behaviour is fine: STABLE in a single txn.
+-- Anonymous-friendly: the count itself is non-PII.
+CREATE OR REPLACE FUNCTION public.region_species_pool_size(
+  p_region_country text
+)
+RETURNS integer
+LANGUAGE sql
+STABLE
+PARALLEL SAFE
+AS $$
+  SELECT COUNT(DISTINCT i.taxon_id)::int
+    FROM public.observations o
+    JOIN public.identifications i
+      ON i.observation_id = o.id AND i.is_primary = true
+    JOIN public.users u
+      ON u.id = o.observer_id
+   WHERE p_region_country IS NOT NULL
+     AND u.country_code = upper(p_region_country)
+     AND o.sync_status = 'synced'
+     AND o.obscure_level <> 'private'
+     AND i.is_research_grade = true
+     AND i.taxon_id IS NOT NULL;
+$$;
+
+REVOKE ALL ON FUNCTION public.region_species_pool_size(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.region_species_pool_size(text)
+  TO anon, authenticated;

--- a/src/components/PokedexView.astro
+++ b/src/components/PokedexView.astro
@@ -18,6 +18,7 @@ const tr = t(lang);
 const px = (tr as unknown as { pokedex: Record<string, unknown> }).pokedex;
 const sc = (tr as unknown as { species_card: Record<string, string> }).species_card ?? {};
 const heroT = (px?.hero as Record<string, string> | undefined) ?? {};
+const missingT = (px?.missing as Record<string, string> | undefined) ?? {};
 
 const title       = px?.title       as string;
 const subtitle    = px?.subtitle    as string;
@@ -69,6 +70,15 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
   data-label-hero-first-cta={heroT.first_visit_cta ?? ''}
   data-href-observe={observeHref}
   data-href-explore={exploreHref}
+  data-label-missing-show={missingT.show ?? ''}
+  data-label-missing-hide={missingT.hide ?? ''}
+  data-label-missing-count-template={missingT.count_template ?? ''}
+  data-label-missing-count-fallback={missingT.count_fallback ?? ''}
+  data-label-missing-disclaimer={missingT.disclaimer ?? ''}
+  data-label-missing-cta={missingT.cta ?? ''}
+  data-label-missing-no-region={missingT.no_region ?? ''}
+  data-label-missing-empty={missingT.empty ?? ''}
+  data-label-missing-card-tag={missingT.card_tag ?? ''}
 >
   <header class="mb-5">
     <h1 data-pokedex-title class="text-2xl md:text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
@@ -100,7 +110,9 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
 
   <div id="pokedex-hero" class="hidden"></div>
   <div id="pokedex-pills" class="hidden"></div>
+  <div id="pokedex-missing-toolbar" class="hidden mt-4 flex flex-wrap items-center gap-3 text-xs"></div>
   <div id="pokedex-grid" class="hidden mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3"></div>
+  <p id="pokedex-missing-disclaimer" class="hidden mt-3 text-[11px] text-zinc-500 dark:text-zinc-500"></p>
 </section>
 
 <style>
@@ -114,6 +126,11 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
   import { getSupabase } from '../lib/supabase';
   import { escAttr } from '../lib/karma';
   import { renderSpeciesCard, type CardLabels } from '../lib/species-card-html';
+  import {
+    loadShowMissing,
+    saveShowMissing,
+    formatRegionCount,
+  } from '../lib/pokedex-missing';
 
   const root      = document.querySelector<HTMLElement>('[data-pokedex-root]');
   const heroEl    = document.getElementById('pokedex-hero');
@@ -124,6 +141,8 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
   const notFound  = document.getElementById('pokedex-not-found');
   const privateEl = document.getElementById('pokedex-private');
   const errorEl   = document.getElementById('pokedex-error');
+  const missingToolbarEl   = document.getElementById('pokedex-missing-toolbar');
+  const missingDisclaimerEl = document.getElementById('pokedex-missing-disclaimer');
   const titleEl    = root?.querySelector<HTMLElement>('[data-pokedex-title]');
   const subtitleEl = root?.querySelector<HTMLElement>('[data-pokedex-subtitle]');
   const backLink   = root?.querySelector<HTMLAnchorElement>('[data-pokedex-back-link]');
@@ -155,6 +174,28 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
     kingdom: string | null;
     thumbnail_url: string | null;
   };
+
+  type MissingRow = {
+    taxon_id: string;
+    scientific_name: string;
+    kingdom: string | null;
+    rarity_bucket: number | null;
+    obs_count: number;
+    common_name_es: string | null;
+    common_name_en: string | null;
+    slug: string | null;
+    endemic_mx: boolean | null;
+    nom059_status: string | null;
+    thumbnail_url: string | null;
+  };
+
+  type FaltaState = {
+    rows: DexRow[];
+    missing: MissingRow[];
+    regionPoolSize: number | null;
+    showMissing: boolean;
+  };
+  let state: FaltaState | null = null;
 
   function readUsername(): string {
     const params = new URLSearchParams(window.location.search);
@@ -247,6 +288,58 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
       if (Array.isArray(data) && data.length > 0) return data[0] as SuggestRow;
     } catch { /* swallow — tile 3 hides */ }
     return null;
+  }
+
+  type FaltaPayload = { missing: MissingRow[]; regionPoolSize: number | null };
+
+  async function loadFalta(
+    supabase: ReturnType<typeof getSupabase>,
+    userId: string,
+  ): Promise<FaltaPayload> {
+    try {
+      const { data, error } = await supabase.rpc('profile_pokedex_with_missing', {
+        p_user_id: userId,
+        p_region_country: null,
+        p_missing_limit: 60,
+      });
+      if (error || !Array.isArray(data)) return { missing: [], regionPoolSize: null };
+      type Row = MissingRow & { is_missing: boolean };
+      const missing = (data as Row[])
+        .filter((r) => r.is_missing === true)
+        .map<MissingRow>((r) => ({
+          taxon_id: r.taxon_id,
+          scientific_name: r.scientific_name,
+          kingdom: r.kingdom,
+          rarity_bucket: r.rarity_bucket,
+          obs_count: r.obs_count,
+          common_name_es: r.common_name_es,
+          common_name_en: r.common_name_en,
+          slug: r.slug,
+          endemic_mx: r.endemic_mx,
+          nom059_status: r.nom059_status,
+          thumbnail_url: r.thumbnail_url,
+        }));
+      // Best-effort denominator. Country code lookup goes through the
+      // companion RPC; failure is non-fatal and the toolbar collapses
+      // to the fallback copy ("N species observed").
+      let regionPoolSize: number | null = null;
+      try {
+        const { data: profileRow } = await supabase
+          .from('users')
+          .select('country_code')
+          .eq('id', userId)
+          .maybeSingle<{ country_code: string | null }>();
+        const cc = profileRow?.country_code ?? null;
+        if (cc) {
+          const { data: poolSize } = await supabase
+            .rpc('region_species_pool_size', { p_region_country: cc });
+          if (typeof poolSize === 'number') regionPoolSize = poolSize;
+        }
+      } catch { /* swallow — denominator hidden */ }
+      return { missing, regionPoolSize };
+    } catch {
+      return { missing: [], regionPoolSize: null };
+    }
   }
 
   function commonNameOf(r: DexRow | SuggestRow): string | null {
@@ -377,6 +470,118 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
     });
   }
 
+  function commonNameOfMissing(r: MissingRow): string | null {
+    return lang === 'es' ? r.common_name_es : r.common_name_en;
+  }
+
+  function renderMissingCards(missing: MissingRow[]): string {
+    if (!gridEl || missing.length === 0) return '';
+    const r = root!;
+    const cardTag = r.dataset.labelMissingCardTag ?? '';
+    const cta     = r.dataset.labelMissingCta ?? '';
+    return missing.map((m) => {
+      const k = m.kingdom ?? '';
+      const common = commonNameOfMissing(m);
+      const href = m.slug
+        ? `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/species'}/?slug=${encodeURIComponent(m.slug)}`
+        : `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/species'}/?slug=${encodeURIComponent(m.scientific_name)}`;
+      // Silhouette-style placeholder: dashed grey border, "?" badge,
+      // greyscaled thumbnail (if any) at low opacity. The card is a
+      // proper <a> so keyboard nav + screen-reader semantics stay.
+      const meta = (() => {
+        const star = '★'.repeat(m.rarity_bucket ?? 1) + '☆'.repeat(5 - (m.rarity_bucket ?? 1));
+        return star;
+      })();
+      const thumb = m.thumbnail_url
+        ? `<img src="${escAttr(m.thumbnail_url)}" alt="${escAttr(m.scientific_name)}" loading="lazy" class="absolute inset-0 w-full h-full object-cover" style="filter: grayscale(1) contrast(.55) brightness(.9); opacity:.5;">`
+        : `<span class="absolute inset-0 flex items-center justify-center text-3xl text-zinc-400">?</span>`;
+      return `<li><a href="${escAttr(href)}" class="block group rounded-xl border-2 border-dashed border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/40 overflow-hidden hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors" data-taxon-id="${escAttr(m.taxon_id)}" data-kingdom="${escAttr(k)}" data-missing="1" aria-label="${escAttr(m.scientific_name)} — ${escAttr(cardTag)}">
+        <div class="relative aspect-[16/10] bg-gradient-to-br from-zinc-100 to-zinc-200 dark:from-zinc-800 dark:to-zinc-900">
+          ${thumb}
+          <span class="absolute top-2 left-2 px-2 py-0.5 rounded-full text-[11px] font-bold shadow-sm bg-white/95 text-zinc-700">?</span>
+          <span class="absolute top-2 right-2 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-zinc-700/80 text-white">${escAttr(cardTag)}</span>
+        </div>
+        <div class="p-3">
+          <p class="text-sm italic font-bold text-zinc-700 dark:text-zinc-200 truncate">${escAttr(m.scientific_name)}</p>
+          ${common ? `<p class="text-sm text-zinc-500 dark:text-zinc-400 truncate">${escAttr(common)}</p>` : ''}
+          <p class="text-amber-600 mt-1 tracking-widest text-xs">${meta}</p>
+          <p class="text-[11px] text-emerald-700 dark:text-emerald-400 font-semibold mt-1.5 group-hover:underline">${escAttr(cta)} →</p>
+        </div>
+      </a></li>`;
+    }).join('');
+  }
+
+  function renderMissingToolbar() {
+    if (!missingToolbarEl || !state) return;
+    const r = root!;
+    const showMissing = state.showMissing;
+    const observedCount = state.rows.length;
+    const total = state.regionPoolSize;
+    const tplCount    = r.dataset.labelMissingCountTemplate ?? '';
+    const tplFallback = r.dataset.labelMissingCountFallback ?? '';
+    const noRegion    = r.dataset.labelMissingNoRegion ?? '';
+
+    const countLine = total != null
+      ? formatRegionCount(observedCount, total, { template: tplCount, fallback: tplFallback })
+      : (state.missing.length === 0 && observedCount > 0
+          ? noRegion
+          : formatRegionCount(observedCount, null, { template: tplCount, fallback: tplFallback }));
+
+    const toggleLabel = showMissing
+      ? (r.dataset.labelMissingHide ?? 'Hide missing')
+      : (r.dataset.labelMissingShow ?? 'Show missing');
+
+    const disabled = state.missing.length === 0 ? 'disabled aria-disabled="true"' : '';
+
+    missingToolbarEl.innerHTML = `
+      <span class="text-zinc-600 dark:text-zinc-400">${escAttr(countLine)}</span>
+      <button type="button"
+              data-pokedex-toggle-missing
+              class="ml-auto inline-flex items-center gap-1 px-3 py-1 rounded-full border font-medium transition-colors ${showMissing ? 'bg-emerald-700 text-white border-emerald-700' : 'bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 border-zinc-200 dark:border-zinc-700'} disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-pressed="${showMissing}"
+              ${disabled}>
+        ${escAttr(toggleLabel)}
+      </button>`;
+    missingToolbarEl.classList.remove('hidden');
+
+    const btn = missingToolbarEl.querySelector<HTMLButtonElement>('[data-pokedex-toggle-missing]');
+    btn?.addEventListener('click', onToggleMissing);
+
+    // Disclaimer copy — show only when the missing surface is active.
+    if (missingDisclaimerEl) {
+      if (showMissing && state.missing.length > 0) {
+        missingDisclaimerEl.textContent = r.dataset.labelMissingDisclaimer ?? '';
+        missingDisclaimerEl.classList.remove('hidden');
+      } else {
+        missingDisclaimerEl.classList.add('hidden');
+      }
+    }
+  }
+
+  function onToggleMissing() {
+    if (!state) return;
+    state.showMissing = !state.showMissing;
+    saveShowMissing(state.showMissing);
+    rerenderGrid();
+    renderMissingToolbar();
+  }
+
+  function rerenderGrid() {
+    if (!gridEl || !state) return;
+    const presentHtml = renderCards(state.rows);
+    const missingHtml = state.showMissing ? renderMissingCards(state.missing) : '';
+    gridEl.innerHTML = `<ul class="contents">${presentHtml}${missingHtml}</ul>`;
+    // Re-apply current kingdom-pill filter if any.
+    const activePill = pillsEl?.querySelector<HTMLElement>('[data-kingdom][aria-pressed="true"]');
+    const k = activePill?.dataset.kingdom ?? '';
+    if (k) {
+      gridEl.querySelectorAll<HTMLElement>('[data-taxon-id]').forEach((card) => {
+        const cardKingdom = card.getAttribute('data-kingdom') ?? '';
+        card.style.display = cardKingdom === k ? '' : 'none';
+      });
+    }
+  }
+
   function renderCards(rows: DexRow[]): string {
     if (!gridEl) return '';
     const labels = cardLabels();
@@ -404,14 +609,34 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
     }).join('');
   }
 
-  function renderAll(rows: DexRow[], suggestion: SuggestRow | null, isVisitor: boolean) {
+  function renderAll(
+    rows: DexRow[],
+    suggestion: SuggestRow | null,
+    isVisitor: boolean,
+    falta?: FaltaPayload,
+  ) {
     if (!heroEl || !pillsEl || !gridEl) return;
+
+    // Owner-only: hydrate the falta-dex state so the toolbar can drive
+    // the show/hide toggle on every render. Visitor view stays as-is.
+    if (!isVisitor && falta) {
+      state = {
+        rows,
+        missing: falta.missing,
+        regionPoolSize: falta.regionPoolSize,
+        showMissing: loadShowMissing(),
+      };
+    } else {
+      state = null;
+    }
 
     if (rows.length === 0) {
       // First-visit owner state: still render hero (tile 1 in first-visit mode)
       if (!isVisitor) {
         heroEl.innerHTML = renderHeroHtml(rows, suggestion, false);
         heroEl.classList.remove('hidden');
+        // Falta-dex toolbar is meaningless on a 0-row dex (no
+        // observations yet → no comparison frame). Hide it.
       } else {
         if (emptyEl) {
           const tpl = root?.dataset.labelVisitorEmpty ?? '';
@@ -425,12 +650,15 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
 
     heroEl.innerHTML  = renderHeroHtml(rows, suggestion, isVisitor);
     pillsEl.innerHTML = renderPillsHtml(rows);
-    gridEl.innerHTML  = `<ul class="contents">${renderCards(rows)}</ul>`;
+    const presentHtml = renderCards(rows);
+    const missingHtml = state?.showMissing ? renderMissingCards(state.missing) : '';
+    gridEl.innerHTML  = `<ul class="contents">${presentHtml}${missingHtml}</ul>`;
 
     heroEl.classList.remove('hidden');
     pillsEl.classList.remove('hidden');
     gridEl.classList.remove('hidden');
     wireKingdomPills();
+    if (!isVisitor) renderMissingToolbar();
     loading?.classList.add('hidden');
   }
 
@@ -451,7 +679,8 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
     let rows = await loadFromView(supabase, user.id);
     if (rows === null) rows = await loadFallback(supabase, user.id);
     const suggestion = await loadSuggestion(supabase, user.id);
-    renderAll(rows, suggestion, false);
+    const falta = await loadFalta(supabase, user.id);
+    renderAll(rows, suggestion, false, falta);
   }
 
   async function runVisitor() {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2007,7 +2007,18 @@
     "visitor_not_found_cta": "Browse recent observations →",
     "visitor_back_to_profile": "← Back to profile",
     "visitor_page_title": "@{handle}'s Pokédex — Rastrum",
-    "visitor_load_error": "Couldn't load this Pokédex. Check your connection and try again."
+    "visitor_load_error": "Couldn't load this Pokédex. Check your connection and try again.",
+    "missing": {
+      "show": "Show missing",
+      "hide": "Hide missing",
+      "count_template": "{observed} of {total} species in your region",
+      "count_fallback": "{observed} species observed",
+      "no_region": "Set your country in Profile → Edit to see what you're missing.",
+      "empty": "No missing species in our regional pool yet — keep observing!",
+      "card_tag": "Missing",
+      "cta": "Observe this",
+      "disclaimer": "Estimate based on Rastrum community observations in your region — incomplete for some areas. (GBIF baseline coming in v1.1.)"
+    }
   },
   "explore_species_hero": {
     "title": "Species",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2007,6 +2007,17 @@
       "first_visit_title": "Empieza tu Pokédex",
       "first_visit_cta": "Haz tu primera observación",
       "kingdom_all": "Todos"
+    },
+    "missing": {
+      "show": "Mostrar faltantes",
+      "hide": "Ocultar faltantes",
+      "count_template": "{observed} de {total} especies en tu región",
+      "count_fallback": "{observed} especies observadas",
+      "no_region": "Configura tu país en Perfil → Editar para ver lo que te falta.",
+      "empty": "Aún no hay especies faltantes en el pool regional — ¡sigue observando!",
+      "card_tag": "Falta",
+      "cta": "Observar esta",
+      "disclaimer": "Estimación basada en observaciones de la comunidad de Rastrum en tu región — datos incompletos para algunas áreas. (Baseline de GBIF llegará en v1.1.)"
     }
   },
   "explore_species_hero": {

--- a/src/lib/pokedex-missing.ts
+++ b/src/lib/pokedex-missing.ts
@@ -1,0 +1,85 @@
+/**
+ * Falta-dex (taxonomic-gap) helpers for PokedexView.
+ *
+ * Owns the localStorage toggle for "Show missing / Hide missing" plus
+ * the count-line formatter ("X of Y species in your region"). Pulled
+ * out of PokedexView.astro so it can be unit-tested without DOM.
+ */
+
+const SHOW_MISSING_KEY = 'rastrum.pokedex.showMissing';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function safeStorage(s?: StorageLike | null): StorageLike | null {
+  if (s === undefined) {
+    try {
+      return typeof localStorage !== 'undefined' ? localStorage : null;
+    } catch {
+      return null;
+    }
+  }
+  return s ?? null;
+}
+
+/**
+ * Read the persisted "show missing" preference. Defaults to false —
+ * users opt in to seeing gaps so the existing dex experience is
+ * unchanged on first load. Malformed payloads also collapse to false.
+ */
+export function loadShowMissing(storage?: StorageLike | null): boolean {
+  const s = safeStorage(storage);
+  if (!s) return false;
+  try {
+    const v = s.getItem(SHOW_MISSING_KEY);
+    return v === '1' || v === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function saveShowMissing(value: boolean, storage?: StorageLike | null): void {
+  const s = safeStorage(storage);
+  if (!s) return;
+  try {
+    if (value) s.setItem(SHOW_MISSING_KEY, '1');
+    else s.removeItem(SHOW_MISSING_KEY);
+  } catch {
+    /* storage may be quota-exceeded or disabled; treat as no-op */
+  }
+}
+
+/**
+ * Format the "X of Y species in your region" line. Pluralisation is
+ * handled by the i18n template (the caller passes en or es copy with
+ * `{observed}` / `{total}` placeholders). When `total` is 0 or the
+ * region pool is unknown, the function falls back to a region-less
+ * count line.
+ */
+export interface CountLabels {
+  /** Template like "{observed} of {total} species in your region" */
+  template: string;
+  /** Fallback like "{observed} species observed" (no region/total). */
+  fallback: string;
+}
+
+export function formatRegionCount(
+  observed: number,
+  total: number | null,
+  labels: CountLabels,
+): string {
+  const safeObserved = Math.max(0, observed | 0);
+  if (total == null || total <= 0) {
+    return labels.fallback.replaceAll('{observed}', String(safeObserved));
+  }
+  // Total in the pool can lag behind the user's observed count (a brand-
+  // new species the user just logged isn't in the regional pool yet).
+  // Clamp denominator so we never show "12 of 8".
+  const safeTotal = Math.max(safeObserved, total | 0);
+  return labels.template
+    .replaceAll('{observed}', String(safeObserved))
+    .replaceAll('{total}', String(safeTotal));
+}

--- a/tests/unit/pokedex-missing.test.ts
+++ b/tests/unit/pokedex-missing.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  loadShowMissing,
+  saveShowMissing,
+  formatRegionCount,
+} from '../../src/lib/pokedex-missing';
+
+describe('pokedex-missing — showMissing localStorage toggle', () => {
+  let store: Map<string, string>;
+  let storage: { getItem: (k: string) => string | null; setItem: (k: string, v: string) => void; removeItem: (k: string) => void };
+
+  beforeEach(() => {
+    store = new Map<string, string>();
+    storage = {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, v); },
+      removeItem: (k: string) => { store.delete(k); },
+    };
+  });
+
+  it('defaults to false on first load', () => {
+    expect(loadShowMissing(storage)).toBe(false);
+  });
+
+  it('round-trips true through save + load', () => {
+    saveShowMissing(true, storage);
+    expect(loadShowMissing(storage)).toBe(true);
+  });
+
+  it('saving false removes the key (default state)', () => {
+    saveShowMissing(true, storage);
+    expect(store.has('rastrum.pokedex.showMissing')).toBe(true);
+    saveShowMissing(false, storage);
+    expect(store.has('rastrum.pokedex.showMissing')).toBe(false);
+  });
+
+  it('accepts legacy "true" value (forwards-compat)', () => {
+    storage.setItem('rastrum.pokedex.showMissing', 'true');
+    expect(loadShowMissing(storage)).toBe(true);
+  });
+
+  it('rejects malformed payloads', () => {
+    storage.setItem('rastrum.pokedex.showMissing', 'maybe');
+    expect(loadShowMissing(storage)).toBe(false);
+  });
+
+  it('uses the documented storage key', () => {
+    saveShowMissing(true, storage);
+    expect(store.has('rastrum.pokedex.showMissing')).toBe(true);
+  });
+
+  it('returns false when storage is unavailable (no throw)', () => {
+    expect(loadShowMissing(null)).toBe(false);
+    expect(() => saveShowMissing(true, null)).not.toThrow();
+  });
+});
+
+describe('pokedex-missing — formatRegionCount', () => {
+  const en = {
+    template: '{observed} of {total} species in your region',
+    fallback: '{observed} species observed',
+  };
+  const es = {
+    template: '{observed} de {total} especies en tu región',
+    fallback: '{observed} especies observadas',
+  };
+
+  it('formats observed/total in English', () => {
+    expect(formatRegionCount(12, 250, en)).toBe('12 of 250 species in your region');
+  });
+
+  it('formats observed/total in Spanish', () => {
+    expect(formatRegionCount(3, 87, es)).toBe('3 de 87 especies en tu región');
+  });
+
+  it('falls back when total is null (region unknown)', () => {
+    expect(formatRegionCount(7, null, en)).toBe('7 species observed');
+  });
+
+  it('falls back when total is zero (empty pool)', () => {
+    expect(formatRegionCount(0, 0, es)).toBe('0 especies observadas');
+  });
+
+  it('clamps total >= observed (pool lag is invisible to user)', () => {
+    // Just-observed species not yet in the regional research-grade pool.
+    expect(formatRegionCount(15, 10, en)).toBe('15 of 15 species in your region');
+  });
+
+  it('floors negative observed counts to 0', () => {
+    expect(formatRegionCount(-3, 50, en)).toBe('0 of 50 species in your region');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a "Show missing" toggle to the Pokédex that appends silhouette cards
for species the user has not observed but are present in their region.
This is **phase-1 of #726** (and supersedes #561 once merged — the
issues describe the same feature from different angles; closing here,
leaving #561 to close naturally on cross-link).

- Owner-only — visitors don't see what someone hasn't observed.
- Cards: dashed grey border, "?" badge, scientific name revealed,
  rarity star rating, "Observe this" CTA → species detail page.
- Toggle persists in `localStorage.rastrum.pokedex.showMissing`
  (default off; existing users get the original dex experience).
- Counts at top: "X of Y species in your region".
- Honest disclaimer — copy spells out the v1 baseline limit.

## Baseline source — Option A

I picked **Option A (Rastrum's own observation data as proxy)** over
Option B (curated GBIF baseline per state/ecoregion):

- No external ETL, no GBIF DOI tracking, no license review needed.
- Refreshes automatically as the community logs new observations.
- Honest about its limits (regions with low Rastrum density show a
  small pool — disclaimer copy says so).
- Option B remains a clear v1.1 upgrade path; runbook spells it out.

The "expected pool" for a country = taxa with `is_research_grade=true`,
`sync_status='synced'`, `obscure_level <> 'private'` observations
made by users whose `country_code` matches.

## SQL surface

Two new functions appended to `supabase-schema.sql` (idempotent
`CREATE OR REPLACE`, GRANTs handled, `db-validate` passes):

- `profile_pokedex_with_missing(p_user_id uuid, p_region_country text default null, p_missing_limit int default 60)`
  → `SETOF (user_id, taxon_id, scientific_name, kingdom, rarity_bucket,
    first_observed_at, obs_count, common_name_es, common_name_en, slug,
    endemic_mx, nom059_status, thumbnail_url, is_missing)`.
  `SECURITY DEFINER`, gated by `can_see_facet`. UNION of present rows
  (from `profile_pokedex` directly so it stays in lock-step) and missing
  rows scoped to `taxa.taxon_rank = 'species'`, ordered
  `taxon_rarity.bucket DESC NULLS LAST, regional_obs_count ASC`.
- `region_species_pool_size(p_region_country text) → int` — cheap
  denominator for the "X of Y" line.

## How the toggle persists

Pure helper in `src/lib/pokedex-missing.ts`:

- Storage key: `rastrum.pokedex.showMissing` (`'1'` truthy, removed when
  off — never persists `'false'`).
- Accepts legacy `'true'` for forward-compat.
- Storage-unavailable path returns `false` without throwing.
- 13 new vitest cases cover round-trip, malformed payloads, count
  formatting, observed/total clamping, and the storage-unavailable case.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 1225/1225 pass (was 1212; +13 new)
- [x] `npm run build` — 231 pages, no errors, EN/ES paired
- [ ] Manual: log in as a user with `country_code='MX'`, click "Show
      missing" on `/profile/dex`. Confirm silhouette cards appear with
      rarity stars, dashed border, "Observe this" CTA, count line, and
      the disclaimer paragraph beneath the grid.
- [ ] Manual: visit someone else's `/u/<handle>/dex` while signed in —
      toolbar should NOT appear.
- [ ] Manual: kingdom-pill filter still works when missing cards are
      visible.
- [ ] Manual: `make db-apply` is idempotent (replay-safe).

## Files changed

- `docs/specs/infra/supabase-schema.sql` — +191 lines (new functions, append-only)
- `src/components/PokedexView.astro` — +231 lines (toolbar + missing-cards + show/hide wiring)
- `src/lib/pokedex-missing.ts` — new helper (storage + count formatter)
- `tests/unit/pokedex-missing.test.ts` — 13 cases
- `src/i18n/{en,es}.json` — `pokedex.missing.*` block in both
- `docs/runbooks/falta-dex.md` + `docs/runbooks/00-index.md` — operator runbook

## v1.1 follow-ups (out of scope)

- GBIF baseline (Option B) — needs separate PR with ETL + DOI tracking.
- Missing-by-rank (orders / families) — the original #726 framing.
- "Where to find" mini-map per missing card.
- `/observe?suggested_taxon=<id>` so the CTA pre-fills the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)