### PR TITLE
docs(roadmap): sync v1.1.5 Persuasive Tech Audit (Fogg principles)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,9 @@
 > Briefing for AI coding agents (Claude Code, Copilot, Cursor, Codex, …)
 > working in this repo. Read this before making changes.
 >
-> **Last full doc sync:** 2026-05-01 (v1.2 + 42 field-bug/admin/docs PRs from
-> 2026-05-01 session — see docs/changelog for details).
+> **Last full doc sync:** 2026-05-08 (v1.1.5 Persuasive Tech Audit — Tier S +
+> Tier A merged, Ola 2b in flight; see `docs/progress.json` v1.1.5 phase).
+> Prior sync: 2026-05-01 (v1.2 + 42 field-bug/admin/docs PRs).
 
 ---
 
@@ -542,6 +543,53 @@ Pause/Resume. Vertex AI tokens auto-rotate via service-account JWT
 Spec: [`docs/specs/modules/32-multi-provider-vision.md`](docs/specs/modules/32-multi-provider-vision.md).
 Runbooks: [`docs/runbooks/multi-provider-vision.md`](docs/runbooks/multi-provider-vision.md),
 [`docs/runbooks/sponsor-pools.md`](docs/runbooks/sponsor-pools.md).
+
+### Persuasive Tech (Fogg) — v1.1.5 conventions
+
+The v1.1.5 phase applied B.J. Fogg's *Persuasive Technology* chapter-by-chapter
+to existing surfaces. Two patterns are now load-bearing across the codebase:
+
+1. **`src/lib/algorithms.ts` is the single source of truth for ranked
+   surfaces.** Every place that ranks something (`community_observers`,
+   `explore_recent`, `explore_species_recent`, future feeds) registers
+   one `AlgorithmId` entry holding inputs/window/settings copy in EN+ES,
+   and renders a `<WhyAmISeeingThis algorithm="..." lang />` pill. The
+   pill opens a single global `WhyAmISeeingThisDialog` (mounted once in
+   `BaseLayout`, mirroring the `ReportDialog` pattern). **Do NOT add a
+   new ranked surface without registering an entry** — the four
+   principles documented at `/docs/algorithms/` ("no black box", "no
+   hidden profiling", "a lever for every input", "no engagement bait")
+   are part of the contract.
+
+2. **Theme is a four-state machine** (`light | dark | auto | field`),
+   not a boolean. The first-paint inline script in both `BaseLayout`
+   and `ConsoleLayout` resolves the stored value through `src/lib/theme.ts`
+   (`parseStoredTheme` → `resolveEffective` → `applyEffective`) before
+   any pixels paint. Field is layered **on top of `.dark`** (so any
+   `dark:*` Tailwind utility stays readable) plus a `<style is:global>`
+   block that crushes the palette to pure black/white. The two-state
+   header / footer / drawer / command-palette toggles must clear `.field`
+   on use so an explicit Light/Dark click escapes Field. Adding a 5th
+   state breaks the inline boot script's switch — extend, don't replace.
+
+3. **Honest-norms invariant.** Any UI that shows a peer comparison
+   (peer_norms bars, percentile cards, falta-dex region pool counts)
+   must hide when `n < 50` (`MIN_N_THRESHOLD`) and never raw-rank.
+   "Datos insuficientes" / "not enough data" is the v1 fallback — Fogg's
+   normative influence applied honestly, never as a default-flip. The
+   threshold lives in `src/lib/{peer-norms,percentile}.ts` so EN/ES
+   never disagree.
+
+4. **Photo praise is taxon-agnostic and EXIF-only.** `pickPraise(exif)`
+   in `src/lib/photo-praise.ts` runs at upload time when the cascade
+   hasn't seen the photo yet — so the praise is *technical* (sharp
+   action / good light / portrait aperture / long lens / balanced
+   exposure) and never aesthetic. Returns `null` when EXIF is missing
+   or when the photo doesn't meet any of the 5 thresholds (don't lie).
+
+Full per-PR context: `docs/progress.json` v1.1.5 phase + the per-PR
+runbooks (`docs/runbooks/falta-dex.md`, `docs/runbooks/contextual-suggestions.md`,
+`docs/runbooks/themes.md` once #769 lands).
 
 ---
 

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -1,8 +1,8 @@
 {
-  "updated": "2026-04-27",
+  "updated": "2026-05-08",
   "v0_1_completed": "2026-04-24",
-  "notes": "v0.1 → v1.0 code-complete in this push. Items marked done include features whose schema, RLS, Edge Function code, and client UI are all shipped to main. Items marked 'blocked' need an external action: API keys, Cornell BirdNET license, ML model training, Apple Developer account, Cloudflare R2 account + DNS, etc. Phases v1.5–v2.5 remain unchanged from prior plan. | 2026-04-25: First real user onboarding session (Eugenio Padilla). 10 bugs found and fixed, 5 new modules designed. Module 14 (User API Tokens) shipped. WebLLM set as default fallback. Identification block added to obs form. | 2026-04-27: v1.1 cross-cutting drops + on-device camera-trap pipeline. Module 22 community validation, owner observation CRUD, atomic delete-observation Edge Function, suggest-from-share-page, OG pipeline (satori build-time + client-side at sync), onboarding v2 (4-step pipeline setup with WCAG focus trap + replay event + telemetry + Anthropic key live verify), MegaDetector v5a YOLOv5 ONNX on-device camera-trap pre-filter (FilteredFrameError short-circuits cascade for empty/human/vehicle frames), bbox-aware species cascade (Phi-vision pre-crops to MegaDetector's bbox), CI smoke check for model-asset URLs, infra/megadetector hosting recipe (convert.sh + INT8 quantise → ~134 MB R2 upload), share/obs locale-neutral 404 fix.",
-  "notes_es": "v0.1 → v1.0 código completo en este push. Los ítems marcados como done incluyen funcionalidades cuyo schema, RLS, Edge Function y UI ya están desplegados en main. Los ítems marcados como 'blocked' requieren una acción externa: API keys, licencia comercial de BirdNET, entrenamiento ML, cuenta Apple Developer, DNS de Cloudflare R2, etc. Las fases v1.5–v2.5 no cambian respecto al plan anterior.",
+  "notes": "v0.1 → v1.0 code-complete in this push. Items marked done include features whose schema, RLS, Edge Function code, and client UI are all shipped to main. Items marked 'blocked' need an external action: API keys, Cornell BirdNET license, ML model training, Apple Developer account, Cloudflare R2 account + DNS, etc. Phases v1.5–v2.5 remain unchanged from prior plan. | 2026-04-25: First real user onboarding session (Eugenio Padilla). 10 bugs found and fixed, 5 new modules designed. Module 14 (User API Tokens) shipped. WebLLM set as default fallback. Identification block added to obs form. | 2026-04-27: v1.1 cross-cutting drops + on-device camera-trap pipeline. Module 22 community validation, owner observation CRUD, atomic delete-observation Edge Function, suggest-from-share-page, OG pipeline (satori build-time + client-side at sync), onboarding v2 (4-step pipeline setup with WCAG focus trap + replay event + telemetry + Anthropic key live verify), MegaDetector v5a YOLOv5 ONNX on-device camera-trap pre-filter (FilteredFrameError short-circuits cascade for empty/human/vehicle frames), bbox-aware species cascade (Phi-vision pre-crops to MegaDetector's bbox), CI smoke check for model-asset URLs, infra/megadetector hosting recipe (convert.sh + INT8 quantise → ~134 MB R2 upload), share/obs locale-neutral 404 fix. | 2026-05-08: Persuasive Tech (Fogg) audit phases 1-2. New phase v1.1.5 captures the principles-driven UX additions: Tier S (Reduction + Tunnelling + Praise + Self-monitoring + Social Facilitation + Responsiveness) shipped via Quick Observation (#759), EXIF-driven photo praise (#757), falta-dex taxonomic gaps (#760), active-observers banner (#758), public triage SLA dashboard (#761). Tier A (Real-World Feel + Reputed Credibility + Transparency) shipped via Field theme for direct sunlight (#768), humanized About page (#770), WhyAmISeeingThis algorithmic disclosure (#772). Cleanup PR #766 removed disambiguation banner / nearby-similar card / places-near-me whose intent is now better served by Fogg replacements. Ola 2b (Conditioning + Kairos + Cause-and-effect + Suggestion + Normative Influence) is in flight: seasonal theme variants (#769), peer-norm bars on license/privacy (#771), tú-vs-promedio percentile card (#773), contextual species suggestions (#774); badge surprises (#727), golden-hour push (#724), ecological-impact viz (#728) remain as open issues.",
+  "notes_es": "v0.1 → v1.0 código completo en este push. Los ítems marcados como done incluyen funcionalidades cuyo schema, RLS, Edge Function y UI ya están desplegados en main. Los ítems marcados como 'blocked' requieren una acción externa: API keys, licencia comercial de BirdNET, entrenamiento ML, cuenta Apple Developer, DNS de Cloudflare R2, etc. Las fases v1.5–v2.5 no cambian respecto al plan anterior. | 2026-05-08: Auditoría Persuasive Tech (Fogg) fases 1-2. Nueva fase v1.1.5 captura los añadidos de UX guiados por principios: Tier S (Reducción + Túnel + Elogio + Auto-monitoreo + Facilitación social + Responsividad) entregado vía Observación rápida (#759), elogio fotográfico desde EXIF (#757), falta-dex de huecos taxonómicos (#760), banner de observadores activos (#758), tablero público de SLA de triage (#761). Tier A (Sensación de mundo real + Credibilidad reputada + Transparencia) entregado vía tema Campo para sol directo (#768), página Acerca humanizada (#770), divulgación algorítmica WhyAmISeeingThis (#772). El PR #766 limpió el banner de desambiguación, la tarjeta de especies similares cercanas y places-near-me, ya superados por sus reemplazos Fogg. Ola 2b (Condicionamiento + Kairos + Causa-efecto + Sugerencia + Influencia normativa) en curso: variantes estacionales de tema (#769), barras de norma de pares en licencia/privacidad (#771), tarjeta tú-vs-promedio (#773), sugerencias contextuales de especies (#774); sorpresas de badges (#727), push de hora dorada (#724), viz de impacto ecológico (#728) siguen como issues abiertos.",
   "phases": {
     "v0.1": {
       "name": "Alpha MVP (online-first)",
@@ -1002,6 +1002,153 @@
           "done_at": "2026-04-29",
           "status": "shipped — PR #143 (closes #115/#116/#118)",
           "status_es": "lanzado — PR #143 (cierra #115/#116/#118)"
+        }
+      ]
+    },
+    "v1.1.5": {
+      "name": "Persuasive Tech Audit (Fogg principles)",
+      "name_es": "Auditoría Persuasive Tech (principios de Fogg)",
+      "period": "2026-05-08 → ongoing",
+      "period_es": "2026-05-08 → en curso",
+      "status": "shipped (mostly) — Tier S + Tier A merged; Ola 2b in flight",
+      "status_es": "lanzado (mayormente) — Tier S + Tier A en main; Ola 2b en curso",
+      "items": [
+        {
+          "id": "fogg-quick-observation",
+          "label": "Reduction — one-tap Quick Observation flow (foto + GPS + async ID). Long-press the centre FAB or open ?quick=1 to collapse the standard 5-tap form into a single action; saves to outbox immediately, identifier cascade runs async, no-GPS path saves as draft and is promoted by promoteDraftsWithGps once a fix arrives",
+          "label_es": "Reducción — flujo Observación rápida de un toque (foto + GPS + ID asíncrona). Mantén presionado el FAB central u abre ?quick=1 para colapsar el formulario estándar de 5 toques en una sola acción; se guarda en outbox de inmediato, la cascade corre asíncrona, sin GPS se guarda como draft y promoteDraftsWithGps lo promueve cuando llega el fix",
+          "done": true,
+          "done_at": "2026-05-08",
+          "status": "shipped — PR #759 (closes #721)",
+          "status_es": "lanzado — PR #759 (cierra #721)"
+        },
+        {
+          "id": "fogg-photo-praise",
+          "label": "Praise — contextual photo praise on upload, EXIF-driven (ISO/FNumber/ExposureTime/FocalLength), never aesthetic. Single small badge next to the thumbnail when one of 5 technical thresholds matches (sharp_action, portrait_aperture, long_lens, good_light, balanced_exposure); silent when EXIF is missing or ISO ≥ 800 (acceptance criterion: don't lie)",
+          "label_es": "Elogio — elogio contextual al subir foto, basado en EXIF (ISO/FNumber/ExposureTime/FocalLength), nunca estético. Una sola insignia pequeña junto a la miniatura cuando coincide uno de 5 umbrales técnicos (sharp_action, portrait_aperture, long_lens, good_light, balanced_exposure); silencioso cuando falta EXIF o ISO ≥ 800 (criterio de aceptación: no mentir)",
+          "done": true,
+          "done_at": "2026-05-08",
+          "status": "shipped — PR #757 (closes #733)",
+          "status_es": "lanzado — PR #757 (cierra #733)"
+        },
+        {
+          "id": "fogg-triage-sla",
+          "label": "Responsiveness — public roadmap-triage SLA dashboard at /docs/status/. Nightly workflow runs scripts/fetch-gh-issue-stats.ts via gh CLI, computes open count + median first-comment hours + resolved-30d, commits triage-stats.json back only when it changes; fault-tolerant fallback preserves last good JSON on transient gh API failure. Surfaces project liveness as a Fogg credibility signal",
+          "label_es": "Responsividad — tablero público de SLA de triage de roadmap en /docs/status/. Workflow nocturno corre scripts/fetch-gh-issue-stats.ts vía gh CLI, computa abiertos + mediana de horas a primer comentario + resueltos en 30 días, hace commit de triage-stats.json solo cuando cambia; fallback tolerante preserva el último JSON bueno ante fallo transitorio de gh. Hace visible la vida del proyecto como señal de credibilidad Fogg",
+          "done": true,
+          "done_at": "2026-05-08",
+          "status": "shipped — PR #761 (closes #740)",
+          "status_es": "lanzado — PR #761 (cierra #740)"
+        },
+        {
+          "id": "fogg-active-observers-banner",
+          "label": "Social Facilitation — active-observers micro-banner at the top of /observe ('Hoy 7 personas observan en Oaxaca · únete'). New community_active_observers_today(p_country) RPC with same eligibility predicate as community_observers (hide_from_leaderboards = false); never reads the centroid view; null-region fallback yields no banner. Empty-state copy flips into a low-pressure invitation to be the seed observer",
+          "label_es": "Facilitación social — micro-banner de observadores activos en /observar ('Hoy 7 personas observan en Oaxaca · únete'). Nueva RPC community_active_observers_today(p_country) con el mismo predicado de elegibilidad que community_observers (hide_from_leaderboards = false); nunca lee la vista con centroide; sin región el banner no se muestra. El estado vacío se vuelve invitación de baja presión para ser el observador semilla",
+          "done": true,
+          "done_at": "2026-05-08",
+          "status": "shipped — PR #758 (closes #743)",
+          "status_es": "lanzado — PR #758 (cierra #743)"
+        },
+        {
+          "id": "fogg-falta-dex",
+          "label": "Self-monitoring — falta-dex 'Show missing' toggle on the Pokédex appends silhouette cards for species in the user's region they haven't observed. Owner-only (privacy: revealing what someone hasn't observed is more invasive than what they have). Baseline = Option A (Rastrum's own observation density per country) — no GBIF ETL; the runbook documents the v1.1 upgrade path. Counts: 'X of Y species in your region'; honest disclaimer about region density",
+          "label_es": "Auto-monitoreo — toggle 'Mostrar faltantes' en la Pokédex agrega tarjetas-silueta para especies de la región del usuario que aún no observa. Solo dueño (privacidad: revelar lo que alguien no ha observado es más invasivo que lo que sí). Línea base = Opción A (densidad de observaciones de Rastrum por país) — sin ETL de GBIF; el runbook documenta la ruta de upgrade v1.1. Contadores: 'X de Y especies en tu región'; aviso honesto sobre densidad regional",
+          "done": true,
+          "done_at": "2026-05-08",
+          "status": "shipped — PR #760 (phase-1 of #726, supersedes #561)",
+          "status_es": "lanzado — PR #760 (fase-1 de #726, supera #561)"
+        },
+        {
+          "id": "fogg-field-theme",
+          "label": "Real-World Feel — high-contrast Field theme (Campo) for direct sunlight on mid-tier mobile. Pure black bg, white text, no gradients, AA-contrast enforced; 1.25× hit-target sizing on mobile FAB and inputs (48 → 60 px) for sweat/gloves. Auto-engages when stored preference is 'auto' AND AmbientLightSensor reports > 5 000 lux (Chromium-only, feature-detected); manual via Settings → Preferences as the cross-browser path",
+          "label_es": "Sensación de mundo real — tema Campo de alto contraste para sol directo en móvil de gama media. Fondo negro puro, texto blanco, sin gradientes, contraste AA; tamaño de hit-target 1.25× en FAB móvil e inputs (48 → 60 px) para sudor/guantes. Se activa automáticamente cuando la preferencia es 'auto' Y AmbientLightSensor reporta > 5 000 lux (solo Chromium, feature-detected); manual vía Ajustes → Preferencias como ruta multiplataforma",
+          "done": true,
+          "done_at": "2026-05-08",
+          "status": "shipped — PR #768",
+          "status_es": "lanzado — PR #768"
+        },
+        {
+          "id": "fogg-about-humanized",
+          "label": "Reputed Credibility — humanized About page replaces auto-generated copy with team / funding / governance transparency sections. Build-time live stats from Supabase REST + publishable anon key (graceful placeholder when env missing); funding section explicit about cost line items (Supabase free, R2 single-digit $/mo, BYO/sponsored AI); governance section links to MIT/AGPL-3.0/CC, GitHub Issues, /docs/contribute. Closes the Fogg credibility loop on who's behind the project",
+          "label_es": "Credibilidad reputada — página Acerca humanizada reemplaza copy auto-generado con secciones de equipo / financiación / gobernanza transparente. Estadísticas en vivo en build-time desde Supabase REST + anon key publicable (placeholder gracioso cuando falta env); sección de financiación explícita sobre los costos (Supabase free, R2 unidades de $/mes, AI BYO/patrocinado); gobernanza enlaza MIT/AGPL-3.0/CC, GitHub Issues, /docs/contribute. Cierra el lazo de credibilidad Fogg sobre quién está detrás",
+          "done": true,
+          "done_at": "2026-05-08",
+          "status": "shipped — PR #770 (closes #739)",
+          "status_es": "lanzado — PR #770 (cierra #739)"
+        },
+        {
+          "id": "fogg-why-am-i-seeing-this",
+          "label": "Transparency — WhyAmISeeingThis algorithmic disclosure on every ranked surface. Single source of truth in src/lib/algorithms.ts (one entry per AlgorithmId), small inline 'i' pill that opens a global WhyAmISeeingThisDialog modal (focus trap, Esc/backdrop close, focus restore). Wired today on community_observers, explore_recent, explore_species_recent. New /docs/algorithms/ reference enumerates the catalog + the 4 principles ('no black box', 'no hidden profiling', 'a lever for every input', 'no engagement bait'). Captology with the lights on (Fogg ch. 9)",
+          "label_es": "Transparencia — divulgación algorítmica WhyAmISeeingThis en toda superficie rankeada. Única fuente de verdad en src/lib/algorithms.ts (una entrada por AlgorithmId), pequeño 'i' inline abre modal global WhyAmISeeingThisDialog (focus trap, cerrar con Esc/fondo, restauración de foco). Hoy cableado en community_observers, explore_recent, explore_species_recent. Nueva referencia /docs/algorithms/ enumera el catálogo + los 4 principios ('sin caja negra', 'sin perfilado oculto', 'una palanca por entrada', 'sin cebos de engagement'). Captología con las luces prendidas (Fogg cap. 9)",
+          "done": true,
+          "done_at": "2026-05-09",
+          "status": "shipped — PR #772 (closes #738)",
+          "status_es": "lanzado — PR #772 (cierra #738)"
+        },
+        {
+          "id": "fogg-cleanup-superseded",
+          "label": "Cleanup — remove disambiguation banner (#684), nearby-similar card (#679), and places-near-me sessionStorage helper (#678) whose user-facing intent is now better served by the Fogg replacements. Net -2048 LOC across 18 files: dropped DisambiguationBanner / NearbySimilarCard components, disambiguation/nearby-similar/places-url libs + tests, the handleDisambiguate branch in the identify EF, and the cascade_config / taxon_pair_disambiguations / nearby_similar_species SQL surface. Replacement intent: #736 'Why this species?' panel (Tier B), #774 contextual species (Tier A in flight), #760 falta-dex (shipped), and the M28 Nearby flow's existing community_observers_nearby_at RPC",
+          "label_es": "Limpieza — eliminar banner de desambiguación (#684), tarjeta de especies similares cercanas (#679) y helper sessionStorage de places-near-me (#678) cuya intención ahora la cubren mejor los reemplazos Fogg. Net -2048 LOC en 18 archivos: se quitaron los componentes DisambiguationBanner / NearbySimilarCard, libs disambiguation/nearby-similar/places-url + tests, la rama handleDisambiguate en la EF identify, y la superficie SQL cascade_config / taxon_pair_disambiguations / nearby_similar_species. Intención de reemplazo: panel #736 '¿Por qué esta especie?' (Tier B), especies contextuales #774 (Tier A en curso), falta-dex #760 (lanzado), y la RPC community_observers_nearby_at del flujo Nearby de M28",
+          "done": true,
+          "done_at": "2026-05-08",
+          "status": "shipped — PR #766 (supersedes #678 / #679 / #684)",
+          "status_es": "lanzado — PR #766 (supera #678 / #679 / #684)"
+        },
+        {
+          "id": "fogg-seasonal-themes",
+          "label": "Conditioning (Ola 2b, in flight) — seasonal + regional theme variants reflecting MX's ecological calendar: monarca (Oct–Mar, monarch overwintering, orange/amber accents), lluvias (Jun–Sep, rainy season, deeper greens), secas (Apr–May, late dry season, warm earth tones), default (brand emerald). Inline boot script resolves the (now, region) lookup before first paint to avoid flicker; data-season='<theme>' on <html>. 5-button picker in Profile → Apariencia overrides the auto pick. MX-Norte / MX-Sur fall back to MX-Centro mapping for v1",
+          "label_es": "Condicionamiento (Ola 2b, en curso) — variantes estacionales y regionales que reflejan el calendario ecológico de MX: monarca (Oct–Mar, invernación de monarcas, naranjas/ámbar), lluvias (Jun–Sep, temporada de lluvias, verdes más profundos), secas (Abr–May, fin de secas, tonos tierra), default (esmeralda de marca). Script inline antes del primer pintado evita parpadeo; data-season='<tema>' en <html>. Selector de 5 botones en Perfil → Apariencia anula la elección auto. MX-Norte / MX-Sur caen al mapeo de MX-Centro para v1",
+          "done": false,
+          "status": "in flight 2026-05-08 — PR #769 (closes #731)",
+          "status_es": "en curso 2026-05-08 — PR #769 (cierra #731)"
+        },
+        {
+          "id": "fogg-peer-norms",
+          "label": "Normative Influence (Ola 2b, in flight) — show peer norms when configuring license / privacy ('82% of MX observers choose this'). license_norm + privacy_norm materialised views, peer_norm_pct(scope, country, key) SECURITY INVOKER lookup, refresh-norms-weekly pg_cron job (Mon 06:00 UTC). Bar hides under MIN_N_THRESHOLD=50; defaults are unchanged. Fogg's normative influence applied honestly, never as a default-flip",
+          "label_es": "Influencia normativa (Ola 2b, en curso) — mostrar normas de pares al configurar licencia / privacidad ('82% de observadores en MX eligen esto'). Vistas materializadas license_norm + privacy_norm, lookup peer_norm_pct(scope, country, key) SECURITY INVOKER, job pg_cron refresh-norms-weekly (lunes 06:00 UTC). Barra se oculta bajo MIN_N_THRESHOLD=50; los defaults no cambian. Influencia normativa de Fogg aplicada honestamente, nunca como flip de default",
+          "done": false,
+          "status": "in flight 2026-05-08 — PR #771 (closes #745)",
+          "status_es": "en curso 2026-05-08 — PR #771 (cierra #745)"
+        },
+        {
+          "id": "fogg-percentile-card",
+          "label": "Self-monitoring (Ola 2b, in flight) — tú-vs-promedio MX comparison card on /profile/. 4 metrics (Diversity Shannon H', Habitats covered, Validations contributed, Geographic spread km² convex hull) each as percentile bar + caption 'estás en el percentil X de los observadores activos en MX (n = N)'. Cohort: users with ≥ 5 synced obs in 90 days. Honest fallback when n < 50. NEVER raw rank, NEVER 'people above you' copy — Fogg-ethical normative comparison over leaderboard toxicity",
+          "label_es": "Auto-monitoreo (Ola 2b, en curso) — tarjeta tú-vs-promedio MX en /perfil/. 4 métricas (Diversidad Shannon H', Hábitats cubiertos, Validaciones aportadas, Extensión geográfica km² convex hull) como barra de percentil + caption 'estás en el percentil X de los observadores activos en MX (n = N)'. Cohorte: usuarios con ≥ 5 obs sincronizadas en 90 días. Fallback honesto cuando n < 50. NUNCA rank crudo, NUNCA copy 'gente por encima de ti' — comparación normativa ética Fogg sobre toxicidad de leaderboard",
+          "done": false,
+          "status": "in flight 2026-05-08 — PR #773 (closes #744)",
+          "status_es": "en curso 2026-05-08 — PR #773 (cierra #744)"
+        },
+        {
+          "id": "fogg-contextual-suggestions",
+          "label": "Suggestion Technology (Ola 2b, in flight) — chip strip on /observe surfaces 5–10 species likely at the user's location + month. probable_taxa_at(p_lat, p_lng, p_month, p_limit) SECURITY INVOKER RPC: ST_DWithin(50 km) + month ±1 (year-wrapping) + research-grade-or-confirmed; top-N by COUNT DESC, MIN(distance) ASC. Tap pre-fills the manual ID input, never auto-submits. Same Option A baseline as falta-dex; honest copy about precision improving with more data. Cache layer deferred (live RPC < 300 ms at current scale)",
+          "label_es": "Tecnología de sugerencia (Ola 2b, en curso) — strip de chips en /observar muestra 5–10 especies probables en la ubicación + mes del usuario. RPC probable_taxa_at(p_lat, p_lng, p_month, p_limit) SECURITY INVOKER: ST_DWithin(50 km) + mes ±1 (con wrap de año) + research-grade-o-confirmada; top-N por COUNT DESC, MIN(distancia) ASC. Tocar pre-llena el input de ID manual, nunca envía automáticamente. Misma línea base Opción A que falta-dex; copy honesto sobre que la precisión mejora con más datos. Capa de caché diferida (RPC en vivo < 300 ms a escala actual)",
+          "done": false,
+          "status": "in flight 2026-05-08 — PR #774 (closes #723)",
+          "status_es": "en curso 2026-05-08 — PR #774 (cierra #723)"
+        },
+        {
+          "id": "fogg-variable-rewards",
+          "label": "Variable Rewards (Ola 2b, planned) — transparent, opt-in 'sorpresa de campo' badges that fire on rare-but-honest milestones (first species in a new genus, first observation in a new ecoregion, first nocturnal observation, etc.). Variable schedule but the underlying rule is always disclosed in the badge tooltip — no slot-machine darkness, just delight you can audit",
+          "label_es": "Recompensas variables (Ola 2b, planeado) — insignias 'sorpresa de campo' transparentes y opt-in que disparan en hitos raros pero honestos (primera especie en un nuevo género, primera observación en una nueva ecorregión, primera observación nocturna, etc.). Calendario variable pero la regla subyacente siempre se divulga en el tooltip de la insignia — sin oscuridad de tragamonedas, solo gusto auditable",
+          "done": false,
+          "status": "planned — issue #727 (no PR yet)",
+          "status_es": "planeado — issue #727 (sin PR todavía)"
+        },
+        {
+          "id": "fogg-kairos-prompts",
+          "label": "Kairos / Right-Time Prompts (Ola 2b, planned) — opt-in Web Push at the right moment: 'golden hour' (sunset ± 30 min, plant macro / bird activity peaks), 'after the rain' (rain stop + 2 h, fungi / amphibians). Geo-aware via the user's region_primary; single nightly cap per channel; explicitly opt-in (Fogg ch. 5 — kairos must be welcomed, not ambushed)",
+          "label_es": "Kairos / Avisos al momento justo (Ola 2b, planeado) — Web Push opt-in en el momento adecuado: 'hora dorada' (atardecer ± 30 min, picos de macro vegetal / actividad de aves), 'después de la lluvia' (cese de lluvia + 2 h, hongos / anfibios). Geo-consciente vía region_primary del usuario; tope único nocturno por canal; opt-in explícito (Fogg cap. 5 — kairos debe ser bienvenido, nunca emboscar)",
+          "done": false,
+          "status": "planned — issue #724 (no PR yet)",
+          "status_es": "planeado — issue #724 (sin PR todavía)"
+        },
+        {
+          "id": "fogg-ecological-impact-viz",
+          "label": "Cause-and-Effect (Ola 2b, planned) — 'mi impacto ecológico' visualization makes the otherwise invisible downstream consequences of one user's observations visible: research-grade contributions used in GBIF, validations that helped peers, sensitive-species records that helped CONANP staff, etc. Honest framing — no inflated metrics, links every claimed effect to a verifiable trace",
+          "label_es": "Causa-efecto (Ola 2b, planeado) — visualización 'mi impacto ecológico' hace visibles las consecuencias antes invisibles de las observaciones de un usuario: contribuciones research-grade usadas en GBIF, validaciones que ayudaron a pares, registros de especies sensibles que ayudaron a personal de CONANP, etc. Framing honesto — sin métricas infladas, cada efecto reclamado se enlaza a una traza verificable",
+          "done": false,
+          "status": "planned — issue #728 (no PR yet)",
+          "status_es": "planeado — issue #728 (sin PR todavía)"
         }
       ]
     },

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -6759,6 +6759,464 @@
           "status": "done"
         }
       ]
+    },
+    "fogg-quick-observation": {
+      "phase": "v1.1.5",
+      "title_en": "Reduction — one-tap Quick Observation",
+      "title_es": "Reducción — Observación rápida de un toque",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "src/lib/quick-observe.ts pure helpers (buildQuickObservationDraft, getQuickGps with 12s timeout, mediaKindFromMime, isNullIsland)",
+          "label_es": "Helpers puros src/lib/quick-observe.ts (buildQuickObservationDraft, getQuickGps con timeout 12s, mediaKindFromMime, isNullIsland)",
+          "status": "done"
+        },
+        {
+          "label_en": "QuickObserveCapture.astro full-screen capture surface, gates on ?quick=1 so the script is inert on default /observe",
+          "label_es": "QuickObserveCapture.astro superficie de captura pantalla completa, se activa con ?quick=1 para no correr en /observar por defecto",
+          "status": "done"
+        },
+        {
+          "label_en": "MobileBottomBar long-press detection (touch + mouse, ≥500 ms, vibration cue if available) → /observe?quick=1",
+          "label_es": "MobileBottomBar detección de long-press (touch + mouse, ≥500 ms, vibración si está disponible) → /observar?quick=1",
+          "status": "done"
+        },
+        {
+          "label_en": "No-GPS path saves with asDraft=true; promoteDraftsWithGps worker flips to pending once a fix arrives",
+          "label_es": "Ruta sin GPS guarda con asDraft=true; el worker promoteDraftsWithGps lo cambia a pending cuando llega el fix",
+          "status": "done"
+        },
+        {
+          "label_en": "posthog.capture('quick_observation_saved', { had_gps, media_kind }) telemetry on success",
+          "label_es": "Telemetría posthog.capture('quick_observation_saved', { had_gps, media_kind }) al éxito",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-photo-praise": {
+      "phase": "v1.1.5",
+      "title_en": "Praise — contextual photo praise on upload",
+      "title_es": "Elogio — elogio contextual al subir foto",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "src/lib/photo-praise.ts pickPraise(exif) pure lookup with 5 priority-ordered rules (sharp_action, portrait_aperture, long_lens, good_light, balanced_exposure)",
+          "label_es": "Lookup puro pickPraise(exif) en src/lib/photo-praise.ts con 5 reglas priorizadas (sharp_action, portrait_aperture, long_lens, good_light, balanced_exposure)",
+          "status": "done"
+        },
+        {
+          "label_en": "Returns null when EXIF missing, ISO ≥ 800, or no rule matches — silent rather than dishonest",
+          "label_es": "Devuelve null cuando falta EXIF, ISO ≥ 800, o ninguna regla coincide — silencioso en vez de deshonesto",
+          "status": "done"
+        },
+        {
+          "label_en": "Single small badge next to thumbnail in ObservationForm; EN+ES copy under photo_praise.* i18n keys",
+          "label_es": "Una sola insignia pequeña junto a la miniatura en ObservationForm; copy EN+ES bajo claves i18n photo_praise.*",
+          "status": "done"
+        },
+        {
+          "label_en": "Taxon-agnostic for v1 (cascade hasn't run at upload time); thresholds work for any subject",
+          "label_es": "Independiente de taxón en v1 (la cascade no ha corrido al subir); umbrales funcionan para cualquier sujeto",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-triage-sla": {
+      "phase": "v1.1.5",
+      "title_en": "Responsiveness — public roadmap-triage SLA dashboard",
+      "title_es": "Responsividad — tablero público de SLA de triage",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "TriageStatusView.astro reads public/data/triage-stats.json at build time and renders three stat tiles + 'who responds' / 'how to report' sections",
+          "label_es": "TriageStatusView.astro lee public/data/triage-stats.json en build-time y renderiza tres tiles de stats + secciones 'quién responde' / 'cómo reportar'",
+          "status": "done"
+        },
+        {
+          "label_en": ".github/workflows/triage-stats.yml nightly at 07:00 UTC; computes via gh CLI (default GITHUB_TOKEN); commits JSON back only when changed",
+          "label_es": ".github/workflows/triage-stats.yml nocturno a 07:00 UTC; computa vía gh CLI (GITHUB_TOKEN por defecto); hace commit del JSON solo cuando cambia",
+          "status": "done"
+        },
+        {
+          "label_en": "scripts/fetch-gh-issue-stats.ts fault-tolerant — preserves last good JSON on transient API failure so the build never breaks",
+          "label_es": "scripts/fetch-gh-issue-stats.ts tolerante a fallos — preserva el último JSON bueno ante fallo transitorio para nunca romper el build",
+          "status": "done"
+        },
+        {
+          "label_en": "src/lib/triage-stats.ts pure helpers (median, hoursBetween, round1) + 9 unit tests",
+          "label_es": "Helpers puros src/lib/triage-stats.ts (median, hoursBetween, round1) + 9 tests unitarios",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-active-observers-banner": {
+      "phase": "v1.1.5",
+      "title_en": "Social Facilitation — active-observers banner on /observe",
+      "title_es": "Facilitación social — banner de observadores activos en /observar",
+      "modules": ["28-community-discovery.md"],
+      "subtasks": [
+        {
+          "label_en": "community_active_observers_today(p_country) RPC — same eligibility predicate as community_observers (hide_from_leaderboards = false); never reads centroid view",
+          "label_es": "RPC community_active_observers_today(p_country) — mismo predicado de elegibilidad que community_observers (hide_from_leaderboards = false); nunca lee vista con centroide",
+          "status": "done"
+        },
+        {
+          "label_en": "ActiveObserversBanner.astro mounts at top of ObserveView2; starts display:none and reveals only after count + region resolve (no SSR flash)",
+          "label_es": "ActiveObserversBanner.astro monta en el top de ObserveView2; arranca display:none y se revela solo cuando se resuelven count + region (sin flash SSR)",
+          "status": "done"
+        },
+        {
+          "label_en": "src/lib/active-observers.ts pure formatter with 11 unit tests covering plural/singular EN+ES, empty, null-region, NULL leakage guard, negative count clamp",
+          "label_es": "Formatter puro src/lib/active-observers.ts con 11 tests unitarios cubriendo plural/singular EN+ES, vacío, null-region, guard contra fuga de NULL, clamp de count negativo",
+          "status": "done"
+        },
+        {
+          "label_en": "Click target uses the M28 serializeFilters() to land on /community/observers/?country=<ISO> — no new URL helpers",
+          "label_es": "Target de click usa serializeFilters() de M28 para aterrizar en /community/observers/?country=<ISO> — sin nuevos helpers de URL",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-falta-dex": {
+      "phase": "v1.1.5",
+      "title_en": "Self-monitoring — falta-dex 'Show missing' Pokédex toggle",
+      "title_es": "Auto-monitoreo — toggle 'Mostrar faltantes' en Pokédex",
+      "modules": ["08-profile.md", "23-karma-reputation.md"],
+      "subtasks": [
+        {
+          "label_en": "profile_pokedex_with_missing(p_user_id, p_region_country, p_missing_limit) SECURITY INVOKER RPC returning observed + silhouette rows in one call",
+          "label_es": "RPC SECURITY INVOKER profile_pokedex_with_missing(p_user_id, p_region_country, p_missing_limit) que devuelve filas observadas + silueta en una sola llamada",
+          "status": "done"
+        },
+        {
+          "label_en": "Owner-only — visitor /u/<handle>/dex never sees the missing surface (privacy: more invasive than what they have)",
+          "label_es": "Solo dueño — /u/<handle>/dex visitante nunca ve la superficie de faltantes (privacidad: más invasivo que lo que sí tiene)",
+          "status": "done"
+        },
+        {
+          "label_en": "Toggle persists in localStorage[rastrum.pokedex.showMissing], default off",
+          "label_es": "Toggle persiste en localStorage[rastrum.pokedex.showMissing], por defecto off",
+          "status": "done"
+        },
+        {
+          "label_en": "Option A baseline: country pool = taxa with research-grade public obs by users with matching country_code. Runbook documents v1.1 GBIF upgrade path",
+          "label_es": "Línea base Opción A: pool por país = taxa con obs research-grade públicas por usuarios con country_code coincidente. Runbook documenta ruta de upgrade a GBIF en v1.1",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-field-theme": {
+      "phase": "v1.1.5",
+      "title_en": "Real-World Feel — high-contrast Field theme",
+      "title_es": "Sensación de mundo real — tema Campo de alto contraste",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "src/lib/theme.ts pure resolver (parseStoredTheme, resolveEffective, applyEffective); Field layered on top of .dark so dark:* utilities stay readable",
+          "label_es": "Resolver puro src/lib/theme.ts (parseStoredTheme, resolveEffective, applyEffective); Campo se apila sobre .dark para que utilidades dark:* sigan legibles",
+          "status": "done"
+        },
+        {
+          "label_en": "First-paint inline script in BaseLayout + ConsoleLayout is now a 4-state machine (light / dark / auto / field)",
+          "label_es": "Script inline de primer pintado en BaseLayout + ConsoleLayout ahora es máquina de 4 estados (light / dark / auto / field)",
+          "status": "done"
+        },
+        {
+          "label_en": "AmbientLightSensor auto-detect at > 5 000 lux when stored preference is 'auto'; feature-detected, manual via Settings as cross-browser path",
+          "label_es": "AmbientLightSensor auto-detect a > 5 000 lux cuando la preferencia es 'auto'; feature-detected, ruta multi-browser manual vía Ajustes",
+          "status": "done"
+        },
+        {
+          "label_en": "1.25× hit-target sizing on mobile FAB and form inputs (48 → 60 px) for sweat/gloves",
+          "label_es": "Tamaño de hit-target 1.25× en FAB móvil e inputs (48 → 60 px) para sudor/guantes",
+          "status": "done"
+        },
+        {
+          "label_en": "9 unit tests in tests/unit/theme.test.ts pin the state machine + Field-on-top-of-dark layering",
+          "label_es": "9 tests unitarios en tests/unit/theme.test.ts fijan la máquina de estado + apilamiento Campo-sobre-dark",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-about-humanized": {
+      "phase": "v1.1.5",
+      "title_en": "Reputed Credibility — humanized About page",
+      "title_es": "Credibilidad reputada — página Acerca humanizada",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "AboutView.astro shared by /en/about + /es/acerca; pages slim to ~15-line wrappers",
+          "label_es": "AboutView.astro compartido por /en/about + /es/acerca; las páginas se reducen a wrappers de ~15 líneas",
+          "status": "done"
+        },
+        {
+          "label_en": "scripts/fetch-about-stats.ts queries Supabase REST + publishable anon key at build time; graceful placeholder when env missing or unreachable",
+          "label_es": "scripts/fetch-about-stats.ts consulta Supabase REST + anon key publicable en build-time; placeholder gracioso cuando falta env o es inalcanzable",
+          "status": "done"
+        },
+        {
+          "label_en": "Sections: team / funding / governance / live stats / press — each backed by i18n (about.people, about.funding, about.governance, about.stats, about.press)",
+          "label_es": "Secciones: equipo / financiación / gobernanza / stats en vivo / prensa — cada una respaldada por i18n (about.people, about.funding, about.governance, about.stats, about.press)",
+          "status": "done"
+        },
+        {
+          "label_en": "Funding: explicit 'currently unfunded' framing with cost line items; preserves the privacy promise via BYO API keys note",
+          "label_es": "Financiación: framing explícito 'sin financiación actual' con líneas de costo; preserva la promesa de privacidad via nota de BYO API keys",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-why-am-i-seeing-this": {
+      "phase": "v1.1.5",
+      "title_en": "Transparency — WhyAmISeeingThis algorithmic disclosure",
+      "title_es": "Transparencia — divulgación algorítmica WhyAmISeeingThis",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "src/lib/algorithms.ts catalog keyed by AlgorithmId; each entry holds headline, summary, EN+ES inputs/window/settings copy, and settings deep-link path",
+          "label_es": "Catálogo src/lib/algorithms.ts indexado por AlgorithmId; cada entrada tiene título, resumen, copy EN+ES de inputs/ventana/ajustes, y deep-link a ajustes",
+          "status": "done"
+        },
+        {
+          "label_en": "WhyAmISeeingThis inline 'i' pill + global WhyAmISeeingThisDialog (focus trap, Esc/backdrop close, focus restore) — single instance in BaseLayout",
+          "label_es": "Pill inline 'i' WhyAmISeeingThis + WhyAmISeeingThisDialog global (focus trap, cerrar con Esc/fondo, restauración de foco) — única instancia en BaseLayout",
+          "status": "done"
+        },
+        {
+          "label_en": "Wired today on community_observers, explore_recent, explore_species_recent; adding a new ranked surface = one catalog entry + one tag",
+          "label_es": "Hoy cableado en community_observers, explore_recent, explore_species_recent; agregar una superficie rankeada nueva = una entrada de catálogo + un tag",
+          "status": "done"
+        },
+        {
+          "label_en": "/{en,es}/docs/algorithms/ reference page enumerates the catalog + 4 principles ('no black box', 'no hidden profiling', 'a lever for every input', 'no engagement bait')",
+          "label_es": "Página de referencia /{en,es}/docs/algorithms/ enumera el catálogo + 4 principios ('sin caja negra', 'sin perfilado oculto', 'una palanca por entrada', 'sin cebos de engagement')",
+          "status": "done"
+        },
+        {
+          "label_en": "8 unit tests pin catalog shape + EN/ES parity",
+          "label_es": "8 tests unitarios fijan la forma del catálogo + paridad EN/ES",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-cleanup-superseded": {
+      "phase": "v1.1.5",
+      "title_en": "Cleanup — remove disambiguation + nearby-similar + places-url",
+      "title_es": "Limpieza — eliminar disambiguation + nearby-similar + places-url",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "Remove DisambiguationBanner.astro + NearbySimilarCard.astro components and their callsites in ObservationForm + ShareObsView + ExplorePlacesView",
+          "label_es": "Eliminar componentes DisambiguationBanner.astro + NearbySimilarCard.astro y sus callsites en ObservationForm + ShareObsView + ExplorePlacesView",
+          "status": "done"
+        },
+        {
+          "label_en": "Remove src/lib/{disambiguation,nearby-similar,places-url}.ts + their tests",
+          "label_es": "Eliminar src/lib/{disambiguation,nearby-similar,places-url}.ts + sus tests",
+          "status": "done"
+        },
+        {
+          "label_en": "Remove handleDisambiguate branch from supabase/functions/identify/index.ts; preserve the #693 fallback chain",
+          "label_es": "Eliminar rama handleDisambiguate de supabase/functions/identify/index.ts; preservar la cadena de fallback #693",
+          "status": "done"
+        },
+        {
+          "label_en": "Remove cascade_config + taxon_pair_disambiguations + nearby_similar_species SQL surface from supabase-schema.sql",
+          "label_es": "Eliminar superficie SQL cascade_config + taxon_pair_disambiguations + nearby_similar_species de supabase-schema.sql",
+          "status": "done"
+        },
+        {
+          "label_en": "Net -2048 LOC across 18 files; intent now served by #736 'Why this species?' panel + #774 contextual species + #760 falta-dex + M28 Nearby flow",
+          "label_es": "Net -2048 LOC en 18 archivos; intención ahora servida por panel #736 '¿Por qué esta especie?' + especies contextuales #774 + falta-dex #760 + flujo Nearby de M28",
+          "status": "done"
+        }
+      ]
+    },
+    "fogg-seasonal-themes": {
+      "phase": "v1.1.5",
+      "title_en": "Conditioning — seasonal + regional theme variants",
+      "title_es": "Condicionamiento — variantes estacionales y regionales de tema",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "src/lib/seasonal-theme.ts pure resolver (now, region) → 'monarca' | 'lluvias' | 'secas' | 'default'",
+          "label_es": "Resolver puro src/lib/seasonal-theme.ts (now, region) → 'monarca' | 'lluvias' | 'secas' | 'default'",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "Inline boot script resolves before first paint; data-season='<theme>' on <html> avoids flicker",
+          "label_es": "Script inline antes del primer pintado; data-season='<tema>' en <html> evita parpadeo",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "5-button picker in Profile → Apariencia (Auto + Default + Monarca + Lluvias + Secas) writes localStorage[rastrum.theme.seasonal]",
+          "label_es": "Selector de 5 botones en Perfil → Apariencia (Auto + Default + Monarca + Lluvias + Secas) escribe localStorage[rastrum.theme.seasonal]",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "MX-Norte / MX-Sur fall back to MX-Centro mapping for v1; registry shape accepts new region keys for v1.1 differentiation",
+          "label_es": "MX-Norte / MX-Sur caen al mapeo MX-Centro en v1; la forma del registro acepta nuevas claves de región para diferenciación v1.1",
+          "status": "planned"
+        }
+      ]
+    },
+    "fogg-peer-norms": {
+      "phase": "v1.1.5",
+      "title_en": "Normative Influence — peer norms on license / privacy",
+      "title_es": "Influencia normativa — normas de pares en licencia / privacidad",
+      "modules": ["07-licensing.md", "25-profile-privacy.md"],
+      "subtasks": [
+        {
+          "label_en": "license_norm + privacy_norm materialised views; refresh-norms-weekly pg_cron (Mon 06:00 UTC)",
+          "label_es": "Vistas materializadas license_norm + privacy_norm; pg_cron refresh-norms-weekly (lunes 06:00 UTC)",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "peer_norm_pct(scope, country, key) SECURITY INVOKER lookup; src/lib/peer-norms.ts wrapper with 9 unit tests + per-page cache",
+          "label_es": "Lookup SECURITY INVOKER peer_norm_pct(scope, country, key); wrapper src/lib/peer-norms.ts con 9 tests unitarios + caché por página",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "License selector on /profile/edit + PrivacyMatrix render small bars; hide when n < 50 (MIN_N_THRESHOLD)",
+          "label_es": "Selector de licencia en /profile/edit + PrivacyMatrix renderizan barras pequeñas; ocultar cuando n < 50 (MIN_N_THRESHOLD)",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "Defaults are unchanged; copy is informational only — no normative-default-flip",
+          "label_es": "Los defaults no cambian; copy es solo informativo — sin flip de default normativo",
+          "status": "in_progress"
+        }
+      ]
+    },
+    "fogg-percentile-card": {
+      "phase": "v1.1.5",
+      "title_en": "Self-monitoring — tú-vs-promedio MX percentile card",
+      "title_es": "Auto-monitoreo — tarjeta tú-vs-promedio MX",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "user_metrics_percentile materialised view computes PERCENT_RANK() over cohort (≥ 5 obs in 90 days, country = MX)",
+          "label_es": "Vista materializada user_metrics_percentile computa PERCENT_RANK() sobre cohorte (≥ 5 obs en 90 días, país = MX)",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "recompute_user_stats() extended via CREATE OR REPLACE with guarded BEGIN/EXCEPTION block — best-effort, never aborts user-stats update",
+          "label_es": "recompute_user_stats() extendido vía CREATE OR REPLACE con bloque BEGIN/EXCEPTION protegido — best-effort, nunca aborta la actualización de user-stats",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "4 cards (Diversity Shannon H', Habitats, Validations, Geographic km²) on /profile/; honest fallback when cohort_n < 50",
+          "label_es": "4 tarjetas (Diversidad Shannon H', Hábitats, Validaciones, Geográfico km²) en /perfil/; fallback honesto cuando cohort_n < 50",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "NEVER raw rank, NEVER 'people above you' copy — Fogg-ethical normative comparison only",
+          "label_es": "NUNCA rank crudo, NUNCA copy 'gente sobre ti' — solo comparación normativa ética Fogg",
+          "status": "in_progress"
+        }
+      ]
+    },
+    "fogg-contextual-suggestions": {
+      "phase": "v1.1.5",
+      "title_en": "Suggestion Technology — contextual species chips on /observe",
+      "title_es": "Tecnología de sugerencia — chips de especies contextuales en /observar",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "probable_taxa_at(p_lat, p_lng, p_month, p_limit) SECURITY INVOKER RPC: ST_DWithin(50 km) + month ±1 + research-grade-or-confirmed; top-N by COUNT DESC, MIN(distance) ASC",
+          "label_es": "RPC SECURITY INVOKER probable_taxa_at(p_lat, p_lng, p_month, p_limit): ST_DWithin(50 km) + mes ±1 + research-grade-o-confirmada; top-N por COUNT DESC, MIN(distancia) ASC",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "ContextualSpeciesChips.astro mounts above DropZone in ObserveView2; emits rastrum:observe-location-ready after first GPS fix",
+          "label_es": "ContextualSpeciesChips.astro monta arriba de DropZone en ObserveView2; emite rastrum:observe-location-ready tras el primer fix de GPS",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "Chip-tap pre-fills the manual ID input (mirrors TaxonAutocomplete.select), never auto-submits",
+          "label_es": "Tocar un chip pre-llena el input de ID manual (refleja TaxonAutocomplete.select), nunca envía automáticamente",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "Cache layer deferred — live RPC < 300 ms at current scale + sessionStorage browser cache; runbook documents migration path",
+          "label_es": "Capa de caché diferida — RPC en vivo < 300 ms a escala actual + caché del navegador en sessionStorage; runbook documenta la ruta de migración",
+          "status": "in_progress"
+        },
+        {
+          "label_en": "24 unit tests in tests/unit/contextual-suggest.test.ts (pickCommonName, formatDistancePill, suggestCacheKey)",
+          "label_es": "24 tests unitarios en tests/unit/contextual-suggest.test.ts (pickCommonName, formatDistancePill, suggestCacheKey)",
+          "status": "in_progress"
+        }
+      ]
+    },
+    "fogg-variable-rewards": {
+      "phase": "v1.1.5",
+      "title_en": "Variable Rewards — transparent 'sorpresa de campo' badges",
+      "title_es": "Recompensas variables — insignias 'sorpresa de campo' transparentes",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "Design rare-but-honest milestones (first species in new genus, first nocturnal observation, first ecoregion, etc.)",
+          "label_es": "Diseñar hitos raros pero honestos (primera especie en nuevo género, primera observación nocturna, primera ecorregión, etc.)",
+          "status": "planned"
+        },
+        {
+          "label_en": "Opt-in toggle in Profile → Preferences; default off (Fogg ch. 5: kairos must be welcomed)",
+          "label_es": "Toggle opt-in en Perfil → Preferencias; por defecto off (Fogg cap. 5: kairos debe ser bienvenido)",
+          "status": "planned"
+        },
+        {
+          "label_en": "Always disclose the underlying rule in the badge tooltip — no slot-machine darkness",
+          "label_es": "Siempre divulgar la regla subyacente en el tooltip de la insignia — sin oscuridad de tragamonedas",
+          "status": "planned"
+        }
+      ]
+    },
+    "fogg-kairos-prompts": {
+      "phase": "v1.1.5",
+      "title_en": "Kairos / Right-Time Prompts — golden hour + after the rain push",
+      "title_es": "Kairos / Avisos al momento justo — push de hora dorada + después de la lluvia",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "Web Push at sunset ± 30 min ('golden hour') and rain stop + 2 h ('after the rain'); geo-aware via region_primary",
+          "label_es": "Web Push en atardecer ± 30 min ('hora dorada') y cese de lluvia + 2 h ('después de la lluvia'); geo-consciente vía region_primary",
+          "status": "planned"
+        },
+        {
+          "label_en": "Single nightly cap per channel; explicitly opt-in (Fogg: kairos must be welcomed, not ambushed)",
+          "label_es": "Tope único nocturno por canal; opt-in explícito (Fogg: kairos debe ser bienvenido, no emboscar)",
+          "status": "planned"
+        },
+        {
+          "label_en": "Cron schedule + push-subscription table + service-worker push handler",
+          "label_es": "Schedule de cron + tabla de subscripciones de push + handler de push en service worker",
+          "status": "planned"
+        }
+      ]
+    },
+    "fogg-ecological-impact-viz": {
+      "phase": "v1.1.5",
+      "title_en": "Cause-and-Effect — 'mi impacto ecológico' visualization",
+      "title_es": "Causa-efecto — visualización 'mi impacto ecológico'",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "Surface research-grade contributions used in GBIF, validations that helped peers, sensitive-species records that helped CONANP staff",
+          "label_es": "Mostrar contribuciones research-grade usadas en GBIF, validaciones que ayudaron a pares, registros de especies sensibles que ayudaron a CONANP",
+          "status": "planned"
+        },
+        {
+          "label_en": "Honest framing — every claimed effect links to a verifiable trace; no inflated metrics",
+          "label_es": "Framing honesto — cada efecto reclamado enlaza a una traza verificable; sin métricas infladas",
+          "status": "planned"
+        },
+        {
+          "label_en": "Renders on /profile/ as a card; per-user data only (privacy: not exposed in /u/<handle>/ visitor view)",
+          "label_es": "Renderiza en /perfil/ como tarjeta; datos solo del usuario (privacidad: no expuesto en vista visitante /u/<handle>/)",
+          "status": "planned"
+        }
+      ]
     }
   }
 }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -4,7 +4,7 @@
 > Source of truth for both surfaces; renders the live page at
 > [/docs/tasks/](https://rastrum.org/en/docs/tasks/).
 > 
-> **Updated:** 2026-04-30 (v1.2 research workflow — M28 community discovery, M29 projects, M30 CLI batch import, M31 camera stations, M32 multi-provider vision, obs-detail redesign, admin console PR16 entity browsers; subtask granularity deepened for 53 roadmap items per #180).
+> **Updated:** 2026-05-08 (v1.1.5 Persuasive Tech Audit — Tier S + Tier A Fogg principles shipped; Ola 2b in flight. v1.2 research workflow — M28 community discovery, M29 projects, M30 CLI batch import, M31 camera stations, M32 multi-provider vision, obs-detail redesign, admin console PR16 entity browsers; subtask granularity deepened for 53 roadmap items per #180).
 
 ---
 
@@ -19,6 +19,7 @@
 | v1.0.x | Post-launch polish | in_progress | 8 / 24 |
 | v1.1 | UX polish + admin console + M22/M26/M27 | shipped (mostly) | 39 / 44 |
 | v1.2 | Research workflow (M28-M32 + obs-detail + privacy) | shipped 2026-04-30 | 17 / 17 |
+| v1.1.5 | Persuasive Tech Audit (Fogg principles) | Tier S+A shipped; Ola 2b in flight | 9 / 16 |
 | **v0.1 → v1.0** | **Public launch** | **shipped 2026-04-26** | **54 / 59** |
 
 Phases v1.5, v2.0, v2.5 are tracked in [`progress.json`](progress.json) but have no shipped code yet — they are planned scope only.
@@ -226,6 +227,45 @@ A second wave landed the same day, focused on the CONANP-Oaxaca / DRFSIPS / PROR
   expiry-monitor crons (PR #207), nightly per-provider smoke probe
   (PR #210). _(✓ shipped — pool dashboard with top-taxa, cost-per-100
   picker, pool karma incentives tracked as #226/#227/#228)_
+
+## v1.1.5 — Persuasive Tech Audit (Fogg principles) — Tier S+A shipped; Ola 2b in flight
+
+**9 of 16 items done.** A principles-driven UX audit applying B.J. Fogg's
+*Persuasive Technology* (Stanford CS) chapter-by-chapter to Rastrum's
+existing surfaces. Tier S (foundation) and Tier A (transparency +
+real-world feel) are merged; Ola 2b (conditioning + kairos + cause-and-effect)
+is partially in flight, partially still as open issues.
+
+### Tier S — shipped 2026-05-08 (Reduction + Praise + Self-monitoring + Social Facilitation + Responsiveness)
+
+- `fogg-quick-observation` — Reduction. One-tap Quick Observation flow (foto + GPS + async ID); long-press the centre FAB or `?quick=1` collapses the standard 5-tap form to a single action; no-GPS path saves as draft + `promoteDraftsWithGps` worker. PR #759 (closes #721). _(✓ done)_
+- `fogg-photo-praise` — Praise. EXIF-driven photo praise badge on upload (5 priority-ordered rules: sharp_action, portrait_aperture, long_lens, good_light, balanced_exposure); silent when EXIF missing or ISO ≥ 800 — never aesthetic, never dishonest. PR #757 (closes #733). _(✓ done)_
+- `fogg-triage-sla` — Responsiveness. Public roadmap-triage SLA dashboard at `/docs/status/`; nightly workflow computes open count + median first-comment hours + resolved-30d via `gh` CLI, fault-tolerant fallback preserves last good JSON. PR #761 (closes #740). _(✓ done)_
+- `fogg-active-observers-banner` — Social Facilitation. Active-observers micro-banner on `/observe` ("Hoy 7 personas observan en Oaxaca · únete"); `community_active_observers_today(p_country)` RPC mirrors the M28 anon-safe predicate (`hide_from_leaderboards = false`). PR #758 (closes #743). _(✓ done)_
+- `fogg-falta-dex` — Self-monitoring. "Show missing" toggle on the Pokédex appends silhouette cards for species the user hasn't observed but are present in their region; owner-only; Option A baseline (Rastrum's own data per country, no GBIF ETL). PR #760 (phase-1 of #726, supersedes #561). _(✓ done — runbook [`docs/runbooks/falta-dex.md`](runbooks/falta-dex.md))_
+
+### Tier A — shipped 2026-05-08 / 2026-05-09 (Real-World Feel + Reputed Credibility + Transparency)
+
+- `fogg-field-theme` — Real-World Feel. High-contrast Field theme (Campo) for direct sunlight; pure black bg / white text / no gradients; 1.25× hit-target sizing on mobile FAB + inputs; auto-engages at > 5 000 lux via `AmbientLightSensor` when stored preference is 'auto'. PR #768. _(✓ done)_
+- `fogg-about-humanized` — Reputed Credibility. Humanized About page replaces auto-generated copy with team / funding / governance / live-stats / press sections; build-time stats from Supabase REST + publishable anon key; explicit "currently unfunded" framing. PR #770 (closes #739). _(✓ done)_
+- `fogg-why-am-i-seeing-this` — Transparency. WhyAmISeeingThis algorithmic disclosure on every ranked surface; single source of truth in `src/lib/algorithms.ts`, global modal pattern (focus trap, Esc/backdrop close), wired today on `community_observers` + `explore_recent` + `explore_species_recent`; new `/docs/algorithms/` reference page enumerates the catalog + 4 principles. PR #772 (closes #738). _(✓ done)_
+
+### Cleanup — superseded features removed
+
+- `fogg-cleanup-superseded` — Net -2048 LOC across 18 files: dropped `DisambiguationBanner` (#684) + `NearbySimilarCard` (#679) + `places-url` (#678) whose user-facing intent is now better served by the Fogg replacements. Replacement intent: #736 "Why this species?" panel (Tier B), #774 contextual species (Tier A in flight), #760 falta-dex (shipped), and the M28 Nearby flow's existing `community_observers_nearby_at` RPC. PR #766. _(✓ done)_
+
+### Ola 2b — in flight 2026-05-08
+
+- `fogg-seasonal-themes` — Conditioning. Seasonal + regional theme variants reflecting MX's ecological calendar: monarca (Oct–Mar), lluvias (Jun–Sep), secas (Apr–May), default (brand emerald). MX-Norte / MX-Sur fall back to MX-Centro mapping for v1. PR #769 (closes #731). _(· in flight)_
+- `fogg-peer-norms` — Normative Influence. Show peer norms when configuring license / privacy ("82% of MX observers choose this"); `license_norm` + `privacy_norm` materialised views, `peer_norm_pct(scope, country, key)` SECURITY INVOKER lookup, weekly refresh cron. Defaults are unchanged; copy is informational only. PR #771 (closes #745). _(· in flight)_
+- `fogg-percentile-card` — Self-monitoring. Tú-vs-promedio MX comparison card on `/profile/` (4 metrics × percentile bar); cohort = users with ≥ 5 obs in 90 days. NEVER raw rank, NEVER "people above you" copy — Fogg-ethical normative comparison only. PR #773 (closes #744). _(· in flight)_
+- `fogg-contextual-suggestions` — Suggestion Technology. Chip strip on `/observe` surfaces 5–10 species likely at the user's location + month via `probable_taxa_at(p_lat, p_lng, p_month, p_limit)` RPC. Tap pre-fills the manual ID, never auto-submits. PR #774 (closes #723). _(· in flight)_
+
+### Ola 2b — planned (open issues, no PR yet)
+
+- `fogg-variable-rewards` — Variable Rewards. Transparent, opt-in "sorpresa de campo" badges on rare-but-honest milestones; rule always disclosed in tooltip. _(! planned — issue #727)_
+- `fogg-kairos-prompts` — Kairos. Opt-in Web Push at "golden hour" (sunset ± 30 min) and "after the rain" (rain stop + 2 h); single nightly cap per channel. _(! planned — issue #724)_
+- `fogg-ecological-impact-viz` — Cause-and-Effect. "Mi impacto ecológico" visualization links every claimed downstream effect to a verifiable trace; honest framing, no inflated metrics. _(! planned — issue #728)_
 
 ---
 


### PR DESCRIPTION
## Summary

Captures the Fogg-driven UX wave that landed across **9 merged PRs and
4 in-flight PRs**. Adds a new `v1.1.5` phase to `progress.json` /
`tasks.json` keeping the principle taxonomy front-and-centre. No code
changes — pure doc sync so the public roadmap (`/docs/roadmap/`) and
tasks page (`/docs/tasks/`) reflect the audit.

## PRs cataloged

### Tier S (Fogg Phase 1) — merged 2026-05-08
- **#759** `feat(observe)` one-tap Quick Observation mode (closes #721) — Reduction
- **#757** `feat(praise)` contextual photo praise on upload, EXIF-driven (closes #733) — Praise
- **#761** `feat(triage)` public roadmap-triage SLA dashboard (closes #740) — Responsiveness
- **#758** `feat(community)` active-observers micro-banner on /observe (closes #743) — Social Facilitation
- **#760** `feat(profile)` falta-dex taxonomic gaps panel (phase-1 of #726, supersedes #561) — Self-monitoring

### Tier A (Fogg Phase 2) — merged 2026-05-08 / 2026-05-09
- **#768** `feat(theme)` high-contrast Field theme for direct sunlight — Real-World Feel
- **#770** `feat(about)` humanize About page — team, funding, governance (closes #739) — Reputed Credibility
- **#772** `feat(meta)` WhyAmISeeingThis algorithmic disclosure on every ranking (closes #738) — Transparency

### Cleanup
- **#766** `chore(cleanup)` remove disambiguation + nearby-similar + places-url. Net -2048 LOC; intent now served by Fogg replacements (#736 "Why this species?" panel, #774 contextual species, #760 falta-dex, M28 Nearby flow).

### Ola 2b — open PRs
- **#769** `feat(theme)` seasonal + regional theme variants — Conditioning
- **#771** `feat(config)` show peer norms when configuring license / privacy — Normative Influence
- **#773** `feat(profile)` tú vs. promedio MX comparison card — Self-monitoring (percentile)
- **#774** `feat(suggest)` contextual species suggestions by location + season — Suggestion Technology

### Ola 2b — open issues (no PR yet)
- **#727** Variable Rewards — transparent 'sorpresa de campo' badges
- **#724** Kairos — 'golden hour' + 'after the rain' contextual prompts
- **#728** Cause-and-Effect — 'mi impacto ecológico' visualization

### Footnote
- **#763** `fix(ai-tab)` JSON.stringify-in-script bug fix is orthogonal but landed in the same window.

## Files changed

- `docs/progress.json` — new `v1.1.5` phase with 16 items (9 done, 4 in flight, 3 planned). Top-level `notes` / `notes_es` get a 2026-05-08 entry summarising the audit.
- `docs/tasks.json` — 16 matching entries with 3-5 subtasks each.
- `docs/tasks.md` — at-a-glance row + new Tier S / Tier A / Ola 2b breakdown.
- `CLAUDE.md` — `Last full doc sync` bumped to 2026-05-08; new "Persuasive Tech (Fogg) — v1.1.5 conventions" section pins four load-bearing rules:
  1. `src/lib/algorithms.ts` is the single source of truth for ranked surfaces (one entry per `AlgorithmId`, single global `WhyAmISeeingThisDialog`).
  2. Theme is a 4-state machine (`light | dark | auto | field`); Field is layered on top of `.dark` so `dark:*` Tailwind utilities stay readable.
  3. Honest-norms invariant — peer comparisons hide when `n < 50` and never raw-rank ("datos insuficientes" fallback).
  4. Photo praise is taxon-agnostic + EXIF-only; `pickPraise(exif)` returns `null` when EXIF missing or no rule matches.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test` — 1264 / 1264 passing (no test changes)
- [x] `npm run build` — 235 pages, EN/ES paired (the `/docs/roadmap/` and `/docs/tasks/` pages read these JSON files at build time, so an invalid JSON would break the site)
- [x] Cross-check `progress.json` IDs match `tasks.json` IDs for the new phase

## Out of scope

- New runbooks for triage SLA / Field theme / WhyAmISeeingThis. The PR
  bodies + the new CLAUDE.md section already cover the conventions; the
  themes runbook will land with #769.
- Updating modules/00-index.md — none of the Fogg features warranted
  their own NN-*.md spec (they're cross-cutting UX rather than new
  modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)