### PR TITLE
feat(profile): karma-tier avatar frames — seedling to legend (#702)

### DIFF
--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -60,14 +60,22 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
     <!-- Identity strip -->
     <header class="mb-8">
       <div class="flex items-start gap-4">
-        <!-- Avatar (large) -->
+        <!-- Avatar (large) — karma-tier ring is applied at hydrate time (#702) -->
         <div class="shrink-0">
-          <img
-            id="avatar-img"
-            src=""
-            alt=""
-            class="w-20 h-20 md:w-24 md:h-24 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover"
-          />
+          <span
+            id="avatar-frame"
+            data-karma-frame
+            data-karma-tier=""
+            class="inline-block rounded-full ring-offset-2 ring-offset-white dark:ring-offset-zinc-900"
+          >
+            <img
+              id="avatar-img"
+              src=""
+              alt=""
+              class="w-20 h-20 md:w-24 md:h-24 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover"
+            />
+            <span id="avatar-tier-label" class="sr-only"></span>
+          </span>
         </div>
 
         <!-- Name + handle + meta -->
@@ -257,11 +265,14 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
 <script>
   import { getSupabase } from '../lib/supabase';
   import { escAttr } from '../lib/karma';
+  import { tierForKarma } from '../lib/karma-frame';
   import type { UserProfile } from '../lib/types';
   import { listCredentials } from '../lib/sponsorships';
 
   const signedOut    = document.getElementById('signed-out') as HTMLDivElement | null;
   const signedIn     = document.getElementById('signed-in') as HTMLDivElement | null;
+  const avatarFrame  = document.getElementById('avatar-frame') as HTMLSpanElement | null;
+  const avatarTierLabel = document.getElementById('avatar-tier-label');
   const avatarImg    = document.getElementById('avatar-img') as HTMLImageElement | null;
   const displayName  = document.getElementById('display-name');
   const usernameAt   = document.getElementById('username-at');
@@ -312,6 +323,28 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
     if (avatarImg) {
       avatarImg.src = profile.avatar_url || initialsAvatar(name);
       avatarImg.alt = name;
+    }
+
+    if (avatarFrame) {
+      const karmaTotal = Number((profile as { karma_total?: number | null }).karma_total ?? 0);
+      const tier = tierForKarma(karmaTotal);
+      avatarFrame.dataset.karmaTier = tier.id;
+      for (const cls of tier.ringClass.split(/\s+/)) {
+        if (cls) avatarFrame.classList.add(cls);
+      }
+      if (avatarTierLabel) {
+        const langCode = document.documentElement.lang === 'es' ? 'es' : 'en';
+        const tierNames: Record<string, { en: string; es: string }> = {
+          seedling:   { en: 'Seedling',   es: 'Plántula' },
+          observer:   { en: 'Observer',   es: 'Observador' },
+          naturalist: { en: 'Naturalist', es: 'Naturalista' },
+          expert:     { en: 'Expert',     es: 'Experto' },
+          master:     { en: 'Master',     es: 'Maestro' },
+          legend:     { en: 'Legend',     es: 'Leyenda' },
+        };
+        const label = tierNames[tier.id]?.[langCode] ?? tier.id;
+        avatarTierLabel.textContent = langCode === 'es' ? `Nivel: ${label}` : `Tier: ${label}`;
+      }
     }
 
     if (profile.username && viewPublicLink) {

--- a/src/components/profile/KarmaFrame.astro
+++ b/src/components/profile/KarmaFrame.astro
@@ -1,0 +1,46 @@
+---
+import { tierForKarma } from '../../lib/karma-frame';
+
+interface Props {
+  karmaTotal: number;
+  src: string;
+  alt: string;
+  size?: 'sm' | 'md' | 'lg';
+  class?: string;
+}
+
+const {
+  karmaTotal,
+  src,
+  alt,
+  size = 'md',
+  class: extraClass = '',
+} = Astro.props;
+
+const tier = tierForKarma(karmaTotal ?? 0);
+
+const sizeClass =
+  size === 'sm' ? 'w-10 h-10'
+  : size === 'lg' ? 'w-24 h-24 md:w-28 md:h-28'
+  : 'w-16 h-16 md:w-20 md:h-20';
+
+const wrapperClass = [
+  'inline-block rounded-full ring-offset-2 ring-offset-white dark:ring-offset-zinc-900',
+  tier.ringClass,
+  extraClass,
+].filter(Boolean).join(' ');
+---
+
+<span
+  class={wrapperClass}
+  data-karma-frame
+  data-karma-tier={tier.id}
+  data-karma-glow={tier.glow ? '1' : '0'}
+>
+  <img
+    src={src}
+    alt={alt}
+    loading="lazy"
+    class={`rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover ${sizeClass}`}
+  />
+</span>

--- a/src/components/profile/KarmaFrame.astro
+++ b/src/components/profile/KarmaFrame.astro
@@ -5,6 +5,7 @@ interface Props {
   karmaTotal: number;
   src: string;
   alt: string;
+  /** Avatar size — defaults to `'md'` (16-20px responsive) when omitted. */
   size?: 'sm' | 'md' | 'lg';
   class?: string;
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2029,7 +2029,33 @@
     "breakdown_loading": "Loading breakdown…",
     "breakdown_empty": "No karma activity in the last 7 days.",
     "breakdown_count_one": "{n} event",
-    "breakdown_count_other": "{n} events"
+    "breakdown_count_other": "{n} events",
+    "tier": {
+      "seedling": {
+        "name": "Seedling",
+        "description": "Just getting started — your first observations grow this ring."
+      },
+      "observer": {
+        "name": "Observer",
+        "description": "Steady contributions are paying off. Keep documenting what you see."
+      },
+      "naturalist": {
+        "name": "Naturalist",
+        "description": "A trusted voice in the community. Your IDs help others learn."
+      },
+      "expert": {
+        "name": "Expert",
+        "description": "Deep expertise on display. Validations from you carry extra weight."
+      },
+      "master": {
+        "name": "Master",
+        "description": "A standout contributor with sustained impact across taxa and regions."
+      },
+      "legend": {
+        "name": "Legend",
+        "description": "Shaping the platform through years of observation, validation, and mentorship."
+      }
+    }
   },
   "validation": {
     "queue_title": "Validation queue",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2029,7 +2029,33 @@
     "breakdown_loading": "Cargando desglose…",
     "breakdown_empty": "Sin actividad de karma en los últimos 7 días.",
     "breakdown_count_one": "{n} evento",
-    "breakdown_count_other": "{n} eventos"
+    "breakdown_count_other": "{n} eventos",
+    "tier": {
+      "seedling": {
+        "name": "Plántula",
+        "description": "Apenas comenzando — tus primeras observaciones hacen crecer este anillo."
+      },
+      "observer": {
+        "name": "Observador",
+        "description": "Tu constancia rinde frutos. Sigue documentando lo que ves."
+      },
+      "naturalist": {
+        "name": "Naturalista",
+        "description": "Una voz confiable en la comunidad. Tus identificaciones enseñan a otros."
+      },
+      "expert": {
+        "name": "Experto",
+        "description": "Conocimiento profundo a la vista. Tus validaciones pesan más."
+      },
+      "master": {
+        "name": "Maestro",
+        "description": "Contribuciones sobresalientes y sostenidas a través de taxones y regiones."
+      },
+      "legend": {
+        "name": "Leyenda",
+        "description": "Moldeando la plataforma con años de observación, validación y mentoría."
+      }
+    }
   },
   "validation": {
     "queue_title": "Cola de validación",

--- a/src/lib/karma-frame.ts
+++ b/src/lib/karma-frame.ts
@@ -1,0 +1,63 @@
+export type KarmaTierId =
+  | 'seedling'
+  | 'observer'
+  | 'naturalist'
+  | 'expert'
+  | 'master'
+  | 'legend';
+
+export interface KarmaTier {
+  id: KarmaTierId;
+  min: number;
+  ringClass: string;
+  glow?: boolean;
+}
+
+const TIERS: readonly KarmaTier[] = [
+  {
+    id: 'seedling',
+    min: 0,
+    ringClass: 'ring-2 ring-emerald-500',
+  },
+  {
+    id: 'observer',
+    min: 100,
+    ringClass: 'ring-2 ring-teal-500',
+  },
+  {
+    id: 'naturalist',
+    min: 500,
+    ringClass: 'ring-2 ring-amber-500',
+  },
+  {
+    id: 'expert',
+    min: 1000,
+    ringClass: 'ring-2 ring-sky-500 motion-safe:animate-pulse',
+    glow: true,
+  },
+  {
+    id: 'master',
+    min: 5000,
+    ringClass: 'ring-4 ring-yellow-400 shadow-[0_0_12px_rgba(250,204,21,0.6)] motion-safe:animate-pulse',
+    glow: true,
+  },
+  {
+    id: 'legend',
+    min: 10000,
+    ringClass: 'ring-4 ring-fuchsia-500 shadow-[0_0_16px_rgba(217,70,239,0.7)] motion-safe:animate-rastrum-legend-spin',
+    glow: true,
+  },
+];
+
+export function tierForKarma(total: number): KarmaTier {
+  const safe = Number.isFinite(total) && total >= 0 ? total : 0;
+  let match = TIERS[0];
+  for (const tier of TIERS) {
+    if (safe >= tier.min) match = tier;
+  }
+  return match;
+}
+
+export function allKarmaTiers(): readonly KarmaTier[] {
+  return TIERS;
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -17,9 +17,31 @@ export default {
     'rastrum-season-accent',
     'rastrum-season-accent-bg',
     'rastrum-season-accent-border',
+    'ring-2', 'ring-4',
+    'ring-emerald-500', 'ring-teal-500', 'ring-amber-500',
+    'ring-sky-500', 'ring-yellow-400', 'ring-fuchsia-500',
+    'ring-offset-2', 'ring-offset-white', 'dark:ring-offset-zinc-900',
+    'shadow-[0_0_12px_rgba(250,204,21,0.6)]',
+    'shadow-[0_0_16px_rgba(217,70,239,0.7)]',
+    'motion-safe:animate-pulse',
+    'motion-safe:animate-rastrum-legend-spin',
   ],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        'rastrum-legend-spin': {
+          '0%, 100%': {
+            'box-shadow': '0 0 12px rgba(217, 70, 239, 0.55), 0 0 22px rgba(168, 85, 247, 0.35)',
+          },
+          '50%': {
+            'box-shadow': '0 0 18px rgba(217, 70, 239, 0.85), 0 0 28px rgba(168, 85, 247, 0.55)',
+          },
+        },
+      },
+      animation: {
+        'rastrum-legend-spin': 'rastrum-legend-spin 3.4s ease-in-out infinite',
+      },
+    },
   },
   plugins: [],
 };

--- a/tests/unit/karma-frame.test.ts
+++ b/tests/unit/karma-frame.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { tierForKarma, allKarmaTiers } from '../../src/lib/karma-frame';
+
+describe('tierForKarma', () => {
+  it('returns seedling for 0', () => {
+    expect(tierForKarma(0).id).toBe('seedling');
+  });
+
+  it('returns seedling just below 100', () => {
+    expect(tierForKarma(99).id).toBe('seedling');
+  });
+
+  it('returns observer at 100 (boundary)', () => {
+    expect(tierForKarma(100).id).toBe('observer');
+  });
+
+  it('returns naturalist at 500', () => {
+    expect(tierForKarma(500).id).toBe('naturalist');
+  });
+
+  it('returns expert at 1000 with glow', () => {
+    const t = tierForKarma(1000);
+    expect(t.id).toBe('expert');
+    expect(t.glow).toBe(true);
+  });
+
+  it('returns master at 5000', () => {
+    expect(tierForKarma(5000).id).toBe('master');
+  });
+
+  it('returns legend at 10000', () => {
+    const t = tierForKarma(10000);
+    expect(t.id).toBe('legend');
+    expect(t.glow).toBe(true);
+  });
+
+  it('returns legend for very large values', () => {
+    expect(tierForKarma(1_000_000).id).toBe('legend');
+  });
+
+  it('clamps negative karma to seedling', () => {
+    expect(tierForKarma(-50).id).toBe('seedling');
+  });
+
+  it('coerces NaN to seedling', () => {
+    expect(tierForKarma(Number.NaN).id).toBe('seedling');
+  });
+
+  it('every tier has a non-empty ringClass', () => {
+    for (const tier of allKarmaTiers()) {
+      expect(tier.ringClass.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('tiers are ordered by ascending min', () => {
+    const tiers = allKarmaTiers();
+    for (let i = 1; i < tiers.length; i++) {
+      expect(tiers[i].min).toBeGreaterThan(tiers[i - 1].min);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a karma-driven ring around profile avatars so contributors see their standing reflected in the chrome they look at most. Pure read of the existing `users.karma_total` column — no new schema, no new endpoints.

## Tiers

| Tier | Range | Ring |
|---|---|---|
| seedling   | 0–99      | emerald-500, static |
| observer   | 100–499   | teal-500, static |
| naturalist | 500–999   | amber-500, static |
| expert     | 1000–4999 | sky-500 + motion-safe pulse |
| master     | 5000–9999 | yellow-400 + glow + pulse |
| legend     | 10000+    | fuchsia-500 + glow + custom animation |

All animations are wrapped in `motion-safe:` Tailwind variants so users with `prefers-reduced-motion` get a static ring.

## What ships

- `src/lib/karma-frame.ts` — `tierForKarma(total)` + tier table (12 unit tests).
- `src/components/profile/KarmaFrame.astro` — reusable wrapper component (`karmaTotal` / `src` / `alt` / `size?`).
- `src/components/ProfileView.astro` — wired the signed-in own-profile avatar (MVP consumer).
- `tailwind.config.mjs` — safelisted ring/glow/animation classes; added `rastrum-legend-spin` keyframes.
- `src/i18n/{en,es}.json` — `karma.tier.*` strings (name + description per tier).

## v1.1 follow-up surfaces (separate PRs)

- `PublicProfileViewV2.astro` (public profile avatar)
- Header avatar
- MyObs observation cards
- Leaderboard rows
- Community observers list

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run test` — 1459/1459 pass (12 new for `tierForKarma`)
- [x] `npm run build` — 241 pages, ring/animation classes present in built CSS
- [ ] Visual check on staging once deployed: signed-in profile shows the right ring, no animation under reduced-motion preference

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)