### PR TITLE
fix(ci): remove duplicate name field in triage-stats.yml

### DIFF
--- a/.github/workflows/triage-stats.yml
+++ b/.github/workflows/triage-stats.yml
@@ -1,5 +1,3 @@
-name: Triage SLA stats — nightly fetch
-
 # Refreshes public/data/triage-stats.json once a day so the public
 # `/{en,es}/docs/status/` page renders fresh "open issues / median time-to-
 # first-comment / resolved last 30 days" numbers on the next site build.


### PR DESCRIPTION
## Why

triage-stats.yml had two top-level `name:` keys (line 1 + line 18). YAML rejects this and GitHub Actions failed the run on main today with 'workflow file issue'.

## Fix

One line removed (the em-dash variant on line 1). The shorter, ASCII-only `name: Triage SLA stats` on line 18 stays.

## Test plan

- [ ] CI re-validates the workflow file
- [ ] Next scheduled tick (07:00 UTC) runs cleanly