### PR TITLE
feat(recents): add view-mode switcher (cards + grid) on explore/recent (#705)

### DIFF
--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -36,6 +36,7 @@ const sgTree = tr as unknown as {
 const sgCards  = sgTree.socialgraph.cards;
 const sgBlock  = sgTree.socialgraph.block.button;
 const sgReport = sgTree.socialgraph.report.button;
+const view = page.view;
 ---
 
 <section
@@ -61,9 +62,39 @@ const sgReport = sgTree.socialgraph.report.button;
   data-label-fave-aria-other={(tr as unknown as { socialgraph: { reactions: Record<string, string> } }).socialgraph.reactions.fave_count_aria_other}
 >
   <header class="space-y-3 py-6">
-    <h1 class="text-3xl font-bold tracking-tight">{page.title}</h1>
-    <p class="text-zinc-600 dark:text-zinc-400">{page.subtitle}</p>
-    <WhyAmISeeingThis algorithm="explore_recent" lang={lang} />
+    <div class="flex items-start justify-between gap-3">
+      <div class="space-y-3 min-w-0">
+        <h1 class="text-3xl font-bold tracking-tight">{page.title}</h1>
+        <p class="text-zinc-600 dark:text-zinc-400">{page.subtitle}</p>
+        <WhyAmISeeingThis algorithm="explore_recent" lang={lang} />
+      </div>
+      <div
+        class="er-view-switcher inline-flex shrink-0 items-center rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-0.5"
+        role="group"
+        aria-label={view.switcher_label}
+      >
+        <button
+          type="button"
+          class="er-view-btn er-view-cards inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          data-mode="cards"
+          aria-label={view.cards}
+          aria-pressed="true"
+          title={view.cards}
+        >
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="7" rx="1.5"/><rect x="3" y="13" width="18" height="7" rx="1.5"/></svg>
+        </button>
+        <button
+          type="button"
+          class="er-view-btn er-view-grid inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          data-mode="grid"
+          aria-label={view.grid}
+          aria-pressed="false"
+          title={view.grid}
+        >
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+        </button>
+      </div>
+    </div>
   </header>
 
   <div class="er-skeleton">
@@ -71,7 +102,7 @@ const sgReport = sgTree.socialgraph.report.button;
   </div>
 
   <ul
-    class="er-list grid grid-cols-1 sm:grid-cols-2 gap-4"
+    class="er-list er-mode-cards grid grid-cols-1 sm:grid-cols-2 gap-4"
     aria-label={page.title}
   ></ul>
 
@@ -80,6 +111,19 @@ const sgReport = sgTree.socialgraph.report.button;
   </p>
 
   <p class="er-error hidden mt-4 rounded-lg border border-red-300 dark:border-red-800 p-4 text-center text-sm text-red-700 dark:text-red-400"></p>
+
+  <style>
+    .er-list.er-mode-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.5rem;
+    }
+    @media (min-width: 768px) {
+      .er-list.er-mode-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+    .er-list.er-mode-grid .er-card { border-radius: 0.5rem; }
+    .er-list.er-mode-grid .er-card > div:last-child { display: none; }
+    .er-list.er-mode-grid .er-overflow { display: none; }
+  </style>
 
   <div class="er-load-more-wrap hidden mt-6 text-center">
     <button
@@ -279,6 +323,37 @@ const sgReport = sgTree.socialgraph.report.button;
       faveAriaOne: root.dataset.labelFaveAriaOne ?? '{{count}} person favorited this',
       faveAriaOther: root.dataset.labelFaveAriaOther ?? '{{count}} people favorited this',
     };
+
+    const VIEW_MODE_KEY = 'rastrum.recents.viewMode';
+    type ViewMode = 'cards' | 'grid';
+    function readViewMode(): ViewMode {
+      try {
+        const v = localStorage.getItem(VIEW_MODE_KEY);
+        return v === 'grid' ? 'grid' : 'cards';
+      } catch { return 'cards'; }
+    }
+    function writeViewMode(mode: ViewMode) {
+      try { localStorage.setItem(VIEW_MODE_KEY, mode); } catch { /* ignore */ }
+    }
+    function applyViewMode(mode: ViewMode) {
+      const list = root.querySelector<HTMLUListElement>('.er-list');
+      if (list) {
+        list.classList.toggle('er-mode-grid', mode === 'grid');
+        list.classList.toggle('er-mode-cards', mode === 'cards');
+      }
+      root.querySelectorAll<HTMLButtonElement>('.er-view-btn').forEach((btn) => {
+        const isActive = btn.dataset.mode === mode;
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+    }
+    applyViewMode(readViewMode());
+    root.querySelectorAll<HTMLButtonElement>('.er-view-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const mode = (btn.dataset.mode === 'grid' ? 'grid' : 'cards') as ViewMode;
+        writeViewMode(mode);
+        applyViewMode(mode);
+      });
+    });
 
     const listEl = root.querySelector('.er-list') as HTMLUListElement | null;
     const skeletonEl = root.querySelector('.er-skeleton') as HTMLElement | null;

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -139,6 +139,12 @@ const view = page.view;
   import { getSupabase } from '../lib/supabase';
   import { formatTimeAgo } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
+  import {
+    RECENTS_VIEW_MODE_KEY,
+    DEFAULT_VIEW_MODE,
+    isViewMode,
+    type ViewMode,
+  } from '../lib/recents-view-mode';
 
   type Lang = 'en' | 'es';
 
@@ -324,16 +330,14 @@ const view = page.view;
       faveAriaOther: root.dataset.labelFaveAriaOther ?? '{{count}} people favorited this',
     };
 
-    const VIEW_MODE_KEY = 'rastrum.recents.viewMode';
-    type ViewMode = 'cards' | 'grid';
     function readViewMode(): ViewMode {
       try {
-        const v = localStorage.getItem(VIEW_MODE_KEY);
-        return v === 'grid' ? 'grid' : 'cards';
-      } catch { return 'cards'; }
+        const v = localStorage.getItem(RECENTS_VIEW_MODE_KEY);
+        return isViewMode(v) ? v : DEFAULT_VIEW_MODE;
+      } catch { return DEFAULT_VIEW_MODE; }
     }
     function writeViewMode(mode: ViewMode) {
-      try { localStorage.setItem(VIEW_MODE_KEY, mode); } catch { /* ignore */ }
+      try { localStorage.setItem(RECENTS_VIEW_MODE_KEY, mode); } catch { /* ignore */ }
     }
     function applyViewMode(mode: ViewMode) {
       const list = root.querySelector<HTMLUListElement>('.er-list');

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1919,7 +1919,12 @@
       "load_more": "Load more",
       "loading": "Loading observations…",
       "anonymous": "Anonymous",
-      "unknown_species": "Unknown species"
+      "unknown_species": "Unknown species",
+      "view": {
+        "switcher_label": "Change view",
+        "cards": "Cards",
+        "grid": "Grid"
+      }
     },
     "watchlist": {
       "title": "Watchlist",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1919,7 +1919,12 @@
       "load_more": "Cargar más",
       "loading": "Cargando observaciones…",
       "anonymous": "Anónimo",
-      "unknown_species": "Especie desconocida"
+      "unknown_species": "Especie desconocida",
+      "view": {
+        "switcher_label": "Cambiar vista",
+        "cards": "Tarjetas",
+        "grid": "Cuadrícula"
+      }
     },
     "watchlist": {
       "title": "Seguimiento",

--- a/src/lib/recents-view-mode.ts
+++ b/src/lib/recents-view-mode.ts
@@ -1,0 +1,9 @@
+export const RECENTS_VIEW_MODE_KEY = 'rastrum.recents.viewMode';
+
+export type ViewMode = 'cards' | 'grid';
+
+export const DEFAULT_VIEW_MODE: ViewMode = 'cards';
+
+export function isViewMode(v: unknown): v is ViewMode {
+  return v === 'cards' || v === 'grid';
+}


### PR DESCRIPTION
## Summary

- Adds a top-right view-mode switcher to `/{en,es}/explore/recent/` with two modes: **Cards** (default, existing layout) and **Grid** (2-col mobile / 3-col md+, square photo tiles only).
- Preference persisted in `localStorage["rastrum.recents.viewMode"]` (`'cards'` | `'grid'`), read on mount, defaults to `'cards'`.
- Segmented icon-button control with `aria-pressed` state; EN + ES i18n under `explore_pages.recent.view.{cards,grid,switcher_label}`.
- No new dependencies — uses existing inline-SVG pattern. Below-fold images already `loading="lazy"`.

## v1.1 follow-ups (deferred)

- List view (single-line, denser metadata)
- Map view (geographic clustering of recents)
- Timeline view (grouped by day)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run test` — 1447/1447 green
- [x] `npm run build` — 241 pages, no errors
- [ ] Manual: load `/en/explore/recent/`, click grid icon → tiles compact to 2/3-col with no metadata; reload → preserves grid mode
- [ ] Manual: switch back to cards → metadata returns; reload → preserves cards mode
- [ ] Manual: ES parity — `/es/explore/recent/` shows "Tarjetas" / "Cuadrícula" tooltips

Closes #705