### PR TITLE
feat(navbar): reorder bottom nav — recents-first, replace explore with discover (#706)

### DIFF
--- a/src/components/MobileBottomBar.astro
+++ b/src/components/MobileBottomBar.astro
@@ -13,28 +13,27 @@ const locale = lang as Locale;
 const fab = getFabTarget(currentPath, lang);
 
 // Build href helpers — these read from `routes` so they stay symmetric across locales.
-const explorePath = getLocalizedPath(lang, routes.explore[locale] + '/');
 const exploreRecentPath = getLocalizedPath(lang, routes.exploreRecent[locale] + '/');
-const chatPath    = getLocalizedPath(lang, routes.chat[locale] + '/');
 const profilePath = getLocalizedPath(lang, routes.profile[locale] + '/');
 const homePath    = getLocalizedPath(lang, '/');
 const observePath = getLocalizedPath(lang, routes.observe[locale] + '/');
 const exploreMapPath = getLocalizedPath(lang, routes.exploreMap[locale] + '/');
+const discoverPath = getLocalizedPath(lang, routes.communityObservers[locale] + '/');
 const signInPath  = getLocalizedPath(lang, routes.signIn[locale] + '/');
 
 // Active-state precomputes (so the markup stays tidy)
-const obsActive    = isActiveSection(currentPath, 'observe',       lang);
-const expActive    = isActiveSection(currentPath, 'explore',       lang);
-const chatActive   = isActiveSection(currentPath, 'chat',          lang);
-const profActive   = isActiveSection(currentPath, 'profile',       lang);
-const homeActive   = isActiveSection(currentPath, 'home',          lang);
-const recentActive = isActiveSection(currentPath, 'exploreRecent', lang);
+const obsActive       = isActiveSection(currentPath, 'observe',       lang);
+const expActive       = isActiveSection(currentPath, 'explore',       lang);
+const profActive      = isActiveSection(currentPath, 'profile',       lang);
+const homeActive      = isActiveSection(currentPath, 'home',          lang);
+const recentActive    = isActiveSection(currentPath, 'exploreRecent', lang);
+const discoverActive  = isActiveSection(currentPath, 'community',     lang);
 ---
 
 <!--
   Mobile bottom bar. Two layouts driven by auth state, swapped by the
-  inline script below: the signed-in 5-slot version (Explore · Chat ·
-  [FAB] · Recent · Profile) and the signed-out 4-slot version (Home ·
+  inline script below: the signed-in 5-slot version (Home · Recents ·
+  [FAB] · Discover · Profile) and the signed-out 4-slot version (Home ·
   Observe · Map · Sign in). The center FAB always means "observe";
   when already on /observe it triggers the camera input directly.
 -->
@@ -44,21 +43,21 @@ const recentActive = isActiveSection(currentPath, 'exploreRecent', lang);
   style="padding-bottom: max(env(safe-area-inset-bottom), 0px);"
   aria-label={tr.nav.bottom.observe}
 >
-  <!-- Signed-in: 5 slots, center FAB -->
+  <!-- Signed-in: 5 slots, center FAB — Home | Recents | [FAB] | Discover | Profile -->
   <div id="mbb-authed" class="hidden grid grid-cols-5 items-end h-16 relative">
-    <a href={explorePath} class:list={[
+    <a href={homePath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
-      expActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
-    ]} data-tour="explore-tab">
-      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-1.447-.894L15 9m0 8V9"/></svg>
-      <span>{tr.nav.bottom.explore}</span>
-    </a>
-    <a href={chatPath} class:list={[
-      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
-      chatActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+      homeActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
     ]}>
-      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.83L3 20l1.41-3.18A8 8 0 0121 12z"/></svg>
-      <span>{tr.nav.bottom.chat}</span>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 12l9-9 9 9M5 10v10a1 1 0 001 1h3v-7h6v7h3a1 1 0 001-1V10"/></svg>
+      <span>{tr.nav.bottom.home}</span>
+    </a>
+    <a href={exploreRecentPath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      recentActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]}>
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      <span>{tr.nav.bottom.recents}</span>
     </a>
 
     <!-- FAB slot — h-full so absolute children measure from the bar's top edge (not from items-end's collapsed bottom strip) -->
@@ -80,12 +79,12 @@ const recentActive = isActiveSection(currentPath, 'exploreRecent', lang);
       </span>
     </div>
 
-    <a href={exploreRecentPath} class:list={[
+    <a href={discoverPath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
-      recentActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
-    ]}>
-      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-      <span>{tr.nav.bottom.recent}</span>
+      discoverActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]} data-tour="discover-tab">
+      <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+      <span>{tr.nav.bottom.discover}</span>
     </a>
     <a href={profilePath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -71,6 +71,8 @@
       "observe": "Observe",
       "quick_id": "Identify mode",
       "recent": "Recent",
+      "recents": "Recents",
+      "discover": "Discover",
       "profile": "Profile",
       "home": "Home",
       "identify": "Identify",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -71,6 +71,8 @@
       "observe": "Observar",
       "quick_id": "Modo identificar",
       "recent": "Recientes",
+      "recents": "Recientes",
+      "discover": "Descubrir",
       "profile": "Perfil",
       "home": "Inicio",
       "identify": "Identificar",


### PR DESCRIPTION
## Summary

Reorders the signed-in mobile bottom bar to lead with Home and put a recency-driven feed in slot 2, per #706.

**Before:** Explore | Chat | [FAB] | Recent | Profile
**After:**  Home | Recents | [FAB] | Discover | Profile

- **Home** — new slot 1, sends users back to the locale root.
- **Recents** — slot 2, links to the existing `routes.exploreRecent` pair (`/explore/recent` / `/explorar/recientes`).
- **FAB** — unchanged. Center camera, still shifts to `/identify` with Quick-ID semantics when the user is already on `/observe`. Long-press → `?quick=1` still works.
- **Discover** — slot 4. **For MVP this aliases `/community/observers`** (`routes.communityObservers`), the existing community-driven discovery surface. A personalized "Discover" feed (per-user ranking, surprise drops, off-the-beaten-path species) is a v1.1 follow-up — explicitly out of scope for this PR per the issue's MVP constraint.
- **Profile** — unchanged.

The signed-out 4-slot variant (Home · Observe · Map · Sign-in) is untouched.

i18n: added `nav.bottom.recents` ("Recents" / "Recientes") and `nav.bottom.discover` ("Discover" / "Descubrir") to both EN and ES. The legacy `nav.bottom.recent` key is left in place — no other callers, but cheap to keep for translator reference.

Active-state highlighting: Recents uses `isActiveSection(_, 'exploreRecent', _)`, Discover uses `isActiveSection(_, 'community', _)` so both `/community/observers` and any future `/community/*` siblings light the tab.

## Discover destination — why /community/observers?

The issue calls for a "discovery"-flavored destination but defers building a real Discover page. `/community/observers` is the closest existing fit: it's the same surface the desktop Explore MegaMenu's Community column lands on (Observers / Top / Nearby / Experts / By country), all driven by the same view, and per AGENTS.md it's already the canonical community-discovery hub. No new pages, no new routes, no new dependencies.

A real personalized Discover feed (v1.1 follow-up) should live behind a new top-level route and reuse the `algorithms.ts` registry pattern + `<WhyAmISeeingThis>` pill so it satisfies the Persuasive-Tech invariants documented in CLAUDE.md.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 1446/1447 pass; the 1 fail is `static-imports.test.ts` timing out under load (unrelated, passes solo in 629ms)
- [x] `npm run build` — 241 pages, no errors, EN/ES paired
- [ ] Manual: signed-in mobile viewport — verify the new order renders, FAB stays centered, FAB-shift on `/observe` still works
- [ ] Manual: signed-out mobile — verify the 4-slot anon variant unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)