### PR TITLE
fix(diagnostics): don't log AbortError as a failed request

### DIFF
--- a/src/components/ReportIssueButton.astro
+++ b/src/components/ReportIssueButton.astro
@@ -271,15 +271,21 @@ const repoSlug = 'ArtemioPadilla/rastrum';
           }
           return res;
         }, function (err) {
-          diag.network.push({
-            ts: new Date().toISOString(),
-            method: method.toUpperCase(),
-            url: urlStr.slice(0, 200),
-            status: 0,
-            statusText: err && err.message ? err.message.slice(0, 100) : 'Network error'
-          });
-          if (diag.network.length > MAX) diag.network.shift();
-          W.__rastrum_updateFabBadge && W.__rastrum_updateFabBadge();
+          // Aborts aren't failures — PostHog SDK supersedes its own /flags/
+          // requests, and PWA navigation cancels in-flight fetches. Both
+          // surface as AbortError; logging them pollutes bug reports.
+          var isAbort = err && (err.name === 'AbortError' || (typeof DOMException !== 'undefined' && err instanceof DOMException && err.name === 'AbortError'));
+          if (!isAbort) {
+            diag.network.push({
+              ts: new Date().toISOString(),
+              method: method.toUpperCase(),
+              url: urlStr.slice(0, 200),
+              status: 0,
+              statusText: err && err.message ? err.message.slice(0, 100) : 'Network error'
+            });
+            if (diag.network.length > MAX) diag.network.shift();
+            W.__rastrum_updateFabBadge && W.__rastrum_updateFabBadge();
+          }
           throw err;
         });
       };


### PR DESCRIPTION
## Summary

The inline fetch wrapper in `ReportIssueButton.astro` was logging *every* fetch rejection into `__rastrum_diag.network` — including `AbortError`. Two things abort fetches in normal operation:

- **PostHog SDK** cancels superseded `/flags/` requests via `AbortController.abort()` (surfaces as `signal is aborted without reason` in Chrome).
- **PWA navigation** cancels in-flight fetches the same way.

Neither is a failure, but both showed up in the bug-report dialog's "Failed Requests" section and ticked the FAB error badge. Filter `AbortError` at the source so both that modal and `src/lib/bug-report.ts` (which reads the same array) stay clean.

## Changes

- `src/components/ReportIssueButton.astro` — fetch-error capture now skips `AbortError` (and the `DOMException` form for older Safari) before pushing into `diag.network`. Still rethrows so callers that care still see the abort.

## How to verify

1. Open the report-bug dialog (FAB → bug icon) in the browser.
2. Trigger a navigation while PostHog is fetching flags — e.g. cold-load a page and immediately click a nav link.
3. Confirm the "Failed Requests" section no longer contains `usage.rastrum.org/flags/ → ERR signal is aborted`.
4. Real network failures (offline, 500s) still show up.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 1389 passed
- [ ] Manual smoke on production-like build to confirm AbortErrors disappear from the bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)