### PR TITLE
fix(sw): use __BUILD_VERSION__ placeholder so source matches deployed state

### DIFF
--- a/docs/runbooks/sw-cache.md
+++ b/docs/runbooks/sw-cache.md
@@ -55,24 +55,24 @@ downloaded offline map intact.
 
 ## Bumping the cache after a problematic deploy
 
-```js
-// public/sw.js
-const VERSION = 'rastrum-shell-v3-2026-04-26';   // ← bump this
-```
+`VERSION` in `public/sw.js` is a placeholder — `__BUILD_VERSION__` —
+substituted at build time by `scripts/inject-version.js` from the
+`PUBLIC_VERSION` env var, which the deploy workflow computes via CalVer
+(`YYYY.M.<patch>`). **Do not edit the placeholder.** The placeholder is
+restored after `astro build` so the working tree stays clean; if you see
+`'rastrum-shell-…'` in source, it's a stale local checkout.
 
-The convention is `rastrum-shell-v<n>-YYYY-MM-DD`. Increment the `v<n>`
-when the cache structure (the SHELL array, the strategy, the
-intercept rules) changes. Update the date for any push that requires
-purging old cached entries.
+To force a cache flush, push any commit on `main` and let the deploy
+workflow's CalVer counter increment the patch — that produces a new
+`VERSION` string in the deployed `sw.js`, which triggers the install →
+activate → cache-prune protocol described below. There is no
+hand-edit step.
 
 ```bash
-# 1. Edit public/sw.js, bump VERSION.
-# 2. Commit + push:
-git add public/sw.js
-git commit -m "fix(sw): bump cache to v4 to flush stale shell entries"
+# Just push something — typo fix, doc tweak, anything.
+git commit --allow-empty -m "chore(sw): force cache flush"
 git push
-# 3. CI runs deploy.yml; the new sw.js lands on rastrum.org.
-gh run watch
+gh run watch   # deploy.yml bumps the patch, builds, ships sw.js
 ```
 
 What happens next on each user's device:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "node scripts/inject-version.js && npm run build:og && npm run build:about-stats && node scripts/build-search-index.js && astro build && node scripts/sitemap-hreflang.js",
+    "build": "node scripts/inject-version.js && npm run build:og && npm run build:about-stats && node scripts/build-search-index.js && astro build && node scripts/sitemap-hreflang.js && node scripts/restore-version-placeholder.js",
     "build:og": "npx --yes tsx scripts/generate-og.ts",
     "build:about-stats": "npx --yes tsx scripts/fetch-about-stats.ts",
     "preview": "astro preview",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
   "name": "Rastrum",
-  "version": "2026.5.2",
+  "version": "__BUILD_VERSION__",
   "short_name": "Rastrum",
   "description": "Offline-first biodiversity identification for Latin America.",
   "start_url": "/en/",

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,8 +8,11 @@
 //     the filename): cache-first (these are immutable per their URL).
 //   - Manifest, favicon, sw.js itself: network-first so updates land fast.
 //
-// Bump VERSION to invalidate every cached entry on the next visit.
-const VERSION = 'rastrum-shell-2026.5.2';
+// VERSION is generated at deploy time by scripts/inject-version.js from the
+// PUBLIC_VERSION env var (CalVer). The placeholder below is substituted in
+// place during `npm run build`; the source must NOT be edited to bump the
+// cache. See docs/runbooks/sw-cache.md for how to force a flush.
+const VERSION = '__BUILD_VERSION__';
 
 // Page-managed cache (written by src/lib/offline-map.ts) holding the
 // full pmtiles archive as a single 200 Response. The fetch handler

--- a/scripts/inject-version.js
+++ b/scripts/inject-version.js
@@ -2,47 +2,85 @@
 /**
  * scripts/inject-version.js
  *
- * Injects the build version into public/manifest.webmanifest and public/sw.js
- * at build time without modifying tracked source files.
+ * Substitutes the __BUILD_VERSION__ placeholder in public/sw.js and
+ * public/manifest.webmanifest with the real build version.
  *
  * Run BEFORE `astro build`. The version is read from PUBLIC_VERSION env var
- * (set by the deploy workflow from git), falling back to package.json.
+ * (set by the deploy workflow from CalVer), falling back to package.json
+ * for local builds.
  *
- * Why: manifest.webmanifest and sw.js ship as static assets — they need the
- * version string baked in. The footer reads import.meta.env.PUBLIC_VERSION
- * already; this script keeps the other two in sync automatically.
+ * Why placeholders: previously this script overwrote a hardcoded
+ * `'rastrum-shell-<version>'` literal in `public/sw.js`. The source therefore
+ * lied about deployed state — a maintainer following the cache-bump runbook
+ * would edit the literal, see the change in git, and assume it took effect,
+ * but CI's inject step overwrote whatever they typed. The placeholder is
+ * unambiguous: there is no version string to bump in source.
+ *
+ * The placeholder is restored after `astro build` by
+ * scripts/restore-version-placeholder.js so the working tree stays clean.
  */
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = resolve(__dirname, '..');
+export const PLACEHOLDER = '__BUILD_VERSION__';
 
-// Resolve version: CI injects PUBLIC_VERSION from git; local dev falls back
-// to package.json so the script always produces a valid output.
-const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
-const version = process.env.PUBLIC_VERSION ?? pkg.version;
-
-// ── manifest.webmanifest ──────────────────────────────────────────────────
-const manifestPath = resolve(root, 'public/manifest.webmanifest');
-const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-if (manifest.version !== version) {
-  manifest.version = version;
-  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
-  console.log(`[inject-version] manifest.webmanifest → ${version}`);
-} else {
-  console.log(`[inject-version] manifest.webmanifest already at ${version}`);
+/**
+ * Substitute the VERSION literal in sw.js. Throws if the placeholder is
+ * missing (means someone removed it — fail loud rather than ship stale).
+ * Returns the new source. Pure: no I/O.
+ */
+export function substituteSwVersion(source, version) {
+  const expected = `const VERSION = '${PLACEHOLDER}';`;
+  if (!source.includes(expected)) {
+    throw new Error(
+      `[inject-version] sw.js is missing the placeholder line ` +
+      `\`${expected}\`. Did someone bump VERSION manually? ` +
+      `See docs/runbooks/sw-cache.md.`
+    );
+  }
+  return source.replace(expected, `const VERSION = 'rastrum-shell-${version}';`);
 }
 
-// ── sw.js ─────────────────────────────────────────────────────────────────
-const swPath = resolve(root, 'public/sw.js');
-let sw = readFileSync(swPath, 'utf8');
-const swVersionLine = `const VERSION = 'rastrum-shell-${version}';`;
-const swUpdated = sw.replace(/^const VERSION = .*$/m, swVersionLine);
-if (swUpdated !== sw) {
-  writeFileSync(swPath, swUpdated);
+/**
+ * Substitute the version field in a parsed manifest object. Throws if the
+ * placeholder is missing. Returns the new object. Pure: no I/O.
+ */
+export function substituteManifestVersion(manifest, version) {
+  if (manifest.version !== PLACEHOLDER) {
+    throw new Error(
+      `[inject-version] manifest.webmanifest "version" is ` +
+      `\`${manifest.version}\`, expected \`${PLACEHOLDER}\`. ` +
+      `Did someone bump it manually? See docs/runbooks/sw-cache.md.`
+    );
+  }
+  return { ...manifest, version };
+}
+
+function main() {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const root = resolve(__dirname, '..');
+
+  const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+  const version = process.env.PUBLIC_VERSION ?? pkg.version;
+
+  const manifestPath = resolve(root, 'public/manifest.webmanifest');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const manifestNext = substituteManifestVersion(manifest, version);
+  writeFileSync(manifestPath, JSON.stringify(manifestNext, null, 2) + '\n');
+  console.log(`[inject-version] manifest.webmanifest → ${version}`);
+
+  const swPath = resolve(root, 'public/sw.js');
+  const swNext = substituteSwVersion(readFileSync(swPath, 'utf8'), version);
+  writeFileSync(swPath, swNext);
   console.log(`[inject-version] sw.js → rastrum-shell-${version}`);
-} else {
-  console.log(`[inject-version] sw.js already at rastrum-shell-${version}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err.message ?? err);
+    process.exit(1);
+  }
 }

--- a/scripts/restore-version-placeholder.js
+++ b/scripts/restore-version-placeholder.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * scripts/restore-version-placeholder.js
+ *
+ * Restores the __BUILD_VERSION__ placeholder in public/sw.js and
+ * public/manifest.webmanifest after `astro build` has copied them into
+ * dist/. Keeps the working tree clean so a `git status` after `npm run
+ * build` shows no spurious changes.
+ *
+ * Idempotent: if the placeholder is already present (e.g. someone ran this
+ * twice, or the build failed before inject-version ran), it's a no-op.
+ */
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { PLACEHOLDER } from './inject-version.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const manifestPath = resolve(root, 'public/manifest.webmanifest');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+if (manifest.version !== PLACEHOLDER) {
+  manifest.version = PLACEHOLDER;
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`[restore-version-placeholder] manifest.webmanifest → ${PLACEHOLDER}`);
+}
+
+const swPath = resolve(root, 'public/sw.js');
+const sw = readFileSync(swPath, 'utf8');
+const swRestored = sw.replace(/^const VERSION = .*$/m, `const VERSION = '${PLACEHOLDER}';`);
+if (swRestored !== sw) {
+  writeFileSync(swPath, swRestored);
+  console.log(`[restore-version-placeholder] sw.js → ${PLACEHOLDER}`);
+}

--- a/tests/unit/inject-version.test.ts
+++ b/tests/unit/inject-version.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression guard for scripts/inject-version.js — pins the placeholder
+ * substitution contract. The CLI is otherwise untested; the bug in #816
+ * was that the source-of-truth `public/sw.js` had a hardcoded literal
+ * that drifted from the deployed version, so we want loud failure if
+ * the placeholder is ever removed.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PLACEHOLDER,
+  substituteSwVersion,
+  substituteManifestVersion,
+} from '../../scripts/inject-version.js';
+
+describe('inject-version', () => {
+  it('exposes the placeholder constant', () => {
+    expect(PLACEHOLDER).toBe('__BUILD_VERSION__');
+  });
+
+  describe('substituteSwVersion', () => {
+    it('replaces the placeholder line with the real VERSION literal', () => {
+      const source = [
+        '// preamble',
+        `const VERSION = '${PLACEHOLDER}';`,
+        '// rest',
+      ].join('\n');
+      const out = substituteSwVersion(source, '2026.5.99');
+      expect(out).toContain(`const VERSION = 'rastrum-shell-2026.5.99';`);
+      expect(out).not.toContain(PLACEHOLDER);
+    });
+
+    it('throws if the placeholder is missing', () => {
+      const source = `const VERSION = 'rastrum-shell-2026.5.1';`;
+      expect(() => substituteSwVersion(source, '2026.5.2')).toThrow(/placeholder/i);
+    });
+
+    it('throws if a maintainer hand-edits the placeholder away', () => {
+      const source = `const VERSION = 'something-else';`;
+      expect(() => substituteSwVersion(source, '2026.5.2')).toThrow();
+    });
+  });
+
+  describe('substituteManifestVersion', () => {
+    it('replaces the version field when the placeholder is present', () => {
+      const manifest = { name: 'Rastrum', version: PLACEHOLDER };
+      const out = substituteManifestVersion(manifest, '2026.5.99');
+      expect(out.version).toBe('2026.5.99');
+      expect(out.name).toBe('Rastrum');
+    });
+
+    it('throws if the version field is not the placeholder', () => {
+      const manifest = { name: 'Rastrum', version: '2026.5.1' };
+      expect(() => substituteManifestVersion(manifest, '2026.5.2')).toThrow(/__BUILD_VERSION__/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `public/sw.js` and `public/manifest.webmanifest` no longer hardcode the version literal — they hold `__BUILD_VERSION__`. `scripts/inject-version.js` (refactored into pure exported helpers + a CLI) substitutes the placeholder for the real CalVer string before `astro build`, and a new `scripts/restore-version-placeholder.js` (chained as the last build step in `package.json`) puts the placeholder back so the working tree stays clean.
- Both helpers throw if the placeholder is missing — fail loud rather than ship stale. This means a future PR that hand-edits the literal away will fail the next build instead of silently breaking the cache-bump runbook.
- Runbook (`docs/runbooks/sw-cache.md`) rewritten to match reality: there is no hand-edit step anymore — push any commit and the deploy workflow's CalVer counter increments the patch.
- New unit test at `tests/unit/inject-version.test.ts` pins the contract.

## Why
PR #795 description noted that `public/sw.js` source said `'rastrum-shell-2026.5.2'` while production said `'rastrum-shell-2026.5.1'`. That divergence wasted ~30 min of the pmtiles abort investigation chasing a phantom version mismatch. With the placeholder, source no longer lies.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run tests/unit/inject-version.test.ts tests/unit/sw-pmtiles-range.test.ts` — 15/15 pass (5 new + 10 existing).
- [x] `npm test` — 1424/1424 pass (was 1391).
- [x] `npm run build` — completes; final two log lines confirm the restore step ran (`[restore-version-placeholder] manifest.webmanifest → __BUILD_VERSION__`, `[restore-version-placeholder] sw.js → __BUILD_VERSION__`).
- [x] `git diff` post-build — only the placeholder lives in source; no substituted version sneaks into the commit.
- [ ] Post-deploy: confirm `https://rastrum.org/sw.js` still has a real `rastrum-shell-YYYY.M.N` string (i.e. the CI inject step ran and the build didn't ship the placeholder).
- [ ] Post-deploy: confirm `https://rastrum.org/manifest.webmanifest` `version` field is the same CalVer string.

## Sibling work
PR #822 (issue #814) makes the CalVer patch counter actually increment by adding `fetch-depth: 0` to `actions/checkout` in deploy.yml. Either order is safe to merge — this PR is correct without #822 (the substitution still works, the patch is just stuck at 1 until #822 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)