### PR TITLE
fix(schema): hotfix — skip extension-owned funcs in advisor remediation

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -9868,7 +9868,12 @@ BEGIN
            pg_get_function_identity_arguments(p.oid) AS args
     FROM pg_proc p
     JOIN pg_namespace n ON n.oid = p.pronamespace
-    WHERE n.nspname = 'public' AND p.prosecdef = true
+    WHERE n.nspname = 'public'
+      AND p.prosecdef = true
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
+      )
   LOOP
     EXECUTE format(
       'REVOKE EXECUTE ON FUNCTION public.%I(%s) FROM PUBLIC',
@@ -9910,6 +9915,11 @@ $$;
 -- gin_trgm_ops opclass keep resolving from inside function bodies after
 -- the schema move above. Idempotent — only ALTERs functions whose
 -- proconfig doesn't already include a search_path entry.
+-- Extension-owned functions (PostGIS, pg_trgm, etc.) are owned by the
+-- extension's role on hosted Supabase, NOT by the role running the apply.
+-- ALTER FUNCTION on a function you don't own raises "must be owner of
+-- function …" — exactly the failure that broke the post-merge db-apply
+-- run for PR #828. Skip them via pg_depend (deptype 'e' = extension).
 DO $$
 DECLARE
   r record;
@@ -9926,6 +9936,10 @@ BEGIN
         SELECT 1
         FROM unnest(COALESCE(p.proconfig, ARRAY[]::text[])) AS c
         WHERE c LIKE 'search_path=%'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
       )
   LOOP
     EXECUTE format(


### PR DESCRIPTION
## Summary

PR #828's post-merge db-apply against **production** failed at the search_path-pinning loop with `must be owner of function public.contains_2d`. PostGIS owns its functions on hosted Supabase; the apply role doesn't. ALTER FUNCTION on a not-owned function aborts the whole DO block, rolling back its in-flight ALTERs and skipping the final blanket grant.

**Hotfix:** add the same `pg_depend.deptype = 'e'` exemption that the linter already applies (`infra/lint-schema-security.sql` checks 2 + 3) to both the search_path loop and the REVOKE FROM PUBLIC loop.

**Production state pre-hotfix** (partial apply from #828):
- ✅ 17 views flipped to `security_invoker = true`
- ✅ SECURITY DEFINER functions revoked from `PUBLIC` role
- ✅ `pg_trgm` relocated to `extensions` schema
- ❌ search_path pinning **rolled back** mid-loop
- ❌ Final `GRANT EXECUTE … TO authenticated` safety net **never ran**

After this PR's db-apply, sections 4 and 5 complete cleanly.

## Why ephemeral CI didn't catch this

`db-validate.yml` runs as `postgres` (superuser) against a fresh container, so `ALTER FUNCTION` on PostGIS functions succeeds in CI. Hosted Supabase's apply role is less privileged. Only the production apply step exposes this class of bug — same pattern as the validate-gate-was-added-after-PR-#42 incident in CLAUDE.md.

## Test plan

- [ ] db-validate passes (idempotency 2× + linter)
- [ ] Post-merge db-apply succeeds on prod
- [ ] Re-run Supabase Database Advisor — "Function Search Path Mutable" warnings clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)