### PR TITLE
docs(readme): add Engagement & Habit-Building section (v1.1.5 Fogg audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,36 @@ Personal `rst_*` tokens authenticate two parallel surfaces:
 
 Both gate on the same scope strings (`observe`, `identify`, `export`).
 
+## Engagement & Habit-Building (v1.1.5 Persuasive Tech Audit)
+
+In May 2026 the v1.1.5 phase applied B.J. Fogg's *Persuasive Technology*
+chapter-by-chapter to existing surfaces. 15 features shipped across 5
+clusters, all with **honest-by-design** primitives — no hidden ranking,
+no manipulative variable rewards, no toxic leaderboards.
+
+### Reduction & flow (Tier S)
+- **Quick Observation** — `/observe?quick=1` opens the camera immediately, GPS + EXIF + outbox draft in 1 tap.
+- **Photo praise** — EXIF-driven micro-feedback ("good light", "sharp action") at upload, never aesthetic.
+- **Falta-dex** — taxonomic gaps panel, ordered by rarity bucket (Option A: Rastrum-own data as proxy).
+- **Active observers banner** — "Hoy 7 personas observan en Oaxaca" on `/observe`, M28 anon-safe view.
+- **Triage SLA dashboard** — `/docs/status` with median time-to-first-comment from gh API, refreshed nightly.
+
+### Credibility & honesty (Tier A)
+- **Field theme** — pure-black, high-contrast variant for direct-sunlight readability; `field` is a 4th theme state.
+- **Seasonal themes** — Monarca / Lluvias / Secas accents auto-resolve by month + region.
+- **Humanized About** — team, funding ledger, governance summary, live stats from Supabase build-time fetcher.
+- **`<WhyAmISeeingThis />`** — pill on every ranked surface; opens a global modal with inputs/window/settings copy. The 4 disclosure principles ship at `/docs/algorithms`.
+
+### Normative & motivational (Ola 2b)
+- **Peer norms in config** — "82% of MX observers choose CC-BY" bars on license + privacy selectors. Honest fallback when n < 50.
+- **Percentile cards** — `/profile/` shows you-vs-cohort percentiles for diversity / habitats / validations / spread. Never raw rank.
+- **Contextual species** — `probable_taxa_at(lat, lng, month)` chip strip on `/observe` + `/identify`. No GBIF ETL — own-data proxy.
+- **Mi impacto ecológico** — 5-card retrospective at `/profile/impacto` (transect-equivalent km, NOM-059 species, expert validations).
+- **Golden-hour kairos** — opt-in Web Push 30 min before sunset; max 1/day; cron `kairos-fire-15min`. Other triggers (after-rain, migration, lunar) are tracked v1.1 follow-ups.
+- **Field surprises** — opt-in catalog of 3 fixed kinds (`dato_curioso`, `rarito`, `comunidad_activa_hoy`); 1/day cap; rules disclosed at `/docs/surprises`.
+
+Roadmap details: [`docs/progress.json`](docs/progress.json) v1.1.5 phase. Conventions: [`CLAUDE.md`](CLAUDE.md) "Persuasive Tech (Fogg) — v1.1.5".
+
 ## Tech Stack
 
 | Component | Technology | Purpose |


### PR DESCRIPTION
## Summary

Adds a new **Engagement & Habit-Building (v1.1.5 Persuasive Tech Audit)** section to the root `README.md`, slotted between `## Features` and `## Tech Stack`. It documents the 15 features shipped in the v1.1.5 phase across 5 clusters, with the honest-by-design framing already documented in `CLAUDE.md`.

- **Reduction & flow (Tier S)** — Quick Observation, photo praise, falta-dex, active-observers banner, triage SLA dashboard.
- **Credibility & honesty (Tier A)** — Field theme, seasonal themes, humanized About page, `<WhyAmISeeingThis />` algorithmic disclosure.
- **Normative & motivational (Ola 2b)** — peer norms, percentile cards, contextual species, `mi impacto ecológico`, golden-hour kairos push, opt-in field surprises.

Cross-links to `docs/progress.json` v1.1.5 phase and `CLAUDE.md` "Persuasive Tech (Fogg) — v1.1.5" for the load-bearing conventions (algorithms registry, theme four-state, honest-norms `n < 50`, EXIF-only photo praise).

No Spanish README exists in the repo, so no ES mirror was needed.

## Test plan

- [x] `npm run build` passes — 241 pages, zero errors.
- [x] Markdown renders cleanly (no broken anchors / fences).
- [x] Only `README.md` modified; staged with `git add README.md`, never `-A`.