### PR TITLE
feat(badges): variable-reward sorpresas (transparent, opt-in)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -9159,3 +9159,121 @@ CREATE POLICY "kairos_subs_delete_own" ON public.kairos_subscriptions
   FOR DELETE TO authenticated USING (auth.uid() = user_id);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.kairos_subscriptions TO authenticated;
+-- ---------------------------------------------------------------------------
+-- M-Surprises — Sorpresas de campo (transparent, opt-in variable rewards)
+-- Closes #727. Catalog is FIXED in the client (src/lib/surprises.ts):
+-- 'dato_curioso' (10 % random), 'rarito' (deterministic on rare bucket),
+-- 'comunidad_activa_hoy' (deterministic, max 1×/day). Defaults OFF.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS surprises_opt_in boolean NOT NULL DEFAULT false;
+
+GRANT UPDATE (surprises_opt_in) ON public.users TO authenticated;
+
+CREATE TABLE IF NOT EXISTS public.surprise_events (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  observation_id  uuid REFERENCES public.observations(id) ON DELETE SET NULL,
+  kind            text NOT NULL CHECK (kind IN ('dato_curioso','rarito','comunidad_activa_hoy')),
+  payload         jsonb NOT NULL DEFAULT '{}'::jsonb,
+  shown_at        timestamptz NOT NULL DEFAULT now(),
+  dismissed_at    timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS surprise_events_user_day_idx
+  ON public.surprise_events (user_id, shown_at DESC);
+
+ALTER TABLE public.surprise_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS surprise_events_self_read ON public.surprise_events;
+CREATE POLICY surprise_events_self_read ON public.surprise_events
+  FOR SELECT USING (user_id = auth.uid());
+
+-- Authenticated users can insert their own rows; the daily cap is
+-- enforced by `record_surprise_event()` below (SECURITY DEFINER) so a
+-- racing tab can't beat it. The direct-insert policy is a safety net
+-- for tests + admin tooling — combined with the cap function nothing
+-- bypasses the rule.
+DROP POLICY IF EXISTS surprise_events_self_insert ON public.surprise_events;
+CREATE POLICY surprise_events_self_insert ON public.surprise_events
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT ON public.surprise_events TO authenticated;
+
+-- ---- Helpers --------------------------------------------------------------
+
+-- Today's count for the calling user. Used by the client to short-circuit
+-- the picker before it hits any other RPC. Cheap (covered by the index).
+CREATE OR REPLACE FUNCTION public.surprise_count_today()
+RETURNS integer
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT COUNT(*)::int
+    FROM public.surprise_events
+   WHERE user_id = auth.uid()
+     AND shown_at >= date_trunc('day', now() AT TIME ZONE 'UTC');
+$$;
+
+REVOKE ALL ON FUNCTION public.surprise_count_today() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.surprise_count_today() TO authenticated;
+
+-- Atomic record-with-cap-check. Returns the inserted row id when the
+-- user is under cap, or NULL when capped or opted-out. Inline-checking
+-- is the only way to avoid TOCTOU between two tabs racing the same
+-- observation.
+CREATE OR REPLACE FUNCTION public.record_surprise_event(
+  p_observation_id uuid,
+  p_kind           text,
+  p_payload        jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_uid          uuid := auth.uid();
+  v_count        int;
+  v_id           uuid;
+  v_opt_in       boolean;
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Honour the per-user opt-in. Insert is silently skipped when off so
+  -- we never log a surprise the user wouldn't have seen.
+  SELECT surprises_opt_in INTO v_opt_in
+    FROM public.users
+   WHERE id = v_uid;
+  IF NOT COALESCE(v_opt_in, false) THEN
+    RETURN NULL;
+  END IF;
+
+  IF p_kind NOT IN ('dato_curioso','rarito','comunidad_activa_hoy') THEN
+    RAISE EXCEPTION 'Unknown surprise kind: %', p_kind;
+  END IF;
+
+  -- 1×/day cap
+  SELECT COUNT(*) INTO v_count
+    FROM public.surprise_events
+   WHERE user_id = v_uid
+     AND shown_at >= date_trunc('day', now() AT TIME ZONE 'UTC');
+  IF v_count >= 1 THEN
+    RETURN NULL;
+  END IF;
+
+  INSERT INTO public.surprise_events (user_id, observation_id, kind, payload)
+  VALUES (v_uid, p_observation_id, p_kind, COALESCE(p_payload, '{}'::jsonb))
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_surprise_event(uuid, text, jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.record_surprise_event(uuid, text, jsonb) TO authenticated;

--- a/src/components/SurpriseOverlay.astro
+++ b/src/components/SurpriseOverlay.astro
@@ -1,0 +1,159 @@
+---
+/**
+ * SurpriseOverlay — modal shown after a synced observation when a
+ * `surprise` candidate is picked (see src/lib/surprises.ts).
+ *
+ * Mounts globally in BaseLayout. The trigger (in src/lib/sync.ts)
+ * dispatches `rastrum:surprise-show` with the resolved candidate;
+ * this component listens on `window` and renders the card.
+ *
+ * Esc / backdrop click closes. Focus trap mirrors ReportDialog. The
+ * "What is this?" link points to /docs/surprises (EN/ES) so the user
+ * can audit the rules.
+ *
+ * #727. Variable rewards under Fogg ch. 9 ethics: rules disclosed,
+ * opt-in default-off, single-source catalog. No hidden behaviour.
+ */
+import { t, getDocPath } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+const { lang } = Astro.props;
+const tr = t(lang);
+const sup = (tr as unknown as { surprises: { overlay_close: string; overlay_what_is_this: string; overlay_aria_label: string } }).surprises;
+const docHref = lang === 'es' ? getDocPath('es', 'surprises') : getDocPath('en', 'surprises');
+---
+
+<div
+  id="rastrum-surprise-overlay"
+  class="hidden fixed inset-0 z-[60] flex items-center justify-center bg-zinc-950/60 backdrop-blur-sm px-4"
+  data-lang={lang}
+  data-doc-href={docHref}
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="rastrum-surprise-title"
+  aria-label={sup.overlay_aria_label}
+>
+  <div
+    class="w-full max-w-md rounded-2xl bg-white dark:bg-zinc-900 ring-1 ring-zinc-200 dark:ring-zinc-800 shadow-2xl overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-200"
+  >
+    <div class="px-5 pt-5 pb-2 flex items-start gap-3">
+      <div
+        data-rs-icon
+        class="shrink-0 mt-0.5 inline-flex h-9 w-9 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 text-lg"
+        aria-hidden="true"
+      >&#10022;</div>
+      <div class="min-w-0 flex-1">
+        <h2 id="rastrum-surprise-title" class="text-base font-semibold text-zinc-900 dark:text-zinc-100" data-rs-title>
+          &mdash;
+        </h2>
+        <p class="mt-1 text-sm text-zinc-700 dark:text-zinc-300" data-rs-body>&mdash;</p>
+      </div>
+    </div>
+
+    <footer class="px-5 py-3 flex items-center justify-between gap-2 border-t border-zinc-100 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-950/30">
+      <a
+        data-rs-doc
+        href={docHref}
+        class="text-xs font-medium text-emerald-700 dark:text-emerald-400 hover:underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {sup.overlay_what_is_this}
+      </a>
+      <button
+        type="button"
+        data-rs-close
+        class="inline-flex min-h-[36px] items-center justify-center rounded-lg bg-emerald-700 hover:bg-emerald-800 px-4 py-1.5 text-sm font-semibold text-white transition-colors"
+      >
+        {sup.overlay_close}
+      </button>
+    </footer>
+  </div>
+</div>
+
+<script>
+  type SurpriseKind = 'dato_curioso' | 'rarito' | 'comunidad_activa_hoy';
+
+  interface ShowDetail {
+    kind: SurpriseKind;
+    title: string;
+    body: string;
+  }
+
+  const root = document.getElementById('rastrum-surprise-overlay');
+  if (root) {
+    const titleEl = root.querySelector<HTMLElement>('[data-rs-title]');
+    const bodyEl  = root.querySelector<HTMLElement>('[data-rs-body]');
+    const iconEl  = root.querySelector<HTMLElement>('[data-rs-icon]');
+    const closeBtn = root.querySelector<HTMLButtonElement>('[data-rs-close]');
+    const docEl   = root.querySelector<HTMLAnchorElement>('[data-rs-doc]');
+
+    let lastFocused: HTMLElement | null = null;
+    const FOCUSABLE_SEL = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    function focusableEls(): HTMLElement[] {
+      return Array.from(root!.querySelectorAll<HTMLElement>(FOCUSABLE_SEL))
+        .filter((el) => el.offsetParent !== null);
+    }
+
+    function close() {
+      root!.classList.add('hidden');
+      lastFocused?.focus();
+      lastFocused = null;
+    }
+
+    function open(detail: ShowDetail) {
+      lastFocused = (document.activeElement as HTMLElement | null) ?? null;
+      if (titleEl) titleEl.textContent = detail.title;
+      if (bodyEl)  bodyEl.textContent  = detail.body;
+      if (iconEl) {
+        iconEl.textContent =
+          detail.kind === 'rarito' ? '✦' :
+          detail.kind === 'comunidad_activa_hoy' ? '◎' : '✦';
+      }
+      root!.classList.remove('hidden');
+      // Focus the close button so Esc/Enter both work without a re-tab.
+      closeBtn?.focus();
+    }
+
+    closeBtn?.addEventListener('click', close);
+    root.addEventListener('click', (e) => {
+      if (e.target === root) close();
+    });
+    document.addEventListener('keydown', (e) => {
+      const ev = e as KeyboardEvent;
+      if (root.classList.contains('hidden')) return;
+      if (ev.key === 'Escape') {
+        close();
+        return;
+      }
+      if (ev.key === 'Tab') {
+        const els = focusableEls();
+        if (els.length === 0) return;
+        const first = els[0];
+        const last = els[els.length - 1];
+        const active = document.activeElement as HTMLElement | null;
+        if (ev.shiftKey && active === first) {
+          ev.preventDefault();
+          last.focus();
+        } else if (!ev.shiftKey && active === last) {
+          ev.preventDefault();
+          first.focus();
+        }
+      }
+    });
+
+    // Make sure the doc link reflects the current locale even after
+    // hydration (the SSR href is correct; this is just defensive).
+    const fallbackDoc = root.dataset.docHref;
+    if (docEl && fallbackDoc) docEl.href = fallbackDoc;
+
+    window.addEventListener('rastrum:surprise-show', (e) => {
+      const ev = e as CustomEvent<ShowDetail>;
+      if (!ev.detail) return;
+      open(ev.detail);
+    });
+  }
+</script>

--- a/src/components/SurprisesDocView.astro
+++ b/src/components/SurprisesDocView.astro
@@ -1,0 +1,109 @@
+---
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+---
+
+<article class="prose prose-zinc dark:prose-invert max-w-none">
+  <h1>{isEs ? 'Sorpresas de campo' : 'Field surprises'}</h1>
+  <p class="lead text-lg text-zinc-600 dark:text-zinc-400">
+    {isEs
+      ? 'De vez en cuando, Rastrum puede mostrarte una pequeña tarjeta tras una observación: un dato curioso, un aviso de especie rara o cuántos otros observadores estuvieron activos hoy en tu región. Esta página explica exactamente cómo se decide y cómo apagarlo.'
+      : 'Now and then, after you log an observation, Rastrum may show you a small card: a fact, a rare-species call-out, or how many other observers were active today in your region. This page explains exactly how that is decided — and how to turn it off.'}
+  </p>
+
+  <h2>{isEs ? 'Por qué existe esto' : 'Why this exists'}</h2>
+  <p>
+    {isEs
+      ? 'B.J. Fogg describe en Persuasive Technology (cap. 9) que las recompensas variables ocultas — del estilo "tragamonedas" — son un patrón oscuro. Pero las recompensas variables transparentes, donde tú conoces las reglas, no son manipulación: son simple sorpresa-y-deleite. Esta página existe para mantener Rastrum del lado correcto de esa línea.'
+      : 'B.J. Fogg describes in Persuasive Technology (ch. 9) that hidden variable rewards — slot-machine style — are a dark pattern. But transparent variable rewards, where you know the rules, are not manipulation: they are surprise-and-delight. This page exists so Rastrum stays on the right side of that line.'}
+  </p>
+  <p>
+    {isEs
+      ? 'El catálogo es FIJO en el código (no se puede agregar un tipo de sorpresa sin un PR). El tope diario es FIJO. La opción está APAGADA por defecto.'
+      : 'The catalog is FIXED in the code (no surprise type can be added without a PR). The daily cap is FIXED. The toggle is OFF by default.'}
+  </p>
+
+  <h2>{isEs ? 'El catálogo (3 tipos)' : 'The catalog (3 kinds)'}</h2>
+
+  <h3><code>dato_curioso</code> &mdash; {isEs ? 'dato curioso' : 'did you know?'}</h3>
+  <ul>
+    <li><strong>{isEs ? 'Cuándo se dispara' : 'When it fires'}:</strong> {isEs
+      ? 'aleatorio, ~10 % de las observaciones sincronizadas que tengan una especie identificada con un dato curado disponible en tu idioma.'
+      : 'random, ~10 % of synced observations that have an identified species with a curated fact available in your locale.'}</li>
+    <li><strong>{isEs ? 'Aleatoriedad' : 'Randomness'}:</strong> {isEs
+      ? 'el sorteo se hace con un PRNG sembrado por el ID de la observación, así que reabrir la app no cambia el resultado.'
+      : 'the dice roll is made with a PRNG seeded by the observation ID, so re-opening the app does not change the outcome.'}</li>
+    <li><strong>{isEs ? 'Datos' : 'Facts'}:</strong> {isEs
+      ? 'curados a mano por especie en src/lib/surprise-facts.ts. Cuando no tenemos un dato para esa especie usamos el pool genérico.'
+      : 'hand-curated per species in src/lib/surprise-facts.ts. When no fact is on file for that species we use a generic pool.'}</li>
+  </ul>
+
+  <h3><code>rarito</code> &mdash; {isEs ? 'observación rara' : 'rare find'}</h3>
+  <ul>
+    <li><strong>{isEs ? 'Cuándo se dispara' : 'When it fires'}:</strong> {isEs
+      ? 'determinista. Si la especie identificada cae en el bucket "rare" del cálculo nocturno de rareza (top ~5 %), aparece esta tarjeta. Sin azar.'
+      : 'deterministic. If the identified species lands in the "rare" bucket of the nightly rarity recompute (top ~5 %), this card shows. No randomness.'}</li>
+    <li><strong>{isEs ? 'Prioridad' : 'Priority'}:</strong> {isEs
+      ? 'rarito gana sobre los otros tipos cuando se dispara — es la información más informativa de las tres.'
+      : 'rarito wins over the others when it fires — it is the most informative of the three.'}</li>
+  </ul>
+
+  <h3><code>comunidad_activa_hoy</code> &mdash; {isEs ? 'comunidad activa hoy' : 'community active today'}</h3>
+  <ul>
+    <li><strong>{isEs ? 'Cuándo se dispara' : 'When it fires'}:</strong> {isEs
+      ? 'determinista, máximo 1 vez al día. Solo cuando hay 2 o más observadores activos en tu país hoy.'
+      : 'deterministic, max once per day. Only when there are 2 or more active observers in your country today.'}</li>
+    <li><strong>{isEs ? 'Cómo se calcula' : 'How it is computed'}:</strong> {isEs
+      ? 'la función SQL community_active_observers_today() cuenta observadores únicos con observaciones sincronizadas hoy en tu país (ISO-3166), excluyendo perfiles que se ocultaron de leaderboards.'
+      : 'the SQL function community_active_observers_today() counts unique observers with synced observations today in your country (ISO-3166), excluding profiles that opted out of leaderboards.'}</li>
+  </ul>
+
+  <h2>{isEs ? 'Tope diario' : 'Daily cap'}</h2>
+  <p>
+    {isEs
+      ? 'Como máximo se muestra UNA sorpresa al día, sin importar cuántas observaciones registres. El tope se aplica en dos lugares: localStorage del navegador (cap rápido) y la función SQL record_surprise_event() en Postgres (a prueba de carreras entre pestañas).'
+      : 'At most ONE surprise per day, no matter how many observations you log. The cap is enforced in two places: browser localStorage (fast cap) and the SQL function record_surprise_event() in Postgres (race-proof across tabs).'}
+  </p>
+
+  <h2>{isEs ? 'Privacidad' : 'Privacy'}</h2>
+  <ul>
+    <li>{isEs
+      ? 'La tabla surprise_events tiene RLS read-own. Solo tú ves tus propias filas.'
+      : 'The surprise_events table is RLS read-own. Only you see your own rows.'}</li>
+    <li>{isEs
+      ? 'No se envía nada a sponsors, terceros ni se publica nunca en tu perfil.'
+      : 'Nothing is sent to sponsors, third parties, nor ever published on your profile.'}</li>
+    <li>{isEs
+      ? 'El conteo de observadores activos se calcula con datos ya públicos (mismo origen que el directorio de la comunidad).'
+      : 'The active-observers count is computed from already-public data (same source as the community directory).'}</li>
+  </ul>
+
+  <h2>{isEs ? 'Cómo apagarlo' : 'How to turn it off'}</h2>
+  <p>
+    {isEs
+      ? 'Ve a Perfil → Ajustes → Preferencias → "Sorpresas de campo" y desactiva el checkbox. El cambio surte efecto inmediatamente.'
+      : 'Go to Profile → Settings → Preferences → "Field surprises" and uncheck the box. The change takes effect immediately.'}
+  </p>
+
+  <h2>{isEs ? 'Lo que NO hace' : 'What this is NOT'}</h2>
+  <ul>
+    <li><strong>{isEs ? 'No es loot' : 'Not loot'}</strong>. {isEs
+      ? 'No hay desbloqueables, monedas, ni "racha de sorpresas". Una sorpresa es un mensaje, no un premio canjeable.'
+      : 'There are no unlockables, currencies, or "surprise streaks". A surprise is a message, not a redeemable prize.'}</li>
+    <li><strong>{isEs ? 'No reemplaza badges' : 'Does not replace badges'}</strong>. {isEs
+      ? 'Los logros y rachas siguen existiendo independientes. Las sorpresas no afectan tu karma, racha ni dex.'
+      : 'Achievements and streaks remain independent. Surprises do not affect your karma, streak, or dex.'}</li>
+    <li><strong>{isEs ? 'No es publicidad' : 'Not advertising'}</strong>. {isEs
+      ? 'Ningún tipo de sorpresa promociona productos, sponsors ni un próximo evento.'
+      : 'No surprise kind promotes products, sponsors, or an upcoming event.'}</li>
+  </ul>
+
+  <p class="text-sm text-zinc-500 mt-8">
+    {isEs ? 'Issue: ' : 'Issue: '}
+    <a href="https://github.com/ArtemioPadilla/rastrum/issues/727" class="underline">#727</a>
+    {' · '}
+    {isEs ? 'Código: ' : 'Code: '}
+    <a href="https://github.com/ArtemioPadilla/rastrum/blob/main/src/lib/surprises.ts" class="underline">src/lib/surprises.ts</a>
+  </p>
+</article>

--- a/src/components/SurprisesPrefsSection.astro
+++ b/src/components/SurprisesPrefsSection.astro
@@ -1,0 +1,105 @@
+---
+/**
+ * SurprisesPrefsSection — toggle for `users.surprises_opt_in` plus a
+ * link to /docs/surprises. Default OFF (column default is `false`).
+ * Closes #727.
+ */
+import { t, getDocPath } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+const { lang } = Astro.props;
+const tr = t(lang);
+const sup = (tr as unknown as { surprises: { section_title: string; section_hint: string; toggle_label: string; toggle_off_status: string; toggle_on_status: string; toggle_save_failed: string; learn_more: string } }).surprises;
+const docHref = lang === 'es' ? getDocPath('es', 'surprises') : getDocPath('en', 'surprises');
+---
+
+<section class="mt-10 border-t border-zinc-200 dark:border-zinc-800 pt-8">
+  <h2 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider mb-2">
+    {sup.section_title}
+  </h2>
+  <p class="text-xs text-zinc-500 dark:text-zinc-400 mb-3">{sup.section_hint}</p>
+
+  <div class="rounded-lg border border-zinc-200 dark:border-zinc-800 p-3 flex flex-col gap-2">
+    <label class="flex items-start gap-3 cursor-pointer">
+      <input
+        id="surprises-opt-in"
+        type="checkbox"
+        class="mt-0.5 h-4 w-4 rounded border-zinc-300 dark:border-zinc-600 text-emerald-600 focus:ring-emerald-500"
+      />
+      <span class="text-sm text-zinc-800 dark:text-zinc-200">{sup.toggle_label}</span>
+    </label>
+    <p id="surprises-opt-in-status" class="text-xs text-zinc-500 dark:text-zinc-400 ml-7"></p>
+    <p id="surprises-opt-in-error" class="hidden ml-7 text-xs text-rose-600 dark:text-rose-400"></p>
+  </div>
+
+  <p class="mt-2 text-xs">
+    <a href={docHref} class="text-emerald-700 dark:text-emerald-400 hover:underline">
+      {sup.learn_more}
+    </a>
+  </p>
+</section>
+
+<script define:vars={{ statusOn: sup.toggle_on_status, statusOff: sup.toggle_off_status, errorMsg: sup.toggle_save_failed }}>
+  (async function () {
+    const cb = /** @type {HTMLInputElement | null} */ (document.getElementById('surprises-opt-in'));
+    const statusEl = document.getElementById('surprises-opt-in-status');
+    const errorEl = document.getElementById('surprises-opt-in-error');
+    if (!cb || !statusEl) return;
+
+    function setStatus(checked) {
+      statusEl.textContent = checked ? statusOn : statusOff;
+    }
+
+    function setError(msg) {
+      if (!errorEl) return;
+      if (!msg) { errorEl.classList.add('hidden'); errorEl.textContent = ''; return; }
+      errorEl.textContent = msg;
+      errorEl.classList.remove('hidden');
+    }
+
+    const { getSupabase } = await import('../lib/supabase.ts');
+    const supabase = getSupabase();
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.user?.id) {
+      cb.disabled = true;
+      setStatus(false);
+      return;
+    }
+    const userId = session.user.id;
+
+    // Read current pref
+    try {
+      const { data } = await supabase
+        .from('users')
+        .select('surprises_opt_in')
+        .eq('id', userId)
+        .maybeSingle();
+      const current = data?.surprises_opt_in === true;
+      cb.checked = current;
+      setStatus(current);
+    } catch {
+      setStatus(false);
+    }
+
+    cb.addEventListener('change', async () => {
+      const desired = cb.checked;
+      cb.disabled = true;
+      setError('');
+      try {
+        const { error } = await supabase
+          .from('users')
+          .update({ surprises_opt_in: desired })
+          .eq('id', userId);
+        if (error) throw error;
+        setStatus(desired);
+      } catch {
+        cb.checked = !desired;
+        setError(errorMsg);
+      } finally {
+        cb.disabled = false;
+      }
+    });
+  })();
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1671,6 +1671,23 @@
       "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
     }
   },
+  "surprises": {
+    "section_title": "Field surprises",
+    "section_hint": "Occasionally show a card after a synced observation: a fact, a rare-species call-out, or how many other observers were active today. Off by default. Capped at 1 per day. Rules are public.",
+    "toggle_label": "Enable field surprises",
+    "toggle_off_status": "Off — no surprises will be shown.",
+    "toggle_on_status": "On — at most one surprise per day.",
+    "toggle_save_failed": "Couldn't save preference. Try again.",
+    "learn_more": "What is this?",
+    "overlay_close": "Close",
+    "overlay_what_is_this": "What is this?",
+    "overlay_aria_label": "Surprise card",
+    "kinds": {
+      "dato_curioso_title": "Did you know?",
+      "rarito_title": "Rare find!",
+      "comunidad_activa_hoy_title": "Community active today"
+    }
+  },
   "docs": {
     "nav_title": "Documentation",
     "toc_aria_label": "Section navigation",
@@ -1700,7 +1717,8 @@
       "sponsor-pools": "Sponsor Pools",
       "obs-detail": "Observation Detail",
       "status": "Triage status",
-      "algorithms": "Algorithms"
+      "algorithms": "Algorithms",
+      "surprises": "Field surprises"
     },
     "descriptions": {
       "vision": "Mission, problem statement, and why Oaxaca is the right place to start.",
@@ -1724,7 +1742,8 @@
       "sponsor-pools": "Multi-provider AI vision and platform sponsor pools. Anthropic, Vertex, and OpenAI with community credit distribution.",
       "obs-detail": "Observation detail page with photo gallery, interactive map, community identifications, and owner management tools.",
       "status": "Public triage SLA dashboard: open issues, median time-to-first-comment over the last 30 days, and recent resolution count.",
-      "algorithms": "Every ranked surface in Rastrum, with the inputs it consumes, the time window it considers, and the settings that change its behavior."
+      "algorithms": "Every ranked surface in Rastrum, with the inputs it consumes, the time window it considers, and the settings that change its behavior.",
+      "surprises": "Transparent variable rewards: 3 fixed surprise kinds, opt-in toggle, capped at 1 per day. The rules and the catalog are public."
     },
     "triage": {
       "title": "Triage status",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1671,6 +1671,23 @@
       "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
     }
   },
+  "surprises": {
+    "section_title": "Sorpresas de campo",
+    "section_hint": "De vez en cuando muestra una tarjeta tras una observación sincronizada: un dato curioso, un aviso de especie rara o cuántos otros observadores estuvieron activos hoy. Apagado por defecto. Tope de 1 al día. Las reglas son públicas.",
+    "toggle_label": "Activar sorpresas de campo",
+    "toggle_off_status": "Apagado — no se mostrarán sorpresas.",
+    "toggle_on_status": "Activado — máximo una sorpresa al día.",
+    "toggle_save_failed": "No se pudo guardar la preferencia. Intenta de nuevo.",
+    "learn_more": "¿Qué es esto?",
+    "overlay_close": "Cerrar",
+    "overlay_what_is_this": "¿Qué es esto?",
+    "overlay_aria_label": "Tarjeta de sorpresa",
+    "kinds": {
+      "dato_curioso_title": "Dato curioso",
+      "rarito_title": "¡Rarito!",
+      "comunidad_activa_hoy_title": "Comunidad activa hoy"
+    }
+  },
   "docs": {
     "nav_title": "Documentación",
     "toc_aria_label": "Navegación de secciones",
@@ -1700,7 +1717,8 @@
       "sponsor-pools": "Pools de Patrocinio",
       "obs-detail": "Detalle de Observación",
       "status": "Estado de triage",
-      "algorithms": "Algoritmos"
+      "algorithms": "Algoritmos",
+      "surprises": "Sorpresas de campo"
     },
     "descriptions": {
       "vision": "Misión, problema y por qué Oaxaca es el lugar correcto para comenzar.",
@@ -1724,7 +1742,8 @@
       "sponsor-pools": "Visión AI multi-proveedor y pools de patrocinio de plataforma. Anthropic, Vertex y OpenAI con distribución de créditos comunitarios.",
       "obs-detail": "Página de detalle de observación con galería de fotos, mapa interactivo, identificaciones comunitarias y herramientas de gestión.",
       "status": "Tablero público de SLA de triage: issues abiertas, tiempo medio a primer comentario en los últimos 30 días y resoluciones recientes.",
-      "algorithms": "Cada superficie ordenada en Rastrum, con las entradas que consume, la ventana de tiempo que considera y los ajustes que cambian su comportamiento."
+      "algorithms": "Cada superficie ordenada en Rastrum, con las entradas que consume, la ventana de tiempo que considera y los ajustes que cambian su comportamiento.",
+      "surprises": "Recompensas variables transparentes: 3 tipos fijos de sorpresa, toggle opt-in, tope de 1 por día. Las reglas y el catálogo son públicos."
     },
     "triage": {
       "title": "Estado de triage",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -127,7 +127,7 @@ export const docPages = [
   'architecture', 'indigenous', 'funding', 'contribute',
   'faq', 'privacy', 'terms', 'console', 'sponsorships', 'mcp',
   'changelog', 'community', 'camera-stations', 'sponsor-pools',
-  'obs-detail', 'status', 'algorithms',
+  'obs-detail', 'status', 'algorithms', 'surprises',
 ] as const;
 
 export type DocPage = (typeof docPages)[number];
@@ -355,6 +355,10 @@ export const docPageMeta = {
   algorithms: {
     en: "Every ranked surface in Rastrum, with the inputs it uses, the time window, and the settings that change its behavior.",
     es: "Cada superficie ordenada en Rastrum, con las entradas que usa, la ventana de tiempo y los ajustes que cambian su comportamiento.",
+  },
+  surprises: {
+    en: "Field surprises: a transparent, opt-in catalog of variable rewards. 3 fixed kinds, 1-per-day cap, full disclosure of how each fires.",
+    es: "Sorpresas de campo: catálogo transparente y opt-in de recompensas variables. 3 tipos fijos, 1 por día como máximo, reglas públicas.",
   },
 } as const satisfies Record<DocPage, { en: string; es: string }>;
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,7 @@ import ReportDialog from '../components/ReportDialog.astro';
 import ConfirmDialog from '../components/ConfirmDialog.astro';
 import PhotoCropModal from '../components/PhotoCropModal.astro';
 import WhyAmISeeingThisDialog from '../components/WhyAmISeeingThisDialog.astro';
+import SurpriseOverlay from '../components/SurpriseOverlay.astro';
 import BanBanner from '../components/BanBanner.astro';
 import { getAlternateUrl } from '../i18n/utils';
 import StructuredData from '../components/StructuredData.astro';
@@ -315,6 +316,7 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <ConfirmDialog lang={installLang} />
     <PhotoCropModal lang={installLang} />
     <WhyAmISeeingThisDialog lang={installLang} />
+    <SurpriseOverlay lang={installLang} />
     <script>
       import { getSupabase } from '../lib/supabase';
       import { subscribeToKarmaEvents } from '../lib/karma-toast';

--- a/src/lib/surprise-facts.ts
+++ b/src/lib/surprise-facts.ts
@@ -1,0 +1,104 @@
+/**
+ * Curated facts for `dato_curioso`. Bilingual EN/ES. Indexed by
+ * scientific name (case-insensitive) with a generic locale fallback
+ * so any species can fire a "did you know" — but only when we have
+ * something honest to say.
+ *
+ * Wikidata-style summaries are a v1.1 follow-up (issue #727 carries
+ * the broader catalog). For v1 we ship a hand-picked seed of LATAM-
+ * relevant species + a grab-bag of generic "biodiversity" facts.
+ *
+ * Editing rules:
+ *   - Keep facts factually true. No embellishment. Cite a source if
+ *     it might be questioned.
+ *   - Keep each ≤ 220 chars to fit the overlay without scrolling on
+ *     a 360 px wide screen.
+ *   - EN + ES required for every entry.
+ */
+
+export interface Fact {
+  es: string;
+  en: string;
+}
+
+const SPECIES_FACTS: Readonly<Record<string, Fact>> = {
+  // LATAM seeds — easily expanded as observations roll in.
+  'panthera onca': {
+    es: 'El jaguar es el felino más grande de América y el tercero del mundo. Su mordida puede atravesar el caparazón de una tortuga.',
+    en: 'The jaguar is the largest cat in the Americas and the third-largest in the world. Its bite can pierce a turtle shell.',
+  },
+  'pharomachrus mocinno': {
+    es: 'El quetzal pierde y regenera las plumas largas de su cola cada temporada reproductiva — único entre las aves trogoniformes.',
+    en: 'The resplendent quetzal sheds and regrows its long tail-coverts every breeding season — unique among trogons.',
+  },
+  'ambystoma mexicanum': {
+    es: 'El ajolote retiene rasgos larvarios toda su vida (neotenia) y puede regenerar extremidades, branquias y partes de su corazón.',
+    en: 'The axolotl keeps larval traits its whole life (neoteny) and can regenerate limbs, gills, and parts of its heart.',
+  },
+  'phocoena sinus': {
+    es: 'La vaquita marina solo vive en el norte del Golfo de California. Es el cetáceo más amenazado del planeta.',
+    en: 'The vaquita lives only in the northern Gulf of California. It is the most endangered cetacean on Earth.',
+  },
+  'ara macao': {
+    es: 'La guacamaya roja puede vivir más de 60 años en estado silvestre y forma parejas que duran toda la vida.',
+    en: 'The scarlet macaw can live more than 60 years in the wild and forms lifelong pair bonds.',
+  },
+  'tapirus bairdii': {
+    es: 'El tapir centroamericano es el mamífero terrestre más grande de Mesoamérica y un dispersor clave de semillas grandes.',
+    en: 'The Baird tapir is Mesoamerica largest land mammal and a key disperser of large seeds.',
+  },
+  'mimus polyglottos': {
+    es: 'El cenzontle puede aprender e imitar más de 200 sonidos distintos a lo largo de su vida.',
+    en: 'The northern mockingbird can learn and imitate more than 200 distinct sounds over its lifetime.',
+  },
+};
+
+const GENERIC_FACTS: ReadonlyArray<Fact> = [
+  {
+    es: 'Cada observación con foto y GPS aporta a la red GBIF y se vuelve evidencia citable en publicaciones científicas.',
+    en: 'Every observation with a photo and GPS feeds the GBIF network and becomes citable evidence in scientific publications.',
+  },
+  {
+    es: 'América Latina concentra cerca del 60 % de la biodiversidad terrestre del planeta.',
+    en: 'Latin America holds about 60 % of the planet terrestrial biodiversity.',
+  },
+  {
+    es: 'Las observaciones casuales — incluso una sola foto — han descrito especies que las expediciones formales no registraron.',
+    en: 'Casual observations — even a single photo — have documented species that formal expeditions had missed.',
+  },
+  {
+    es: 'México alberga más de 200 000 especies, lo que lo coloca entre los cinco países megadiversos del mundo.',
+    en: 'Mexico harbors more than 200,000 species, ranking among the five megadiverse countries in the world.',
+  },
+];
+
+/**
+ * Resolve a fact for a scientific name, falling back to a generic
+ * pool. Returns `null` when nothing fits — caller treats null as
+ * "skip dato_curioso for this observation".
+ */
+export function resolveFact(scientificName: string | null): Fact | null {
+  if (scientificName) {
+    const key = scientificName.trim().toLowerCase();
+    const direct = SPECIES_FACTS[key];
+    if (direct) return direct;
+    // Genus-level fallback: try the first word.
+    const genus = key.split(/\s+/)[0];
+    if (genus) {
+      for (const [k, v] of Object.entries(SPECIES_FACTS)) {
+        if (k.startsWith(genus + ' ')) return v;
+      }
+    }
+  }
+  // Cheap pseudo-random pick keyed on the scientific name (or a
+  // constant when missing). The picker uses the seed for the
+  // probability roll; here we only need a reproducible pool draw.
+  if (GENERIC_FACTS.length === 0) return null;
+  const seed = scientificName ?? 'rastrum-default';
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) | 0;
+  const idx = Math.abs(h) % GENERIC_FACTS.length;
+  return GENERIC_FACTS[idx];
+}
+
+export const __TESTING = { SPECIES_FACTS, GENERIC_FACTS };

--- a/src/lib/surprise-trigger.ts
+++ b/src/lib/surprise-trigger.ts
@@ -1,0 +1,229 @@
+/**
+ * Post-sync hook: maybe show a sorpresa de campo.
+ *
+ * Called from `syncOutboxInner` (sync.ts) after each successful row.
+ * This module is the bridge between the pure picker (`./surprises.ts`)
+ * and the side-effecting world (Supabase reads, the DOM event that
+ * mounts the overlay, the daily-cap localStorage).
+ *
+ * Closes #727. Side effects are kept paranoid: any failure (RPC down,
+ * RLS denial, malformed taxon row) is swallowed silently — a missed
+ * surprise is invisible by definition. We never block sync.
+ */
+
+import { getSupabase } from './supabase';
+import {
+  pickSurprise,
+  dailyCapReached,
+  recordShown,
+  type PickInputs,
+  type SurpriseCandidate,
+} from './surprises';
+import { resolveFact } from './surprise-facts';
+
+const SURPRISE_SHOW_EVENT = 'rastrum:surprise-show';
+
+interface UserPrefs {
+  surprises_opt_in: boolean;
+  region_primary: string | null;
+  country_code: string | null;
+  preferred_lang: 'en' | 'es';
+}
+
+/**
+ * Resolve current locale. We honour the URL prefix when present,
+ * otherwise fall back to `users.preferred_lang`. Pure UI thing —
+ * the picker itself is locale-agnostic except for the body text.
+ */
+function currentLang(prefs: UserPrefs | null): 'en' | 'es' {
+  if (typeof window !== 'undefined') {
+    const seg = window.location.pathname.split('/')[1];
+    if (seg === 'es') return 'es';
+    if (seg === 'en') return 'en';
+  }
+  return prefs?.preferred_lang === 'es' ? 'es' : 'en';
+}
+
+async function fetchUserPrefs(): Promise<UserPrefs | null> {
+  const supabase = getSupabase();
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return null;
+    const { data } = await supabase
+      .from('users')
+      .select('surprises_opt_in, region_primary, country_code, preferred_lang')
+      .eq('id', user.id)
+      .maybeSingle();
+    if (!data) return null;
+    const row = data as Record<string, unknown>;
+    return {
+      surprises_opt_in: row.surprises_opt_in === true,
+      region_primary:   typeof row.region_primary === 'string' ? row.region_primary : null,
+      country_code:     typeof row.country_code === 'string' ? row.country_code : null,
+      preferred_lang:   row.preferred_lang === 'es' ? 'es' : 'en',
+    };
+  } catch {
+    return null;
+  }
+}
+
+interface ObsContext {
+  observation_id: string;
+  primary_taxon_id: string | null;
+  scientific_name: string | null;
+  common_name_es: string | null;
+  common_name_en: string | null;
+  rarity_bucket: 'common' | 'uncommon' | 'rare' | null;
+}
+
+async function fetchObsContext(observationId: string): Promise<ObsContext | null> {
+  const supabase = getSupabase();
+  try {
+    const { data: obs } = await supabase
+      .from('observations')
+      .select('id, primary_taxon_id')
+      .eq('id', observationId)
+      .maybeSingle();
+    if (!obs) return null;
+    const obsRow = obs as { id: string; primary_taxon_id: string | null };
+
+    let scientificName: string | null = null;
+    let commonNameEs: string | null = null;
+    let commonNameEn: string | null = null;
+    let rarityBucket: 'common' | 'uncommon' | 'rare' | null = null;
+
+    if (obsRow.primary_taxon_id) {
+      const { data: taxa } = await supabase
+        .from('taxa')
+        .select('scientific_name, common_name_es, common_name_en')
+        .eq('id', obsRow.primary_taxon_id)
+        .maybeSingle();
+      if (taxa) {
+        const taxaRow = taxa as Record<string, unknown>;
+        scientificName = typeof taxaRow.scientific_name === 'string' ? taxaRow.scientific_name : null;
+        commonNameEs   = typeof taxaRow.common_name_es   === 'string' ? taxaRow.common_name_es   : null;
+        commonNameEn   = typeof taxaRow.common_name_en   === 'string' ? taxaRow.common_name_en   : null;
+      }
+      const { data: rarity } = await supabase
+        .from('taxon_rarity')
+        .select('bucket')
+        .eq('taxon_id', obsRow.primary_taxon_id)
+        .maybeSingle();
+      if (rarity) {
+        const rarityRow = rarity as Record<string, unknown>;
+        const b = rarityRow.bucket;
+        if (b === 'common' || b === 'uncommon' || b === 'rare') rarityBucket = b;
+      }
+    }
+
+    return {
+      observation_id: observationId,
+      primary_taxon_id: obsRow.primary_taxon_id,
+      scientific_name: scientificName,
+      common_name_es: commonNameEs,
+      common_name_en: commonNameEn,
+      rarity_bucket: rarityBucket,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchActiveObserversToday(country: string | null): Promise<number> {
+  if (!country) return 0;
+  const supabase = getSupabase();
+  try {
+    const { data, error } = await supabase.rpc('community_active_observers_today', {
+      p_country: country,
+    });
+    if (error) return 0;
+    const n = typeof data === 'number' ? data : Number(data ?? 0);
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function regionLabel(prefs: UserPrefs): string | null {
+  if (prefs.region_primary && prefs.region_primary.trim().length > 0) {
+    return prefs.region_primary.trim();
+  }
+  if (prefs.country_code) return prefs.country_code;
+  return null;
+}
+
+async function recordRemote(
+  observationId: string,
+  candidate: SurpriseCandidate,
+): Promise<boolean> {
+  const supabase = getSupabase();
+  try {
+    const { data, error } = await supabase.rpc('record_surprise_event', {
+      p_observation_id: observationId,
+      p_kind: candidate.kind,
+      p_payload: candidate.payload,
+    });
+    if (error) return false;
+    // RPC returns NULL when capped or opt-in off; treat that as a no-show
+    return data !== null && data !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+function emitShow(candidate: SurpriseCandidate): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(SURPRISE_SHOW_EVENT, {
+    detail: {
+      kind: candidate.kind,
+      title: candidate.title,
+      body:  candidate.body,
+    },
+  }));
+}
+
+/**
+ * Public entry. Called once per successfully synced observation.
+ * Best-effort: returns silently on any error. Never throws.
+ */
+export async function maybeShowSurpriseAfterSync(observationId: string): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  // Cheapest gate first: client-side daily cap.
+  if (dailyCapReached()) return;
+
+  const prefs = await fetchUserPrefs();
+  if (!prefs || !prefs.surprises_opt_in) return;
+
+  const lang = currentLang(prefs);
+  const ctx = await fetchObsContext(observationId);
+  if (!ctx) return;
+
+  const fact = resolveFact(ctx.scientific_name);
+  const activeCount = await fetchActiveObserversToday(prefs.country_code);
+
+  const inputs: PickInputs = {
+    seed: observationId,
+    rarityBucket: ctx.rarity_bucket,
+    factEs: fact?.es ?? null,
+    factEn: fact?.en ?? null,
+    scientificName: ctx.scientific_name,
+    commonNameEs:   ctx.common_name_es,
+    commonNameEn:   ctx.common_name_en,
+    activeObserversToday: activeCount,
+    regionLabel: regionLabel(prefs),
+  };
+
+  const candidate = pickSurprise(inputs, lang);
+  if (!candidate) return;
+
+  // Server-side cap check (atomic, race-free across tabs). Only show
+  // when the row was actually inserted.
+  const stored = await recordRemote(observationId, candidate);
+  if (!stored) return;
+
+  recordShown(candidate.kind);
+  emitShow(candidate);
+}
+
+export { SURPRISE_SHOW_EVENT };

--- a/src/lib/surprises.ts
+++ b/src/lib/surprises.ts
@@ -1,0 +1,255 @@
+/**
+ * Sorpresas de campo — transparent, opt-in variable rewards.
+ *
+ * Closes #727. Per Fogg ch. 9 ethics: variable reinforcement is a red
+ * flag UNLESS the user knows the rules and can opt out in one click.
+ * This module enforces both: the catalog of `surprise.kind` is FIXED
+ * (no runtime extension), the rules are documented at /docs/surprises,
+ * the toggle defaults OFF, and the picker is a pure function so the
+ * rules are auditable in tests.
+ *
+ * v1 catalog (3 kinds):
+ *
+ *   - dato_curioso          random, ~10% per synced obs (one fact card)
+ *   - rarito                deterministic, fires when the obs's primary
+ *                           taxon is `taxon_rarity.bucket = 'rare'`
+ *   - comunidad_activa_hoy  deterministic, max 1×/day; "you were 1 of N
+ *                           active observers in {region} today"
+ *
+ * Hard cap: 1 surprise / day total across kinds (regardless of which
+ * one fired). Tracked in localStorage + the DB row, so a tab close
+ * won't suddenly unlock a second surprise.
+ *
+ * Privacy: the row in `surprise_events` is read-own RLS. The same
+ * 1/day rule is enforced at the SQL layer via record_surprise_event()
+ * so racing tabs can't beat the cap.
+ */
+
+export const SURPRISE_KINDS = [
+  'dato_curioso',
+  'rarito',
+  'comunidad_activa_hoy',
+] as const;
+
+export type SurpriseKind = (typeof SURPRISE_KINDS)[number];
+
+export interface SurprisePayload {
+  /** Free-form per-kind payload. Bounded to ~1 KB after JSON.stringify. */
+  [k: string]: unknown;
+}
+
+export interface SurpriseCandidate {
+  kind: SurpriseKind;
+  payload: SurprisePayload;
+  /** Human-readable, locale-resolved title shown in the overlay header. */
+  title: string;
+  /** Human-readable body. May contain {placeholders}. */
+  body: string;
+}
+
+/**
+ * Probability that `dato_curioso` fires after each synced observation.
+ * Documented at /docs/surprises — changing this requires updating both
+ * docs pages so the rules stay honest.
+ */
+export const DATO_CURIOSO_PROBABILITY = 0.1;
+
+/**
+ * Cap surprises at 1/day across kinds. Surface in the docs page too.
+ */
+export const MAX_SURPRISES_PER_DAY = 1;
+
+const TODAY_KEY = 'rastrum.surprises.today';
+
+/**
+ * Mulberry32 PRNG. Seeded so tests are deterministic. We don't need
+ * cryptographic strength for surprise selection — just reproducible
+ * jitter across sessions. Not exported as a class because we want
+ * the seed to be explicit at every call site (audit trail in tests).
+ */
+export function makeRng(seed: number): () => number {
+  let s = seed | 0;
+  return function rng() {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Hash a string to a 32-bit seed. djb2; deterministic across runs.
+ */
+export function hashSeed(input: string): number {
+  let h = 5381;
+  for (let i = 0; i < input.length; i++) {
+    h = (h * 33) ^ input.charCodeAt(i);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Date key used for the daily cap. ISO yyyy-mm-dd in the user's local
+ * timezone — surprises are a "field-trip moment" not a server-clock
+ * thing, so local-day matches user expectations.
+ */
+export function todayKey(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export interface DailyState {
+  date: string;
+  count: number;
+  kinds: SurpriseKind[];
+}
+
+export function readDailyState(now: Date = new Date()): DailyState {
+  if (typeof localStorage === 'undefined') {
+    return { date: todayKey(now), count: 0, kinds: [] };
+  }
+  try {
+    const raw = localStorage.getItem(TODAY_KEY);
+    if (!raw) return { date: todayKey(now), count: 0, kinds: [] };
+    const parsed = JSON.parse(raw) as DailyState;
+    if (parsed.date !== todayKey(now)) {
+      return { date: todayKey(now), count: 0, kinds: [] };
+    }
+    return parsed;
+  } catch {
+    return { date: todayKey(now), count: 0, kinds: [] };
+  }
+}
+
+export function writeDailyState(state: DailyState): void {
+  if (typeof localStorage === 'undefined') return;
+  try { localStorage.setItem(TODAY_KEY, JSON.stringify(state)); }
+  catch { /* full storage — fine */ }
+}
+
+export function dailyCapReached(now: Date = new Date()): boolean {
+  return readDailyState(now).count >= MAX_SURPRISES_PER_DAY;
+}
+
+export function recordShown(kind: SurpriseKind, now: Date = new Date()): void {
+  const state = readDailyState(now);
+  state.count += 1;
+  state.kinds.push(kind);
+  writeDailyState(state);
+}
+
+/**
+ * Inputs the picker needs to evaluate the catalog. All optional —
+ * missing data just means that kind can't fire (deterministic
+ * exclusion, never a silent random failure).
+ */
+export interface PickInputs {
+  /** Used to seed the RNG for `dato_curioso`. Typically observation_id. */
+  seed: string;
+  /** When the obs's primary taxon is in `taxon_rarity` bucket 'rare'. */
+  rarityBucket?: 'common' | 'uncommon' | 'rare' | null;
+  /** Resolved fact for `dato_curioso` — null when none was found. */
+  factEs?: string | null;
+  factEn?: string | null;
+  scientificName?: string | null;
+  commonNameEs?: string | null;
+  commonNameEn?: string | null;
+  /**
+   * Active-observers count for the user's region today, paired with the
+   * region label (e.g. 'México', 'Oaxaca'). Both required to fire
+   * `comunidad_activa_hoy`.
+   */
+  activeObserversToday?: number | null;
+  regionLabel?: string | null;
+}
+
+/**
+ * Pure picker — given the inputs, return the candidate to show, or
+ * null when no kind is eligible. Order:
+ *
+ *   1. `rarito` — deterministic; takes precedence when the species is rare
+ *      (it's the most informative + most rare → highest signal).
+ *   2. `comunidad_activa_hoy` — deterministic; only when activeObserversToday
+ *      ≥ 2 (so the user really is "1 of N" with N ≥ 2).
+ *   3. `dato_curioso` — random; fires with 10% probability and only
+ *      when a fact is available for the locale.
+ *
+ * Daily cap is enforced by the caller; this function is pure and
+ * doesn't read any side-channel. All decisions are visible to tests.
+ */
+export function pickSurprise(
+  inputs: PickInputs,
+  lang: 'en' | 'es',
+): SurpriseCandidate | null {
+  const speciesLabel = inputs[lang === 'es' ? 'commonNameEs' : 'commonNameEn']
+    ?? inputs.scientificName
+    ?? null;
+
+  // 1) rarito — deterministic
+  if (inputs.rarityBucket === 'rare') {
+    const title = lang === 'es' ? '¡Rarito!' : 'Rare find!';
+    const body = lang === 'es'
+      ? speciesLabel
+        ? `Tu observación de ${speciesLabel} cayó en el 5 % más raro de Rastrum.`
+        : 'Tu observación cayó en el 5 % más raro de Rastrum.'
+      : speciesLabel
+        ? `Your observation of ${speciesLabel} is in the rarest 5 % on Rastrum.`
+        : 'Your observation is in the rarest 5 % on Rastrum.';
+    return {
+      kind: 'rarito',
+      payload: {
+        scientific_name: inputs.scientificName ?? null,
+        rarity_bucket: inputs.rarityBucket,
+      },
+      title, body,
+    };
+  }
+
+  // 2) comunidad_activa_hoy — deterministic, needs 2+ observers
+  const n = inputs.activeObserversToday ?? 0;
+  if (n >= 2 && inputs.regionLabel) {
+    const title = lang === 'es' ? 'Comunidad activa hoy' : 'Community active today';
+    const body = lang === 'es'
+      ? `Fuiste 1 de ${n} observadores activos hoy en ${inputs.regionLabel}.`
+      : `You were 1 of ${n} active observers today in ${inputs.regionLabel}.`;
+    return {
+      kind: 'comunidad_activa_hoy',
+      payload: { count: n, region: inputs.regionLabel },
+      title, body,
+    };
+  }
+
+  // 3) dato_curioso — random, requires a fact
+  const fact = lang === 'es' ? inputs.factEs : inputs.factEn;
+  if (fact) {
+    const rng = makeRng(hashSeed(inputs.seed));
+    const r = rng();
+    if (r < DATO_CURIOSO_PROBABILITY) {
+      const title = lang === 'es' ? 'Dato curioso' : 'Did you know?';
+      return {
+        kind: 'dato_curioso',
+        payload: {
+          scientific_name: inputs.scientificName ?? null,
+          fact,
+        },
+        title,
+        body: fact,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Probability check used by the trigger to skip the DB roundtrip when
+ * the random gate already says "no". Same RNG/seed the picker uses;
+ * keep them in sync.
+ */
+export function gateRoll(seed: string): boolean {
+  const rng = makeRng(hashSeed(seed));
+  return rng() < DATO_CURIOSO_PROBABILITY;
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -295,6 +295,24 @@ async function triggerEnvEnrichment(observationId: string): Promise<void> {
   });
 }
 
+/**
+ * Fire-and-forget post-sync surprise check. Lazy-imported so the
+ * surprises bundle (~2 KB + the curated facts catalog) is only paid
+ * for when sync actually succeeds. Closes #727.
+ *
+ * Any failure is swallowed — a missing surprise is invisible by
+ * definition. Never blocks sync.
+ */
+function maybeFireSurprise(observationId: string): void {
+  // Don't await — explicitly fire-and-forget so the outbox loop keeps
+  // moving. The trigger module also has its own daily-cap and opt-in
+  // gates so a stale call (e.g. observation already had a surprise)
+  // is a no-op.
+  import('./surprise-trigger').then(({ maybeShowSurpriseAfterSync }) => {
+    maybeShowSurpriseAfterSync(observationId).catch(() => { /* swallow */ });
+  }).catch(() => { /* surprises module not bundled — fine */ });
+}
+
 // Local-AI prefs extracted to ./local-ai-prefs.ts (#583). Re-exported for
 // backwards compat with consumers (ObservationForm) importing from sync.ts.
 export {
@@ -547,6 +565,7 @@ async function syncOutboxInner(): Promise<SyncResult> {
               await syncOne(upgraded);
               synced++;
               emit<SyncRowDetail>(SYNC_EVENTS.rowDone, { observation_id: rec.id });
+              maybeFireSurprise(rec.id);
             } catch (err) {
               failed++;
               const msg = err instanceof Error ? err.message : String(err);
@@ -570,6 +589,7 @@ async function syncOutboxInner(): Promise<SyncResult> {
       await syncOne(rec);
       synced++;
       emit<SyncRowDetail>(SYNC_EVENTS.rowDone, { observation_id: rec.id });
+      maybeFireSurprise(rec.id);
     } catch (err) {
       failed++;
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/pages/en/docs/surprises.astro
+++ b/src/pages/en/docs/surprises.astro
@@ -1,0 +1,13 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import SurprisesDocView from '../../../components/SurprisesDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'en';
+const tr = t(lang);
+const sections = (tr.docs.sections as Record<string, string>);
+---
+
+<DocLayout title={sections.surprises} lang={lang} section="surprises" editPath="src/pages/en/docs/surprises.astro">
+  <SurprisesDocView lang={lang} />
+</DocLayout>

--- a/src/pages/en/profile/settings/[tab].astro
+++ b/src/pages/en/profile/settings/[tab].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import SettingsShell from '../../../../components/SettingsShell.astro';
 import ProfileEditForm from '../../../../components/ProfileEditForm.astro';
 import StreakRemindersSection from '../../../../components/StreakRemindersSection.astro';
+import SurprisesPrefsSection from '../../../../components/SurprisesPrefsSection.astro';
 import PrivacyMatrix from '../../../../components/PrivacyMatrix.astro';
 import BlockedUsersList from '../../../../components/BlockedUsersList.astro';
 import { t, getLocalizedPath, routes } from '../../../../i18n/utils';
@@ -144,6 +145,9 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
             </a>
           </p>
         </section>
+
+        <!-- Field surprises (variable rewards, opt-in, capped at 1/day) -->
+        <SurprisesPrefsSection lang={lang} />
       </div>
     )}
 

--- a/src/pages/es/docs/surprises.astro
+++ b/src/pages/es/docs/surprises.astro
@@ -1,0 +1,13 @@
+---
+import DocLayout from '../../../layouts/DocLayout.astro';
+import SurprisesDocView from '../../../components/SurprisesDocView.astro';
+import { t } from '../../../i18n/utils';
+
+const lang = 'es';
+const tr = t(lang);
+const sections = (tr.docs.sections as Record<string, string>);
+---
+
+<DocLayout title={sections.surprises} lang={lang} section="surprises" editPath="src/pages/es/docs/surprises.astro">
+  <SurprisesDocView lang={lang} />
+</DocLayout>

--- a/src/pages/es/perfil/ajustes/[tab].astro
+++ b/src/pages/es/perfil/ajustes/[tab].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import SettingsShell from '../../../../components/SettingsShell.astro';
 import ProfileEditForm from '../../../../components/ProfileEditForm.astro';
 import StreakRemindersSection from '../../../../components/StreakRemindersSection.astro';
+import SurprisesPrefsSection from '../../../../components/SurprisesPrefsSection.astro';
 import PrivacyMatrix from '../../../../components/PrivacyMatrix.astro';
 import BlockedUsersList from '../../../../components/BlockedUsersList.astro';
 import { t, getLocalizedPath, routes } from '../../../../i18n/utils';
@@ -144,6 +145,9 @@ const mcpUrl = 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/mcp';
             </a>
           </p>
         </section>
+
+        <!-- Sorpresas de campo (recompensas variables, opt-in, tope 1/día) -->
+        <SurprisesPrefsSection lang={lang} />
       </div>
     )}
 

--- a/tests/unit/surprise-facts.test.ts
+++ b/tests/unit/surprise-facts.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFact, __TESTING } from '../../src/lib/surprise-facts';
+
+describe('resolveFact', () => {
+  it('returns the curated species fact when the scientific name matches exactly', () => {
+    const f = resolveFact('Panthera onca');
+    expect(f).not.toBeNull();
+    expect(f?.es).toMatch(/jaguar/i);
+    expect(f?.en).toMatch(/jaguar/i);
+  });
+
+  it('matching is case-insensitive and tolerates trailing whitespace', () => {
+    expect(resolveFact('panthera onca')).toEqual(__TESTING.SPECIES_FACTS['panthera onca']);
+    expect(resolveFact('  PANTHERA  ONCA  '.replace(/\s+/g, ' ').trim())).toEqual(
+      __TESTING.SPECIES_FACTS['panthera onca'],
+    );
+  });
+
+  it('falls back to the genus when the exact species is not in the catalog', () => {
+    const f = resolveFact('Panthera leo'); // not in catalog
+    expect(f).not.toBeNull();
+    // Should pick the Panthera onca entry as the genus fallback
+    expect(f?.es).toMatch(/jaguar/i);
+  });
+
+  it('always returns a fact for any non-empty scientific name (generic pool fallback)', () => {
+    const f = resolveFact('Zzzz unknownus');
+    expect(f).not.toBeNull();
+    expect(typeof f?.es).toBe('string');
+    expect(typeof f?.en).toBe('string');
+  });
+
+  it('is deterministic: same input → same fallback', () => {
+    const a = resolveFact('Some random name');
+    const b = resolveFact('Some random name');
+    expect(a).toEqual(b);
+  });
+
+  it('returns a fact even when the scientific name is null', () => {
+    const f = resolveFact(null);
+    expect(f).not.toBeNull();
+    expect(typeof f?.es).toBe('string');
+  });
+
+  it('every curated species fact has both EN and ES strings', () => {
+    for (const [k, v] of Object.entries(__TESTING.SPECIES_FACTS)) {
+      expect(typeof v.en, `EN missing for ${k}`).toBe('string');
+      expect(typeof v.es, `ES missing for ${k}`).toBe('string');
+      expect(v.en.length, `EN empty for ${k}`).toBeGreaterThan(0);
+      expect(v.es.length, `ES empty for ${k}`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every generic fact has both EN and ES strings', () => {
+    for (const [i, v] of __TESTING.GENERIC_FACTS.entries()) {
+      expect(v.en.length, `EN empty at index ${i}`).toBeGreaterThan(0);
+      expect(v.es.length, `ES empty at index ${i}`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/surprises.test.ts
+++ b/tests/unit/surprises.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  pickSurprise,
+  makeRng,
+  hashSeed,
+  todayKey,
+  readDailyState,
+  writeDailyState,
+  recordShown,
+  dailyCapReached,
+  gateRoll,
+  DATO_CURIOSO_PROBABILITY,
+  MAX_SURPRISES_PER_DAY,
+  SURPRISE_KINDS,
+  type PickInputs,
+} from '../../src/lib/surprises';
+
+// ---------------------------------------------------------------------------
+// localStorage shim — Node 22 ships a half-baked one that breaks happy-dom
+// (see CLAUDE.md "Vitest: localStorage.clear is not a function").
+// ---------------------------------------------------------------------------
+const store = new Map<string, string>();
+const fakeLocalStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, String(v)); },
+  removeItem: (k: string) => { store.delete(k); },
+  clear: () => { store.clear(); },
+  key: (i: number) => Array.from(store.keys())[i] ?? null,
+  get length() { return store.size; },
+};
+beforeEach(() => {
+  store.clear();
+  vi.stubGlobal('localStorage', fakeLocalStorage);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SURPRISE_KINDS catalog', () => {
+  it('is exactly the 3 v1 kinds, in fixed order', () => {
+    expect(SURPRISE_KINDS).toEqual([
+      'dato_curioso',
+      'rarito',
+      'comunidad_activa_hoy',
+    ]);
+  });
+
+  it('uses constants for the daily cap and the dato_curioso probability', () => {
+    expect(MAX_SURPRISES_PER_DAY).toBe(1);
+    expect(DATO_CURIOSO_PROBABILITY).toBeCloseTo(0.1, 6);
+  });
+});
+
+describe('makeRng / hashSeed', () => {
+  it('makeRng is deterministic for the same seed', () => {
+    const a = makeRng(42);
+    const b = makeRng(42);
+    const seqA = [a(), a(), a(), a()];
+    const seqB = [b(), b(), b(), b()];
+    expect(seqA).toEqual(seqB);
+  });
+
+  it('makeRng produces different sequences for different seeds', () => {
+    const a = makeRng(1);
+    const b = makeRng(2);
+    expect(a()).not.toEqual(b());
+  });
+
+  it('hashSeed is deterministic', () => {
+    expect(hashSeed('abc')).toBe(hashSeed('abc'));
+    expect(hashSeed('abc')).not.toBe(hashSeed('abd'));
+  });
+
+  it('produces uniform-ish output (sanity check, not a stats test)', () => {
+    const rng = makeRng(hashSeed('seed'));
+    const samples = Array.from({ length: 1000 }, () => rng());
+    const min = Math.min(...samples);
+    const max = Math.max(...samples);
+    expect(min).toBeGreaterThan(0);
+    expect(max).toBeLessThan(1);
+    const mean = samples.reduce((s, v) => s + v, 0) / samples.length;
+    // Mean should be roughly 0.5 ± 0.05 with 1k samples
+    expect(mean).toBeGreaterThan(0.4);
+    expect(mean).toBeLessThan(0.6);
+  });
+});
+
+describe('gateRoll', () => {
+  it('returns the same boolean for the same seed', () => {
+    expect(gateRoll('obs-123')).toBe(gateRoll('obs-123'));
+  });
+
+  it('roughly hits the documented probability over many seeds', () => {
+    let hits = 0;
+    const N = 5000;
+    for (let i = 0; i < N; i++) {
+      if (gateRoll(`obs-${i}`)) hits++;
+    }
+    const ratio = hits / N;
+    // Wide tolerance: 5–15 % covers RNG variance comfortably
+    expect(ratio).toBeGreaterThan(0.05);
+    expect(ratio).toBeLessThan(0.15);
+  });
+});
+
+describe('todayKey / daily state', () => {
+  it('todayKey is yyyy-mm-dd', () => {
+    const k = todayKey(new Date(2026, 4, 7)); // 2026-05-07
+    expect(k).toBe('2026-05-07');
+  });
+
+  it('readDailyState returns zeros when localStorage is empty', () => {
+    expect(readDailyState()).toEqual({
+      date: todayKey(),
+      count: 0,
+      kinds: [],
+    });
+  });
+
+  it('writeDailyState + readDailyState round-trip', () => {
+    writeDailyState({ date: todayKey(), count: 1, kinds: ['rarito'] });
+    expect(readDailyState()).toEqual({
+      date: todayKey(),
+      count: 1,
+      kinds: ['rarito'],
+    });
+  });
+
+  it('readDailyState resets when the stored date is from a previous day', () => {
+    const yesterday = '2025-01-01';
+    writeDailyState({ date: yesterday, count: 5, kinds: ['rarito'] });
+    const fresh = readDailyState();
+    expect(fresh.date).toBe(todayKey());
+    expect(fresh.count).toBe(0);
+  });
+
+  it('recordShown increments the count and remembers the kind', () => {
+    recordShown('rarito');
+    expect(readDailyState().count).toBe(1);
+    expect(readDailyState().kinds).toEqual(['rarito']);
+  });
+
+  it('dailyCapReached respects the cap', () => {
+    expect(dailyCapReached()).toBe(false);
+    recordShown('dato_curioso');
+    expect(dailyCapReached()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure picker — the load-bearing audit of the rules. Order matters:
+//   rarito > comunidad_activa_hoy > dato_curioso.
+// Each kind's preconditions are deterministic.
+// ---------------------------------------------------------------------------
+
+const baseInputs: PickInputs = {
+  seed: 'obs-deterministic',
+  rarityBucket: null,
+  factEs: null,
+  factEn: null,
+  scientificName: null,
+  commonNameEs: null,
+  commonNameEn: null,
+  activeObserversToday: null,
+  regionLabel: null,
+};
+
+describe('pickSurprise', () => {
+  it('returns null when no kind is eligible', () => {
+    expect(pickSurprise(baseInputs, 'es')).toBeNull();
+    expect(pickSurprise(baseInputs, 'en')).toBeNull();
+  });
+
+  it('rarito wins when rarity_bucket === "rare", regardless of other inputs', () => {
+    const inputs: PickInputs = {
+      ...baseInputs,
+      rarityBucket: 'rare',
+      scientificName: 'Panthera onca',
+      commonNameEs: 'Jaguar',
+      commonNameEn: 'Jaguar',
+      activeObserversToday: 100,
+      regionLabel: 'México',
+      factEs: 'fact es',
+      factEn: 'fact en',
+    };
+    const c = pickSurprise(inputs, 'es');
+    expect(c?.kind).toBe('rarito');
+    expect(c?.body).toMatch(/Jaguar/);
+    expect(c?.body).toMatch(/5 %/);
+  });
+
+  it('rarito does NOT fire when bucket is uncommon or common', () => {
+    const inputs: PickInputs = { ...baseInputs, rarityBucket: 'uncommon' };
+    expect(pickSurprise(inputs, 'es')).toBeNull();
+    const inputs2: PickInputs = { ...baseInputs, rarityBucket: 'common' };
+    expect(pickSurprise(inputs2, 'es')).toBeNull();
+  });
+
+  it('comunidad_activa_hoy fires when activeObserversToday >= 2 and a regionLabel exists', () => {
+    const inputs: PickInputs = {
+      ...baseInputs,
+      activeObserversToday: 14,
+      regionLabel: 'Oaxaca',
+    };
+    const c = pickSurprise(inputs, 'es');
+    expect(c?.kind).toBe('comunidad_activa_hoy');
+    expect(c?.body).toMatch(/14/);
+    expect(c?.body).toMatch(/Oaxaca/);
+  });
+
+  it('comunidad_activa_hoy needs at least 2 observers — 1 observer (just the user) does not fire', () => {
+    const inputs: PickInputs = {
+      ...baseInputs,
+      activeObserversToday: 1,
+      regionLabel: 'México',
+    };
+    expect(pickSurprise(inputs, 'es')).toBeNull();
+  });
+
+  it('comunidad_activa_hoy needs a region label', () => {
+    const inputs: PickInputs = {
+      ...baseInputs,
+      activeObserversToday: 50,
+      regionLabel: null,
+    };
+    expect(pickSurprise(inputs, 'es')).toBeNull();
+  });
+
+  it('dato_curioso fires deterministically when its seed gate passes and a fact is available', () => {
+    // Find a seed whose first RNG draw is < 0.1 — borrow the gateRoll helper.
+    let seed = '';
+    for (let i = 0; i < 1000; i++) {
+      const candidate = `seed-${i}`;
+      if (gateRoll(candidate)) { seed = candidate; break; }
+    }
+    expect(seed).not.toBe('');
+    const inputs: PickInputs = {
+      ...baseInputs,
+      seed,
+      factEs: 'Es un dato.',
+      factEn: 'It is a fact.',
+    };
+    const c = pickSurprise(inputs, 'en');
+    expect(c?.kind).toBe('dato_curioso');
+    expect(c?.body).toBe('It is a fact.');
+  });
+
+  it('dato_curioso does NOT fire when no fact exists for the locale', () => {
+    let seed = '';
+    for (let i = 0; i < 1000; i++) {
+      const candidate = `seed-${i}`;
+      if (gateRoll(candidate)) { seed = candidate; break; }
+    }
+    const inputs: PickInputs = {
+      ...baseInputs,
+      seed,
+      factEn: 'fact only in en',
+      factEs: null,
+    };
+    expect(pickSurprise(inputs, 'es')).toBeNull();
+  });
+
+  it('dato_curioso does NOT fire when the gate roll lands above 0.1', () => {
+    // Find a seed where gateRoll is false.
+    let seed = '';
+    for (let i = 0; i < 1000; i++) {
+      const candidate = `noseed-${i}`;
+      if (!gateRoll(candidate)) { seed = candidate; break; }
+    }
+    const inputs: PickInputs = {
+      ...baseInputs,
+      seed,
+      factEs: 'Algo',
+      factEn: 'Something',
+    };
+    expect(pickSurprise(inputs, 'es')).toBeNull();
+  });
+
+  it('uses the locale-correct title and body', () => {
+    const inputsEs: PickInputs = { ...baseInputs, rarityBucket: 'rare', scientificName: 'X' };
+    const cEs = pickSurprise(inputsEs, 'es');
+    expect(cEs?.title).toMatch(/Rarito/);
+    const inputsEn: PickInputs = { ...baseInputs, rarityBucket: 'rare', scientificName: 'X' };
+    const cEn = pickSurprise(inputsEn, 'en');
+    expect(cEn?.title).toMatch(/Rare/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #727.

Implements variable-reward "sorpresas de campo" with full Fogg ch. 9 ethics: rules disclosed, opt-in default-OFF, single fixed catalog, hard daily cap.

**Catalog (FIXED, no runtime extension):**
1. `dato_curioso` — 10% random per synced obs, requires a curated fact for the species' locale.
2. `rarito` — deterministic; fires when the obs's primary taxon is `taxon_rarity.bucket = 'rare'`.
3. `comunidad_activa_hoy` — deterministic; fires only when 2+ active observers in the user's country today.

**Hard cap:** 1 surprise / day total across kinds. Enforced in two places:
- Client-side in `localStorage` (fast, prevents wasted DB roundtrips).
- Server-side via `record_surprise_event()` SECURITY DEFINER (race-proof across tabs).

**Schema (additive, idempotent):**
- `users.surprises_opt_in boolean default false`
- `surprise_events` table with RLS read-own + insert-own
- `surprise_count_today()` and `record_surprise_event()` SECURITY DEFINER helpers

**Trigger location:** client-side post-sync hook in `syncOutboxInner()` (sync.ts), lazy-imports `src/lib/surprise-trigger.ts` so the surprises bundle is only paid for after a successful sync.

**UI:**
- `SurpriseOverlay.astro` — global modal mounted in `BaseLayout`, mirrors the `ReportDialog` focus-trap pattern. Esc / backdrop / Close button all dismiss; "What is this?" link opens `/docs/surprises`.
- `SurprisesPrefsSection.astro` — new section under Settings → Preferences with the opt-in toggle.

**Docs:**
- `/en/docs/surprises/` and `/es/docs/surprises/` — operator-auditable, explains all 3 kinds, the 10% probability, the cap, the privacy model, and the off-switch.

**i18n:** all strings under `surprises.*` namespace in both `en.json` and `es.json`. Note: per the existing convention, both locales use the English slug `/docs/surprises/` (mirroring `/docs/sponsorships/`, `/docs/community/`, etc.); the in-page heading is "Sorpresas de campo" / "Field surprises".

## Test plan

- [x] `npm run typecheck` passes (no errors)
- [x] `npm run test` passes — 1296 tests, 32 new (picker order, RNG determinism, daily-cap state, facts resolution)
- [x] `npm run build` passes — 237 pages built (was 235; +2 docs pages)
- [x] Both `/en/docs/surprises/` and `/es/docs/surprises/` render in `dist/`
- [ ] Manual smoke after merge: toggle on in Settings → Preferences, log 1 obs, confirm overlay shows; close + log 2nd obs same day, confirm cap enforces; open in incognito tab + flip on, confirm RPC honors opt-in.
- [ ] Verify schema applies cleanly via `make db-apply` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)