### PR TITLE
fix(posthog): reset on sign-out + CI guards (refs #767)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,25 @@ jobs:
           fi
 
       - name: Build (static site)
+        # PostHog secrets (PUBLIC_POSTHOG_*) are deliberately NOT passed here —
+        # CI builds shouldn't fire capture events into prod analytics. Only
+        # deploy.yml gets them. See docs/runbooks/posthog.md.
         run: npm run build
         env:
           PUBLIC_SUPABASE_URL:       ${{ secrets.PUBLIC_SUPABASE_URL }}
           PUBLIC_SUPABASE_ANON_KEY:  ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
           PUBLIC_R2_MEDIA_URL:       ${{ secrets.PUBLIC_R2_MEDIA_URL }}
           PUBLIC_R2_TILES_URL:       ${{ secrets.PUBLIC_R2_TILES_URL }}
+
+      - name: Verify search-index up to date
+        # public/search-index.{en,es}.json is regenerated on every build; if a
+        # PR edits the i18n routes/docs without rebuilding + committing, prod
+        # ⌘K search would silently miss new entries. Fail loudly here.
+        run: |
+          if ! git diff --exit-code public/search-index.en.json public/search-index.es.json; then
+            echo "::error::public/search-index.{en,es}.json drift detected. Run 'npm run build' locally and commit the regenerated files."
+            exit 1
+          fi
 
       - name: Report bundle size
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,17 @@ jobs:
           PUBLIC_R2_MEDIA_URL:       ${{ secrets.PUBLIC_R2_MEDIA_URL }}
           PUBLIC_R2_TILES_URL:       ${{ secrets.PUBLIC_R2_TILES_URL }}
 
+      - name: Verify search-index up to date
+        # Post-merge canary: this workflow also runs on push to main, so it
+        # catches search-index drift that bypassed PR review (admin commit,
+        # branch-protection bypass, force-push). Mirrors ci.yml's PR-time
+        # guard. See docs/runbooks/posthog.md.
+        run: |
+          if ! git diff --exit-code public/search-index.en.json public/search-index.es.json; then
+            echo "::error::public/search-index.{en,es}.json drift detected. Run 'npm run build' locally and commit the regenerated files."
+            exit 1
+          fi
+
       - name: Run Playwright tests
         run: npm run test:e2e
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,9 @@ jobs:
           (sudo apt-get update -qq && npx playwright install --with-deps chromium)
 
       - name: Build (static site)
+        # PostHog secrets (PUBLIC_POSTHOG_*) are deliberately NOT passed here —
+        # E2E runs shouldn't fire capture events into prod analytics. Only
+        # deploy.yml gets them. See docs/runbooks/posthog.md.
         run: npm run build
         env:
           PUBLIC_SUPABASE_URL:       ${{ secrets.PUBLIC_SUPABASE_URL }}

--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -33,6 +33,9 @@ jobs:
         run: npm ci
 
       - name: Build (static site)
+        # PostHog secrets (PUBLIC_POSTHOG_*) are deliberately NOT passed here —
+        # Lighthouse loads shouldn't fire pageview events into prod analytics.
+        # Only deploy.yml gets them. See docs/runbooks/posthog.md.
         run: npm run build
         env:
           PUBLIC_SUPABASE_URL:       ${{ secrets.PUBLIC_SUPABASE_URL }}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -409,6 +409,7 @@ const docColumns = [
   signOutBtn?.addEventListener('click', async () => {
     try { await signOut(); } catch { /* dead refresh token — fall through to local cleanup */ }
     try {
+      window.posthog?.reset();
       localStorage.removeItem(AVATAR_CACHE_KEY);
       localStorage.removeItem(AVATAR_NAME_KEY);
       localStorage.removeItem(SUPABASE_AUTH_STORAGE_KEY);

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -244,6 +244,7 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
   signOutBtn?.addEventListener('click', async () => {
     try { await signOut(); } catch { /* dead refresh token — fall through to local cleanup */ }
     try {
+      window.posthog?.reset();
       localStorage.removeItem(HEADER_AVATAR_CACHE_KEY);
       localStorage.removeItem(HEADER_AVATAR_NAME_KEY);
       localStorage.removeItem(SUPABASE_AUTH_STORAGE_KEY);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -38,6 +38,7 @@ interface PostHog {
   __loaded?: boolean;
   capture(event: string, properties?: Record<string, unknown>): void;
   identify(distinctId: string, properties?: Record<string, unknown>): void;
+  reset(): void;
 }
 
 interface Window {

--- a/tests/e2e/nav.spec.ts
+++ b/tests/e2e/nav.spec.ts
@@ -45,7 +45,7 @@ test.describe('navigation', () => {
     const observeLink = page.locator('a[href="/en/observe/"]').first();
     await observeLink.click();
     await expect(page).toHaveURL(/\/en\/observe\/?$/);
-    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /log observation/i })).toBeVisible();
   });
 
   test('language switcher swaps locale', async ({ page }) => {


### PR DESCRIPTION
## Summary

Closes the actionable items from #767. The remaining items (interactive ingest verification, v1.1+ scope) stay open on the issue.

### Correctness

- **`posthog.reset()` on sign-out** — `Header.astro` and `MobileDrawer.astro` call `signOut()` but never reset PostHog. After sign-out the previous user's `distinct_id` stays attached, so a different account signing in on the same tab inherits their event history until `posthog.identify(newUid)` resolves. Two-line fix per handler, plus `reset(): void` on the `Window.posthog` type.

### Repo hygiene

- **Search-index drift CI guard** (`ci.yml`) — adds a step that runs `git diff --exit-code public/search-index.{en,es}.json` after build. Catches the next contributor who edits i18n routes/docs without rebuilding. PR #761 hit exactly this; subsequent PRs healed it accidentally — the guard prevents recurrence.
- **Workflow comments** (`ci.yml`, `e2e.yml`, `lhci.yml`) — one-line note on each Build step explaining why `PUBLIC_POSTHOG_*` secrets are deliberately NOT passed (capture events from CI/test/audit would pollute prod analytics; only `deploy.yml` gets them). Already in `docs/runbooks/posthog.md`; the inline pointer keeps a future contributor from "fixing" it.

## What's left on #767

- [ ] Interactive: confirm `sign_in_initiated` lands in the PostHog activity feed (operator-only, can't be CI'd)
- [ ] v1.1+: server-side ingest from Edge Functions, DNT/consent for LatAm, `captureException` wiring

## Test plan

- [x] `npx tsc --noEmit` — clean (Window.posthog.reset typed)
- [x] `npm test` — 1264/1264 green
- [x] `npm run build` — 235 pages, no errors, search-index matches main (no drift today)
- [ ] After merge: open https://us.posthog.com/project/405068/activity, sign in to rastrum.org, sign out, sign in as a different account → confirm two distinct `distinct_id`s rather than one merged identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)