### PR TITLE
feat(posthog): reverse-proxy host + ui_host + person_profiles + wire CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,8 @@ jobs:
           PUBLIC_PMTILES_MX_URL:      ${{ secrets.PUBLIC_PMTILES_MX_URL }}
           PUBLIC_MEGADETECTOR_WEIGHTS_URL: ${{ secrets.PUBLIC_MEGADETECTOR_WEIGHTS_URL }}
           PUBLIC_MEGADETECTOR_ENDPOINT: ${{ secrets.PUBLIC_MEGADETECTOR_ENDPOINT }}
+          PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.PUBLIC_POSTHOG_PROJECT_TOKEN }}
+          PUBLIC_POSTHOG_HOST:        ${{ secrets.PUBLIC_POSTHOG_HOST }}
           PUBLIC_BUILD_SHA:           ${{ github.sha }}
           PUBLIC_VERSION:             ${{ steps.pkg.outputs.version }}
 

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -1,16 +1,22 @@
 ---
 // PostHog analytics snippet
 // Uses is:inline + define:vars to inject env vars without Astro TypeScript processing
+// `apiHost` should be the managed reverse proxy domain in prod (e.g. https://usage.rastrum.org)
+// so PostHog requests share an origin with the app and survive content blockers.
+// `uiHost` is the canonical PostHog UI host — used to rewrite deep-links so they
+// point back at PostHog cloud instead of the proxy.
 ---
-<script is:inline define:vars={{ apiKey: import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN, apiHost: import.meta.env.PUBLIC_POSTHOG_HOST }}>
+<script is:inline define:vars={{ apiKey: import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN, apiHost: import.meta.env.PUBLIC_POSTHOG_HOST, uiHost: 'https://us.posthog.com' }}>
   // Guard: skip PostHog entirely when credentials are missing. Without
   // this, the snippet builds the SDK URL as `"" + "/static/array.js"`,
   // which resolves to the app's own domain and 404s.
   if (apiKey && apiHost) {
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="Mi Ri init Vi Gi Rr Wi Ji Bi capture calculateEventProperties tn register register_once register_for_session unregister unregister_for_session an getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync un identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty nn Xi createPersonProfile setInternalOrTestUser sn Hi cn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Ki debug Lr rn getPageViewId captureTraceFeedback captureTraceMetric Di".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init(apiKey, {
       api_host: apiHost,
-      defaults: '2026-01-30'
+      ui_host: uiHost,
+      defaults: '2026-01-30',
+      person_profiles: 'identified_only',
     });
   }
 </script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -13,6 +13,8 @@ interface ImportMetaEnv {
   readonly PUBLIC_PLANTNET_KEY?: string;
   readonly PUBLIC_ANTHROPIC_KEY?: string;
   readonly PUBLIC_VAPID_PUBLIC_KEY?: string;
+  readonly PUBLIC_POSTHOG_PROJECT_TOKEN?: string;
+  readonly PUBLIC_POSTHOG_HOST?: string;
   readonly PUBLIC_BUILD_SHA?: string;
   /**
    * App version string (year.month.N format, e.g. "2026.5.0").


### PR DESCRIPTION
## Summary

Updates the PostHog init snippet (`src/components/posthog.astro`) to the current managed reverse-proxy guidance, and fixes a latent CI gap where the relevant env vars were never being passed to the production build.

- **New init options:** `ui_host: 'https://us.posthog.com'` (so deep-links resolve back to PostHog cloud through the proxy) and `person_profiles: 'identified_only'` (no anonymous-user profiles by default — privacy posture matches the rest of the app).
- **Bumped SDK loader:** double-init guard via `window.posthog.__loaded`, refreshed method list, and the new `/static/array.js` URL pattern (`.i.posthog.com` → `-assets.i.posthog.com`, a no-op for proxy hosts — the reverse proxy serves `/static/array.js` directly).
- **Wires `PUBLIC_POSTHOG_PROJECT_TOKEN` + `PUBLIC_POSTHOG_HOST` into `.github/workflows/deploy.yml`** build env. These secrets weren't being passed at all, so the snippet's `apiKey && apiHost` guard has been short-circuiting on every prod build — **PostHog has been silently disabled in production since the wizard set it up**. The 14 `window.posthog?.capture(...)` call-sites in the codebase have been firing against `undefined`.
- **`src/env.d.ts`:** adds the two env vars (the wizard report claimed they were there; they weren't).

The 14 capture call-sites (`SignInForm`, `OnboardingTour`, `ObservationForm`, `SuggestIdModal`, `ProfileEditForm`, `Comments`, `ReportDialog`, `FollowButton`, `ReactionStrip`, `ProjectNewView`, `InstallPwaButton`, `ExportView`, `SponsoringView`) all use the optional-chaining pattern (`window.posthog?.capture(...)`), so they're insulated from the snippet change. Service worker only intercepts same-origin, so the proxy host needs no SW allowlist work.

## Operator follow-up — required for the fix to take effect in prod

The two secrets aren't set on the repo today:

```bash
gh secret set PUBLIC_POSTHOG_PROJECT_TOKEN   # value from .env.local
gh secret set PUBLIC_POSTHOG_HOST            # https://usage.rastrum.org
```

Once those are set, the next push to `main` will produce a build with PostHog actually wired up.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1227/1227 green
- [x] `npm run build` — 231 pages built; verified the new snippet (with `ui_host`, `person_profiles`, `posthog.__loaded` guard, new `array.js` URL transform) is baked into `dist/en/index.html` + `dist/es/index.html`
- [ ] After merge + secret set: open prod, hit DevTools Network → confirm requests go to `usage.rastrum.org`, not `us.i.posthog.com`
- [ ] Confirm a `sign_in_initiated` event lands in PostHog after a real sign-in attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)