### PR TITLE
feat(triage): public roadmap-triage SLA dashboard

### DIFF
--- a/.github/workflows/triage-stats.yml
+++ b/.github/workflows/triage-stats.yml
@@ -1,0 +1,77 @@
+name: Triage SLA stats — nightly fetch
+
+# Refreshes public/data/triage-stats.json once a day so the public
+# `/{en,es}/docs/status/` page renders fresh "open issues / median time-to-
+# first-comment / resolved last 30 days" numbers on the next site build.
+#
+# Why nightly + commit (instead of on-demand at build time):
+#   - The site is a static GitHub Pages build; we want the stats to be
+#     deterministic at build time, not racey against gh API rate limits.
+#   - Nightly cadence is plenty for an SLA dashboard.
+#
+# Auth: the script shells out to `gh`, which authenticates with the
+# default GITHUB_TOKEN we hand it via env. No PAT, no repo secret.
+#
+# The fetcher is fault-tolerant: on gh API failure it preserves the
+# previous JSON (commit becomes a no-op) so a transient outage never
+# breaks the build.
+name: Triage SLA stats
+
+on:
+  schedule:
+    # 07:00 UTC — after enrich-taxa (06:00) and before community
+    # backfill so they don't pile onto the same minute.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: triage-stats
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Fetch + commit triage-stats.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run fetcher
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          npx --yes tsx scripts/fetch-gh-issue-stats.ts
+
+      - name: Commit refreshed JSON if changed
+        run: |
+          set -euo pipefail
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          if git diff --quiet -- public/data/triage-stats.json; then
+            echo '::notice::No change to triage-stats.json; skipping commit.'
+            exit 0
+          fi
+
+          git add public/data/triage-stats.json
+          git commit -m 'chore(triage): refresh triage-stats.json [skip ci]'
+          git push origin HEAD:main
+
+          {
+            echo '## Triage SLA stats refreshed'
+            echo ''
+            echo 'Updated `public/data/triage-stats.json`.'
+            echo ''
+            echo '```json'
+            cat public/data/triage-stats.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/public/data/triage-stats.json
+++ b/public/data/triage-stats.json
@@ -1,0 +1,9 @@
+{
+  "generated_at": "2026-05-08T00:00:00.000Z",
+  "repo": "ArtemioPadilla/rastrum",
+  "window_days": 30,
+  "open_count": 0,
+  "resolved_30d": 0,
+  "median_first_comment_h": null,
+  "sample_size": 0
+}

--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -80,6 +80,7 @@ const docPages = [
   { key: 'faq',           en: 'FAQ',           es: 'Preguntas frecuentes', group: 'Product' },
   { key: 'privacy',       en: 'Privacy',       es: 'Privacidad',          group: 'Community' },
   { key: 'terms',         en: 'Terms',         es: 'Términos',            group: 'Community' },
+  { key: 'status',        en: 'Triage status', es: 'Estado de triage',    group: 'Community' },
 ];
 
 // ---------------------------------------------------------------------------

--- a/scripts/fetch-gh-issue-stats.ts
+++ b/scripts/fetch-gh-issue-stats.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env tsx
+/**
+ * Build-time / nightly fetcher for triage SLA stats.
+ *
+ * Outputs `public/data/triage-stats.json`. The doc page
+ * `/{en,es}/docs/status/` reads it via Node fs at build time.
+ *
+ * Stats produced:
+ *   - open_count            : total open issues right now
+ *   - resolved_30d          : issues closed in the last 30 days
+ *   - median_first_comment_h: median hours from issue.created_at to the
+ *                             first non-author comment, across the last
+ *                             30 days of opened issues
+ *   - generated_at          : ISO timestamp of this run
+ *   - sample_size           : number of issues sampled for the median
+ *
+ * Auth: relies on the `gh` CLI being authenticated in the calling
+ * environment. In GitHub Actions, `${{ secrets.GITHUB_TOKEN }}` is the
+ * default and gh picks it up via `GH_TOKEN`/`GITHUB_TOKEN` env vars —
+ * we never store a token in the repo or write it to disk.
+ *
+ * Rate-limit: the script falls back to the previous JSON on error so a
+ * transient API hiccup never breaks the build / the site.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { median, hoursBetween, round1, type TriageStats } from '../src/lib/triage-stats';
+
+const execFileP = promisify(execFile);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const OUT_DIR = join(ROOT, 'public', 'data');
+const OUT_FILE = join(OUT_DIR, 'triage-stats.json');
+
+const REPO = process.env.RASTRUM_REPO || 'ArtemioPadilla/rastrum';
+const WINDOW_DAYS = 30;
+
+interface IssueListItem {
+  number: number;
+  user: { login: string } | null;
+  created_at: string;
+  closed_at: string | null;
+  state: 'open' | 'closed';
+  pull_request?: unknown;
+}
+
+interface IssueComment {
+  user: { login: string } | null;
+  created_at: string;
+}
+
+async function ghJson<T>(args: string[]): Promise<T> {
+  const { stdout } = await execFileP('gh', args, {
+    maxBuffer: 32 * 1024 * 1024,
+    env: process.env,
+  });
+  return JSON.parse(stdout) as T;
+}
+
+async function ghApiPaged<T>(path: string): Promise<T[]> {
+  return ghJson<T[]>(['api', '--paginate', path]);
+}
+
+async function fetchOpenCount(): Promise<number> {
+  const data = await ghJson<{ total_count: number }>([
+    'api',
+    `/search/issues?q=repo:${REPO}+is:issue+is:open&per_page=1`,
+  ]);
+  return data.total_count;
+}
+
+async function fetchClosed30dCount(sinceIso: string): Promise<number> {
+  const data = await ghJson<{ total_count: number }>([
+    'api',
+    `/search/issues?q=${encodeURIComponent(
+      `repo:${REPO} is:issue is:closed closed:>=${sinceIso}`,
+    )}&per_page=1`,
+  ]);
+  return data.total_count;
+}
+
+async function fetchRecentIssues(sinceIso: string): Promise<IssueListItem[]> {
+  // /repos/{owner}/{repo}/issues returns both PRs and issues; we filter
+  // PRs out below. `since` is an inclusive timestamp filter (last
+  // updated >= sinceIso) which is broader than created — that's fine
+  // because we drop anything created before sinceIso below.
+  const items = await ghApiPaged<IssueListItem>(
+    `/repos/${REPO}/issues?state=all&since=${sinceIso}&per_page=100`,
+  );
+  return items.filter(
+    (i) => !i.pull_request && new Date(i.created_at).toISOString() >= sinceIso,
+  );
+}
+
+async function firstNonAuthorCommentDelay(
+  issue: IssueListItem,
+): Promise<number | null> {
+  const comments = await ghApiPaged<IssueComment>(
+    `/repos/${REPO}/issues/${issue.number}/comments?per_page=100`,
+  );
+  const authorLogin = issue.user?.login ?? '';
+  const first = comments.find((c) => (c.user?.login ?? '') !== authorLogin);
+  if (!first) return null;
+  return hoursBetween(issue.created_at, first.created_at);
+}
+
+function readPrevious(): TriageStats | null {
+  if (!existsSync(OUT_FILE)) return null;
+  try {
+    const raw = readFileSync(OUT_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as TriageStats;
+    if (typeof parsed.open_count === 'number') return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  const since = new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const sinceIso = since.toISOString();
+
+  try {
+    const [openCount, resolved30d, recent] = await Promise.all([
+      fetchOpenCount(),
+      fetchClosed30dCount(sinceIso),
+      fetchRecentIssues(sinceIso),
+    ]);
+
+    const delays: number[] = [];
+    // Sequential to be polite to the API; recent windows are small (~25-50
+    // issues for this repo) so total time stays under ~30s even at 100 issues.
+    for (const issue of recent) {
+      const d = await firstNonAuthorCommentDelay(issue);
+      if (d !== null) delays.push(d);
+    }
+
+    const med = median(delays);
+
+    const stats: TriageStats = {
+      generated_at: new Date().toISOString(),
+      repo: REPO,
+      window_days: WINDOW_DAYS,
+      open_count: openCount,
+      resolved_30d: resolved30d,
+      median_first_comment_h: med === null ? null : round1(med),
+      sample_size: delays.length,
+    };
+
+    mkdirSync(OUT_DIR, { recursive: true });
+    writeFileSync(OUT_FILE, JSON.stringify(stats, null, 2) + '\n', 'utf8');
+    console.log(
+      `triage-stats: open=${stats.open_count} resolved30d=${stats.resolved_30d} ` +
+        `median_h=${stats.median_first_comment_h ?? 'n/a'} (n=${stats.sample_size})`,
+    );
+  } catch (err) {
+    const prev = readPrevious();
+    const message = err instanceof Error ? err.message : String(err);
+    if (prev) {
+      console.warn(
+        `triage-stats: gh API failed (${message}); preserving previous JSON dated ${prev.generated_at}`,
+      );
+      // Nothing to write — leave the existing file in place.
+      return;
+    }
+    console.error(`triage-stats: gh API failed and no previous JSON to fall back on: ${message}`);
+    // Emit a zero-valued stub so the build still has something to render.
+    const stub: TriageStats = {
+      generated_at: new Date().toISOString(),
+      repo: REPO,
+      window_days: WINDOW_DAYS,
+      open_count: 0,
+      resolved_30d: 0,
+      median_first_comment_h: null,
+      sample_size: 0,
+    };
+    mkdirSync(OUT_DIR, { recursive: true });
+    writeFileSync(OUT_FILE, JSON.stringify(stub, null, 2) + '\n', 'utf8');
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/src/components/TriageStatusView.astro
+++ b/src/components/TriageStatusView.astro
@@ -1,0 +1,162 @@
+---
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { t } from '../i18n/utils';
+
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const tr = t(lang);
+const triage = (tr.docs as unknown as { triage: Record<string, string> }).triage;
+
+interface TriageStats {
+  generated_at: string;
+  repo: string;
+  window_days: number;
+  open_count: number;
+  resolved_30d: number;
+  median_first_comment_h: number | null;
+  sample_size: number;
+}
+
+const FALLBACK: TriageStats = {
+  generated_at: '1970-01-01T00:00:00.000Z',
+  repo: 'ArtemioPadilla/rastrum',
+  window_days: 30,
+  open_count: 0,
+  resolved_30d: 0,
+  median_first_comment_h: null,
+  sample_size: 0,
+};
+
+function loadStats(): TriageStats {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const file = resolve(here, '..', '..', 'public', 'data', 'triage-stats.json');
+  if (!existsSync(file)) return FALLBACK;
+  try {
+    const raw = readFileSync(file, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<TriageStats>;
+    return {
+      ...FALLBACK,
+      ...parsed,
+    } as TriageStats;
+  } catch {
+    return FALLBACK;
+  }
+}
+
+const stats = loadStats();
+
+function formatGenerated(iso: string, locale: 'en' | 'es'): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(locale === 'es' ? 'es-MX' : 'en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+  }) + ' UTC';
+}
+
+function formatNumber(n: number, locale: 'en' | 'es'): string {
+  return n.toLocaleString(locale === 'es' ? 'es-MX' : 'en-US');
+}
+
+const medianLabel = stats.median_first_comment_h === null
+  ? triage.stat_median_none
+  : `${formatNumber(stats.median_first_comment_h, lang)} ${triage.stat_median_unit_h}`;
+
+const generatedLabel = formatGenerated(stats.generated_at, lang);
+const isStub = stats.generated_at.startsWith('1970-');
+
+const repoUrl = `https://github.com/${stats.repo}`;
+const issuesNew = `${repoUrl}/issues/new/choose`;
+const issuesOpen = `${repoUrl}/issues?q=is%3Aissue+is%3Aopen`;
+const issuesClosed = `${repoUrl}/issues?q=is%3Aissue+is%3Aclosed`;
+---
+
+<div class="prose dark:prose-invert max-w-none">
+  <h1>{triage.title}</h1>
+  <p class="text-zinc-600 dark:text-zinc-400">{triage.subtitle}</p>
+  <p>{triage.intro}</p>
+
+  <div class="not-prose grid sm:grid-cols-3 gap-4 mt-6">
+    <a href={issuesOpen} target="_blank" rel="noopener"
+       class="block p-5 rounded-xl bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 hover:border-emerald-500/40 transition-colors">
+      <p class="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+        {triage.stat_open}
+      </p>
+      <p class="text-3xl font-bold text-zinc-900 dark:text-zinc-100 tabular-nums">
+        {formatNumber(stats.open_count, lang)}
+      </p>
+      <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-2">{triage.stat_open_help}</p>
+    </a>
+
+    <div class="block p-5 rounded-xl bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+      <p class="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+        {triage.stat_median}
+      </p>
+      <p class="text-3xl font-bold text-emerald-600 dark:text-emerald-400 tabular-nums">
+        {medianLabel}
+      </p>
+      <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-2">{triage.stat_median_help}</p>
+    </div>
+
+    <a href={issuesClosed} target="_blank" rel="noopener"
+       class="block p-5 rounded-xl bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 hover:border-emerald-500/40 transition-colors">
+      <p class="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+        {triage.stat_resolved}
+      </p>
+      <p class="text-3xl font-bold text-zinc-900 dark:text-zinc-100 tabular-nums">
+        {formatNumber(stats.resolved_30d, lang)}
+      </p>
+      <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-2">{triage.stat_resolved_help}</p>
+    </a>
+  </div>
+
+  <h2 class="mt-10">{triage.team_heading}</h2>
+  <p>{triage.team_body}</p>
+
+  <h2>{triage.report_heading}</h2>
+  <p>{triage.report_body}</p>
+  <ul>
+    <li>
+      <a href={`${repoUrl}/issues/new?template=bug.md`} target="_blank" rel="noopener">
+        {triage.report_bug}
+      </a>
+    </li>
+    <li>
+      <a href={`${repoUrl}/issues/new?template=feature.md`} target="_blank" rel="noopener">
+        {triage.report_feature}
+      </a>
+    </li>
+    <li>
+      <a href={`${repoUrl}/issues/new?template=question.md`} target="_blank" rel="noopener">
+        {triage.report_question}
+      </a>
+    </li>
+    <li>
+      <a href={issuesNew} target="_blank" rel="noopener">
+        {lang === 'es' ? 'Nueva issue (cualquier plantilla)' : 'New issue (any template)'}
+      </a>
+    </li>
+  </ul>
+  <p class="text-sm text-zinc-500 dark:text-zinc-400">{triage.report_inapp}</p>
+
+  <hr class="my-8" />
+
+  <dl class="not-prose text-sm grid sm:grid-cols-3 gap-x-6 gap-y-2 text-zinc-500 dark:text-zinc-400">
+    <div>
+      <dt class="font-semibold text-zinc-700 dark:text-zinc-300">{triage.data_freshness}</dt>
+      <dd class={isStub ? 'italic' : ''}>{isStub ? '—' : generatedLabel}</dd>
+    </div>
+    <div>
+      <dt class="font-semibold text-zinc-700 dark:text-zinc-300">{triage.data_window}</dt>
+      <dd>{stats.window_days} {lang === 'es' ? 'días' : 'days'}</dd>
+    </div>
+    <div>
+      <dt class="font-semibold text-zinc-700 dark:text-zinc-300">{triage.data_sample_size}</dt>
+      <dd>{formatNumber(stats.sample_size, lang)}</dd>
+    </div>
+  </dl>
+  <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-2">{triage.data_source}</p>
+</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1595,7 +1595,8 @@
       "community": "Community",
       "camera-stations": "Camera Stations",
       "sponsor-pools": "Sponsor Pools",
-      "obs-detail": "Observation Detail"
+      "obs-detail": "Observation Detail",
+      "status": "Triage status"
     },
     "descriptions": {
       "vision": "Mission, problem statement, and why Oaxaca is the right place to start.",
@@ -1617,7 +1618,33 @@
       "community": "Community discovery: find observers, experts, and naturalists near you. Filter by country, taxon, and activity.",
       "camera-stations": "Camera-trap station management with active periods, trap-night computation, and wildlife detection indices.",
       "sponsor-pools": "Multi-provider AI vision and platform sponsor pools. Anthropic, Vertex, and OpenAI with community credit distribution.",
-      "obs-detail": "Observation detail page with photo gallery, interactive map, community identifications, and owner management tools."
+      "obs-detail": "Observation detail page with photo gallery, interactive map, community identifications, and owner management tools.",
+      "status": "Public triage SLA dashboard: open issues, median time-to-first-comment over the last 30 days, and recent resolution count."
+    },
+    "triage": {
+      "title": "Triage status",
+      "subtitle": "How fast Rastrum responds to bug reports and feature requests.",
+      "intro": "Rastrum is open-source and maintained by a small team. This page shows a public SLA so you can tell at a glance how responsive the project is.",
+      "stat_open": "Open issues",
+      "stat_open_help": "Total issues currently open in the repo.",
+      "stat_resolved": "Resolved last 30 days",
+      "stat_resolved_help": "Issues closed in the last 30 days.",
+      "stat_median": "Median time to first reply",
+      "stat_median_help": "Across issues opened in the last 30 days, half got their first non-author comment in less than this.",
+      "stat_median_unit_h": "h",
+      "stat_median_none": "n/a",
+      "team_heading": "Who responds",
+      "team_body": "Rastrum is currently maintained by Artemio Padilla with help from community contributors. There is no on-call rotation — responses come on a best-effort basis, usually within a couple of days.",
+      "report_heading": "How to report",
+      "report_body": "The fastest way is to open a GitHub issue with the right template:",
+      "report_bug": "Bug report",
+      "report_feature": "Feature request",
+      "report_question": "Question",
+      "report_inapp": "Or use the in-app reporter (the bell icon in the header) — it auto-attaches diagnostics.",
+      "data_freshness": "Data refreshed",
+      "data_window": "30-day rolling window",
+      "data_sample_size": "Sample size",
+      "data_source": "Source: GitHub Issues API · refreshed nightly via GitHub Actions."
     },
     "status": {
       "current": "Active",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1595,7 +1595,8 @@
       "community": "Comunidad",
       "camera-stations": "Estaciones de Cámara",
       "sponsor-pools": "Pools de Patrocinio",
-      "obs-detail": "Detalle de Observación"
+      "obs-detail": "Detalle de Observación",
+      "status": "Estado de triage"
     },
     "descriptions": {
       "vision": "Misión, problema y por qué Oaxaca es el lugar correcto para comenzar.",
@@ -1617,7 +1618,33 @@
       "community": "Descubrimiento de comunidad: encuentra observadores, expertos y naturalistas cerca de ti. Filtra por país, taxón y actividad.",
       "camera-stations": "Gestión de estaciones de cámara trampa con periodos activos, cálculo de noches-trampa e índices de detección de vida silvestre.",
       "sponsor-pools": "Visión AI multi-proveedor y pools de patrocinio de plataforma. Anthropic, Vertex y OpenAI con distribución de créditos comunitarios.",
-      "obs-detail": "Página de detalle de observación con galería de fotos, mapa interactivo, identificaciones comunitarias y herramientas de gestión."
+      "obs-detail": "Página de detalle de observación con galería de fotos, mapa interactivo, identificaciones comunitarias y herramientas de gestión.",
+      "status": "Tablero público de SLA de triage: issues abiertas, tiempo medio a primer comentario en los últimos 30 días y resoluciones recientes."
+    },
+    "triage": {
+      "title": "Estado de triage",
+      "subtitle": "Qué tan rápido responde Rastrum a reportes de bugs y solicitudes de funcionalidad.",
+      "intro": "Rastrum es open-source y lo mantiene un equipo pequeño. Esta página muestra un SLA público para que veas de un vistazo qué tan responsivo es el proyecto.",
+      "stat_open": "Issues abiertas",
+      "stat_open_help": "Total de issues abiertas en el repo en este momento.",
+      "stat_resolved": "Resueltas en los últimos 30 días",
+      "stat_resolved_help": "Issues cerradas en los últimos 30 días.",
+      "stat_median": "Tiempo medio a primer respuesta",
+      "stat_median_help": "Sobre las issues abiertas en los últimos 30 días, la mitad recibió su primer comentario no-autor en menos de este tiempo.",
+      "stat_median_unit_h": "h",
+      "stat_median_none": "n/d",
+      "team_heading": "Quiénes responden",
+      "team_body": "Rastrum lo mantiene actualmente Artemio Padilla con ayuda de la comunidad. No hay rotación de guardia — las respuestas son por mejor esfuerzo, normalmente en un par de días.",
+      "report_heading": "Cómo reportar",
+      "report_body": "La forma más rápida es abrir un issue en GitHub con la plantilla adecuada:",
+      "report_bug": "Reporte de bug",
+      "report_feature": "Solicitud de funcionalidad",
+      "report_question": "Pregunta",
+      "report_inapp": "O usa el reportador en la app (el ícono de campana en la cabecera) — adjunta diagnósticos automáticamente.",
+      "data_freshness": "Datos actualizados",
+      "data_window": "Ventana móvil de 30 días",
+      "data_sample_size": "Tamaño de muestra",
+      "data_source": "Fuente: API de GitHub Issues · refrescado cada noche por GitHub Actions."
     },
     "status": {
       "current": "Activo",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -126,7 +126,7 @@ export const docPages = [
   'architecture', 'indigenous', 'funding', 'contribute',
   'faq', 'privacy', 'terms', 'console', 'sponsorships', 'mcp',
   'changelog', 'community', 'camera-stations', 'sponsor-pools',
-  'obs-detail',
+  'obs-detail', 'status',
 ] as const;
 
 export type DocPage = (typeof docPages)[number];
@@ -345,6 +345,10 @@ export const docPageMeta = {
   'obs-detail': {
     en: "Observation detail page: photo gallery, interactive map, community identifications, owner management tools, and public sharing with OG cards.",
     es: "Página de detalle de observación: galería de fotos, mapa interactivo, identificaciones comunitarias, herramientas de gestión y compartir público con tarjetas OG.",
+  },
+  status: {
+    en: "Public triage SLA dashboard: open issues, median time-to-first-comment over the last 30 days, and recent resolution count.",
+    es: "Tablero público de SLA de triage: issues abiertas, tiempo medio a primer comentario en los últimos 30 días y resoluciones recientes.",
   },
 } as const satisfies Record<DocPage, { en: string; es: string }>;
 

--- a/src/lib/triage-stats.ts
+++ b/src/lib/triage-stats.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure helpers for the triage SLA dashboard. Extracted from
+ * `scripts/fetch-gh-issue-stats.ts` so the math can be unit-tested
+ * without standing up the gh CLI.
+ */
+
+export interface TriageStats {
+  generated_at: string;
+  repo: string;
+  window_days: number;
+  open_count: number;
+  resolved_30d: number;
+  median_first_comment_h: number | null;
+  sample_size: number;
+}
+
+/**
+ * Returns the median of `values` in their original units, or `null`
+ * for an empty input. Even-length arrays return the average of the
+ * two middle values; odd-length arrays return the middle value.
+ */
+export function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+/**
+ * Hours between two ISO-8601 timestamps. Returns `null` if either
+ * is unparseable or if `replied` is before `created` (clock skew or
+ * malformed data).
+ */
+export function hoursBetween(createdIso: string, repliedIso: string): number | null {
+  const created = new Date(createdIso).getTime();
+  const replied = new Date(repliedIso).getTime();
+  if (Number.isNaN(created) || Number.isNaN(replied) || replied < created) {
+    return null;
+  }
+  return (replied - created) / (1000 * 60 * 60);
+}
+
+/**
+ * Round a float to 1 decimal place. Used so median values render
+ * cleanly in the public dashboard (`38.4 h` rather than `38.39999…`).
+ */
+export function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}

--- a/src/pages/en/docs/status.astro
+++ b/src/pages/en/docs/status.astro
@@ -1,0 +1,13 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import TriageStatusView from '../../../components/TriageStatusView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+const triage = (tr.docs as unknown as { triage: { title: string } }).triage;
+---
+
+<DocLayout title={triage.title} lang={lang} section="status" editPath="src/pages/en/docs/status.astro">
+  <TriageStatusView lang={lang} />
+</DocLayout>

--- a/src/pages/es/docs/status.astro
+++ b/src/pages/es/docs/status.astro
@@ -1,0 +1,13 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import TriageStatusView from '../../../components/TriageStatusView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+const triage = (tr.docs as unknown as { triage: { title: string } }).triage;
+---
+
+<DocLayout title={triage.title} lang={lang} section="status" editPath="src/pages/es/docs/status.astro">
+  <TriageStatusView lang={lang} />
+</DocLayout>

--- a/tests/unit/triage-stats.test.ts
+++ b/tests/unit/triage-stats.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for the pure helpers consumed by the nightly fetcher
+ * (`scripts/fetch-gh-issue-stats.ts`) and the doc-page renderer
+ * (`src/components/TriageStatusView.astro`). The math is small but
+ * load-bearing — getting the median wrong in the public dashboard
+ * would mis-state the project's responsiveness SLA.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { median, hoursBetween, round1 } from '../../src/lib/triage-stats';
+
+describe('median', () => {
+  it('returns null for an empty array', () => {
+    expect(median([])).toBeNull();
+  });
+
+  it('returns the only value for a single-element array', () => {
+    expect(median([42])).toBe(42);
+  });
+
+  it('returns the middle value for an odd-length array', () => {
+    expect(median([1, 7, 3])).toBe(3);
+  });
+
+  it('returns the average of the two middle values for an even-length array', () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('does not mutate the input', () => {
+    const input = [9, 1, 5, 3];
+    const copy = [...input];
+    median(input);
+    expect(input).toEqual(copy);
+  });
+});
+
+describe('hoursBetween', () => {
+  it('returns the gap in hours for a normal pair', () => {
+    const a = '2026-05-01T00:00:00Z';
+    const b = '2026-05-02T12:00:00Z';
+    expect(hoursBetween(a, b)).toBe(36);
+  });
+
+  it('returns null when the reply is before the issue', () => {
+    const a = '2026-05-02T00:00:00Z';
+    const b = '2026-05-01T00:00:00Z';
+    expect(hoursBetween(a, b)).toBeNull();
+  });
+
+  it('returns null on unparseable input', () => {
+    expect(hoursBetween('not a date', '2026-05-01T00:00:00Z')).toBeNull();
+    expect(hoursBetween('2026-05-01T00:00:00Z', 'also bad')).toBeNull();
+  });
+});
+
+describe('round1', () => {
+  it('rounds to one decimal place', () => {
+    expect(round1(38.39999)).toBe(38.4);
+    expect(round1(38.35)).toBe(38.4);
+    expect(round1(38)).toBe(38);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #740. Adds a public `/docs/status/` page (EN + ES) that surfaces the project's triage SLA: how many issues are open, how long it typically takes to get a first reply, and how many issues were resolved in the last 30 days. Builds the Fogg principle of responsiveness into the docs surface itself — visitors can now tell at a glance whether the project is alive and answering.

- New shared component `src/components/TriageStatusView.astro` reads `public/data/triage-stats.json` at build time and renders three stat tiles + a "who responds" / "how to report" section.
- New nightly workflow `.github/workflows/triage-stats.yml` runs `scripts/fetch-gh-issue-stats.ts` at 07:00 UTC, computes stats via the `gh` CLI (default `GITHUB_TOKEN`, no PAT or repo secret needed), and commits the JSON back to `main` only when it changes. The fetcher is fault-tolerant: on a gh API failure it preserves the last good JSON so a transient outage never breaks the build.
- Pure helpers (`median`, `hoursBetween`, `round1`) moved into `src/lib/triage-stats.ts` and unit-tested.

## JSON shape (`public/data/triage-stats.json`)

```json
{
  "generated_at": "ISO-8601 timestamp",
  "repo": "ArtemioPadilla/rastrum",
  "window_days": 30,
  "open_count": 0,
  "resolved_30d": 0,
  "median_first_comment_h": null,
  "sample_size": 0
}
```

`median_first_comment_h` is `null` when no qualifying issues exist; `sample_size` is the count of issues that had a non-author first comment in the rolling 30-day window.

## Cron schedule

`0 7 * * *` (07:00 UTC, daily). Sandwiched between the existing nightly jobs (`enrich-taxa` at 06:00 and the community backfill family) so they don't pile onto the same minute. `workflow_dispatch` is also available for an on-demand refresh.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 1210 / 1210 pass, including 9 new unit tests for `median` / `hoursBetween` / `round1`
- [x] `npm run build` — 233 pages built, including `/en/docs/status/` and `/es/docs/status/`
- [ ] After merge, watch the first nightly run of `Triage SLA stats` in Actions and confirm `triage-stats.json` is refreshed.
- [ ] After the first refresh, sanity-check that `/en/docs/status/` and `/es/docs/status/` show real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)