### PR TITLE
docs(runbook): VAPID keys production deploy checklist for kairos

### DIFF
--- a/docs/runbooks/00-index.md
+++ b/docs/runbooks/00-index.md
@@ -66,7 +66,7 @@ high-level system view.
 
 | Runbook | Covers |
 |---|---|
-| [`kairos-prompts.md`](kairos-prompts.md) | M34 — golden-hour push, `kairos-fire` 15-min cron, hard 1-per-day cap, manual fire instructions. |
+| [`kairos-prompts.md`](kairos-prompts.md) | M34 — golden-hour push, `kairos-fire` 15-min cron, hard 1-per-day cap, manual fire instructions, VAPID prod-deploy checklist. |
 
 ## Operator hygiene + ops
 

--- a/docs/runbooks/kairos-prompts.md
+++ b/docs/runbooks/kairos-prompts.md
@@ -96,6 +96,142 @@ UPDATE public.kairos_subscriptions
  WHERE user_id = '<uuid>' AND kind = 'golden_hour';
 ```
 
+## Production deploy checklist (operator action required)
+
+Closes the post-merge ops gap on [#777](https://github.com/ArtemioPadilla/rastrum/pull/777):
+without VAPID keys configured, `kairos-fire` cron runs every 15 min and
+returns `{ "error": "vapid_unconfigured" }` on every iteration — the EF
+exits before touching `push_subscriptions`, so failures are silent
+(no exceptions raised, no rows updated). Run this checklist once after
+merging M34, then again any time the keys are rotated.
+
+The full rotation flow (and why each env var exists) lives in
+[`rotate-secret.md`](rotate-secret.md) → "VAPID keys"; the steps below
+are the minimum kairos operator path.
+
+### Generate VAPID key pair (one-time)
+
+```bash
+npx web-push generate-vapid-keys --json
+# → { "publicKey": "B…", "privateKey": "Y…" }
+```
+
+Both halves are base64url-encoded EC P-256. The public key is 65 bytes
+raw (uncompressed, starts with `0x04`); the private key is a 32-byte
+scalar. `supabase/functions/_shared/web-push.ts` validates the public
+key shape on import — a wrong-format key surfaces as
+`VAPID public key must be uncompressed (65 bytes, starts with 0x04)`.
+
+### Set env vars in Supabase (Edge Functions)
+
+```bash
+gh secret set VAPID_PUBLIC_KEY              # paste publicKey
+gh secret set VAPID_PRIVATE_KEY             # paste privateKey
+gh secret set VAPID_SUBJECT                 # paste mailto:owner@rastrum.org
+```
+
+Or via the Supabase dashboard: Project Settings → Edge Functions →
+Secrets. `VAPID_SUBJECT` MUST be a `mailto:` URL or an https origin —
+RFC 8292 requires the JWT `sub` claim to be one of the two; FCM/APNS
+will 401 otherwise.
+
+### Set client-exposed env var
+
+```bash
+gh secret set PUBLIC_VAPID_PUBLIC_KEY       # SAME value as VAPID_PUBLIC_KEY
+```
+
+Must match the Supabase `VAPID_PUBLIC_KEY` exactly. The browser pins the
+subscription to this public key; if the static bundle and the EF disagree,
+every push will 4xx and the EF will treat each subscription as dead.
+
+### Verify deploy
+
+1. **Re-deploy the EF and the static bundle:**
+
+   ```bash
+   gh workflow run deploy-functions.yml --ref main -f function=kairos-fire
+   gh workflow run deploy.yml --ref main
+   gh run watch
+   ```
+
+2. **Manual fire** (mirrors the `recompute-streaks` curl-with-CRON_SECRET
+   pattern documented in [`cron-secret-rotation.md`](cron-secret-rotation.md)):
+
+   ```bash
+   curl -sS -X POST \
+     https://reppvlqejgoqvitturxp.supabase.co/functions/v1/kairos-fire \
+     -H "X-Cron-Secret: $CRON_SECRET" \
+     -H "Content-Type: application/json" \
+     -d '{}'
+   # Expected: { "sent": 0, "candidates": 0, "errored": 0, "total": <n> }
+   # NOT expected: { "error": "vapid_unconfigured", "sent": 0 }
+   ```
+
+   If the response is `vapid_unconfigured`, the secrets didn't reach
+   the EF — re-check the Supabase dashboard secrets list and re-deploy.
+
+3. **Opt in on a signed-in dev account** at `/profile/notifications/`
+   (EN) or `/perfil/notificaciones/` (ES). Toggling on must (a) prompt
+   for the browser notification permission, (b) call
+   `pushManager.subscribe()` with the `PUBLIC_VAPID_PUBLIC_KEY`, and
+   (c) upsert a row into `public.push_subscriptions`. Verify:
+
+   ```sql
+   SELECT user_id, endpoint, created_at
+     FROM public.push_subscriptions
+    ORDER BY created_at DESC
+    LIMIT 5;
+   ```
+
+4. **Force-fire a real push at yourself.** The 15-min cron only fires
+   when local time is in `[sunset-30min, sunset-15min]` AND
+   `last_sent_at` is NULL or stale. To test out-of-window:
+
+   ```sql
+   UPDATE public.kairos_subscriptions
+      SET last_sent_at = NULL
+    WHERE user_id = '<you>' AND kind = 'golden_hour';
+   ```
+
+   Set your laptop clock to ~25 min before local sunset, then run the
+   manual-fire curl above. Expected response: `"sent": 1` and a push
+   notification rendered by the SW with golden-hour copy. If `sent` is
+   1 but no notification arrives, the SW handler may not be wired —
+   verify `_shared/web-push.ts` is imported by `kairos-fire/index.ts`
+   (see Troubleshooting below).
+
+### Rotation (key compromise / yearly hygiene)
+
+Use the same flow above with new keys. The full secret-rotation flow
+lives in [`rotate-secret.md`](rotate-secret.md) → "VAPID keys".
+
+**User-visible side effect:** every existing push subscription is tied
+to the old public key from the browser's perspective; after rotation
+the next push attempt to each subscription will 410, and the EF reaps
+those rows automatically. Users must re-toggle on
+`/profile/notifications/` to re-subscribe under the new key. The
+in-app toast surfaced after rotation reads:
+
+> "Notifications re-subscribed required after operator key rotation."
+
+To force-clear instead of waiting for the 410 reap:
+
+```sql
+DELETE FROM public.push_subscriptions;
+```
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `{ "error": "vapid_unconfigured" }` | `VAPID_PUBLIC_KEY` or `VAPID_PRIVATE_KEY` missing on the EF | Re-set the Supabase secrets and re-deploy `kairos-fire`. |
+| Push 401 from FCM/APNS endpoint (visible in `errored`) | `VAPID_SUBJECT` not a `mailto:` URL or an https origin, or the public/private keys are mismatched halves | Verify `VAPID_SUBJECT` per RFC 8292; regenerate the pair if half is missing. |
+| No `push_subscriptions` rows after opt-in | `PUBLIC_VAPID_PUBLIC_KEY` is missing or doesn't match `VAPID_PUBLIC_KEY` on the EF | Re-set the GitHub secret to the SAME value as the Supabase secret and re-deploy `deploy.yml`. |
+| Cron fires `"sent": 1` but no notification arrives | SW push handler not wired, or `_shared/web-push.ts` import path stale | Check `supabase/functions/kairos-fire/index.ts` imports `sendPushNoPayload` from `../_shared/web-push.ts`, and that the SW (`public/sw.js`) has a `push` event listener rendering the kairos copy. |
+| `errored` > 0 with 5xx statuses | Transient FCM/APNS outage | Retry on the next 15-min tick. The EF doesn't queue. |
+| `errored` > 0 with 410 statuses | Browser uninstalled the SW or the user revoked permission | The EF auto-deletes 404/410 endpoints. No action needed. |
+
 ## v1.1 follow-ups (separate issues)
 
 - After-rain trigger.

--- a/docs/runbooks/rotate-secret.md
+++ b/docs/runbooks/rotate-secret.md
@@ -144,8 +144,11 @@ will reject the next call).
 
 ### VAPID keys (`VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `PUBLIC_VAPID_PUBLIC_KEY`)
 
-Used by the `streak-push` Edge Function to send Web Push notifications
-(see `ux-streak-push` in the v1.1 backlog). Three env vars work together:
+Used by the `streak-push` and `kairos-fire` Edge Functions to send Web
+Push notifications. The kairos prod-deploy checklist (the minimum
+operator path to make M34 actually fire pushes) lives in
+[`kairos-prompts.md`](kairos-prompts.md#production-deploy-checklist-operator-action-required);
+the rotation flow below applies to both. Three env vars work together:
 
 - **`VAPID_PUBLIC_KEY`** (Supabase secret) — uncompressed P-256 public key,
   base64url-encoded (65 bytes raw, starts with `0x04`).


### PR DESCRIPTION
Operator runbook addition for #777 kairos push prod deploy. Closes part of post-merge ops gap.

## Summary

- Adds a "Production deploy checklist (operator action required)" section to `docs/runbooks/kairos-prompts.md` covering: generate VAPID pair, set Supabase + GitHub secrets, redeploy EF + static bundle, manual-fire smoke test, opt-in verification, and force-fire-at-yourself test
- Documents rotation user-visible side effect (existing subscriptions 410 on next push, users must re-toggle) + the in-app toast copy
- Adds a focused troubleshooting matrix for the kairos-specific failure modes (`vapid_unconfigured`, FCM/APNS 401 on subject mismatch, missing `push_subscriptions` rows on client/server key mismatch, sent-but-not-rendered on SW import drift)
- Cross-links from `docs/runbooks/rotate-secret.md` → "VAPID keys" back at the kairos minimum-deploy path
- Updates `docs/runbooks/00-index.md` description for kairos-prompts

## Why

PR #777 ships a 15-min `kairos-fire` cron, but without `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `PUBLIC_VAPID_PUBLIC_KEY` / `VAPID_SUBJECT` configured, the EF returns `{ "error": "vapid_unconfigured" }` and exits before touching `push_subscriptions`. Failures are silent — no exceptions, no audit trail, no rows updated. This runbook gives an operator a single, ordered checklist to make M34 actually fire pushes in production.

## Test plan

- [x] `npm run build` — 241 pages, zero errors
- [ ] Operator follows the checklist in production; manual-fire returns `"sent": <n>` (not `"vapid_unconfigured"`)
- [ ] Opt-in flow on `/profile/notifications/` produces a `push_subscriptions` row
- [ ] Force-fire test (set `last_sent_at = NULL`, set clock to ~25 min before sunset, manual-fire) delivers a real golden-hour notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)