### PR TITLE
fix(profile): correct watchlist table name + user_expertise taxon count (#698 #699 #700)

### DIFF
--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -378,9 +378,9 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
     if (statObs)   statObs.textContent   = String(stats?.total_observations ?? profile.observation_count ?? 0);
     if (statStreak) statStreak.textContent = String(stats?.current_streak ?? 0);
 
-    // Watchlist count
+    // Watchlist count — table is 'watchlists' (not 'watchlist_entries', fixes #698)
     const { count: watchlistCount } = await supabase
-      .from('watchlist_entries')
+      .from('watchlists')
       .select('*', { count: 'exact', head: true })
       .eq('user_id', user.id);
     if (statWatchlist) statWatchlist.textContent = String(watchlistCount ?? 0);
@@ -392,11 +392,12 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
         const DISMISS_KEY = 'rastrum.profile.expertPromptDismissed';
         const dismissed = sessionStorage.getItem(DISMISS_KEY) === '1';
 
-        const { data: expertiseRow } = await supabase
+        // Count distinct taxa rows for this user — user_expertise has no taxon_count
+        // column; the count of rows IS the taxon diversity metric (fixes #699)
+        const { count: userTaxonCount } = await supabase
           .from('user_expertise')
-          .select('taxon_count')
-          .eq('user_id', user.id)
-          .maybeSingle<{ taxon_count: number }>();
+          .select('*', { count: 'exact', head: true })
+          .eq('user_id', user.id);
 
         const eligibility = evaluateExpertEligibility(
           {
@@ -404,7 +405,7 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
             is_expert: profile.is_expert ?? false,
             expert_application_status: (profile as unknown as { expert_application_status?: string | null }).expert_application_status as 'pending' | 'approved' | 'rejected' | null,
           },
-          { taxon_count: expertiseRow?.taxon_count ?? 0 },
+          { taxon_count: userTaxonCount ?? 0 },
         );
 
         const promptEl  = document.getElementById('expert-prompt');


### PR DESCRIPTION
## Scope shipped

### #698 — watchlist HEAD 404 on Android Chrome
The client called `.from('watchlist_entries')` but the table in the schema is `watchlists`. PostgREST returns 404 on HEAD for unknown tables. Fixed: rename to `.from('watchlists')`.

### #699 — user_expertise 400: taxon_count column missing
`user_expertise` schema has `(user_id, taxon_id, score, verified_at, verified_by, updated_at)` — no `taxon_count` column. The old code used `.select('taxon_count').maybeSingle()`, which PostgREST rejects with 400. Fixed: replaced with `.select('*', {count:'exact',head:true})` and passed `count` as `taxon_count` to `evaluateExpertEligibility()`. This is semantically correct because the count of distinct `user_expertise` rows for a user equals their distinct-taxa score.

### #700 — order param truncated
Confirmed already correct in the codebase: `.order('observed_at', {ascending:false})`. Closing as fixed, no code change needed.

## Files changed
- `src/components/ProfileView.astro` — 2 surgical patches, lines 382-384 and 394-399

## Test plan
- `npx tsc --noEmit`: no new errors (3 pre-existing `@huggingface/transformers` errors in baseline)
- `npm run test`: 1486 passed, 4 pre-existing gemma-vision failures (same as `main`)
- Manual: load /es/perfil/ on Android Chrome → no 404, no 400 in network tab

## v1.1.x follow-up
- #698 v1.1: add RLS smoke test for `watchlists` table in CI
- #699 v1.1: consider adding `taxon_count` as a generated/materialized column to `user_expertise` if the count query becomes a hotspot