### PR TITLE
fix(security): close SECURITY DEFINER views + harden function ACLs

### DIFF
--- a/.github/workflows/db-validate.yml
+++ b/.github/workflows/db-validate.yml
@@ -263,6 +263,23 @@ jobs:
         run: |
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/sql/rls.sql
 
+      - name: Schema security invariants
+        # Three load-bearing rules enforced post-apply:
+        #   1. Every public-schema view is security_invoker (no SECURITY
+        #      DEFINER views — they bypass RLS at the view-owner's perms).
+        #   2. No user-defined SECURITY DEFINER function in public is
+        #      executable by PUBLIC (the implicit role that includes anon).
+        #      Explicit anon/authenticated grants are fine.
+        #   3. Every plpgsql / plpgsql-equivalent function in public has
+        #      its search_path pinned (defends against malicious schemas
+        #      ahead of public in the resolution path).
+        # Any violation fails the PR. See docs/specs/infra/supabase-schema.sql
+        # "Security Advisor remediation" section + CLAUDE.md "Schema security
+        # invariants" subsection for the rationale.
+        run: |
+          set -euo pipefail
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/lint-schema-security.sql
+
       - name: Summary
         run: |
-          echo "::notice::db-validate passed — schema applies cleanly, is idempotent (2× apply pass), all sentinels exist, every public table has RLS enabled, and the RLS regression suite passed (35 assertions)."
+          echo "::notice::db-validate passed — schema applies cleanly, is idempotent (2× apply pass), all sentinels exist, every public table has RLS enabled, the RLS regression suite passed (35 assertions), and all security invariants hold."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 > Briefing for AI coding agents (Claude Code, Copilot, Cursor, Codex, …)
 > working in this repo. Read this before making changes.
 >
-> **Last full doc sync:** 2026-05-08 (v1.1.5 Persuasive Tech Audit — Tier S +
-> Tier A merged, Ola 2b in flight; see `docs/progress.json` v1.1.5 phase).
+> **Last full doc sync:** 2026-05-08 (v1.1.5 Persuasive Tech Audit + schema
+> security invariants — see "Schema security invariants" section below).
 > Prior sync: 2026-05-01 (v1.2 + 42 field-bug/admin/docs PRs).
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,39 @@ const item = map[key];
   to coarsen public coordinates; precise coords only readable by the
   observer or a credentialed researcher.
 
+### Schema security invariants
+
+Three rules are enforced in `db-validate.yml` via
+[`infra/lint-schema-security.sql`](infra/lint-schema-security.sql) and will
+fail any PR that breaks them:
+
+1. **Every view in `public` is `security_invoker = true`.** Postgres 15+
+   defaults views to "definer" semantics, which bypass RLS at the view
+   owner's perms. The Supabase advisor flags any view without this option
+   as critical. Add `WITH (security_invoker = true)` at create time, or use
+   `ALTER VIEW … SET (security_invoker = true)` to flip an existing view.
+2. **No SECURITY DEFINER function in `public` is callable by `PUBLIC`.**
+   Postgres' default ACL grants EXECUTE on new functions to PUBLIC (the
+   implicit role that includes `anon`). Every definer function ships with
+   an explicit `REVOKE EXECUTE … FROM PUBLIC` followed by a grant to the
+   minimal role that needs it (typically `authenticated` or `service_role`).
+   Extension-provided functions are exempt (the linter skips them).
+3. **Every `pl*` function in `public` pins its `search_path`.** Defends
+   against an attacker who can create objects in another schema earlier
+   in the resolution path. Use
+   `SET search_path = public, extensions, pg_temp` in the function
+   declaration. The end-of-file remediation block in
+   `supabase-schema.sql` ALTERs any function whose `proconfig` is missing
+   this entry, so adding a new function without the clause will still
+   pass — but explicit is better than implicit. `LANGUAGE sql` functions
+   are exempt because they bind references at definition time.
+
+`pg_trgm` lives in the `extensions` schema (post-2026-05-08); `pg_net`
+keeps its self-managed `net` schema; `postgis` stays in `public` because
+moving it post-install requires rewriting every geometry/geography
+column reference. The advisor's "Extension in Public" warning for
+`postgis` is accepted with that rationale.
+
 ### Module spec convention
 - Implementation specs live at `docs/specs/modules/NN-*.md`, numbered
   sequentially. **The module spec wins** when it disagrees with

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -9531,3 +9531,158 @@ SELECT cron.unschedule('refresh-norms-weekly')
 SELECT cron.schedule('refresh-norms-weekly', '0 6 * * 1',
   $$REFRESH MATERIALIZED VIEW public.license_norm;
     REFRESH MATERIALIZED VIEW public.privacy_norm;$$);
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Security Advisor remediation — 2026-05-08
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Closes the critical + warning findings from the Supabase Database Advisor:
+--
+--   1. SECURITY DEFINER views (17) — flipped to security_invoker so RLS on
+--      underlying tables is honoured at the caller's perspective. The views'
+--      existing privacy gates (`can_see_facet()`, `hide_from_leaderboards`)
+--      keep doing their job; flipping just adds RLS as a second line of
+--      defence and stops the underlying-table-bypass class.
+--   2. PUBLIC role EXECUTE on user-defined SECURITY DEFINER functions —
+--      revoked surgically (definer-only, not all functions, so PostGIS /
+--      pgcrypto / etc. stay PUBLIC-callable). The blanket grant to
+--      `authenticated` upstream stays untouched. Net effect: every
+--      definer function now requires an explicit role grant — anon can't
+--      escalate via the "PUBLIC default ACL" path.
+--   3. Function search_path — every public-schema function gets
+--      `search_path = public, extensions, pg_temp` so opclasses /
+--      operators from extensions resolve cleanly and a malicious schema
+--      ahead of public can't shadow built-ins.
+--   4. pg_trgm extension moved out of `public` into `extensions` schema.
+--      pg_net keeps its own `net` schema (extension home is cosmetic).
+--      PostGIS stays in public — moving post-install is high-risk for
+--      negligible payoff.
+--
+-- Storage `media` bucket listing restriction is deliberately deferred to a
+-- follow-up because R2 is the primary path; verifying Supabase Storage's
+-- public-read flow under tightened RLS warrants its own dedicated PR.
+-- Track at https://github.com/ArtemioPadilla/rastrum/issues (TBD).
+--
+-- Auth → Leaked Password Protection is a Dashboard toggle (no SQL).
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. Flip 17 views to security_invoker = true
+-- ─────────────────────────────────────────────────────────────────────────
+-- ALTER VIEW … SET (security_invoker = true) is PG15+. Idempotent — replays
+-- of make db-apply are no-ops once the option is set.
+ALTER VIEW public.community_observers                SET (security_invoker = true);
+ALTER VIEW public.community_observers_with_centroid  SET (security_invoker = true);
+ALTER VIEW public.featured_species_current           SET (security_invoker = true);
+ALTER VIEW public.moderator_trust_scores             SET (security_invoker = true);
+ALTER VIEW public.profile_activity_feed              SET (security_invoker = true);
+ALTER VIEW public.profile_badges_visible             SET (security_invoker = true);
+ALTER VIEW public.profile_calendar_buckets           SET (security_invoker = true);
+ALTER VIEW public.profile_karma                      SET (security_invoker = true);
+ALTER VIEW public.profile_observation_pins           SET (security_invoker = true);
+ALTER VIEW public.profile_pokedex                    SET (security_invoker = true);
+ALTER VIEW public.profile_stats_counts               SET (security_invoker = true);
+ALTER VIEW public.profile_taxonomic_donut            SET (security_invoker = true);
+ALTER VIEW public.profile_top_species                SET (security_invoker = true);
+ALTER VIEW public.profile_validation_reputation      SET (security_invoker = true);
+ALTER VIEW public.taxa_thumbnails                    SET (security_invoker = true);
+ALTER VIEW public.user_expertise_regional            SET (security_invoker = true);
+ALTER VIEW public.validation_queue                   SET (security_invoker = true);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. Revoke EXECUTE from PUBLIC on user-defined SECURITY DEFINER functions
+-- ─────────────────────────────────────────────────────────────────────────
+-- Postgres' default ACL grants EXECUTE on new functions to PUBLIC, which is
+-- why ~50 trigger / internal helpers showed up as "Public Can Execute
+-- SECURITY DEFINER Function" in the advisor. The blanket grant to
+-- `authenticated` upstream (line ~563) is unaffected — `authenticated` is a
+-- distinct role from PUBLIC.
+--
+-- Surgical: we only revoke from SECURITY DEFINER functions, not all
+-- functions. PostGIS, pgcrypto, and other extension-provided functions
+-- live in `public` and are PUBLIC-callable by design — sweeping them up
+-- in a blanket REVOKE would break anon's ability to read views that call
+-- `ST_AsGeoJSON`, `gen_random_uuid`, etc. through PostgREST.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT p.proname,
+           pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.prosecdef = true
+  LOOP
+    EXECUTE format(
+      'REVOKE EXECUTE ON FUNCTION public.%I(%s) FROM PUBLIC',
+      r.proname, r.args
+    );
+  END LOOP;
+END
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 3. Move pg_trgm to the extensions schema
+-- ─────────────────────────────────────────────────────────────────────────
+-- pg_net intentionally untouched: its functions live in a self-managed
+-- `net` schema regardless of where the extension is installed, so the
+-- advisor "Extension in Public" warning for pg_net is cosmetic and moving
+-- it adds no security value while risking noise in net._http_response
+-- joins. PostGIS likewise stays in public (post-install moves are
+-- industry-known anti-patterns; the geometry/geography column-type
+-- references would all need rewriting).
+CREATE SCHEMA IF NOT EXISTS extensions;
+GRANT USAGE ON SCHEMA extensions TO anon, authenticated, service_role;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_extension e
+    JOIN pg_namespace n ON n.oid = e.extnamespace
+    WHERE e.extname = 'pg_trgm' AND n.nspname = 'public'
+  ) THEN
+    EXECUTE 'ALTER EXTENSION pg_trgm SET SCHEMA extensions';
+  END IF;
+END
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 4. Pin search_path on every public function that doesn't already have one
+-- ─────────────────────────────────────────────────────────────────────────
+-- Includes `extensions` so pg_trgm's `similarity()`, `%` operator, and the
+-- gin_trgm_ops opclass keep resolving from inside function bodies after
+-- the schema move above. Idempotent — only ALTERs functions whose
+-- proconfig doesn't already include a search_path entry.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT n.nspname,
+           p.proname,
+           pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind IN ('f', 'p')  -- regular functions + procedures (not aggregates)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest(COALESCE(p.proconfig, ARRAY[]::text[])) AS c
+        WHERE c LIKE 'search_path=%'
+      )
+  LOOP
+    EXECUTE format(
+      'ALTER FUNCTION public.%I(%s) SET search_path = public, extensions, pg_temp',
+      r.proname, r.args
+    );
+  END LOOP;
+END
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 5. Reassert the authenticated-role blanket grant
+-- ─────────────────────────────────────────────────────────────────────────
+-- The REVOKE FROM PUBLIC above doesn't touch `authenticated`'s grants,
+-- but reapplying the blanket grant here is defensive: any function added
+-- between the line ~563 grant and this remediation block (e.g., via a
+-- `CREATE OR REPLACE FUNCTION` declared above) gets re-granted explicitly.
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO authenticated;

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -17,6 +17,15 @@ CREATE EXTENSION IF NOT EXISTS "postgis";
 -- Deferred: pg_partman (v0.8+, when observations table crosses ~1M rows)
 -- Deferred: pgvector (v0.5+, when Scout AI RAG lands)
 
+-- The `extensions` schema holds relocated extensions (pg_trgm — see the
+-- "Security Advisor remediation" block at the end of this file). We create
+-- it here, and pre-add it to the session search_path, so that any DDL
+-- referencing pg_trgm operators / opclasses resolves whether or not the
+-- extension has already been moved on this database. Idempotent.
+CREATE SCHEMA IF NOT EXISTS extensions;
+GRANT USAGE ON SCHEMA extensions TO anon, authenticated, service_role;
+SET search_path TO public, extensions, pg_temp;
+
 -- ============================================================
 -- USERS
 -- ============================================================

--- a/infra/lint-schema-security.sql
+++ b/infra/lint-schema-security.sql
@@ -1,0 +1,122 @@
+-- Schema security invariants — pre-merge gate
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Wired into .github/workflows/db-validate.yml. Run against the ephemeral
+-- Postgres after the schema has been applied (and the second-pass idempotency
+-- check has succeeded). Three checks; each emits a NOTICE on pass, a fatal
+-- error with the offending list on fail.
+--
+-- Rationale lives in docs/specs/infra/supabase-schema.sql under the
+-- "Security Advisor remediation — 2026-05-08" section, and in CLAUDE.md
+-- under "Schema security invariants".
+
+\set ON_ERROR_STOP on
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Check 1: every view in public must have security_invoker = true
+-- ─────────────────────────────────────────────────────────────────────────
+DO $check1$
+DECLARE
+  offenders text;
+BEGIN
+  SELECT string_agg(format('public.%I', c.relname), E'\n  - ' ORDER BY c.relname)
+    INTO offenders
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relkind = 'v'
+     AND NOT EXISTS (
+       SELECT 1
+         FROM unnest(COALESCE(c.reloptions, ARRAY[]::text[])) opt
+        WHERE opt = 'security_invoker=true'
+     );
+
+  IF offenders IS NOT NULL THEN
+    RAISE EXCEPTION E'Views without security_invoker=true (would bypass RLS):\n  - %', offenders;
+  END IF;
+  RAISE NOTICE 'check1: all public views are security_invoker ✓';
+END
+$check1$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Check 2: no user-defined SECURITY DEFINER function in public may be
+--          callable by PUBLIC (the implicit catch-all role)
+-- ─────────────────────────────────────────────────────────────────────────
+-- pg_proc.proacl is null when the function uses the system default ACL,
+-- which grants EXECUTE to PUBLIC. We treat null-ACL as "PUBLIC has execute"
+-- and require an explicit ACL that doesn't include the empty grantee
+-- (=X means "PUBLIC has EXECUTE"). The pg_has_role(...) check excludes
+-- extension-owned functions whose ACL is managed by the extension itself.
+DO $check2$
+DECLARE
+  offenders text;
+BEGIN
+  SELECT string_agg(
+           format('public.%I(%s)',
+                  p.proname,
+                  pg_get_function_identity_arguments(p.oid)),
+           E'\n  - '
+           ORDER BY p.proname
+         )
+    INTO offenders
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public'
+     AND p.prosecdef = true
+     AND has_function_privilege('public', p.oid, 'EXECUTE')
+     -- Skip functions that came from an installed extension; their ACL is
+     -- the extension author's call, not ours.
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
+     );
+
+  IF offenders IS NOT NULL THEN
+    RAISE EXCEPTION E'SECURITY DEFINER functions executable by PUBLIC (anon escalation risk):\n  - %\n\nFix: add `REVOKE EXECUTE ON FUNCTION public.fn(args) FROM PUBLIC;` after the function definition, then `GRANT EXECUTE ... TO authenticated` (or service_role) explicitly.', offenders;
+  END IF;
+  RAISE NOTICE 'check2: no SECURITY DEFINER function is PUBLIC-callable ✓';
+END
+$check2$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Check 3: every plpgsql / plpython / etc. function in public must have
+--          search_path pinned in proconfig
+-- ─────────────────────────────────────────────────────────────────────────
+-- LANGUAGE sql functions whose body is a single SELECT/etc. don't strictly
+-- need a search_path (they're parsed at definition time and bind their
+-- references early), but pl* functions resolve names at execute time using
+-- the caller's search_path unless overridden — so pin them.
+DO $check3$
+DECLARE
+  offenders text;
+BEGIN
+  SELECT string_agg(
+           format('public.%I(%s)',
+                  p.proname,
+                  pg_get_function_identity_arguments(p.oid)),
+           E'\n  - '
+           ORDER BY p.proname
+         )
+    INTO offenders
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    JOIN pg_language l ON l.oid = p.prolang
+   WHERE n.nspname = 'public'
+     AND p.prokind IN ('f', 'p')
+     AND l.lanname NOT IN ('sql', 'internal', 'c')   -- pl* languages only
+     AND NOT EXISTS (
+       SELECT 1
+         FROM unnest(COALESCE(p.proconfig, ARRAY[]::text[])) c
+        WHERE c LIKE 'search_path=%'
+     )
+     -- Extension-owned functions don't need our search_path discipline.
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
+     );
+
+  IF offenders IS NOT NULL THEN
+    RAISE EXCEPTION E'pl* functions without SET search_path (search-path-shadow risk):\n  - %\n\nFix: append `SET search_path = public, extensions, pg_temp` to the function declaration, or rely on the bulk ALTER FUNCTION block at the end of supabase-schema.sql.', offenders;
+  END IF;
+  RAISE NOTICE 'check3: all pl* functions pin search_path ✓';
+END
+$check3$;

--- a/infra/lint-schema-security.sql
+++ b/infra/lint-schema-security.sql
@@ -12,8 +12,11 @@
 \set ON_ERROR_STOP on
 
 -- ─────────────────────────────────────────────────────────────────────────
--- Check 1: every view in public must have security_invoker = true
+-- Check 1: every user-defined view in public must have security_invoker = true
 -- ─────────────────────────────────────────────────────────────────────────
+-- Extension-owned views (e.g. PostGIS's geography_columns, geometry_columns,
+-- spatial_ref_sys) are exempt — their reloptions are the extension author's
+-- call, not ours.
 DO $check1$
 DECLARE
   offenders text;
@@ -28,6 +31,10 @@ BEGIN
        SELECT 1
          FROM unnest(COALESCE(c.reloptions, ARRAY[]::text[])) opt
         WHERE opt = 'security_invoker=true'
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = c.oid AND d.deptype = 'e'
      );
 
   IF offenders IS NOT NULL THEN


### PR DESCRIPTION
## Summary

Closes the critical + warning findings from the Supabase Database Advisor in a single principled migration, plus a new pre-merge linter so the regression class can't recur.

**Real fixes (silences ~20 critical + ~50 warning advisor entries):**
- 17 views in `public` flipped from SECURITY DEFINER to `security_invoker = true` so RLS on the underlying tables is honoured at the caller's perspective. The views' existing privacy gates (`can_see_facet()`, `hide_from_leaderboards`) keep gating rows — flipping just adds RLS as defence in depth and stops the table-bypass class.
- All user-defined SECURITY DEFINER functions in `public` revoked from the implicit `PUBLIC` role. Surgical (definer-only), so PostGIS / pgcrypto / extension functions remain PUBLIC-callable.
- Every `pl*` function in `public` gets `search_path = public, extensions, pg_temp` pinned.
- `pg_trgm` moved out of `public` into a dedicated `extensions` schema. `pg_net` keeps its self-managed `net` schema. `postgis` stays put (post-install moves are an industry-known anti-pattern).

**Regression prevention:**
- New `infra/lint-schema-security.sql` runs at the end of `db-validate.yml`. Three invariants enforced: every public view is `security_invoker`, no definer function in public is PUBLIC-callable, every `pl*` function pins `search_path`. Any violation fails the PR.
- Documented in CLAUDE.md under "Schema security invariants".

**Audit findings re-classified during the work:**
- `karma_leaderboard_30d` already filters `hide_from_leaderboards = false` (line 7804). No bug there — confirmed clean.
- `public.spatial_ref_sys` RLS warning is a PostGIS-owned table — false positive, will mark accepted in advisor UI post-merge.
- "Signed-In Users Can Execute SECURITY DEFINER Function" warning class is the price for the line-563 blanket grant to `authenticated`. Each definer function does its own internal authorization (`has_role`, owner check, etc.); the blanket grant is reviewable in one place. Accepted with rationale.

**Deliberately out of scope:**
- `storage.media` bucket listing restriction. R2 is the primary path and tightening Supabase Storage RLS needs its own PR with a public-read smoke test. Will follow up.
- Auth → Leaked Password Protection. Dashboard toggle (no SQL); will flip post-merge.

## Test plan

- [ ] db-validate workflow passes (idempotency 2× + schema security invariants)
- [ ] Post-merge db-apply succeeds against production
- [ ] Manual smoke as anon (signed out) — public profile pages still load (`/profile/u/<username>` shows pokedex / karma / etc.)
- [ ] Manual smoke as authenticated — `community_observers_with_centroid` query returns rows
- [ ] Manual smoke as authenticated — moderator role can still see `validation_queue`
- [ ] Re-run Database Advisor in Supabase dashboard — 17 critical view entries clear, ~50 "Public Can Execute" entries clear
- [ ] Flip Auth → Leaked Password Protection ON in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)