### PR TITLE
chore(ci): detect Astro define:vars + dynamic-import bug pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit
 
+      - name: Check Astro define:vars + dynamic imports
+        # Fails when a <script define:vars …> block contains a dynamic
+        # `import(` call. define:vars implicitly enables is:inline, which
+        # disables bundling — the import 404s at runtime against the
+        # page URL. See CLAUDE.md "Astro define:vars + dynamic-import
+        # pitfall" and PR #825.
+        run: npm run check:define-vars
+
       - name: Unit tests (Vitest)
         run: npm test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -632,6 +632,12 @@ runbooks (`docs/runbooks/falta-dex.md`, `docs/runbooks/contextual-suggestions.md
 | Map page hits network for pmtiles even after user clicked "Download offline map" | Cache API entry written by `src/lib/offline-map.ts` was orphaned — MapLibre's pmtiles protocol uses `fetch()` directly, never consults the Cache API; the SW didn't intercept after the `.app → .org` migration | SW now intercepts `media.rastrum.org/maps/*.pmtiles` and slices the cached 200 into 206 Partial Content. Algorithm pinned by `tests/unit/sw-pmtiles-range.test.ts`. Fixed in PR #636. |
 | Downloaded offline map (and in-flight share-target stash) silently wiped on every SW upgrade | `activate` handler deleted any cache whose name wasn't the current `VERSION`; `rastrum/pmtiles` and `rastrum-share-target-v1` are page-managed and got nuked too | `PERSISTENT_CACHES` allowlist in `public/sw.js` now skips those caches when pruning. Fixed in PR #636. |
 
+### Pitfalls discovered 2026-05-09
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Dynamic `await import('../lib/foo')` 404s as `/<page-path>/lib/foo` (not `/_astro/...`) | `<script define:vars={...}>` implicitly sets `is:inline=true` → no bundling, so the dynamic import ships as raw text and resolves against the page URL | Drop `define:vars`; read state from the DOM (`document.documentElement.lang`) or `data-*` attributes on a wrapper element. CI guard: `scripts/check-define-vars-imports.sh` (wired in `.github/workflows/ci.yml`). Pattern fixed in PRs #825 (kairos/streak-push) and the follow-up (surprises/pool-donate). |
+
 ---
 
 ## Things you should NOT do without asking

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:e2e:all": "playwright test",
     "test:lhci": "lhci autorun",
     "test:audit": "npm run build && npm run test:e2e && npm run test:lhci",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "check:define-vars": "bash scripts/check-define-vars-imports.sh"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.2",

--- a/scripts/check-define-vars-imports.sh
+++ b/scripts/check-define-vars-imports.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# check-define-vars-imports.sh — fail when a `<script ... define:vars ...>`
+# block contains a dynamic `import(` call.
+#
+# Why: `define:vars` implicitly enables `is:inline=true` on Astro scripts,
+# which disables bundling. A dynamic `import('../lib/foo')` then ships as
+# raw text and the browser resolves it relative to the page URL → 404.
+# See CLAUDE.md "Astro define:vars + dynamic-import pitfall" and PR #825.
+#
+# Usage:  bash scripts/check-define-vars-imports.sh
+#         npm run check:define-vars
+# Exits 0 if no violations, non-zero otherwise.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+violations=0
+files_scanned=0
+
+while IFS= read -r file; do
+  files_scanned=$((files_scanned + 1))
+
+  # AWK state machine, BSD/POSIX awk compatible (no \> word boundaries):
+  #   - open_buf accumulates a `<script ... >` opening tag (may span lines).
+  #   - When the closing `>` of the opening tag is reached, decide whether
+  #     it had `define:vars` — if yes, in_block = 1.
+  #   - Inside the block, flag any `import(` (after stripping line comments
+  #     to avoid false positives).
+  out=$(awk '
+    BEGIN { in_open = 0; in_block = 0; open_buf = "" }
+    {
+      line = $0
+      # Strip // line comments and /* ... */ same-line block comments so a
+      # commented-out `import(` does not trigger.
+      stripped = line
+      sub(/\/\/.*$/, "", stripped)
+      gsub(/\/\*[^*]*\*\//, "", stripped)
+
+      if (in_block) {
+        if (index(stripped, "</script>") > 0) {
+          in_block = 0
+          next
+        }
+        # Match `import(` allowing whitespace between identifier and paren.
+        if (match(stripped, /import[ \t]*\(/)) {
+          printf("%d\n", NR)
+        }
+        next
+      }
+
+      if (!in_open) {
+        # Look for the start of an opening <script tag on this line.
+        pos = index(stripped, "<script")
+        if (pos == 0) next
+        # Ensure it is the opening tag boundary (`<script` followed by
+        # `>`, whitespace, `\t`, or end of line) — not e.g. `<scriptable>`.
+        next_char = substr(stripped, pos + length("<script"), 1)
+        if (next_char != "" && next_char != ">" && next_char != " " && next_char != "\t") {
+          next
+        }
+        in_open = 1
+        open_buf = substr(stripped, pos)
+      } else {
+        open_buf = open_buf " " stripped
+      }
+
+      # If we now have the closing `>` of the opening tag, evaluate.
+      gt_pos = index(open_buf, ">")
+      if (gt_pos > 0) {
+        opening = substr(open_buf, 1, gt_pos)
+        if (index(opening, "define:vars") > 0) {
+          in_block = 1
+        }
+        in_open = 0
+        open_buf = ""
+        # Trailing content on this line after the opening tag may itself
+        # contain </script> or import( — handle by re-feeding the tail.
+        tail = substr(stripped, length(stripped) - length(open_buf) + 1)
+        # (Tail handling intentionally minimal — none of our real files put
+        # script body on the same line as the opening tag.)
+      }
+    }
+  ' "$file") || true
+
+  if [ -n "$out" ]; then
+    while IFS= read -r lineno; do
+      [ -z "$lineno" ] && continue
+      echo "ERROR  $file:$lineno  <script define:vars> + import() — would 404 at runtime (see CLAUDE.md \"Astro define:vars + dynamic-import pitfall\")"
+      violations=$((violations + 1))
+    done <<< "$out"
+  fi
+done < <(find src -type f -name '*.astro')
+
+if [ "$violations" -gt 0 ]; then
+  echo
+  echo "FAIL: $violations violation(s) across $files_scanned scanned .astro files."
+  echo "Fix: drop define:vars; read state from the DOM (e.g. document.documentElement.lang) or data-* attributes. See PR #825 for the canonical pattern."
+  exit 1
+fi
+
+echo "OK: scanned $files_scanned .astro files, no <script define:vars> + import() violations."
+exit 0

--- a/src/components/PoolDonateView.astro
+++ b/src/components/PoolDonateView.astro
@@ -25,7 +25,17 @@ const sp = (tr as unknown as { sponsoring: SponsoringStrings }).sponsoring;
 const cancelLabel = lang === 'es' ? 'Cancelar' : 'Cancel';
 ---
 
-<section class="max-w-4xl mx-auto p-6 space-y-8">
+<section
+  class="max-w-4xl mx-auto p-6 space-y-8"
+  data-pool-donate
+  data-pool-label={sp.donate_pool_label}
+  data-model-label={sp.donate_model}
+  data-capacity-label={sp.donate_capacity}
+  data-confirm-label={sp.donate_confirm}
+  data-success-msg={sp.donate_success}
+  data-error-msg={sp.donate_error}
+  data-no-creds-msg={sp.donate_no_credentials}
+>
   <header>
     <h1 class="text-2xl md:text-3xl font-bold text-zinc-900 dark:text-zinc-100">{sp.donate_title}</h1>
     <p class="mt-2 text-zinc-600 dark:text-zinc-400">{sp.donate_subtitle}</p>
@@ -90,29 +100,35 @@ const cancelLabel = lang === 'es' ? 'Cancelar' : 'Cancel';
   </dialog>
 </section>
 
-<script define:vars={{
-  poolLabel: sp.donate_pool_label,
-  modelLabel: sp.donate_model,
-  capacityLabel: sp.donate_capacity,
-  confirmLabel: sp.donate_confirm,
-  successMsg: sp.donate_success,
-  errorMsg: sp.donate_error,
-  noCredsMsg: sp.donate_no_credentials,
-}}>
+<script>
+  // NOTE: do NOT use define:vars — it implicitly sets is:inline=true, which
+  // disables Astro bundling. The dynamic `await import('../lib/supabase')`
+  // and `await import('../lib/sponsorships')` below would then 404 at
+  // runtime. Read i18n strings from data-* attributes instead. See
+  // CLAUDE.md "Astro define:vars + dynamic-import pitfall".
   (async function initDonate() {
-    const signInEl   = document.getElementById('donate-sign-in');
-    const loadingEl  = document.getElementById('donate-loading');
-    const emptyEl    = document.getElementById('donate-empty');
-    const poolsEl    = document.getElementById('donate-pools');
-    const dialog     = document.getElementById('donate-dialog');
-    const form       = document.getElementById('donate-form');
-    const poolIdIn   = document.getElementById('donate-pool-id');
-    const credSelect = document.getElementById('donate-credential');
-    const callsIn    = document.getElementById('donate-calls');
-    const feedback   = document.getElementById('donate-feedback');
-    const submitBtn  = document.getElementById('donate-submit-btn');
-    const cancelBtn  = document.getElementById('donate-cancel-btn');
-    const noCredsEl  = document.getElementById('donate-no-creds-hint');
+    const root        = /** @type {HTMLElement | null} */ (document.querySelector('[data-pool-donate]'));
+    const signInEl    = document.getElementById('donate-sign-in');
+    const loadingEl   = document.getElementById('donate-loading');
+    const emptyEl     = document.getElementById('donate-empty');
+    const poolsEl     = document.getElementById('donate-pools');
+    const dialog      = document.getElementById('donate-dialog');
+    const form        = document.getElementById('donate-form');
+    const poolIdIn    = document.getElementById('donate-pool-id');
+    const credSelect  = document.getElementById('donate-credential');
+    const callsIn     = document.getElementById('donate-calls');
+    const feedback    = document.getElementById('donate-feedback');
+    const submitBtn   = document.getElementById('donate-submit-btn');
+    const cancelBtn   = document.getElementById('donate-cancel-btn');
+    const noCredsEl   = document.getElementById('donate-no-creds-hint');
+    if (!root) return;
+    const poolLabel    = root.dataset.poolLabel ?? '';
+    const modelLabel   = root.dataset.modelLabel ?? '';
+    const capacityLabel = root.dataset.capacityLabel ?? '';
+    const confirmLabel = root.dataset.confirmLabel ?? '';
+    const successMsg   = root.dataset.successMsg ?? '';
+    const errorMsg     = root.dataset.errorMsg ?? '';
+    const noCredsMsg   = root.dataset.noCredsMsg ?? '';
 
     // Dynamic imports to keep the page lightweight for anonymous visitors
     const { getSupabase } = await import('../lib/supabase');

--- a/src/components/SurprisesPrefsSection.astro
+++ b/src/components/SurprisesPrefsSection.astro
@@ -21,7 +21,13 @@ const docHref = lang === 'es' ? getDocPath('es', 'surprises') : getDocPath('en',
   </h2>
   <p class="text-xs text-zinc-500 dark:text-zinc-400 mb-3">{sup.section_hint}</p>
 
-  <div class="rounded-lg border border-zinc-200 dark:border-zinc-800 p-3 flex flex-col gap-2">
+  <div
+    class="rounded-lg border border-zinc-200 dark:border-zinc-800 p-3 flex flex-col gap-2"
+    data-surprises-strings
+    data-status-on={sup.toggle_on_status}
+    data-status-off={sup.toggle_off_status}
+    data-error-msg={sup.toggle_save_failed}
+  >
     <label class="flex items-start gap-3 cursor-pointer">
       <input
         id="surprises-opt-in"
@@ -41,12 +47,20 @@ const docHref = lang === 'es' ? getDocPath('es', 'surprises') : getDocPath('en',
   </p>
 </section>
 
-<script define:vars={{ statusOn: sup.toggle_on_status, statusOff: sup.toggle_off_status, errorMsg: sup.toggle_save_failed }}>
+<script>
+  // NOTE: do NOT use define:vars — it implicitly sets is:inline=true, which
+  // disables Astro bundling. The dynamic `await import('../lib/supabase')`
+  // below would then 404 at runtime. Read i18n strings from data-* on the
+  // wrapper instead. See CLAUDE.md "Astro define:vars + dynamic-import pitfall".
   (async function () {
     const cb = /** @type {HTMLInputElement | null} */ (document.getElementById('surprises-opt-in'));
     const statusEl = document.getElementById('surprises-opt-in-status');
     const errorEl = document.getElementById('surprises-opt-in-error');
-    if (!cb || !statusEl) return;
+    const strings = /** @type {HTMLElement | null} */ (document.querySelector('[data-surprises-strings]'));
+    if (!cb || !statusEl || !strings) return;
+    const statusOn = strings.dataset.statusOn ?? '';
+    const statusOff = strings.dataset.statusOff ?? '';
+    const errorMsg = strings.dataset.errorMsg ?? '';
 
     function setStatus(checked) {
       statusEl.textContent = checked ? statusOn : statusOff;


### PR DESCRIPTION
## Summary

Closes #826.

`<script define:vars={...}>` implicitly sets `is:inline=true`, which disables Astro bundling. Any `await import('../lib/foo')` inside such a block then ships as raw text and 404s at runtime against the page URL (not `/_astro/...`). PR #825 fixed two cases; this adds a CI guard so it can't slip back, plus fixes two latent bombs the script caught on first run.

## What changed

- **`scripts/check-define-vars-imports.sh`** — AWK state machine that walks every `src/**/*.astro`, tracks `<script ... define:vars ...>` blocks (multi-line opening tags supported), strips `//` and `/* ... */` comments to avoid false positives, and flags any `import(` inside the block. Exits non-zero with `<file>:<line>` violations.
- **`package.json`** — `npm run check:define-vars` wrapper.
- **`.github/workflows/ci.yml`** — new step "Check Astro define:vars + dynamic imports" runs after typecheck, before unit tests.
- **`src/components/SurprisesPrefsSection.astro`** + **`src/components/PoolDonateView.astro`** — same fix pattern as PR #825 (move strings to `data-*` attributes, drop `define:vars`). Build now emits real `_astro/supabase.<hash>.js` and `_astro/sponsorships.<hash>.js` chunks for both. These were the same latent-bomb shape PR #825 called out: dead-code paths nobody had hit yet.
- **`CLAUDE.md`** — new "Pitfalls discovered 2026-05-09" subsection documents the symptom / cause / fix and the CI guard.

## Verification

Clean main:
```
$ npm run check:define-vars
OK: scanned 431 .astro files, no <script define:vars> + import() violations.
exit=0
```

Regression test (temporarily added `define:vars={{...}}` to `KairosGoldenHourSection`'s `<script>`):
```
ERROR  src/components/KairosGoldenHourSection.astro:88  <script define:vars> + import() — would 404 at runtime (see CLAUDE.md "Astro define:vars + dynamic-import pitfall")
FAIL: 1 violation(s) across 431 scanned .astro files.
exit=1
```

Then reverted; clean again.

Pre-PR:
- `npm run typecheck` clean
- `npm test` — 1438 tests pass (124 files)
- `npm run build` — 241 pages built
- Built `dist/_astro/{sponsorships,supabase}.<hash>.js` chunks present, confirming the two fixed files now bundle properly.

## Test plan

- [x] Local typecheck + tests + build green
- [x] Lint script catches the bug on regression test (Kairos), passes on clean main
- [x] Latent-bomb files (`SurprisesPrefsSection`, `PoolDonateView`) emit proper bundled chunks instead of raw text imports
- [ ] CI green on this PR
- [ ] Manually verify `/profile/notifications/` (surprises toggle) and `/sponsoring/donate/` still work post-deploy

## Notes / decisions

- Wired into `ci.yml` (not a new `audit.yml`) because `ci.yml` is the workflow that already runs typecheck/tests/build on every PR — the natural home for a static lint check. No `audit.yml` exists today.
- Fixed the two latent bombs the script caught (`SurprisesPrefsSection`, `PoolDonateView`) rather than tracking them as a follow-up — otherwise the new CI step would block every PR on day one. Same fix pattern as PR #825.
- Script is BSD/POSIX-awk compatible (no `\>` word boundaries) so it runs locally on macOS and on the Ubuntu CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)