### PR TITLE
fix(notifications): drop define:vars on push-toggle scripts so dynamic imports bundle

### DIFF
--- a/src/components/KairosGoldenHourSection.astro
+++ b/src/components/KairosGoldenHourSection.astro
@@ -41,8 +41,13 @@ const k = (tr as unknown as {
   <p id="kairos-gh-warning" class="hidden mt-2 text-xs text-amber-700 dark:text-amber-400"></p>
 </section>
 
-<script define:vars={{ isEsLang: lang === 'es' }}>
+<script>
+  // NOTE: do NOT use define:vars — it implicitly sets is:inline=true, which
+  // disables Astro bundling. Dynamic imports like `await import('../lib/kairos')`
+  // would then ship as raw text and resolve relative to the page URL
+  // (`/profile/notifications/lib/kairos` 404). Read lang from the DOM instead.
   (async function () {
+    const isEsLang = document.documentElement.lang === 'es';
     const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('kairos-gh-toggle'));
     if (!btn) return;
     const labelEl = /** @type {HTMLElement | null} */ (btn.querySelector('[data-kairos-label]'));

--- a/src/components/StreakRemindersSection.astro
+++ b/src/components/StreakRemindersSection.astro
@@ -28,11 +28,17 @@ const psp = (tr as unknown as { profile_streak_push: { section_title: string; se
   <p id="streak-push-warning" class="hidden mt-2 text-xs text-amber-700 dark:text-amber-400"></p>
 </section>
 
-<script define:vars={{ isEsLang: lang === 'es' }}>
+<script>
   // Streak push reminder toggle (ux-streak-push). Strict opt-in; never
   // multiple notifications per day. Single 8 PM local-time reminder when
   // your streak is one day from breaking.
+  //
+  // NOTE: do NOT use define:vars — it implicitly sets is:inline=true, which
+  // disables Astro bundling. Dynamic imports like `await import('../lib/push')`
+  // would then ship as raw text and resolve relative to the page URL
+  // (`/profile/lib/push` 404). Read lang from the DOM instead.
   (async function () {
+    const isEsLang = document.documentElement.lang === 'es';
     const sppBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('streak-push-toggle'));
     if (!sppBtn) return;
     const sppLabel = /** @type {HTMLElement | null} */ (sppBtn.querySelector('[data-spp-label]'));


### PR DESCRIPTION
## Why

User console error from `/en/profile/notifications/` (production):
```
Failed to fetch dynamically imported module:
  https://rastrum.org/en/profile/lib/kairos
Failed to fetch dynamically imported module:
  https://rastrum.org/en/profile/lib/push
```

## Root cause

`KairosGoldenHourSection` and `StreakRemindersSection` used `<script define:vars={{ isEsLang }}>`. Astro implicitly sets `is:inline=true` on define:vars scripts, which **disables bundling**. Their dynamic imports shipped as raw text. The browser resolved them relative to the page URL → 404.

## Fix

- Drop `define:vars`.
- Read `isEsLang` from `document.documentElement.lang === 'es'` (BaseLayout already populates the `<html lang>` attribute).
- Plain `<script>` tags get bundled by Astro; dynamic imports resolve to proper `/_astro/<chunk>.js` paths at build time.

Build verification: emits `kairos.auDb-2cg.js` + `push.DraPE5dn.js` chunks.

## Impact

- **Unblocks #777** kairos client-side subscription.
- **Fixes silent streak-push regression** that has been broken since shipping (same bug pattern).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` emits the right chunks
- [ ] Visit `/profile/notifications` post-deploy, click toggle — no 404 in console
- [ ] Check `push_subscriptions` table gets a row