### PR TITLE
fix(deploy): inject PUBLIC_VAPID_PUBLIC_KEY into Astro build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
           PUBLIC_MEGADETECTOR_ENDPOINT: ${{ secrets.PUBLIC_MEGADETECTOR_ENDPOINT }}
           PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.PUBLIC_POSTHOG_PROJECT_TOKEN }}
           PUBLIC_POSTHOG_HOST:        ${{ secrets.PUBLIC_POSTHOG_HOST }}
+          PUBLIC_VAPID_PUBLIC_KEY:    ${{ secrets.VAPID_PUBLIC_KEY }}
           PUBLIC_BUILD_SHA:           ${{ github.sha }}
           PUBLIC_VERSION:             ${{ steps.pkg.outputs.version }}
 


### PR DESCRIPTION
## Why

`deploy.yml` passes 13 `PUBLIC_*` env vars to the Astro build but was missing `PUBLIC_VAPID_PUBLIC_KEY`. Without it, the client bundle has no VAPID key and `PushManager.subscribe()` throws `'vapid_missing'` — which is exactly what the kairos prompts toggle reports today.

The gh secret `VAPID_PUBLIC_KEY` already exists; this PR just wires it through to the build env so `import.meta.env.PUBLIC_VAPID_PUBLIC_KEY` resolves at build time.

## What changes

One line added to `.github/workflows/deploy.yml`:
```yaml
PUBLIC_VAPID_PUBLIC_KEY:    ${{ secrets.VAPID_PUBLIC_KEY }}
```

## Unblocks

PR #777 (kairos) client-side subscription. After merge:
1. Trigger a deploy (push to main).
2. `/profile/notifications` toggle will subscribe successfully instead of throwing `vapid_missing`.

## Test plan

- [ ] CI green
- [ ] After merge + redeploy: visit /profile/notifications, opt in, verify no 'vapid_missing' warning
- [ ] Verify push_subscriptions table gets a row