### PR TITLE
fix(observe): show post-form on pipeline error + SyncPill 15s timeout (#783)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -544,7 +544,18 @@ document.addEventListener('rastrum:files-dropped', async (e: Event) => {
   startGPS();
 
   // Run pipeline
-  await runPipeline(pipelineState);
+  // #783: wrap in try/catch so that an unexpected error (e.g. the
+  // gotrue auth-lock timeout that fires mid-pipeline on Android Chrome)
+  // doesn't leave postForm permanently hidden — we always show it so
+  // the user can still manually enter species and save.
+  try {
+    await runPipeline(pipelineState);
+  } catch (err) {
+    console.error('[rastrum] pipeline error — showing post-form as fallback', err);
+    pipelineState.status = 'failed';
+    await savePipelineState(pipelineState).catch(() => {});
+    showPostForm();
+  }
 });
 
 // ── Registry-based plugin gate ─────────────────────────────────────────────
@@ -1045,7 +1056,16 @@ async function resumePipeline(state: PipelineState) {
   startGPS();
 
   if (state.status !== 'done') {
-    await runPipeline(state);
+    // #783: same try/catch as files-dropped handler — always show post-form
+    // on pipeline error so the user can still save manually.
+    try {
+      await runPipeline(state);
+    } catch (err) {
+      console.error('[rastrum] resume pipeline error — showing post-form as fallback', err);
+      state.status = 'failed';
+      await savePipelineState(state).catch(() => {});
+      showPostForm();
+    }
   } else {
     showPostForm();
   }

--- a/src/components/SyncPill.astro
+++ b/src/components/SyncPill.astro
@@ -93,6 +93,14 @@ const pillAria     = profile.sync_pill_aria ?? 'Sync pending observations';
     window.addEventListener(SYNC_EVENTS.start, () => {
       busy = true;
       paintSyncing();
+      // #783: safety timeout — if sync never fires 'done' within 15s
+      // (e.g. auth lock stall on Android Chrome), reset the pill so the
+      // user isn't stuck looking at an infinite spinner.
+      setTimeout(() => {
+        if (!busy) return;
+        busy = false;
+        void refresh();
+      }, 15_000);
     });
     window.addEventListener(SYNC_EVENTS.done, async () => {
       busy = false;


### PR DESCRIPTION
## Problem

On Android Chrome (reported by Eugenio, Android 10 / Chrome 147, Oaxaca), the observe form showed photos loaded but **no submit button** — the form was permanently stuck. Separately, the header showed an infinite **'Sincronizando…'** spinner.

**Root cause:** The gotrue auth lock fires a `[warn] Lock was not released within 5000ms` on Android Chrome mid-pipeline. This causes an unhandled rejection in `runPipeline()`, which never calls `showPostForm()` — leaving `obs2-post-form` permanently hidden (it starts as `class="hidden"` and only `showPostForm()` reveals it).

The sync spinner was caused by the same stall: `SYNC_EVENTS.done` never fired, leaving `busy = true` and the pill stuck in syncing state forever.

## Changes

### `ObserveView2.astro`
Wrap both `runPipeline()` call sites in `try/catch`:
- `rastrum:files-dropped` event handler  
- `resumePipeline()`

On error: mark pipeline `status = 'failed'`, persist to IndexedDB, and call `showPostForm()` as fallback. The user lands on the form with the manual species input — they lose the AI identification but can still save the observation.

```ts
// Before
await runPipeline(pipelineState);

// After
try {
  await runPipeline(pipelineState);
} catch (err) {
  console.error('[rastrum] pipeline error — showing post-form as fallback', err);
  pipelineState.status = 'failed';
  await savePipelineState(pipelineState).catch(() => {});
  showPostForm();
}
```

### `SyncPill.astro`
Add a 15s safety timeout on `SYNC_EVENTS.start`. If `SYNC_EVENTS.done` never fires, `busy` resets and `refresh()` re-paints with the real pending count — no more infinite spinner.

```ts
window.addEventListener(SYNC_EVENTS.start, () => {
  busy = true;
  paintSyncing();
  setTimeout(() => {
    if (!busy) return;
    busy = false;
    void refresh();
  }, 15_000); // safety reset
});
```

## Testing

1. Open `/en/observe/` on Android Chrome with a slow/unstable connection
2. Load photos from gallery
3. Even if the AI identification fails or throws, the post-form (species input + Save button) should appear
4. The 'Sincronizando…' badge should disappear within 15s if sync stalls

## Notes
- The underlying auth lock issue (`@supabase/gotrue-js`) is upstream — tracked separately
- This PR is a defensive fix: pipeline errors are now always recoverable from the user's perspective

Closes #783