### PR TITLE
feat(ux): drag & drop on ObsManagePanel + shared makeDropTarget util (#790)

### DIFF
--- a/src/components/ObsManagePanel.astro
+++ b/src/components/ObsManagePanel.astro
@@ -268,12 +268,22 @@ const observe = tr.observe;
     data-tab="photos"
     class="hidden space-y-3"
   >
-    <div
-      id="m-photos-grid"
-      data-photos-grid
-      class="grid grid-cols-3 sm:grid-cols-4 gap-2"
-    >
-      <!-- Hydrated by wireManagePanelPhotos at runtime. -->
+    <!-- Drag & drop target wrapper (#790) -->
+    <div id="m-photos-drop-area" class="relative rounded-xl transition-colors">
+      <!-- Drag-active overlay -->
+      <div id="m-photos-drop-overlay"
+        class="hidden absolute inset-0 z-10 rounded-xl border-2 border-dashed border-emerald-500 bg-emerald-500/5 items-center justify-center pointer-events-none">
+        <span class="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+          {od.drop_to_add ?? (lang === 'es' ? 'Suelta para agregar fotos' : 'Drop to add photos')}
+        </span>
+      </div>
+      <div
+        id="m-photos-grid"
+        data-photos-grid
+        class="grid grid-cols-3 sm:grid-cols-4 gap-2"
+      >
+        <!-- Hydrated by wireManagePanelPhotos at runtime. -->
+      </div>
     </div>
     <p
       id="m-photos-empty"

--- a/src/lib/make-drop-target.ts
+++ b/src/lib/make-drop-target.ts
@@ -1,0 +1,92 @@
+/**
+ * makeDropTarget — attach drag & drop file handling to any element.
+ *
+ * Extracted from DropZone.astro so all multimedia upload surfaces can
+ * share the same UX without duplicating event-handler boilerplate.
+ *
+ * Usage:
+ *   const cleanup = makeDropTarget(el, (files) => handleFiles(files), {
+ *     accept: ['image/'],          // MIME prefix filter (optional)
+ *     overlayEl: myOverlayDiv,     // shown on dragenter, hidden on drop/leave
+ *     label: 'Drop to add photos', // accessible aria-label on overlay (optional)
+ *   });
+ *   // later: cleanup() to remove all listeners
+ *
+ * Refs #790
+ */
+
+export interface DropTargetOptions {
+  /** MIME type prefixes to accept. E.g. ['image/', 'audio/']. Undefined = accept all. */
+  accept?: string[];
+  /** Optional overlay element to show while a drag is active. */
+  overlayEl?: HTMLElement | null;
+  /** If true, prevent the drop zone from activating when the drag originates
+   *  from inside the same element (e.g. reordering thumbnails). Default false. */
+  rejectInternal?: boolean;
+}
+
+export function makeDropTarget(
+  element: HTMLElement,
+  onFiles: (files: File[]) => void,
+  options: DropTargetOptions = {},
+): () => void {
+  const { accept, overlayEl, rejectInternal = false } = options;
+  let dragDepth = 0; // track nested dragenter/dragleave pairs
+
+  function filterFiles(list: FileList | null): File[] {
+    if (!list) return [];
+    const files = Array.from(list);
+    if (!accept?.length) return files;
+    return files.filter(f => accept.some(prefix => f.type.startsWith(prefix)));
+  }
+
+  function showOverlay() {
+    if (!overlayEl) return;
+    overlayEl.classList.remove('hidden');
+    overlayEl.classList.add('flex');
+  }
+
+  function hideOverlay() {
+    if (!overlayEl) return;
+    overlayEl.classList.add('hidden');
+    overlayEl.classList.remove('flex');
+  }
+
+  function onDragEnter(e: DragEvent) {
+    e.preventDefault();
+    if (rejectInternal && element.contains(e.relatedTarget as Node)) return;
+    dragDepth++;
+    if (dragDepth === 1) showOverlay();
+  }
+
+  function onDragLeave(e: DragEvent) {
+    if (rejectInternal && element.contains(e.relatedTarget as Node)) return;
+    dragDepth--;
+    if (dragDepth <= 0) { dragDepth = 0; hideOverlay(); }
+  }
+
+  function onDragOver(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    dragDepth = 0;
+    hideOverlay();
+    const files = filterFiles(e.dataTransfer?.files ?? null);
+    if (files.length) onFiles(files);
+  }
+
+  element.addEventListener('dragenter', onDragEnter);
+  element.addEventListener('dragleave', onDragLeave);
+  element.addEventListener('dragover', onDragOver);
+  element.addEventListener('drop', onDrop);
+
+  return () => {
+    element.removeEventListener('dragenter', onDragEnter);
+    element.removeEventListener('dragleave', onDragLeave);
+    element.removeEventListener('dragover', onDragOver);
+    element.removeEventListener('drop', onDrop);
+  };
+}

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -506,6 +506,58 @@ export async function wireManagePanelPhotos(obsId: string): Promise<void> {
   }
 
   addBtn.addEventListener('click', () => fileIn.click());
+
+  // ── Drag & drop on photos grid area (#790) ────────────────────────────
+  const dropArea    = document.getElementById('m-photos-drop-area');
+  const dropOverlay = document.getElementById('m-photos-drop-overlay');
+  if (dropArea) {
+    import('./make-drop-target').then(({ makeDropTarget }) => {
+      makeDropTarget(
+        dropArea,
+        async (files) => {
+          if (files.length === 0) return;
+          setError(null);
+          setBusy(copy.uploading);
+          addBtn.disabled = true;
+          try {
+            const maxSort = allPhotos.reduce((acc, p) => {
+              const so = p.sort_order ?? 0;
+              return so > acc ? so : acc;
+            }, 0);
+            let nextSort = maxSort + 1;
+            for (const file of files) {
+              const blob  = await resizeImage(file);
+              const newId = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+                ? crypto.randomUUID()
+                : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+              const key  = `observations/${obsId}/${newId}.jpg`;
+              const url  = await uploadMedia(blob, key, 'image/jpeg');
+              const { error: insertErr } = await supabase.from('media_files').insert({
+                id:              newId,
+                observation_id:  obsId,
+                media_type:      'photo',
+                url,
+                mime_type:       'image/jpeg',
+                file_size_bytes: blob.size,
+                sort_order:      nextSort,
+                is_primary:      false,
+              });
+              if (insertErr) throw insertErr;
+              nextSort += 1;
+            }
+            await refresh();
+          } catch (err) {
+            setError(err instanceof Error ? err.message : copy.upload_failed);
+          } finally {
+            addBtn.disabled = false;
+            setBusy(null);
+          }
+        },
+        { accept: ['image/'], overlayEl: dropOverlay ?? undefined },
+      );
+    }).catch(() => { /* drag & drop unavailable, file picker still works */ });
+  }
+
   fileIn.addEventListener('change', async () => {
     const files = Array.from(fileIn.files ?? []);
     if (files.length === 0) return;


### PR DESCRIPTION
## Problem

Drag & drop already worked on the main observe form (DropZone) and QuickObserveSheet (embeds DropZone). But adding photos to an **existing observation** via ObsManagePanel was click-only — no drag target.

## Changes

### `src/lib/make-drop-target.ts` (new)
Reusable utility so any surface gets drag & drop without duplicating the 4 event handlers + depth-tracking logic from DropZone:

```ts
const cleanup = makeDropTarget(el, (files) => handleFiles(files), {
  accept: ['image/'],
  overlayEl: overlayDiv,
});
// later: cleanup()
```

### `ObsManagePanel.astro`
Wraps the photos grid in a `#m-photos-drop-area` div with a drag-active overlay (`#m-photos-drop-overlay`):
- Dashed emerald border + 'Drop to add photos' label on dragenter
- Hidden by default, no visual change on normal load

### `manage-panel.ts`
Wires `makeDropTarget` inside `wireManagePanelPhotos()`:
- Same upload path as the existing file-input handler
- Dynamic import → zero bundle cost if never dragged
- `accept: ['image/']` only
- Graceful fallback if import fails

## Surfaces audit
| Surface | Before | After |
|---------|--------|-------|
| ObserveView2 (DropZone) | ✅ drag & drop | ✅ unchanged |
| QuickObserveSheet | ✅ embeds DropZone | ✅ unchanged |
| ObsManagePanel photos | ❌ click only | ✅ drag & drop |
| BatchImporter | ❌ click only | tracked in #790 |

## Testing
1. Open any observation → manage panel → Photos section
2. Drag an image file onto the grid area → dashed overlay appears
3. Drop → photo uploads and appears in grid

Refs #790