### PR TITLE
feat(config): show peer norms when configuring license / privacy

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -9413,3 +9413,121 @@ $$;
 REVOKE ALL ON FUNCTION public.compute_user_impact(uuid) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.compute_user_impact(uuid)
   TO authenticated, service_role;
+-- M07 / #745 — Peer norms for license + privacy choice
+-- =====================================================================
+-- Two materialised views aggregate community-wide choices:
+--   - license_norm:  per (country, license) observation count
+--   - privacy_norm:  per (country, facet, visibility) observer count
+-- A SECURITY INVOKER lookup (peer_norm_pct) returns the percentage for a
+-- given (scope, country, key). The UI renders a small bar next to each
+-- option using "X% de observadores en MX eligen esto" copy. Refreshed
+-- weekly (Mondays 06:00 UTC) — these counts move slowly and a fresh
+-- read every page-load would burn quota for cold-cache benefits.
+--
+-- Honesty rules:
+--   * Anonymous observers and private profiles still count for license_norm
+--     (the license sits on the observation, not the user surface).
+--   * privacy_norm counts only observers whose `profile_privacy` is set
+--     (i.e. anyone with a row in users) — opting out of leaderboards does
+--     NOT remove you from the denominator (see below — observer counts).
+--   * The bar should be hidden when n < 50 (UI gate, not a SQL gate; the
+--     view still ships the count so the client decides).
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.license_norm AS
+SELECT
+  COALESCE(u.country_code, 'XX') AS country_code,
+  COALESCE(o.license, u.observer_license) AS license,
+  COUNT(*)::bigint AS n
+FROM public.observations o
+JOIN public.users u ON u.id = o.observer_id
+WHERE o.sync_status = 'synced'
+GROUP BY 1, 2;
+
+CREATE UNIQUE INDEX IF NOT EXISTS license_norm_unique
+  ON public.license_norm (country_code, license);
+
+GRANT SELECT ON public.license_norm TO anon, authenticated;
+
+-- privacy_norm: pivot the profile_privacy jsonb into (facet, visibility)
+-- pairs. Each user contributes one row per facet. Facets we don't recognise
+-- still flow through (forward-compat for new facets shipped before a
+-- migration).
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.privacy_norm AS
+SELECT
+  COALESCE(u.country_code, 'XX')   AS country_code,
+  pf.key                            AS facet,
+  pf.value #>> '{}'                 AS visibility,
+  COUNT(*)::bigint                  AS n
+FROM public.users u,
+     LATERAL jsonb_each(u.profile_privacy) AS pf(key, value)
+WHERE u.profile_privacy IS NOT NULL
+GROUP BY 1, 2, 3;
+
+CREATE UNIQUE INDEX IF NOT EXISTS privacy_norm_unique
+  ON public.privacy_norm (country_code, facet, visibility);
+
+GRANT SELECT ON public.privacy_norm TO anon, authenticated;
+
+-- peer_norm_pct(scope, country, key): single-row helper the UI hits per
+-- option. Returns a row with both pct (0-100) and n so the client can
+-- decide whether to render the bar (n >= 50) or fall back to copy.
+--
+-- scope must be 'license' or 'privacy:<facet>' (e.g. 'privacy:profile').
+-- country is an ISO-3166 alpha-2 (e.g. 'MX'); pass NULL to mean "global"
+-- (sum all rows). key is the option being asked about (license string or
+-- visibility level).
+CREATE OR REPLACE FUNCTION public.peer_norm_pct(
+  p_scope   text,
+  p_country text,
+  p_key     text
+)
+RETURNS TABLE (pct numeric, n bigint, total bigint)
+LANGUAGE plpgsql
+STABLE
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_country text := upper(NULLIF(trim(p_country), ''));
+  v_facet   text;
+  v_n       bigint := 0;
+  v_total   bigint := 0;
+BEGIN
+  IF p_scope = 'license' THEN
+    SELECT COALESCE(SUM(n) FILTER (WHERE license = p_key), 0),
+           COALESCE(SUM(n), 0)
+      INTO v_n, v_total
+      FROM public.license_norm
+     WHERE v_country IS NULL OR country_code = v_country;
+  ELSIF p_scope LIKE 'privacy:%' THEN
+    v_facet := substr(p_scope, 9);
+    SELECT COALESCE(SUM(n) FILTER (WHERE visibility = p_key), 0),
+           COALESCE(SUM(n), 0)
+      INTO v_n, v_total
+      FROM public.privacy_norm
+     WHERE facet = v_facet
+       AND (v_country IS NULL OR country_code = v_country);
+  ELSE
+    RETURN QUERY SELECT 0::numeric, 0::bigint, 0::bigint;
+    RETURN;
+  END IF;
+
+  IF v_total = 0 THEN
+    RETURN QUERY SELECT 0::numeric, 0::bigint, 0::bigint;
+  ELSE
+    RETURN QUERY SELECT
+      ROUND((v_n::numeric / v_total::numeric) * 100, 1),
+      v_n,
+      v_total;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.peer_norm_pct(text, text, text)
+  TO anon, authenticated;
+
+-- Weekly refresh (Mondays 06:00 UTC). Idempotent — unschedule first.
+SELECT cron.unschedule('refresh-norms-weekly')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'refresh-norms-weekly');
+SELECT cron.schedule('refresh-norms-weekly', '0 6 * * 1',
+  $$REFRESH MATERIALIZED VIEW public.license_norm;
+    REFRESH MATERIALIZED VIEW public.privacy_norm;$$);

--- a/docs/specs/modules/07-licensing.md
+++ b/docs/specs/modules/07-licensing.md
@@ -46,6 +46,23 @@ The license does **not** extend to:
 - Taxonomic backbone data (GBIF / POWO / IOC — carry their own licenses).
 - Environmental enrichment (OpenMeteo, NDVI — carry their own terms).
 
+### Peer norms at the moment of choice (#745)
+
+The license selector on `/profile/preferences` (and, when shipped, the
+per-observation `license-per-record-ui`) renders a small bar next to each
+option showing the percentage of fellow observers in the user's country who
+chose that license — e.g. *"82% of MX observers choose this"*.
+
+The numbers come from the `license_norm` materialised view, refreshed every
+Monday at 06:00 UTC by the `refresh-norms-weekly` pg_cron job. The lookup
+is a single-row `peer_norm_pct(scope, country, key)` SQL function (SECURITY
+INVOKER, granted to anon + authenticated). Per the principle of normative
+influence (Fogg, *Persuasive Technology* ch. 8), this is **informational
+only** — the default option does not change, and we hide the bar entirely
+when the country denominator falls below 50 observations to avoid noisy
+norms. Same pattern is reused on the M25 privacy matrix (`privacy_norm`
+view).
+
 ---
 
 ## ML Training Gates (v2.0 regional pipeline)

--- a/src/components/PrivacyMatrix.astro
+++ b/src/components/PrivacyMatrix.astro
@@ -124,24 +124,38 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
         </button>
         <div id={`pm-section-body-${section.key}`} data-section-body class="px-4 pb-3 space-y-3">
           {section.rows.map(facet => (
-            <div data-facet-row={facet} class="flex items-start gap-3 sm:gap-4 py-2 border-t border-zinc-100 dark:border-zinc-800/60 first:border-t-0">
+            <div data-facet-row={facet} class="flex flex-col sm:flex-row sm:items-start gap-3 sm:gap-4 py-2 border-t border-zinc-100 dark:border-zinc-800/60 first:border-t-0">
               <div class="flex-1 min-w-0">
                 <p class="text-sm font-medium text-zinc-900 dark:text-zinc-100">{pm.facet[facet]?.label ?? facet}</p>
                 <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">{pm.facet[facet]?.description ?? ''}</p>
               </div>
-              <div role="radiogroup" aria-label={pm.facet[facet]?.label ?? facet} class="inline-flex rounded-lg border border-zinc-300 dark:border-zinc-700 overflow-hidden text-xs font-medium shrink-0">
-                {levels.map(level => (
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked="false"
-                    data-facet={facet}
-                    data-level={level.key}
-                    class="px-2.5 py-1.5 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 border-r border-zinc-300 dark:border-zinc-700 last:border-r-0"
-                  >
-                    {level.label}
-                  </button>
-                ))}
+              <div class="shrink-0 flex flex-col items-start sm:items-end gap-1.5">
+                <div role="radiogroup" aria-label={pm.facet[facet]?.label ?? facet} class="inline-flex rounded-lg border border-zinc-300 dark:border-zinc-700 overflow-hidden text-xs font-medium">
+                  {levels.map(level => (
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked="false"
+                      data-facet={facet}
+                      data-level={level.key}
+                      class="px-2.5 py-1.5 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 border-r border-zinc-300 dark:border-zinc-700 last:border-r-0"
+                    >
+                      {level.label}
+                    </button>
+                  ))}
+                </div>
+                <ul
+                  class="flex flex-wrap gap-x-3 gap-y-1 text-xs"
+                  data-peer-norms-list
+                  data-scope={`privacy:${facet}`}
+                >
+                  {levels.map(level => (
+                    <li class="flex items-center gap-1.5" data-key={level.key}>
+                      <span class="text-zinc-500 dark:text-zinc-400">{level.label}</span>
+                      <span data-peer-norm-bar class="text-zinc-400 dark:text-zinc-500 italic">…</span>
+                    </li>
+                  ))}
+                </ul>
               </div>
             </div>
           ))}
@@ -177,6 +191,13 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
     </form>
   </dialog>
 </section>
+
+<script
+  type="application/json"
+  id="rastrum-privacy-peer-norm-copy"
+  hidden
+  set:html={JSON.stringify((tr as unknown as { peer_norms: Record<string, string> }).peer_norms)}
+/>
 
 <script>
   import { getSupabase } from '../lib/supabase';
@@ -246,6 +267,62 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
 
     bindAccordions(rootEl);
     bindBeforeUnloadFlush(rootEl, () => user.id);
+
+    // Best-effort peer-norm bars; non-blocking and silent on failure.
+    const country = await readUserCountry(supabase, user.id);
+    void hydratePeerNormBars(rootEl, country);
+  }
+
+  async function readUserCountry(
+    supabase: ReturnType<typeof getSupabase>,
+    userId: string,
+  ): Promise<string | null> {
+    try {
+      const { data } = await supabase
+        .from('users')
+        .select('country_code')
+        .eq('id', userId)
+        .maybeSingle<{ country_code: string | null }>();
+      const v = (data?.country_code ?? '').trim().toUpperCase();
+      return /^[A-Z]{2}$/.test(v) ? v : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function hydratePeerNormBars(rootEl: HTMLElement, country: string | null) {
+    const lists = rootEl.querySelectorAll<HTMLElement>('[data-peer-norms-list]');
+    if (!lists.length) return;
+    const { fetchPeerNorm, renderPeerNormHtml } = await import('../lib/peer-norms');
+    const isEs = rootEl.dataset.lang === 'es';
+    const copyJson = JSON.parse(
+      document.getElementById('rastrum-privacy-peer-norm-copy')?.textContent ?? '{}'
+    ) as { with_pct_country?: string; with_pct_global?: string; insufficient?: string };
+    const fallback = isEs
+      ? { with_pct_country: '{pct}% en {country}', with_pct_global: '{pct}% global', insufficient: 'datos insuficientes' }
+      : { with_pct_country: '{pct}% in {country}', with_pct_global: '{pct}% globally', insufficient: 'not enough data' };
+    const copy = {
+      withPct: (pct: string) => {
+        const tmpl = country
+          ? (copyJson.with_pct_country ?? fallback.with_pct_country)
+          : (copyJson.with_pct_global ?? fallback.with_pct_global);
+        return tmpl.replace('{pct}', pct).replace('{country}', country ?? '');
+      },
+      insufficient: copyJson.insufficient ?? fallback.insufficient,
+    };
+    await Promise.all(Array.from(lists).map(async list => {
+      const scope = list.dataset.scope as `license` | `privacy:${string}` | undefined;
+      if (!scope) return;
+      const items = list.querySelectorAll<HTMLElement>('li[data-key]');
+      await Promise.all(Array.from(items).map(async item => {
+        const key = item.dataset.key;
+        if (!key) return;
+        const slot = item.querySelector<HTMLElement>('[data-peer-norm-bar]');
+        if (!slot) return;
+        const result = await fetchPeerNorm(scope, country, key);
+        slot.innerHTML = renderPeerNormHtml(result, copy);
+      }));
+    }));
   }
 
   function paintMatrix(rootEl: HTMLElement, matrix: PrivacyMatrix) {

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -97,6 +97,25 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
           <option value="CC0">CC0</option>
         </select>
         <p class="mt-1 text-xs text-zinc-500">{tr.profile.license_hint}</p>
+        <ul
+          class="mt-2 space-y-1 text-xs"
+          aria-label={(tr as unknown as { peer_norms: { aria_label: string } }).peer_norms.aria_label}
+          data-peer-norms-list
+          data-scope="license"
+        >
+          <li class="flex items-center justify-between gap-3" data-key="CC BY 4.0">
+            <span class="text-zinc-600 dark:text-zinc-400">CC BY 4.0</span>
+            <span data-peer-norm-bar class="text-xs text-zinc-400 dark:text-zinc-500 italic">…</span>
+          </li>
+          <li class="flex items-center justify-between gap-3" data-key="CC BY-NC 4.0">
+            <span class="text-zinc-600 dark:text-zinc-400">CC BY-NC 4.0</span>
+            <span data-peer-norm-bar class="text-xs text-zinc-400 dark:text-zinc-500 italic">…</span>
+          </li>
+          <li class="flex items-center justify-between gap-3" data-key="CC0">
+            <span class="text-zinc-600 dark:text-zinc-400">CC0</span>
+            <span data-peer-norm-bar class="text-xs text-zinc-400 dark:text-zinc-500 italic">…</span>
+          </li>
+        </ul>
       </div>
     </div>
 
@@ -311,6 +330,12 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
 </div>
 
 <script type="application/json" id="rastrum-section-labels" hidden set:html={JSON.stringify(sectionLabels)} />
+<script
+  type="application/json"
+  id="rastrum-peer-norm-copy"
+  hidden
+  set:html={JSON.stringify((tr as unknown as { peer_norms: Record<string, string> }).peer_norms)}
+/>
 
 <script>
   import { getSupabase } from '../lib/supabase';
@@ -417,6 +442,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
     const countrySelect = form.elements.namedItem('country_code') as HTMLSelectElement | null;
     countrySelect?.addEventListener('change', () => {
       inferredBadge?.classList.add('hidden');
+      hydratePeerNormBars().catch(() => {});
     });
 
     syncCommunityVisibleEnabled(Boolean(profile.profile_public));
@@ -516,7 +542,62 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
     }
   });
 
-  load().catch(console.error);
+  load().then(() => hydratePeerNormBars().catch(() => {})).catch(console.error);
+
+  async function hydratePeerNormBars(): Promise<void> {
+    const lists = document.querySelectorAll<HTMLElement>('[data-peer-norms-list]');
+    if (!lists.length) return;
+    const { fetchPeerNorm, renderPeerNormHtml } = await import('../lib/peer-norms');
+    const isEs = document.documentElement.lang === 'es';
+    const country = readSelectedCountry();
+    const copy = peerNormCopy(isEs, country);
+    await Promise.all(Array.from(lists).map(async list => {
+      const scope = (list.dataset.scope ?? '') as `license` | `privacy:${string}`;
+      if (!scope) return;
+      const items = list.querySelectorAll<HTMLElement>('li[data-key]');
+      await Promise.all(Array.from(items).map(async item => {
+        const key = item.dataset.key;
+        if (!key) return;
+        const slot = item.querySelector<HTMLElement>('[data-peer-norm-bar]');
+        if (!slot) return;
+        const result = await fetchPeerNorm(scope, country, key);
+        slot.innerHTML = renderPeerNormHtml(result, copy);
+      }));
+    }));
+  }
+
+  function readSelectedCountry(): string | null {
+    const select = document.querySelector<HTMLSelectElement>('select[name="country_code"]');
+    const v = (select?.value ?? '').trim().toUpperCase();
+    return /^[A-Z]{2}$/.test(v) ? v : null;
+  }
+
+  function peerNormCopy(isEs: boolean, country: string | null) {
+    type PeerNormI18n = {
+      peer_norms: {
+        with_pct_country: string;
+        with_pct_global: string;
+        insufficient: string;
+      };
+    };
+    const labels = JSON.parse(
+      document.getElementById('rastrum-peer-norm-copy')?.textContent ?? '{}'
+    ) as Partial<PeerNormI18n['peer_norms']> & { country_label?: string };
+    const fallback = isEs
+      ? { with_pct_country: '{pct}% en {country}', with_pct_global: '{pct}% global', insufficient: 'datos insuficientes' }
+      : { with_pct_country: '{pct}% in {country}', with_pct_global: '{pct}% globally', insufficient: 'not enough data' };
+    return {
+      withPct: (pct: string) => {
+        const tmpl = country
+          ? (labels.with_pct_country ?? fallback.with_pct_country)
+          : (labels.with_pct_global ?? fallback.with_pct_global);
+        return tmpl
+          .replace('{pct}', pct)
+          .replace('{country}', country ?? '');
+      },
+      insufficient: labels.insufficient ?? fallback.insufficient,
+    };
+  }
 
   // ── Security: passkey + sign-out-everywhere ──
   const passkeyBtn  = document.getElementById('passkey-btn') as HTMLButtonElement | null;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3546,5 +3546,11 @@
       "label": "At-risk species you have helped track",
       "tooltip": "Distinct species you have observed that are listed under NOM-059 (P/A/Pr/E) or IUCN (CR/EN/VU/NT). Coordinates of these observations are coarsened in public views by the obscure_level mechanism."
     }
+  },
+  "peer_norms": {
+    "aria_label": "What other observers chose",
+    "with_pct_country": "{pct}% of {country} observers choose this",
+    "with_pct_global": "{pct}% of observers choose this",
+    "insufficient": "not enough data"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -3546,5 +3546,11 @@
       "label": "Especies en riesgo que has ayudado a rastrear",
       "tooltip": "Especies distintas que has observado y están listadas en NOM-059 (P/A/Pr/E) o IUCN (CR/EN/VU/NT). Las coordenadas de estas observaciones se ofuscan en las vistas públicas mediante obscure_level."
     }
+  },
+  "peer_norms": {
+    "aria_label": "Qué eligen otros observadores",
+    "with_pct_country": "{pct}% de los observadores en {country} eligen esto",
+    "with_pct_global": "{pct}% de los observadores eligen esto",
+    "insufficient": "datos insuficientes"
   }
 }

--- a/src/lib/peer-norms.ts
+++ b/src/lib/peer-norms.ts
@@ -1,0 +1,129 @@
+/**
+ * M07 / #745 — Peer norms helper.
+ *
+ * Fetches a percentage from the `peer_norm_pct(scope, country, key)` SQL
+ * function and renders the result in a small bar next to license / privacy
+ * options.
+ *
+ * Honest copy: when n < `MIN_N_THRESHOLD` we return `null` for `pct` so the
+ * UI can fall back to "datos insuficientes" / "not enough data" — a noisy
+ * 1-of-2 sample is worse than no number at all.
+ */
+
+import { getSupabase } from './supabase';
+
+export const MIN_N_THRESHOLD = 50;
+
+export type PeerNormScope = 'license' | `privacy:${string}`;
+
+export interface PeerNormResult {
+  /** Percentage 0-100, or null when below the n threshold. */
+  pct: number | null;
+  /** Observers/observations matching the key. */
+  n: number;
+  /** Total observers/observations across all keys for that scope. */
+  total: number;
+}
+
+interface PeerNormRow {
+  pct: number | string | null;
+  n: number | string | null;
+  total: number | string | null;
+}
+
+const cache = new Map<string, Promise<PeerNormResult>>();
+
+function cacheKey(scope: string, country: string | null, key: string): string {
+  return `${scope}::${country ?? ''}::${key}`;
+}
+
+function toNum(v: number | string | null | undefined): number {
+  if (v === null || v === undefined) return 0;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Fetch the peer-norm percentage for one option. Per-key results are cached
+ * for the lifetime of the page (the SQL views refresh weekly, so a single
+ * tab session can safely reuse them).
+ */
+export function fetchPeerNorm(
+  scope: PeerNormScope,
+  country: string | null,
+  key: string,
+): Promise<PeerNormResult> {
+  const ck = cacheKey(scope, country, key);
+  const hit = cache.get(ck);
+  if (hit) return hit;
+
+  const promise = doFetch(scope, country, key);
+  cache.set(ck, promise);
+  return promise;
+}
+
+async function doFetch(
+  scope: PeerNormScope,
+  country: string | null,
+  key: string,
+): Promise<PeerNormResult> {
+  try {
+    const supabase = getSupabase();
+    const { data, error } = await supabase.rpc('peer_norm_pct', {
+      p_scope: scope,
+      p_country: country,
+      p_key: key,
+    });
+    if (error || !data) return { pct: null, n: 0, total: 0 };
+    const row: PeerNormRow = Array.isArray(data) ? data[0] : data;
+    if (!row) return { pct: null, n: 0, total: 0 };
+    const n = toNum(row.n);
+    const total = toNum(row.total);
+    const rawPct = toNum(row.pct);
+    return {
+      pct: total >= MIN_N_THRESHOLD ? rawPct : null,
+      n,
+      total,
+    };
+  } catch {
+    return { pct: null, n: 0, total: 0 };
+  }
+}
+
+/**
+ * Render the bar's HTML. Pure function so it can be unit-tested without a
+ * DOM. Returns the inner HTML for a `<span data-peer-norm-bar>` host.
+ */
+export function renderPeerNormHtml(
+  result: PeerNormResult,
+  copy: { withPct: (pct: string) => string; insufficient: string },
+): string {
+  if (result.pct === null) {
+    return `<span class="text-xs text-zinc-400 dark:text-zinc-500 italic">${escapeHtml(copy.insufficient)}</span>`;
+  }
+  const pctRounded = Math.round(result.pct * 10) / 10;
+  const widthPct = Math.max(0, Math.min(100, result.pct));
+  const label = copy.withPct(pctRounded.toString());
+  return `
+    <span class="inline-flex items-center gap-2">
+      <span class="inline-block w-16 h-1.5 rounded-full bg-zinc-200 dark:bg-zinc-700 overflow-hidden" aria-hidden="true">
+        <span class="block h-full bg-emerald-500 dark:bg-emerald-400" style="width: ${widthPct}%"></span>
+      </span>
+      <span class="text-xs text-zinc-500 dark:text-zinc-400">${escapeHtml(label)}</span>
+    </span>
+  `.trim();
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Test-only: clear the in-memory cache. */
+export function _resetPeerNormCacheForTests(): void {
+  cache.clear();
+}

--- a/tests/unit/peer-norms.test.ts
+++ b/tests/unit/peer-norms.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for `src/lib/peer-norms.ts`.
+ *
+ * The SQL side (`license_norm`, `privacy_norm`, `peer_norm_pct`) is
+ * exercised by the `db-validate.yml` workflow which applies the schema
+ * twice; here we lock in the JS contract — caching, n-threshold gating,
+ * and the rendered bar HTML — without a real Supabase round-trip.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rpcMock = vi.fn();
+
+vi.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => ({
+    rpc: rpcMock,
+  }),
+}));
+
+import {
+  MIN_N_THRESHOLD,
+  fetchPeerNorm,
+  renderPeerNormHtml,
+  _resetPeerNormCacheForTests,
+} from '../../src/lib/peer-norms';
+
+const COPY = {
+  withPct: (p: string) => `${p}% of MX observers choose this`,
+  insufficient: 'not enough data',
+};
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  _resetPeerNormCacheForTests();
+});
+
+afterEach(() => {
+  rpcMock.mockReset();
+});
+
+describe('fetchPeerNorm', () => {
+  it('returns pct + n + total for an above-threshold row', async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: [{ pct: 82, n: 820, total: 1000 }],
+      error: null,
+    });
+    const r = await fetchPeerNorm('license', 'MX', 'CC BY 4.0');
+    expect(r).toEqual({ pct: 82, n: 820, total: 1000 });
+    expect(rpcMock).toHaveBeenCalledWith('peer_norm_pct', {
+      p_scope: 'license',
+      p_country: 'MX',
+      p_key: 'CC BY 4.0',
+    });
+  });
+
+  it(`hides pct (returns null) when total < ${MIN_N_THRESHOLD}`, async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: [{ pct: 50, n: 1, total: 2 }],
+      error: null,
+    });
+    const r = await fetchPeerNorm('license', 'MX', 'CC0');
+    expect(r.pct).toBeNull();
+    expect(r.n).toBe(1);
+    expect(r.total).toBe(2);
+  });
+
+  it('caches per (scope, country, key) for the page lifetime', async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: [{ pct: 12, n: 120, total: 1000 }],
+      error: null,
+    });
+    await fetchPeerNorm('privacy:profile', 'MX', 'public');
+    await fetchPeerNorm('privacy:profile', 'MX', 'public');
+    await fetchPeerNorm('privacy:profile', 'MX', 'public');
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a zeroed result on RPC error', async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'boom' },
+    });
+    const r = await fetchPeerNorm('license', null, 'CC BY 4.0');
+    expect(r).toEqual({ pct: null, n: 0, total: 0 });
+  });
+
+  it('coerces stringy numerics returned by PostgREST', async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: [{ pct: '37.5', n: '375', total: '1000' }],
+      error: null,
+    });
+    const r = await fetchPeerNorm('privacy:bio', 'MX', 'signed_in');
+    expect(r.pct).toBe(37.5);
+    expect(r.n).toBe(375);
+    expect(r.total).toBe(1000);
+  });
+});
+
+describe('renderPeerNormHtml', () => {
+  it('renders the insufficient-data fallback when pct is null', () => {
+    const html = renderPeerNormHtml({ pct: null, n: 5, total: 5 }, COPY);
+    expect(html).toContain('not enough data');
+    expect(html).not.toContain('width:');
+  });
+
+  it('renders a bar with width = pct when above threshold', () => {
+    const html = renderPeerNormHtml(
+      { pct: 82, n: 820, total: 1000 },
+      COPY,
+    );
+    expect(html).toContain('width: 82%');
+    expect(html).toContain('82% of MX observers choose this');
+  });
+
+  it('clamps pct to [0,100] for the bar width', () => {
+    const html = renderPeerNormHtml(
+      { pct: 150, n: 1, total: 1 },
+      COPY,
+    );
+    expect(html).toContain('width: 100%');
+  });
+
+  it('escapes HTML in the copy strings', () => {
+    const html = renderPeerNormHtml(
+      { pct: 50, n: 50, total: 100 },
+      {
+        withPct: (p) => `<script>alert(${p})</script>`,
+        insufficient: 'n/a',
+      },
+    );
+    expect(html).not.toContain('<script>alert');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});


### PR DESCRIPTION
## Summary
- New SQL: `license_norm` + `privacy_norm` materialised views, `peer_norm_pct(scope, country, key)` SECURITY INVOKER lookup, and a `refresh-norms-weekly` pg_cron job that refreshes both views every Monday at 06:00 UTC.
- New client lib `src/lib/peer-norms.ts` (cached per-page, stringy-numeric coercion for PostgREST, HTML escape) + 9 unit tests.
- License selector on `/profile/edit` now renders a small bar next to each option showing the % of fellow observers in the user's country who chose that license (e.g. "82% of MX observers choose this"). Re-hydrates when the country select changes.
- M25 privacy matrix (`PrivacyMatrix.astro`) renders the same bar under each facet's level radio group.
- Bar is hidden when n < 50 (`MIN_N_THRESHOLD` in the lib); falls back to "datos insuficientes" / "not enough data".
- Defaults are unchanged; copy is informational only — Fogg's principle of normative influence applied honestly.

License-count source: `observations` joined with `users.country_code`, using `COALESCE(observations.license, users.observer_license)` so the per-record override (when set) takes precedence over the observer's profile default.

Privacy-count source: `users.profile_privacy` jsonb, expanded via `LATERAL jsonb_each` into (facet, visibility, country) triples.

i18n: new `peer_norms.*` namespace, 4 keys, EN + ES parity.

Closes #745

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run test` — 1309 / 1309 pass (9 new tests in `peer-norms.test.ts`)
- [x] `npm run build` — 233 pages, EN/ES paired
- [ ] Manual: visit `/en/profile/edit/` after schema applies, confirm bars render below the license `<select>` and re-hydrate on country change
- [ ] Manual: visit `/en/profile/settings/privacy/`, confirm bars appear under each facet's level radio group
- [ ] Operator: schedule check — `select * from cron.job where jobname = 'refresh-norms-weekly';`

🤖 Generated with [Claude Code](https://claude.com/claude-code)