### PR TITLE
feat(disclosure): wire WhyAmISeeingThis on remaining v1.1.5 ranked surfaces

### DIFF
--- a/src/components/ActiveObserversBanner.astro
+++ b/src/components/ActiveObserversBanner.astro
@@ -19,6 +19,7 @@
  * form.
  */
 import { t } from '../i18n/utils';
+import WhyAmISeeingThis from './WhyAmISeeingThis.astro';
 
 interface Props { lang: 'en' | 'es'; }
 const { lang } = Astro.props;
@@ -33,18 +34,21 @@ const banner = (tr.observe as Record<string, unknown>).active_banner as {
 const observersHref = isEs ? '/es/comunidad/observadores' : '/en/community/observers';
 ---
 
-<a
-  id="active-observers-banner"
-  href={observersHref}
-  aria-label={banner.aria_label}
-  class="hidden rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 px-3 py-1.5 text-xs text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 transition-colors w-fit"
-  data-lang={lang}
-  data-copy-today-n={banner.today_n}
-  data-copy-today-one={banner.today_one}
-  data-copy-empty={banner.empty}
->
-  <span id="active-observers-banner-text">{banner.empty.replace('{region}', '')}</span>
-</a>
+<div id="active-observers-banner-wrap" class="hidden flex flex-wrap items-center gap-2">
+  <a
+    id="active-observers-banner"
+    href={observersHref}
+    aria-label={banner.aria_label}
+    class="rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 px-3 py-1.5 text-xs text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 transition-colors w-fit"
+    data-lang={lang}
+    data-copy-today-n={banner.today_n}
+    data-copy-today-one={banner.today_one}
+    data-copy-empty={banner.empty}
+  >
+    <span id="active-observers-banner-text">{banner.empty.replace('{region}', '')}</span>
+  </a>
+  <WhyAmISeeingThis algorithm="active_observers_today" lang={lang} />
+</div>
 
 <script>
   import { loadViewerRegion, loadActiveObserversToday } from '../lib/community';
@@ -85,7 +89,8 @@ const observersHref = isEs ? '/es/comunidad/observadores' : '/en/community/obser
 
     const qs = serializeFilters({ ...DEFAULT_FILTERS, country: region.countryCode });
     el.href = `${el.pathname}${qs}`;
-    el.classList.remove('hidden');
+    const wrap = document.getElementById('active-observers-banner-wrap');
+    wrap?.classList.remove('hidden');
   }
 
   hydrate();

--- a/src/components/ContextualSpeciesChips.astro
+++ b/src/components/ContextualSpeciesChips.astro
@@ -17,6 +17,7 @@
  *   - Falls back silently when the RPC returns no rows or errors.
  */
 import { t } from '../i18n/utils';
+import WhyAmISeeingThis from './WhyAmISeeingThis.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -65,6 +66,7 @@ const useLabel = ctx.use_label ?? (isEs ? 'Usar como identificación' : 'Use as 
         {caveatText}
       </p>
     </div>
+    <WhyAmISeeingThis algorithm="contextual_species_chips" lang={lang} className="shrink-0" />
   </div>
 
   <div id="obs2-contextual-status" class="text-xs text-zinc-400 dark:text-zinc-500">

--- a/src/components/PokedexView.astro
+++ b/src/components/PokedexView.astro
@@ -1,6 +1,7 @@
 ---
 import type { Locale } from '../i18n/utils';
 import { t } from '../i18n/utils';
+import WhyAmISeeingThis from './WhyAmISeeingThis.astro';
 
 interface Props {
   lang: Locale;
@@ -111,6 +112,11 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
   <div id="pokedex-hero" class="hidden"></div>
   <div id="pokedex-pills" class="hidden"></div>
   <div id="pokedex-missing-toolbar" class="hidden mt-4 flex flex-wrap items-center gap-3 text-xs"></div>
+  {!visitor && (
+    <div id="pokedex-why-falta" class="hidden mt-2">
+      <WhyAmISeeingThis algorithm="falta_dex_missing" lang={lang} />
+    </div>
+  )}
   <div id="pokedex-grid" class="hidden mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3"></div>
   <p id="pokedex-missing-disclaimer" class="hidden mt-3 text-[11px] text-zinc-500 dark:text-zinc-500"></p>
 </section>
@@ -543,6 +549,8 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
         ${escAttr(toggleLabel)}
       </button>`;
     missingToolbarEl.classList.remove('hidden');
+    // Reveal the falta-dex disclosure pill once the toolbar is rendered.
+    document.getElementById('pokedex-why-falta')?.classList.remove('hidden');
 
     const btn = missingToolbarEl.querySelector<HTMLButtonElement>('[data-pokedex-toggle-missing]');
     btn?.addEventListener('click', onToggleMissing);

--- a/src/components/profile/ProfilePercentileCards.astro
+++ b/src/components/profile/ProfilePercentileCards.astro
@@ -1,6 +1,7 @@
 ---
 import type { Locale } from '../../i18n/utils';
 import { t } from '../../i18n/utils';
+import WhyAmISeeingThis from '../WhyAmISeeingThis.astro';
 
 interface Props {
   lang: Locale;
@@ -47,7 +48,10 @@ const aria                = tp.aria_bar            ?? (lang === 'es' ? 'Barra de
       {ownerOnly}
     </span>
   </header>
-  <p class="text-xs text-zinc-500 dark:text-zinc-400 mb-4">{subheading}</p>
+  <p class="text-xs text-zinc-500 dark:text-zinc-400 mb-2">{subheading}</p>
+  <div class="mb-4">
+    <WhyAmISeeingThis algorithm="profile_percentile_cards" lang={lang} />
+  </div>
 
   <p data-state="loading" class="text-xs text-zinc-500 italic py-4">{loading}</p>
 

--- a/src/lib/algorithms.ts
+++ b/src/lib/algorithms.ts
@@ -13,7 +13,11 @@ import { routes } from '../i18n/utils';
 export type AlgorithmId =
   | 'community_observers'
   | 'explore_recent'
-  | 'explore_species_recent';
+  | 'explore_species_recent'
+  | 'falta_dex_missing'
+  | 'contextual_species_chips'
+  | 'profile_percentile_cards'
+  | 'active_observers_today';
 
 export interface AlgorithmCopy {
   /** Inputs the ranker consumes — one bullet per input. */
@@ -138,6 +142,154 @@ export const ALGORITHMS: Record<AlgorithmId, AlgorithmEntry> = {
     settings_path: {
       en: routes.profileSettingsPrivacy.en,
       es: routes.profileSettingsPrivacy.es,
+    },
+  },
+  falta_dex_missing: {
+    headline: {
+      en: 'Why am I seeing these missing species?',
+      es: '¿Por qué veo estas especies faltantes?',
+    },
+    summary: {
+      en: 'Species you have not yet logged, sorted by rarity bucket so the rarest gaps surface first.',
+      es: 'Especies que aún no registras, ordenadas por bucket de rareza para que las más raras aparezcan primero.',
+    },
+    copy: {
+      en: {
+        inputs: [
+          'Rarity bucket of each missing species (rare → common)',
+          'Region pool for your country (your profile country, set in Edit profile)',
+          'Your existing pokédex (only species you have NOT yet observed are included)',
+          'No personalisation beyond country — same pool regardless of who is signed in',
+        ],
+        window: 'Snapshot of the current region pool — refreshed when the page loads',
+        settings_label: 'Edit profile (change country)',
+      },
+      es: {
+        inputs: [
+          'Bucket de rareza de cada especie faltante (raro → común)',
+          'Pool regional de tu país (tu país de perfil, configurable en Editar perfil)',
+          'Tu pokédex actual (solo se incluyen especies que aún NO has observado)',
+          'Sin personalización más allá del país — el mismo pool para cualquiera que inicie sesión',
+        ],
+        window: 'Instantánea del pool regional actual — refresca al cargar la página',
+        settings_label: 'Editar perfil (cambiar país)',
+      },
+    },
+    settings_path: {
+      en: routes.profileEdit.en,
+      es: routes.profileEdit.es,
+    },
+  },
+  contextual_species_chips: {
+    headline: {
+      en: 'Why am I seeing these probable species?',
+      es: '¿Por qué veo estas especies probables?',
+    },
+    summary: {
+      en: 'A density estimate from public observations near the location and month of the photo you are about to log.',
+      es: 'Una estimación de densidad a partir de observaciones públicas cercanas a la ubicación y al mes de la foto que vas a registrar.',
+    },
+    copy: {
+      en: {
+        inputs: [
+          'Approximate location (geohash-5 cell, ≈ ±2.4 km) of the photo or your device',
+          'Current calendar month (seasonality)',
+          'Count of public community observations matching that cell + month, descending',
+          'Distance to the closest matching observation (tiebreaker)',
+          'No model, no curated baseline — these are real community sightings only',
+        ],
+        window: 'Public observations within the same geohash-5 cell, in the current month, all years',
+        settings_label: 'Edit profile (location & defaults)',
+      },
+      es: {
+        inputs: [
+          'Ubicación aproximada (celda geohash-5, ≈ ±2.4 km) de la foto o tu dispositivo',
+          'Mes calendario actual (estacionalidad)',
+          'Conteo de observaciones públicas de la comunidad en esa celda + mes, descendente',
+          'Distancia a la observación coincidente más cercana (desempate)',
+          'Sin modelo, sin baseline curado — solo son observaciones reales de la comunidad',
+        ],
+        window: 'Observaciones públicas dentro de la misma celda geohash-5, en el mes actual, todos los años',
+        settings_label: 'Editar perfil (ubicación y predeterminados)',
+      },
+    },
+    settings_path: {
+      en: routes.profileEdit.en,
+      es: routes.profileEdit.es,
+    },
+  },
+  profile_percentile_cards: {
+    headline: {
+      en: 'Why am I seeing these percentiles?',
+      es: '¿Por qué veo estos percentiles?',
+    },
+    summary: {
+      en: 'A private comparison against an anonymous cohort of active MX observers — only you see this card.',
+      es: 'Una comparación privada contra una cohorte anónima de observadores activos en MX — solo tú la ves.',
+    },
+    copy: {
+      en: {
+        inputs: [
+          'Cohort definition: users with ≥ 5 observations in the last 90 days, country MX',
+          'Your four metrics: Shannon diversity, distinct habitats, validations cast, geographic spread (km²)',
+          'Each percentile is your rank within the cohort for that one metric',
+          'Hidden when the cohort is too small (n < 50) — no rank shown until the comparison is meaningful',
+          'No public leaderboard — these numbers never leave your screen',
+        ],
+        window: 'Last 90 days for the cohort; metrics are recomputed on each page visit',
+        settings_label: 'Privacy & leaderboards settings',
+      },
+      es: {
+        inputs: [
+          'Definición de cohorte: usuarios con ≥ 5 observaciones en los últimos 90 días, país MX',
+          'Tus cuatro métricas: diversidad de Shannon, hábitats distintos, validaciones, alcance geográfico (km²)',
+          'Cada percentil es tu rango dentro de la cohorte para esa única métrica',
+          'Se oculta si la cohorte es muy pequeña (n < 50) — no se muestra rango hasta que la comparación sea significativa',
+          'Sin tabla pública — estos números no salen de tu pantalla',
+        ],
+        window: 'Últimos 90 días para la cohorte; las métricas se recalculan en cada visita a la página',
+        settings_label: 'Privacidad y leaderboards',
+      },
+    },
+    settings_path: {
+      en: routes.profileSettingsPrivacy.en,
+      es: routes.profileSettingsPrivacy.es,
+    },
+  },
+  active_observers_today: {
+    headline: {
+      en: 'Why am I seeing this banner?',
+      es: '¿Por qué veo este banner?',
+    },
+    summary: {
+      en: 'A non-personal count of distinct observers in your country who have synced at least one observation today.',
+      es: 'Un conteo no personalizado de observadores distintos en tu país que han sincronizado al menos una observación hoy.',
+    },
+    copy: {
+      en: {
+        inputs: [
+          'Country code from your profile (or inferred from your most-used region)',
+          'Distinct count of observers who synced ≥ 1 public observation since 00:00 UTC today',
+          'Aggregate only — no observer IDs, names, or locations are surfaced',
+          'Banner is hidden entirely when no profile country is set (never shows "in NULL")',
+        ],
+        window: 'Today (UTC) — resets at 00:00 UTC each day',
+        settings_label: 'Edit profile (country)',
+      },
+      es: {
+        inputs: [
+          'Código de país de tu perfil (o inferido de tu región más usada)',
+          'Conteo distinto de observadores que sincronizaron ≥ 1 observación pública desde las 00:00 UTC de hoy',
+          'Solo agregado — no se exponen IDs, nombres ni ubicaciones de observadores',
+          'El banner se oculta cuando no hay país en el perfil (nunca muestra "en NULL")',
+        ],
+        window: 'Hoy (UTC) — reinicia a las 00:00 UTC cada día',
+        settings_label: 'Editar perfil (país)',
+      },
+    },
+    settings_path: {
+      en: routes.profileEdit.en,
+      es: routes.profileEdit.es,
     },
   },
 };

--- a/tests/unit/algorithms.test.ts
+++ b/tests/unit/algorithms.test.ts
@@ -8,6 +8,10 @@ describe('algorithms catalog', () => {
     expect(ids).toContain('community_observers');
     expect(ids).toContain('explore_recent');
     expect(ids).toContain('explore_species_recent');
+    expect(ids).toContain('falta_dex_missing');
+    expect(ids).toContain('contextual_species_chips');
+    expect(ids).toContain('profile_percentile_cards');
+    expect(ids).toContain('active_observers_today');
   });
 
   it.each(ids)('"%s" has parity EN/ES copy with the required shape', (id) => {


### PR DESCRIPTION
## Summary

PR #772 shipped the `<WhyAmISeeingThis />` disclosure component, the
`src/lib/algorithms.ts` catalog, and the global `WhyAmISeeingThisDialog`
mounted in BaseLayout — but only 3 surfaces (`community_observers`,
`explore_recent`, `explore_species_recent`) were wired. Other ranked
surfaces shipped during v1.1.5 had no entries, breaking the
load-bearing invariant in CLAUDE.md:

> Do NOT add a new ranked surface without registering an entry.

This PR closes the gap by adding 4 catalog entries and wiring the pill
on 4 components.

## New catalog entries (4)

| AlgorithmId | Surface | Settings link |
|---|---|---|
| `falta_dex_missing` | `PokedexView` (owner mode, missing toggle) | Edit profile (country) |
| `contextual_species_chips` | `ContextualSpeciesChips` (`/observe`) | Edit profile |
| `profile_percentile_cards` | `ProfilePercentileCards` (`/profile`) | Privacy & leaderboards |
| `active_observers_today` | `ActiveObserversBanner` (`/observe`) | Edit profile (country) |

Each entry has honest EN+ES copy: explicit input bullets, time-window
phrasing, settings_label, settings_path. No marketing.

## Surfaces wired (4)

- **`PokedexView`** — pill above the missing-species toolbar (owner-only;
  revealed alongside toolbar render so it doesn't appear on a 0-row dex)
- **`ContextualSpeciesChips`** — pill in the section header next to the
  caveat copy (`/observe` consumer auto-picks it up)
- **`ProfilePercentileCards`** — pill under the subheading (visible only
  when the cohort gate is met, mirrors the existing card visibility)
- **`ActiveObserversBanner`** — wrap the banner anchor in a flex
  container; pill renders adjacent. The hydrate script now toggles the
  wrap (so banner + pill appear together once a country resolves)

## Deferred (justified)

- **`ImpactView`** (`/profile/impact`) — not a *ranked* surface; 5
  retrospective metrics scoped to the user with no inter-item ordering.
  Each card already has a tooltip explaining the computation (the
  Fogg "cause and effect" pattern). Adding a generic disclosure would
  duplicate per-card explanations.
- **`SurpriseOverlay`** — variable-reward picker. The full rule catalog
  is public at `/docs/surprises`, and the modal itself already exposes
  a "What is this?" link to it. Adding the WhyAmISeeingThis pattern
  would create two parallel disclosure surfaces for the same content.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 1397 tests pass (added expectations for the 4 new ids in `algorithms.test.ts`)
- [x] `npm run build` — 241 pages built
- [x] Verified pill renders on `dist/{en,es}/observe/`, `dist/{en,es}/profile/`, `dist/{en,es}/profile/dex/`
- [x] Verified `/docs/algorithms/` lists 7 entries in EN and ES
- [ ] Manual smoke: open `/observe`, click the active-observers "Why am I seeing this?" pill — modal opens with `active_observers_today` content
- [ ] Manual smoke: same on `/profile/dex` (missing toggle on), `/profile/`, `/observe` (contextual chips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)