### PR TITLE
fix(sw): memoize pmtiles archive buffer across range fetches

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -137,7 +137,19 @@ function isHtmlNavigation(req, url) {
 // makes byte-range fetches, so we slice the cached body and return a
 // 206 Partial Content. On cache miss we fall through to network.
 //
+// MapLibre fires several byte-range fetches in parallel at first paint
+// (header + root directory + visible tiles). Reading the cached 50 MB
+// archive once per fetch via cached.arrayBuffer() multiplies disk I/O
+// and memory pressure by N, slowing the SW response enough that
+// MapLibre's tile-priority logic cancels the slower ones — surfacing
+// as "ERR signal is aborted without reason" in the network panel.
+// The module-level memo keeps a single decoded ArrayBuffer per archive
+// keyed by URL + ETag; the SW process being torn down (or a fresh
+// download bumping the ETag) flushes it.
+//
 // Spec: tests/unit/sw-pmtiles-range.test.ts pins the slicing algorithm.
+let pmtilesBufferMemo = null; // { key: string, buf: ArrayBuffer }
+
 async function servePmtilesRange(req, url) {
   try {
     const cache = await caches.open(PMTILES_CACHE_NAME);
@@ -152,7 +164,15 @@ async function servePmtilesRange(req, url) {
 
     const start = parseInt(m[1], 10);
     const end   = parseInt(m[2], 10);
-    const buf   = await cached.arrayBuffer();
+    const etag  = cached.headers.get('etag') || '';
+    const memoKey = `${url.href}|${etag}`;
+    let buf;
+    if (pmtilesBufferMemo && pmtilesBufferMemo.key === memoKey) {
+      buf = pmtilesBufferMemo.buf;
+    } else {
+      buf = await cached.arrayBuffer();
+      pmtilesBufferMemo = { key: memoKey, buf };
+    }
     const total = buf.byteLength;
     if (start >= total) {
       return new Response(null, {
@@ -167,7 +187,6 @@ async function servePmtilesRange(req, url) {
     const headers = new Headers();
     const contentType = cached.headers.get('content-type');
     if (contentType) headers.set('Content-Type', contentType);
-    const etag = cached.headers.get('etag');
     if (etag) headers.set('ETag', etag);
     headers.set('Content-Range', `bytes ${start}-${sliceEnd - 1}/${total}`);
     headers.set('Content-Length', String(slice.byteLength));

--- a/tests/unit/sw-pmtiles-range.test.ts
+++ b/tests/unit/sw-pmtiles-range.test.ts
@@ -40,6 +40,8 @@ const PMTILES_CACHE_NAME = 'rastrum/pmtiles';
 
 // Mirror of public/sw.js#servePmtilesRange. Keep in sync — divergence is
 // caught by e2e in production but should not happen in code review.
+let pmtilesBufferMemo: { key: string; buf: ArrayBuffer } | null = null;
+
 async function servePmtilesRange(req: Request, url: URL): Promise<Response> {
   try {
     const cache = await cachesShim.open(PMTILES_CACHE_NAME);
@@ -54,7 +56,15 @@ async function servePmtilesRange(req: Request, url: URL): Promise<Response> {
 
     const start = parseInt(m[1], 10);
     const end   = parseInt(m[2], 10);
-    const buf   = await cached.arrayBuffer();
+    const etag  = cached.headers.get('etag') || '';
+    const memoKey = `${url.href}|${etag}`;
+    let buf: ArrayBuffer;
+    if (pmtilesBufferMemo && pmtilesBufferMemo.key === memoKey) {
+      buf = pmtilesBufferMemo.buf;
+    } else {
+      buf = await cached.arrayBuffer();
+      pmtilesBufferMemo = { key: memoKey, buf };
+    }
     const total = buf.byteLength;
     if (start >= total) {
       return new Response(null, {
@@ -69,7 +79,6 @@ async function servePmtilesRange(req: Request, url: URL): Promise<Response> {
     const headers = new Headers();
     const contentType = cached.headers.get('content-type');
     if (contentType) headers.set('Content-Type', contentType);
-    const etag = cached.headers.get('etag');
     if (etag) headers.set('ETag', etag);
     headers.set('Content-Range', `bytes ${start}-${sliceEnd - 1}/${total}`);
     headers.set('Content-Length', String(slice.byteLength));
@@ -89,12 +98,12 @@ function fillBytes(n: number): Uint8Array {
   return a;
 }
 
-async function seed(body: Uint8Array): Promise<void> {
+async function seed(body: Uint8Array, etag = 'W/"test-etag"'): Promise<void> {
   const cache = await cachesShim.open(PMTILES_CACHE_NAME);
   const headers = new Headers({
     'Content-Type': 'application/octet-stream',
     'Content-Length': String(body.byteLength),
-    'ETag': 'W/"test-etag"',
+    'ETag': etag,
   });
   await cache.put(ARCHIVE_URL, new Response(body as BodyInit, { status: 200, headers }));
 }
@@ -102,6 +111,7 @@ async function seed(body: Uint8Array): Promise<void> {
 describe('servePmtilesRange', () => {
   beforeEach(() => {
     cacheBuckets.clear();
+    pmtilesBufferMemo = null;
   });
 
   it('returns the full body when no Range header is present', async () => {
@@ -188,5 +198,50 @@ describe('servePmtilesRange', () => {
     const res = await servePmtilesRange(req, new URL(ARCHIVE_URL));
     expect(res.status).toBe(599);
     await expect(res.text()).resolves.toBe('network-fallback');
+  });
+
+  // The buffer memo exists so MapLibre's parallel byte-range fetches at
+  // first paint don't each pay the cost of decoding the full ~50 MB
+  // archive. Without it, the redundant arrayBuffer() reads slow each
+  // SW response enough that MapLibre cancels the slowest tile fetches,
+  // surfacing as "ERR signal is aborted without reason".
+  it('reuses the decoded buffer across range fetches with matching ETag', async () => {
+    const body = fillBytes(2048);
+    await seed(body, 'W/"v1"');
+
+    const req1 = new Request(ARCHIVE_URL, { headers: { Range: 'bytes=0-15' } });
+    await servePmtilesRange(req1, new URL(ARCHIVE_URL));
+    const memoAfterFirst = pmtilesBufferMemo;
+    expect(memoAfterFirst).not.toBeNull();
+    expect(memoAfterFirst!.key).toBe(`${ARCHIVE_URL}|W/"v1"`);
+    expect(memoAfterFirst!.buf.byteLength).toBe(2048);
+
+    const req2 = new Request(ARCHIVE_URL, { headers: { Range: 'bytes=100-200' } });
+    const res2 = await servePmtilesRange(req2, new URL(ARCHIVE_URL));
+    expect(res2.status).toBe(206);
+    expect(pmtilesBufferMemo).toBe(memoAfterFirst); // same object identity → not reread
+  });
+
+  it('invalidates the memo when the cached archive ETag changes', async () => {
+    const body1 = fillBytes(512);
+    await seed(body1, 'W/"v1"');
+    await servePmtilesRange(
+      new Request(ARCHIVE_URL, { headers: { Range: 'bytes=0-31' } }),
+      new URL(ARCHIVE_URL),
+    );
+    expect(pmtilesBufferMemo!.key).toBe(`${ARCHIVE_URL}|W/"v1"`);
+
+    // Operator re-downloads the archive — different content, new ETag.
+    cacheBuckets.clear();
+    const body2 = fillBytes(1024);
+    await seed(body2, 'W/"v2"');
+    const res = await servePmtilesRange(
+      new Request(ARCHIVE_URL, { headers: { Range: 'bytes=0-31' } }),
+      new URL(ARCHIVE_URL),
+    );
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe('bytes 0-31/1024');
+    expect(pmtilesBufferMemo!.key).toBe(`${ARCHIVE_URL}|W/"v2"`);
+    expect(pmtilesBufferMemo!.buf.byteLength).toBe(1024);
   });
 });


### PR DESCRIPTION
## Summary
- The SW was reading the full ~50 MB pmtiles archive via `cached.arrayBuffer()` on every byte-range request. MapLibre fires several byte-range fetches in parallel at first paint (header + root directory + visible tiles), so N concurrent fetches spent N × archive size on disk I/O. The slowdown gave MapLibre's tile-priority logic time to cancel the slowest in-flight tiles, surfacing as repeated `ERR signal is aborted without reason` entries against `media.rastrum.org/maps/*.pmtiles` in the user's network panel.
- Memoize the decoded `ArrayBuffer` in a module-level variable keyed by URL+ETag. First request still pays the decode cost; subsequent ones slice from the in-memory copy. Re-downloading the archive bumps the ETag and invalidates the memo automatically.
- The slicing algorithm itself is unchanged; the spec test (`tests/unit/sw-pmtiles-range.test.ts`) still mirrors `public/sw.js` byte-for-byte.

## Diagnosis
Reported on `/es/explorar/mapa/` at 2026-05-09T02:22 — five aborts to `https://media.rastrum.org/maps/mexico_z0_10.pmtiles` clustered ~5 s apart. R2, CORS, and Range support are healthy (verified via `curl`). pmtiles 4.4.1's `FetchSource.getBytes` uses MapLibre's tile signal for tile fetches; when MapLibre cancels a tile, the underlying fetch aborts. The cancellations correlate with SW response latency on a populated `rastrum/pmtiles` cache. The redundant 50 MB reads are the only obvious cause of that latency in our pipeline.

## Test plan
- [x] `npx vitest run tests/unit/sw-pmtiles-range.test.ts` — 9 passed (7 existing + 2 new memo cases)
- [x] `npm test` — 1391/1391 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — 241 pages built
- [ ] Post-deploy: confirm the abort cluster does not recur on `/es/explorar/mapa/` for users with the offline map downloaded
- [ ] Post-deploy: confirm `Profile → Edit → Offline maps → Re-download` still flushes the memo (ETag-keyed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)