### PR TITLE
fix(security): RLS on public.spatial_ref_sys with permissive read

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -9958,3 +9958,33 @@ $$;
 -- between the line ~563 grant and this remediation block (e.g., via a
 -- `CREATE OR REPLACE FUNCTION` declared above) gets re-granted explicitly.
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO authenticated;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 6. PostGIS spatial_ref_sys — enable RLS with a permissive read policy
+-- ─────────────────────────────────────────────────────────────────────────
+-- Advisor flags `public.spatial_ref_sys` as a public-exposed table without
+-- RLS. The data is non-sensitive SRID/projection metadata (same on every
+-- PostGIS install), but our "every public table has RLS" invariant should
+-- be uniform across the schema rather than carve-outs.
+--
+-- The table is PostGIS-owned; the apply role may or may not be able to
+-- ALTER it. The DO blocks swallow insufficient_privilege so the apply
+-- doesn't fail — in that case the advisor entry persists and the
+-- operator falls back to dashboard-level acceptance.
+DO $$
+BEGIN
+  ALTER TABLE public.spatial_ref_sys ENABLE ROW LEVEL SECURITY;
+EXCEPTION WHEN insufficient_privilege THEN
+  RAISE NOTICE 'spatial_ref_sys is owned by a higher role; skipping RLS toggle. Mark advisor entry accepted in dashboard.';
+END
+$$;
+
+DROP POLICY IF EXISTS spatial_ref_sys_world_read ON public.spatial_ref_sys;
+DO $$
+BEGIN
+  CREATE POLICY spatial_ref_sys_world_read ON public.spatial_ref_sys
+    FOR SELECT USING (true);
+EXCEPTION WHEN insufficient_privilege THEN
+  RAISE NOTICE 'apply role cannot CREATE POLICY on spatial_ref_sys; advisor entry will persist.';
+END
+$$;


### PR DESCRIPTION
## Summary

Closes the last critical Database Advisor finding after #828 + #829: **RLS Disabled in Public — `public.spatial_ref_sys`**.

`spatial_ref_sys` is PostGIS-owned SRID/projection metadata, non-sensitive, identical on every PostGIS install. But CLAUDE.md's "every public table has RLS, no exceptions" invariant should hold uniformly rather than via carve-outs.

## Approach

`ALTER TABLE … ENABLE ROW LEVEL SECURITY` + a permissive `SELECT USING (true)` policy. Zero functional change — same rows readable by the same callers.

Defensive `DO`-blocks swallow `insufficient_privilege` so the apply doesn't fail if the apply role can't alter the PostGIS-owned table on hosted Supabase. In that case the advisor entry persists and the operator falls back to dashboard-level acceptance (tracked in #832).

## Why not just accept it in the dashboard

Two reasons:
1. The "every public table has RLS" invariant is documented in CLAUDE.md and enforced in `db-validate.yml`'s RLS-presence check. Carving out one table for "but it's PostGIS" weakens the rule.
2. Production Supabase projects routinely apply this exact fix; standard Supabase support guidance is "either is fine."

## Test plan

- [ ] db-validate passes (RLS-presence check still ignores extension-owned tables, but `spatial_ref_sys` now has RLS enabled regardless)
- [ ] Post-merge db-apply succeeds against prod
- [ ] Re-run Database Advisor — "RLS Disabled in Public" entry for `public.spatial_ref_sys` clears
- [ ] Smoke an anon PostGIS query that joins against `spatial_ref_sys` (e.g. anything using `ST_Transform`) — confirm no regression

## Risk note

PostGIS upgrade scripts may interact with RLS on `spatial_ref_sys` in some edge cases. Risk is low (this table is rarely written); if a future PostGIS upgrade fails on it, dropping the policy + disabling RLS is a one-liner.

## Refs
- Parent: #828
- Hotfix: #829
- Acceptlist (fallback): #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)