### PR TITLE
feat(posthog): exception autocapture + roadmap/tasks doc sync

### DIFF
--- a/docs/progress.json
+++ b/docs/progress.json
@@ -566,6 +566,13 @@
           "label_es": "Montar WatchlistView existente en /explore/watchlist con CTA de inicio de sesión para visitantes anónimos",
           "done": true,
           "done_at": "2026-04-25"
+        },
+        {
+          "id": "posthog-analytics",
+          "label": "PostHog analytics — managed reverse-proxy snippet (api_host=usage.rastrum.org + ui_host=us.posthog.com), person_profiles=identified_only, exception autocapture, posthog.reset() on sign-out, build-env wired into deploy.yml (was silent in prod from wizard-setup until #764), search-index drift CI guard (ci.yml + e2e.yml). 14 capture call-sites: sign-in funnel, observation save, identification suggested + promoted, reactions, follows, comments, exports, onboarding, profile updated, PWA install, project created, sponsorship credential added, content reported. See docs/runbooks/posthog.md.",
+          "label_es": "Analítica con PostHog — snippet con reverse-proxy gestionado (api_host=usage.rastrum.org + ui_host=us.posthog.com), person_profiles=identified_only, autocaptura de excepciones, posthog.reset() al cerrar sesión, build-env cableado en deploy.yml (estuvo silencioso en prod desde el setup del wizard hasta #764), guard de drift del search-index en CI (ci.yml + e2e.yml). 14 puntos de captura: embudo de sign-in, guardado de observaciones, identificación sugerida + promovida, reacciones, follows, comentarios, exports, onboarding, perfil actualizado, instalación de PWA, proyecto creado, credencial de patrocinio añadida, contenido reportado. Ver docs/runbooks/posthog.md.",
+          "done": true,
+          "done_at": "2026-05-08"
         }
       ]
     },

--- a/docs/runbooks/posthog.md
+++ b/docs/runbooks/posthog.md
@@ -20,6 +20,7 @@ posthog.init(apiKey, {
   ui_host: 'https://us.posthog.com',      // so deep-links resolve to PostHog cloud
   defaults: '2026-01-30',
   person_profiles: 'identified_only',     // no anonymous-user profiles by default
+  capture_exceptions: true,               // hooks window.onerror + unhandledrejection
 });
 ```
 
@@ -27,6 +28,12 @@ The snippet has a runtime `if (apiKey && apiHost)` guard, so missing env vars
 silently disable PostHog rather than 404 a static script. Capture call-sites
 all use optional chaining (`window.posthog?.capture(...)`), so they no-op when
 the SDK never loaded.
+
+**Exception autocapture** (`capture_exceptions: true`) hooks `window.onerror`,
+`unhandledrejection`, and `console.error` — uncaught browser errors land in
+PostHog → Errors automatically. For caught errors that you want logged anyway
+(e.g. a fetch that failed but the UI recovered), call
+`window.posthog?.captureException(err, { context: '…' })` manually.
 
 ## Captured events
 
@@ -100,3 +107,8 @@ never loaded. Capture call-sites no-op'd against `window.posthog ===
 undefined`. PR #764 added the build-env wiring, the secrets were set,
 and the snippet was upgraded to the reverse-proxy-ready format with
 `ui_host` + `person_profiles: 'identified_only'`.
+
+## Future scope
+
+- **Server-side ingest from Edge Functions** — see [#780](https://github.com/ArtemioPadilla/rastrum/issues/780).
+- **DNT-respect + consent banner (LFPDPPP / LGPD)** — see [#781](https://github.com/ArtemioPadilla/rastrum/issues/781).

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -4005,6 +4005,54 @@
         }
       ]
     },
+    "posthog-analytics": {
+      "phase": "v1.0.x",
+      "title_en": "PostHog analytics — reverse-proxy snippet + hardening",
+      "title_es": "Analítica con PostHog — snippet con reverse-proxy + endurecimiento",
+      "modules": [],
+      "subtasks": [
+        {
+          "label_en": "Snippet at src/components/posthog.astro mounted in BaseLayout <head> (is:inline + define:vars to inject env at build time)",
+          "label_es": "Snippet en src/components/posthog.astro montado en <head> de BaseLayout (is:inline + define:vars para inyectar env en build)",
+          "status": "done"
+        },
+        {
+          "label_en": "init options: api_host=usage.rastrum.org (managed reverse proxy), ui_host=us.posthog.com (deep-link rewrite), defaults='2026-01-30', person_profiles='identified_only', capture_exceptions=true (autocapture window.onerror + unhandledrejection) — see PR #764, runbook docs/runbooks/posthog.md",
+          "label_es": "Opciones de init: api_host=usage.rastrum.org (reverse proxy gestionado), ui_host=us.posthog.com (reescritura de deep-links), defaults='2026-01-30', person_profiles='identified_only', capture_exceptions=true (autocaptura de window.onerror + unhandledrejection) — ver PR #764, runbook docs/runbooks/posthog.md",
+          "status": "done"
+        },
+        {
+          "label_en": "Build-env wired: PUBLIC_POSTHOG_PROJECT_TOKEN + PUBLIC_POSTHOG_HOST in .github/workflows/deploy.yml. Deliberately NOT in ci.yml/e2e.yml/lhci.yml so test/audit runs don't pollute prod analytics. Was silent in prod from wizard-setup until #764 — secrets weren't passed at all",
+          "label_es": "Build-env cableado: PUBLIC_POSTHOG_PROJECT_TOKEN + PUBLIC_POSTHOG_HOST en .github/workflows/deploy.yml. Deliberadamente NO en ci.yml/e2e.yml/lhci.yml para que las corridas de test/audit no contaminen la analítica de prod. Estuvo silencioso en prod desde el setup del wizard hasta #764 — los secrets no se pasaban en absoluto",
+          "status": "done"
+        },
+        {
+          "label_en": "14 capture call-sites (window.posthog?.capture pattern with optional chaining): sign_in_initiated/completed/failed (SignInForm), observation_saved (ObservationForm), identification_suggested + identification_promoted_to_research_grade (SuggestIdModal), observation_reaction_toggled (ReactionStrip), user_followed/unfollowed (FollowButton), comment_posted (Comments), observations_exported (ExportView, csv + dwca), onboarding_completed/dismissed (OnboardingTour), profile_updated (ProfileEditForm), pwa_install_prompted/installed (InstallPwaButton), project_created (ProjectNewView), sponsorship_credential_added (SponsoringView), content_reported (ReportDialog)",
+          "label_es": "14 puntos de captura (patrón window.posthog?.capture con optional chaining): sign_in_initiated/completed/failed (SignInForm), observation_saved (ObservationForm), identification_suggested + identification_promoted_to_research_grade (SuggestIdModal), observation_reaction_toggled (ReactionStrip), user_followed/unfollowed (FollowButton), comment_posted (Comments), observations_exported (ExportView, csv + dwca), onboarding_completed/dismissed (OnboardingTour), profile_updated (ProfileEditForm), pwa_install_prompted/installed (InstallPwaButton), project_created (ProjectNewView), sponsorship_credential_added (SponsoringView), content_reported (ReportDialog)",
+          "status": "done"
+        },
+        {
+          "label_en": "posthog.identify(userId) on sign-in success, posthog.reset() on sign-out (Header + MobileDrawer) — prevents distinct_id leak across users on the same tab",
+          "label_es": "posthog.identify(userId) al completar sign-in, posthog.reset() al cerrar sesión (Header + MobileDrawer) — previene fuga de distinct_id entre usuarios en la misma pestaña",
+          "status": "done"
+        },
+        {
+          "label_en": "Window.posthog interface in src/env.d.ts (capture, captureException, identify, reset, __loaded) — catches typos at compile time vs lib.dom's any-typed index signature",
+          "label_es": "Interfaz Window.posthog en src/env.d.ts (capture, captureException, identify, reset, __loaded) — atrapa typos en compile time vs el index signature any-tipado de lib.dom",
+          "status": "done"
+        },
+        {
+          "label_en": "search-index drift CI guard: ci.yml asserts public/search-index.{en,es}.json matches npm run build output (PR-time enforcement); e2e.yml mirrors it (push-to-main canary, covers admin/force-push paths)",
+          "label_es": "Guard de drift del search-index en CI: ci.yml asegura que public/search-index.{en,es}.json coincida con la salida de npm run build (enforcement en PR-time); e2e.yml lo replica (canario en push-to-main, cubre rutas de admin/force-push)",
+          "status": "done"
+        },
+        {
+          "label_en": ".env.example documents both PostHog env vars; operator runbook at docs/runbooks/posthog.md covers verification curls + token rotation + future-scope cross-refs to #780 (server-side EF ingest) and #781 (DNT/consent banner)",
+          "label_es": ".env.example documenta ambas variables de entorno de PostHog; runbook operativo en docs/runbooks/posthog.md cubre curls de verificación + rotación de tokens + cross-refs de scope futuro a #780 (ingest server-side desde EFs) y #781 (banner DNT/consent)",
+          "status": "done"
+        }
+      ]
+    },
     "community-validation": {
       "phase": "v1.1",
       "title_en": "Community validation queue (Module 22)",

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -16,7 +16,7 @@
 | v0.3 | Offline intelligence + activity | done | 11 / 11 |
 | v0.5 | Beta | shipped (partial) | 11 / 13 |
 | v1.0 | Public Launch | shipped (partial) | 18 / 21 |
-| v1.0.x | Post-launch polish | in_progress | 8 / 24 |
+| v1.0.x | Post-launch polish | in_progress | 9 / 25 |
 | v1.1 | UX polish + admin console + M22/M26/M27 | shipped (mostly) | 39 / 44 |
 | v1.2 | Research workflow (M28-M32 + obs-detail + privacy) | shipped 2026-04-30 | 17 / 17 |
 | v1.1.5 | Persuasive Tech Audit (Fogg principles) | Tier S+A shipped; Ola 2b in flight | 9 / 16 |
@@ -61,7 +61,7 @@ Remaining:
 
 ## v1.0.x — Post-launch polish — in_progress
 
-**8 of 24 items done.**
+**9 of 25 items done.** (Latest done: `posthog-analytics` 2026-05-08 — reverse-proxy snippet + 14 capture sites + exception autocapture + identify/reset on auth + drift CI guards + runbook. See `docs/runbooks/posthog.md`.)
 
 Remaining:
 

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -17,6 +17,7 @@
       ui_host: uiHost,
       defaults: '2026-01-30',
       person_profiles: 'identified_only',
+      capture_exceptions: true,
     });
   }
 </script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -37,6 +37,7 @@ interface ImportMeta {
 interface PostHog {
   __loaded?: boolean;
   capture(event: string, properties?: Record<string, unknown>): void;
+  captureException(error: unknown, properties?: Record<string, unknown>): void;
   identify(distinctId: string, properties?: Record<string, unknown>): void;
   reset(): void;
 }


### PR DESCRIPTION
## Summary

Closes the last actionable item from #767 AND the doc-surface gap that audit found:

### Code

- **`capture_exceptions: true`** in `posthog.init` — enables PostHog's built-in exception autocapture (hooks `window.onerror` + `unhandledrejection` automatically). Cleaner than wiring our own global error handler.
- **`Window.posthog.captureException(err, props?)`** added to the typed interface for caught-error opt-in capture.

### Doc-surface sync (the audit gap)

PostHog had a runbook + `.env.example` but **never appeared in `progress.json`, `tasks.json`, or `tasks.md`** — it was infrastructure-silent on the canonical roadmap surface. Auto-rendered pages at `/docs/roadmap/` and `/docs/tasks/` showed nothing for ~3 PRs of work. Fixed:

- `docs/progress.json` — adds `posthog-analytics` to the v1.0.x phase with bilingual labels (`done_at: 2026-05-08`).
- `docs/tasks.json` — 8-subtask breakdown matching the surface area (snippet, init options, build-env wiring, 14 capture sites, identify/reset on auth, Window types, drift CI guard, runbook + cross-refs).
- `docs/tasks.md` — bumps v1.0.x count from 8/24 to 9/25.

### Issue followups (one per item, as requested)

`docs/runbooks/posthog.md` "Future scope" prose section replaced with cross-refs to the two new issues:

- **#780** — PostHog: server-side ingest from Edge Functions
- **#781** — PostHog: DNT-respect + consent banner for LatAm (LFPDPPP / LGPD)

After this PR merges, **#767 will be closed** with pointers to the new per-item issues.

## Test plan

- [x] `jq . docs/progress.json` + `jq . docs/tasks.json` — both parse
- [x] `npx tsc --noEmit` — clean (`captureException` typed)
- [x] `npm test` — 1320/1320 green
- [x] `npm run build` — 237 pages, no errors
- [x] `grep -c "capture_exceptions" dist/en/index.html` → 1 (init option baked in)
- [x] `grep -c "PostHog" dist/en/docs/roadmap/index.html` → 5 (roadmap picks up the new item)
- [x] `grep -c "PostHog" dist/en/docs/tasks/index.html` → 4 (tasks page picks up the new item)
- [ ] Post-merge: trigger an exception in prod (e.g., `throw new Error('test')` in DevTools), confirm it lands in PostHog → Errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)