### PR TITLE
fix(observe): treat status=failed as terminal in resumePipeline (#786)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -1114,9 +1114,11 @@ async function resumePipeline(state: PipelineState) {
   updatePipelineUI();
   startGPS();
 
-  if (state.status !== 'done') {
+  if (state.status !== 'done' && state.status !== 'failed') {
     // #783: same try/catch as files-dropped handler — always show post-form
     // on pipeline error so the user can still save manually.
+    // #786: don't retry when prior status is 'failed' — a persistent
+    // underlying error (e.g. auth lock) would loop on every reload.
     try {
       await runPipeline(state);
     } catch (err) {


### PR DESCRIPTION
## Summary
- `resumePipeline` no longer retries `runPipeline` when prior state was `status='failed'` — shows post-form directly.
- Prevents reload loops if the failure cause persists (e.g. gotrue auth lock from #785).

## Test plan
- [x] `npx tsc --noEmit`
- [ ] Manual: run identify, force-fail (e.g. offline + bad URL), reload, confirm post-form renders without retry.

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)