### PR TITLE
feat(observe): wire crop/rotate into ObserveView2 + DropZone edit buttons (#787)

### DIFF
--- a/src/components/DropZone.astro
+++ b/src/components/DropZone.astro
@@ -178,7 +178,8 @@ function showPreviews(files: File[]) {
       // #787: edit/crop button overlay
       const editBtn = document.createElement('button');
       editBtn.type = 'button';
-      editBtn.className = 'absolute bottom-0 right-0 w-6 h-6 bg-black/60 hover:bg-emerald-600 flex items-center justify-center rounded-tl-md transition-colors';
+      // w-11 h-11 = 44px touch target (WCAG 2.5.5 — Nyx review #789)
+      editBtn.className = 'absolute bottom-0 right-0 w-11 h-11 bg-black/60 hover:bg-emerald-600 flex items-center justify-center rounded-tl-md transition-colors';
       editBtn.setAttribute('aria-label', 'Edit photo');
       editBtn.innerHTML = '<svg class="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536M9 11l6-6 3 3-6 6H9v-3z"/></svg>';
       editBtn.addEventListener('click', async (ev) => {
@@ -187,8 +188,11 @@ function showPreviews(files: File[]) {
           const { openCropModal } = await import('../lib/photo-crop-controller');
           const result = await openCropModal(file);
           if (result.kind === 'use') {
-            // Replace preview image
+            // Revoke old preview URL before replacing to avoid memory leak
+            // on repeated edits (Nyx review #789)
+            const oldSrc = img.src;
             img.src = URL.createObjectURL(result.file);
+            URL.revokeObjectURL(oldSrc);
             // Notify ObserveView2 to replace the file in pipelineFiles
             document.dispatchEvent(new CustomEvent('rastrum:photo-edited', {
               detail: { original: file, edited: result.file },

--- a/src/components/DropZone.astro
+++ b/src/components/DropZone.astro
@@ -174,6 +174,31 @@ function showPreviews(files: File[]) {
       img.className = 'w-full h-full object-cover';
       img.alt = file.name;
       thumb.appendChild(img);
+
+      // #787: edit/crop button overlay
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.className = 'absolute bottom-0 right-0 w-6 h-6 bg-black/60 hover:bg-emerald-600 flex items-center justify-center rounded-tl-md transition-colors';
+      editBtn.setAttribute('aria-label', 'Edit photo');
+      editBtn.innerHTML = '<svg class="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536M9 11l6-6 3 3-6 6H9v-3z"/></svg>';
+      editBtn.addEventListener('click', async (ev) => {
+        ev.stopPropagation();
+        try {
+          const { openCropModal } = await import('../lib/photo-crop-controller');
+          const result = await openCropModal(file);
+          if (result.kind === 'use') {
+            // Replace preview image
+            img.src = URL.createObjectURL(result.file);
+            // Notify ObserveView2 to replace the file in pipelineFiles
+            document.dispatchEvent(new CustomEvent('rastrum:photo-edited', {
+              detail: { original: file, edited: result.file },
+            }));
+          }
+        } catch (err) {
+          console.warn('[rastrum] crop modal failed', err);
+        }
+      });
+      thumb.appendChild(editBtn);
     } else if (file.type.startsWith('audio/')) {
       thumb.innerHTML = '<div class="w-full h-full flex items-center justify-center text-2xl">🎵</div>';
     } else if (file.type.startsWith('video/')) {

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -1,5 +1,6 @@
 ---
 import DropZone from "./DropZone.astro";
+import PhotoCropModal from "./PhotoCropModal.astro";
 import PipelineGraph from "./PipelineGraph.astro";
 import MapPicker from "./MapPicker.astro";
 import TaxonAutocomplete from "./TaxonAutocomplete.astro";
@@ -333,6 +334,9 @@ const weathers = WEATHERS;
   </div>
 </div>
 
+<!-- Photo crop/rotate modal (#787) — single global instance, triggered by DropZone edit buttons -->
+<PhotoCropModal lang={lang} />
+
 <script>
 import type { PipelineFile, PipelineNode, PipelineState } from '../lib/pipeline-engine';
 import {
@@ -508,6 +512,36 @@ const confEl          = document.getElementById('obs2-conf');
 })();
 
 // ── Files dropped ──────────────────────────────────────────────────────────
+
+// ── Photo edited (crop/rotate from DropZone) — #787 ──────────────────────
+document.addEventListener('rastrum:photo-edited', (e: Event) => {
+  const ev = e as CustomEvent<{ original: File; edited: File }>;
+  if (!pipelineState) return;
+  const idx = pipelineState.files.findIndex(f => f.file === ev.detail.original);
+  if (idx === -1) return;
+  // Replace the file and revoke the old blobUrl to free memory
+  const old = pipelineState.files[idx];
+  URL.revokeObjectURL(old.blobUrl);
+  pipelineState.files[idx] = {
+    ...old,
+    file: ev.detail.edited,
+    blobUrl: URL.createObjectURL(ev.detail.edited),
+  };
+  // If pipeline already ran, re-run with the edited photo
+  if (pipelineState.status === 'done' || pipelineState.status === 'failed') {
+    pipelineState.status = 'processing';
+    const node = pipelineState.nodes.find(n => n.kind === 'identify' && n.fileId === old.id);
+    if (node) { node.state = 'pending'; node.output = undefined; node.error = undefined; }
+    postForm?.classList.add('hidden');
+    pipelineSection?.classList.remove('hidden');
+    updatePipelineUI();
+    runPipeline(pipelineState).catch(err => {
+      console.error('[rastrum] re-run after edit failed', err);
+      showPostForm();
+    });
+  }
+});
+
 document.addEventListener('rastrum:files-dropped', async (e: Event) => {
   const ev = e as CustomEvent<{ files: File[] }>;
   const files: File[] = ev.detail.files;


### PR DESCRIPTION
## Problem

Eugenio couldn't crop or adjust his moth photo (*Eumorpha vitis*) before submitting. The classic form had crop/rotate via `PhotoCropModal` — the new Drop & Discover form (`ObserveView2`) had nothing.

## What this PR does (Part 1 of #787)

### `DropZone.astro`
Adds a ✏️ pencil icon button overlay on each image thumbnail:
- Bottom-right corner, 44px touch target (mobile-friendly)
- Tap → opens `PhotoCropModal` via `openCropModal(file)`
- On confirm → updates the thumbnail preview + dispatches `rastrum:photo-edited`

### `ObserveView2.astro`
- Imports and mounts `PhotoCropModal` (single global instance, same pattern as classic form)
- Listens for `rastrum:photo-edited`:
  - Replaces the `PipelineFile` with the edited `File` + fresh `blobUrl`
  - If pipeline already ran: resets the identify node to `pending` and re-runs the pipeline so Claude/PlantNet gets the better-cropped image
  - Falls back to `showPostForm()` if re-run fails

## What's NOT in this PR (Part 2 — tracked in #787)
- Brightness / contrast / exposure sliders in `PhotoCropModal`
- Auto-enhance button (one-tap brightness+20, contrast+15)

## Testing
1. `/en/observe/` → load any photo from gallery
2. Tap the ✏️ icon on the thumbnail corner → crop modal opens
3. Crop/rotate → Confirm → thumbnail refreshes with the edited version
4. If AI already ran: re-identification triggers automatically with the new crop

Fixes the issue Eugenio hit during beta testing (Oaxaca, Android 10).
Refs #787