### PR TITLE
fix(ai-tab): JSON.stringify expression in <script> tag was rendered literal

### DIFF
--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -310,7 +310,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
   )}
 </div>
 
-<script type="application/json" id="rastrum-section-labels" hidden>{JSON.stringify(sectionLabels)}</script>
+<script type="application/json" id="rastrum-section-labels" hidden set:html={JSON.stringify(sectionLabels)} />
 
 <script>
   import { getSupabase } from '../lib/supabase';


### PR DESCRIPTION
## Why

Five e2e tests in `tests/e2e/ai-tab.spec.ts` started failing on `main` after #694 (`fix(ai-tab): single source of truth for section labels via i18n JSON`) was merged. All five timed out in `waitForRegistry` waiting for `<h3>` elements that never appeared inside `#identifier-list`.

## Root cause

```astro
<script type="application/json" id="rastrum-section-labels" hidden>{JSON.stringify(sectionLabels)}</script>
```

Astro **does not evaluate JSX expressions inside `<script>` tag bodies** — it treats them as opaque text. So the rendered HTML contained the literal string `{JSON.stringify(sectionLabels)}` instead of the serialized JSON.

When `paintRegistry()` then ran:

```ts
const sectionLabels: Record<string, string> = jsonEl?.textContent
  ? JSON.parse(jsonEl.textContent)
  : {};
```

`JSON.parse('{JSON.stringify(sectionLabels)}')` threw:

```
SyntaxError: Expected property name or '}' in JSON at position 1
```

The error was swallowed by `paintRegistry().catch(() => {})`, leaving the identifier list stuck on "Loading…" forever — silent failure.

## Fix

Switch to Astro's `set:html` directive on a self-closing tag, which DOES evaluate the expression and place the result as the inner HTML:

```astro
<script type="application/json" id="rastrum-section-labels" hidden set:html={JSON.stringify(sectionLabels)} />
```

## Verification

Before: `npx playwright test tests/e2e/ai-tab.spec.ts` → 5 failures, all `TimeoutError: page.waitForFunction: Timeout 15000ms exceeded`.

After: all 5 pass in **4.0 s**:

```
[1/5] tests/e2e/ai-tab.spec.ts:153:3 › Storage migration › legacy keys migrate
[2/5] tests/e2e/ai-tab.spec.ts:75:3  › PlantNet toggle lifecycle
[3/5] tests/e2e/ai-tab.spec.ts:206:3 › AI tab — ES locale › PlantNet pill
[4/5] tests/e2e/ai-tab.spec.ts:43:3  › AI tab — EN load › expected section headers
[5/5] tests/e2e/ai-tab.spec.ts:188:3 › AI tab — ES locale › section headers in Spanish
  5 passed (4.0s)
```

Rendered HTML now contains the evaluated JSON:
```html
<script type="application/json" id="rastrum-section-labels" hidden>{"section_photo_specialists":"📷 Photo identifiers · Specialists",...}</script>
```

## Test plan

- [x] All 5 ai-tab.spec.ts tests pass locally
- [x] `npm run build` succeeds (231 pages)
- [x] Rendered HTML in `dist/en/profile/settings/ai/index.html` contains valid JSON inside `#rastrum-section-labels`
- [ ] Wait for CI to confirm e2e passes on the runner

## Unblocks

PRs #757, #758, #759, #760, #761 (Fogg Persuasive Tech Tier S) are all blocked on `test` CI failure inherited from this regression. After this merges, those should re-run green.