### PR TITLE
feat(theme): high-contrast Field theme for direct sunlight

### DIFF
--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -377,6 +377,7 @@ const s = tr.search;
     window.addEventListener('rastrum:palette-action', (e: Event) => {
       const detail = (e as CustomEvent<{ action: string }>).detail;
       if (detail.action === 'toggle-theme') {
+        document.documentElement.classList.remove('field');
         const dark = document.documentElement.classList.toggle('dark');
         try { localStorage.setItem('theme', dark ? 'dark' : 'light'); } catch { /* ignore */ }
       } else if (detail.action === 'switch-lang') {

--- a/src/components/ConsoleLayout.astro
+++ b/src/components/ConsoleLayout.astro
@@ -123,12 +123,17 @@ const knownPills: Set<UserRole> | null = allRoles ?? null;
     <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
     <script is:inline>
       (function() {
-        const theme = localStorage.getItem('theme');
-        if (theme === 'light') {
-          document.documentElement.classList.remove('dark');
-        } else {
-          document.documentElement.classList.add('dark');
-        }
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var eff;
+        if (stored === 'field')      eff = 'field';
+        else if (stored === 'light') eff = 'light';
+        else if (stored === 'dark')  eff = 'dark';
+        else                         eff = prefersDark ? 'dark' : 'light';
+        var el = document.documentElement.classList;
+        if (eff === 'field')      { el.add('dark'); el.add('field'); }
+        else if (eff === 'dark')  { el.add('dark'); el.remove('field'); }
+        else                      { el.remove('dark'); el.remove('field'); }
       })();
     </script>
   </head>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -234,6 +234,7 @@ const mLinkClass = 'text-zinc-500 dark:text-zinc-400';
 <script>
   const themeBtn = document.getElementById('footer-theme-toggle');
   themeBtn?.addEventListener('click', () => {
+    document.documentElement.classList.remove('field');
     const dark = document.documentElement.classList.toggle('dark');
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   });

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -287,6 +287,7 @@ const docColumns = [
 <script is:inline>
   // Theme + lang toggles (desktop chrome — kept until PR 3 moves them into the footer/Preferences)
   document.getElementById('theme-toggle')?.addEventListener('click', () => {
+    document.documentElement.classList.remove('field');
     const dark = document.documentElement.classList.toggle('dark');
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   });

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -252,6 +252,7 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
   });
 
   themeBtn?.addEventListener('click', () => {
+    document.documentElement.classList.remove('field');
     const dark = document.documentElement.classList.toggle('dark');
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2077,6 +2077,8 @@
       "theme_light": "Light",
       "theme_dark": "Dark",
       "theme_auto": "Auto",
+      "theme_field": "Field",
+      "theme_field_hint": "Pure black, max contrast, larger hit targets — for direct sunlight.",
       "byo_keys_title": "API Keys (BYO)",
       "byo_keys_subtitle": "Your own keys for paid identifiers — never sent to our servers, only forwarded per-request to the provider.",
       "plantnet_key_label": "PlantNet API Key",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2077,6 +2077,8 @@
       "theme_light": "Claro",
       "theme_dark": "Oscuro",
       "theme_auto": "Automático",
+      "theme_field": "Campo",
+      "theme_field_hint": "Negro puro, máximo contraste, botones más grandes — para luz solar directa.",
       "byo_keys_title": "Claves API (propias)",
       "byo_keys_subtitle": "Tus propias claves para identificadores de pago — nunca se envían a nuestros servidores, solo se reenvían por solicitud al proveedor.",
       "plantnet_key_label": "Clave API de PlantNet",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -155,14 +155,96 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <PostHog />
     <script is:inline>
       (function() {
-        const theme = localStorage.getItem('theme');
-        if (theme === 'light') {
-          document.documentElement.classList.remove('dark');
-        } else {
-          document.documentElement.classList.add('dark');
-        }
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var eff;
+        if (stored === 'field')      eff = 'field';
+        else if (stored === 'light') eff = 'light';
+        else if (stored === 'dark')  eff = 'dark';
+        else                         eff = prefersDark ? 'dark' : 'light';
+        var el = document.documentElement.classList;
+        if (eff === 'field')      { el.add('dark'); el.add('field'); }
+        else if (eff === 'dark')  { el.add('dark'); el.remove('field'); }
+        else                      { el.remove('dark'); el.remove('field'); }
       })();
     </script>
+    <style is:global>
+      /*
+        Field theme — high-contrast, OLED-true black for direct-sunlight use.
+        Layered on top of the .dark base so any element styled only with
+        `dark:*` Tailwind variants stays readable; we then crush the palette
+        to pure black/white and disable gradients for crisp edges in glare.
+      */
+      html.field {
+        background: #000 !important;
+        color: #fff !important;
+        color-scheme: dark;
+      }
+      html.field body { background: #000 !important; color: #fff !important; }
+      html.field *,
+      html.field *::before,
+      html.field *::after {
+        background-image: none !important;
+        text-shadow: none !important;
+        box-shadow: none !important;
+      }
+      html.field *:not(svg):not(path):not(circle):not(rect):not(line):not(polyline):not(polygon):not(g) {
+        color: #fff !important;
+      }
+      html.field a,
+      html.field button,
+      html.field [role="link"],
+      html.field [role="button"] {
+        color: #fff !important;
+      }
+      html.field [class*="bg-emerald-"],
+      html.field [class*="bg-zinc-"],
+      html.field [class*="bg-white"],
+      html.field [class*="bg-slate-"],
+      html.field [class*="bg-stone-"],
+      html.field [class*="bg-teal-"],
+      html.field [class*="bg-sky-"] {
+        background-color: #000 !important;
+      }
+      html.field [class*="border-"] {
+        border-color: #fff !important;
+      }
+      /* Keep emerald accent strokes on critical CTAs (FAB, sign-in) so the
+         primary action remains pickable; we re-color the surface, not text. */
+      html.field #mbb-fab,
+      html.field [data-rastrum-cta="primary"] {
+        background-color: #fff !important;
+        color: #000 !important;
+        border: 2px solid #fff !important;
+      }
+      html.field #mbb-fab svg,
+      html.field [data-rastrum-cta="primary"] svg { color: #000 !important; }
+
+      /* 1.25x hit-target sizing on the mobile bottom bar + form inputs.
+         48px (Tailwind h-12 ≈ touch baseline) becomes 60px. */
+      html.field #mobile-bottom-bar { height: auto; }
+      html.field #mobile-bottom-bar > div { height: 5rem !important; }
+      html.field #mbb-fab { width: 4.5rem !important; height: 4.5rem !important; }
+      html.field input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+      html.field select,
+      html.field textarea,
+      html.field button:not(#mbb-fab) {
+        min-height: 3rem !important;
+        font-size: 1rem !important;
+      }
+      html.field input,
+      html.field select,
+      html.field textarea {
+        background: #000 !important;
+        color: #fff !important;
+        border: 2px solid #fff !important;
+      }
+      /* Visible focus ring at AA contrast on black. */
+      html.field :focus-visible {
+        outline: 3px solid #fff !important;
+        outline-offset: 2px !important;
+      }
+    </style>
     <script is:inline>
       // Register the service worker in production only. `import.meta.env.DEV`
       // is replaced at build time; in dev we skip to avoid aggressive caching.
@@ -171,6 +253,44 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
           navigator.serviceWorker.register('/sw.js').catch(() => {});
         });
       }
+    </script>
+    <script is:inline>
+      /*
+        Ambient-light auto-engage for the Field theme. Only fires when the
+        user's stored preference is 'auto' (the default) — explicit
+        light/dark/field choices win. AmbientLightSensor ships in Chromium
+        behind a flag in many builds, so this is best-effort: the absence
+        of the API just means manual override is the only path. We never
+        prompt for permission unconditionally — the sensor is constructed
+        in a try/catch and we listen for SecurityError to back off silently.
+      */
+      (function () {
+        var FIELD_LUX = 5000;
+        var stored = localStorage.getItem('theme');
+        if (stored && stored !== 'auto') return;
+        if (typeof AmbientLightSensor === 'undefined') return;
+        try {
+          var sensor = new AmbientLightSensor({ frequency: 1 });
+          sensor.addEventListener('reading', function () {
+            var lux = sensor.illuminance;
+            if (typeof lux !== 'number') return;
+            var current = localStorage.getItem('theme');
+            if (current && current !== 'auto') return;
+            var el = document.documentElement.classList;
+            if (lux > FIELD_LUX) {
+              el.add('dark'); el.add('field');
+            } else if (el.contains('field')) {
+              el.remove('field');
+              var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+              if (!prefersDark) el.remove('dark');
+            }
+          });
+          sensor.addEventListener('error', function () { /* permission denied or unavailable */ });
+          sensor.start();
+        } catch (e) {
+          /* ReferenceError, SecurityError, NotSupportedError — manual-only fallback */
+        }
+      })();
     </script>
   </head>
   <body class="min-h-screen bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100 transition-colors pb-20 sm:pb-0">

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,55 @@
+export type Theme = 'light' | 'dark' | 'auto' | 'field';
+export type EffectiveTheme = 'light' | 'dark' | 'field';
+
+export const STORAGE_KEY = 'theme';
+
+/**
+ * Lux threshold above which the Field theme auto-engages when the user's
+ * stored preference is 'auto'. Direct sunlight measures ~10 000 lux; an
+ * overcast outdoor sky ~1 000 lux. 5 000 picks the bright outdoor regime
+ * without flipping for indoor task lighting (~300–500 lux).
+ */
+export const FIELD_LUX_THRESHOLD = 5000;
+
+const VALID = new Set<Theme>(['light', 'dark', 'auto', 'field']);
+
+export function parseStoredTheme(raw: string | null | undefined): Theme {
+  if (raw && VALID.has(raw as Theme)) return raw as Theme;
+  return 'auto';
+}
+
+export interface ResolveContext {
+  prefersDark: boolean;
+  /**
+   * Latest ambient-light reading in lux, or null if AmbientLightSensor is
+   * unavailable / not yet permitted. Only consulted when stored is 'auto'.
+   */
+  lux?: number | null;
+}
+
+export function resolveEffective(stored: Theme, ctx: ResolveContext): EffectiveTheme {
+  if (stored === 'field') return 'field';
+  if (stored === 'light') return 'light';
+  if (stored === 'dark') return 'dark';
+  if (typeof ctx.lux === 'number' && ctx.lux > FIELD_LUX_THRESHOLD) return 'field';
+  return ctx.prefersDark ? 'dark' : 'light';
+}
+
+/**
+ * Apply an effective theme to a documentElement-shaped target. Field implies
+ * the dark base palette so any element styled only with `dark:*` Tailwind
+ * variants stays readable; the `.field` class then layers max-contrast
+ * overrides on top via `<style is:global>` in BaseLayout / ConsoleLayout.
+ */
+export function applyEffective(el: { classList: DOMTokenList }, effective: EffectiveTheme): void {
+  if (effective === 'field') {
+    el.classList.add('dark');
+    el.classList.add('field');
+  } else if (effective === 'dark') {
+    el.classList.add('dark');
+    el.classList.remove('field');
+  } else {
+    el.classList.remove('dark');
+    el.classList.remove('field');
+  }
+}

--- a/src/pages/en/profile/settings/[tab].astro
+++ b/src/pages/en/profile/settings/[tab].astro
@@ -72,7 +72,7 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
         <!-- Theme -->
         <section>
           <h2 class="text-base font-semibold text-zinc-900 dark:text-zinc-100 mb-3">{settings.preferences.theme_label}</h2>
-          <div class="flex gap-2">
+          <div class="flex flex-wrap gap-2">
             <button id="theme-light" class="px-4 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 text-sm font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
               {settings.preferences.theme_light}
             </button>
@@ -82,7 +82,11 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
             <button id="theme-auto" class="px-4 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 text-sm font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
               {settings.preferences.theme_auto}
             </button>
+            <button id="theme-field" class="px-4 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 text-sm font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
+              {settings.preferences.theme_field}
+            </button>
           </div>
+          <p class="mt-2 text-xs text-zinc-500 dark:text-zinc-400">{settings.preferences.theme_field_hint}</p>
         </section>
 
         <!-- BYO API Keys -->
@@ -211,15 +215,21 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
 <script>
   // Theme buttons
   (function () {
-    const buttons: Record<string, string> = { 'theme-light': 'light', 'theme-dark': 'dark', 'theme-auto': 'auto' };
-    function applyTheme(value: string) {
-      if (value === 'dark') {
-        document.documentElement.classList.add('dark');
+    const buttons: Record<string, 'light' | 'dark' | 'auto' | 'field'> = {
+      'theme-light': 'light', 'theme-dark': 'dark', 'theme-auto': 'auto', 'theme-field': 'field',
+    };
+    function applyTheme(value: 'light' | 'dark' | 'auto' | 'field') {
+      const cls = document.documentElement.classList;
+      if (value === 'field') {
+        cls.add('dark'); cls.add('field');
+      } else if (value === 'dark') {
+        cls.add('dark'); cls.remove('field');
       } else if (value === 'light') {
-        document.documentElement.classList.remove('dark');
+        cls.remove('dark'); cls.remove('field');
       } else {
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.classList.toggle('dark', prefersDark);
+        cls.toggle('dark', prefersDark);
+        cls.remove('field');
       }
       localStorage.setItem('theme', value);
     }

--- a/src/pages/es/perfil/ajustes/[tab].astro
+++ b/src/pages/es/perfil/ajustes/[tab].astro
@@ -72,7 +72,7 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
         <!-- Theme -->
         <section>
           <h2 class="text-base font-semibold text-zinc-900 dark:text-zinc-100 mb-3">{settings.preferences.theme_label}</h2>
-          <div class="flex gap-2">
+          <div class="flex flex-wrap gap-2">
             <button id="theme-light" class="px-4 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 text-sm font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
               {settings.preferences.theme_light}
             </button>
@@ -82,7 +82,11 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
             <button id="theme-auto" class="px-4 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 text-sm font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
               {settings.preferences.theme_auto}
             </button>
+            <button id="theme-field" class="px-4 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 text-sm font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
+              {settings.preferences.theme_field}
+            </button>
           </div>
+          <p class="mt-2 text-xs text-zinc-500 dark:text-zinc-400">{settings.preferences.theme_field_hint}</p>
         </section>
 
         <!-- BYO API Keys -->
@@ -211,15 +215,21 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
 <script>
   // Theme buttons
   (function () {
-    const buttons: Record<string, string> = { 'theme-light': 'light', 'theme-dark': 'dark', 'theme-auto': 'auto' };
-    function applyTheme(value: string) {
-      if (value === 'dark') {
-        document.documentElement.classList.add('dark');
+    const buttons: Record<string, 'light' | 'dark' | 'auto' | 'field'> = {
+      'theme-light': 'light', 'theme-dark': 'dark', 'theme-auto': 'auto', 'theme-field': 'field',
+    };
+    function applyTheme(value: 'light' | 'dark' | 'auto' | 'field') {
+      const cls = document.documentElement.classList;
+      if (value === 'field') {
+        cls.add('dark'); cls.add('field');
+      } else if (value === 'dark') {
+        cls.add('dark'); cls.remove('field');
       } else if (value === 'light') {
-        document.documentElement.classList.remove('dark');
+        cls.remove('dark'); cls.remove('field');
       } else {
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.classList.toggle('dark', prefersDark);
+        cls.toggle('dark', prefersDark);
+        cls.remove('field');
       }
       localStorage.setItem('theme', value);
     }

--- a/tests/unit/theme.test.ts
+++ b/tests/unit/theme.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseStoredTheme,
+  resolveEffective,
+  applyEffective,
+  FIELD_LUX_THRESHOLD,
+} from '../../src/lib/theme';
+
+describe('parseStoredTheme', () => {
+  it('returns the stored value when valid', () => {
+    expect(parseStoredTheme('light')).toBe('light');
+    expect(parseStoredTheme('dark')).toBe('dark');
+    expect(parseStoredTheme('auto')).toBe('auto');
+    expect(parseStoredTheme('field')).toBe('field');
+  });
+
+  it('falls back to auto on missing or invalid input', () => {
+    expect(parseStoredTheme(null)).toBe('auto');
+    expect(parseStoredTheme(undefined)).toBe('auto');
+    expect(parseStoredTheme('')).toBe('auto');
+    expect(parseStoredTheme('FIELD')).toBe('auto');
+    expect(parseStoredTheme('garbage')).toBe('auto');
+  });
+});
+
+describe('resolveEffective', () => {
+  it('honors explicit light/dark/field over context', () => {
+    expect(resolveEffective('light', { prefersDark: true,  lux: 99999 })).toBe('light');
+    expect(resolveEffective('dark',  { prefersDark: false, lux: 0     })).toBe('dark');
+    expect(resolveEffective('field', { prefersDark: false, lux: 0     })).toBe('field');
+  });
+
+  it('auto falls through to system dark preference', () => {
+    expect(resolveEffective('auto', { prefersDark: true })).toBe('dark');
+    expect(resolveEffective('auto', { prefersDark: false })).toBe('light');
+  });
+
+  it('auto engages field when lux exceeds threshold', () => {
+    expect(resolveEffective('auto', { prefersDark: false, lux: FIELD_LUX_THRESHOLD + 1 })).toBe('field');
+    expect(resolveEffective('auto', { prefersDark: true,  lux: FIELD_LUX_THRESHOLD + 1 })).toBe('field');
+  });
+
+  it('auto does not engage field at or below threshold', () => {
+    expect(resolveEffective('auto', { prefersDark: false, lux: FIELD_LUX_THRESHOLD })).toBe('light');
+    expect(resolveEffective('auto', { prefersDark: false, lux: 1000 })).toBe('light');
+    expect(resolveEffective('auto', { prefersDark: false, lux: null })).toBe('light');
+    expect(resolveEffective('auto', { prefersDark: false })).toBe('light');
+  });
+});
+
+describe('applyEffective', () => {
+  function fakeEl(): { classList: DOMTokenList; tokens: Set<string> } {
+    const tokens = new Set<string>();
+    const classList = {
+      add: (c: string) => { tokens.add(c); },
+      remove: (c: string) => { tokens.delete(c); },
+      contains: (c: string) => tokens.has(c),
+      toggle: (c: string, force?: boolean) => {
+        const next = force ?? !tokens.has(c);
+        if (next) tokens.add(c); else tokens.delete(c);
+        return next;
+      },
+    } as unknown as DOMTokenList;
+    return { classList, tokens };
+  }
+
+  it('field sets both dark and field', () => {
+    const el = fakeEl();
+    applyEffective(el, 'field');
+    expect(el.tokens.has('dark')).toBe(true);
+    expect(el.tokens.has('field')).toBe(true);
+  });
+
+  it('dark sets dark, removes field', () => {
+    const el = fakeEl();
+    el.tokens.add('field');
+    applyEffective(el, 'dark');
+    expect(el.tokens.has('dark')).toBe(true);
+    expect(el.tokens.has('field')).toBe(false);
+  });
+
+  it('light removes both classes', () => {
+    const el = fakeEl();
+    el.tokens.add('dark');
+    el.tokens.add('field');
+    applyEffective(el, 'light');
+    expect(el.tokens.has('dark')).toBe(false);
+    expect(el.tokens.has('field')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a fourth theme — **Campo / Field** — alongside Light, Dark, and Auto. Designed for use under direct sunlight on mid-tier mobile devices where the existing palette becomes unreadable.

- Pure black background (#000), white text, no gradients, no shadows, AA-contrast enforced on every component.
- 1.25x hit-target sizing on the mobile FAB and form inputs (48px → 60px) so taps land reliably with sweat or gloves.
- Auto-engages when stored preference is 'auto' and `AmbientLightSensor` reports > 5 000 lux. Explicit Light/Dark/Field choices always win.
- `AmbientLightSensor` is feature-detected (Chromium-only, behind permission); on any platform without it, Field is manual-only via Settings → Preferences.

## Architecture

- `src/lib/theme.ts` — pure resolver (`parseStoredTheme`, `resolveEffective`, `applyEffective`). Field is layered on top of `.dark` so any element styled only with Tailwind `dark:*` variants stays readable, then `<style is:global>` in `BaseLayout` and `ConsoleLayout` crushes the palette to pure black/white.
- First-paint inline script in both layouts is now a four-state machine (`light` / `dark` / `auto` / `field`).
- The two-state header / footer / drawer / command-palette toggles clear `.field` on use so they don't get stuck after a Field selection.

## Files changed

- `src/lib/theme.ts` *(new)*
- `tests/unit/theme.test.ts` *(new — 9 tests)*
- `src/layouts/BaseLayout.astro` *(first-paint script + Field CSS + ambient-light auto-detect)*
- `src/components/ConsoleLayout.astro` *(first-paint script parity)*
- `src/components/Header.astro`, `Footer.astro`, `MobileDrawer.astro`, `CommandPalette.astro` *(clear .field on toggle)*
- `src/pages/{en/profile/settings,es/perfil/ajustes}/[tab].astro` *(Field button + hint)*
- `src/i18n/{en,es}.json` *(theme_field, theme_field_hint)*

## Ambient-light auto-detect

`AmbientLightSensor` is constructed inside a `try/catch` and gated on `typeof AmbientLightSensor !== 'undefined'`. Permission errors and `NotSupportedError` fall through silently — manual override via Settings is the cross-browser path. Threshold pinned at 5 000 lux (overcast outdoors ~1 000, direct sun ~10 000) so it doesn't flip for indoor task lighting.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 1309 tests pass (9 new in `theme.test.ts`)
- [x] `npm run build` — 233 pages, EN/ES paired
- [ ] Manual: pick **Field** in `/en/profile/settings/preferences/`; verify pure black bg, white text, FAB grows, inputs grow.
- [ ] Manual: toggle Light → Dark via header sun/moon button; verify `.field` clears (stored value flips to dark/light).
- [ ] Manual on Chrome Android with sensor flag enabled: walk outside in sun; with theme = Auto, verify Field auto-engages.
- [ ] Manual: cycle Light → Field → Auto → Dark in EN and ES preferences pages; verify both stop applying immediately.

Closes #737