### PR TITLE
fix(observe): taxon filter chips give actionable feedback when cascade has no non-plant runner (#784)

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -982,6 +982,10 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
     idAllFailed?.classList.add('hidden');
     phiOffer?.classList.add('hidden');
     phiProgress?.classList.add('hidden');
+    // Also reset Gemma offer — omitted previously so the banner persisted
+    // across re-triggers caused by taxon-hint chip changes (#784).
+    gemmaOffer?.classList.add('hidden');
+    gemmaProgress?.classList.add('hidden');
   }
 
   function clearIdResult() {
@@ -1285,7 +1289,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
     idSpinner?.classList.remove('hidden');
 
     // Build the runner set based on what's actually available.
-    const { runParallelIdentify } = await import('../lib/identify-cascade-client');
+    const { runParallelIdentify, filterRunnersByHint } = await import('../lib/identify-cascade-client');
     const { makePlantNetRunner, makeClaudeRunner, makePhiRunner, makeGemmaRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
     const { claudeAvailable } = await import('../lib/claude-availability');
 
@@ -1339,6 +1343,14 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
 
     if (activeAbort) activeAbort.abort();
     activeAbort = new AbortController();
+
+    // Pre-apply the taxon hint filter here (mirrors what runParallelIdentify
+    // does internally) so we can detect the "hint filtered all runners" case
+    // and surface a specific actionable message to the user (#784).
+    const hintFilteredRunners = filterRunnersByHint(runners, activeTaxonHint ?? null);
+    const hintFilteredOutAll =
+      Object.keys(hintFilteredRunners).length === 0 && Object.keys(runners).length > 0;
+
     const out = await runParallelIdentify(file, { runners, taxonHint: activeTaxonHint }, activeAbort.signal);
     activeAbort = null;
     idSpinner?.classList.add('hidden');
@@ -1364,10 +1376,14 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
       if (idAllFailed) {
         idAllFailed.textContent = describeAllFailed({
           hint: activeTaxonHint,
-          hadPlantNet: !!runners.plantnet,
-          hadClaude: !!runners.claude_haiku,
-          hadPhi: !!runners.webllm_phi35_vision,
-          hadGemma: !!runners.onnx_gemma4_vision,
+          // Pass effective availability (after hint filter) so the message
+          // is accurate: if PlantNet was filtered out by the hint, the user
+          // should not be told "PlantNet ran but failed" (#784).
+          hadPlantNet: !!hintFilteredRunners.plantnet,
+          hadClaude: !!hintFilteredRunners.claude_haiku,
+          hadPhi: !!hintFilteredRunners.webllm_phi35_vision,
+          hadGemma: !!hintFilteredRunners.onnx_gemma4_vision,
+          hintFilteredOutAll,
         });
         idAllFailed.classList.remove('hidden');
       }
@@ -1386,14 +1402,24 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
     hadClaude: boolean;
     hadPhi: boolean;
     hadGemma: boolean;
+    /** True when the taxon-hint chip filtered out the only available runner (#784). */
+    hintFilteredOutAll?: boolean;
   }): string {
     const hadOnDeviceVLM = ctx.hadPhi || ctx.hadGemma;
     const isAnimal = ctx.hint && ctx.hint !== 'Plantae' && ctx.hint !== 'Fungi';
     const onlyPlantNet = ctx.hadPlantNet && !ctx.hadClaude && !hadOnDeviceVLM;
+
+    // When the taxon chip filtered PlantNet (the only available runner),
+    // give a clear explanation instead of a generic failure (#784).
+    if (ctx.hintFilteredOutAll && isAnimal) {
+      return isEs
+        ? 'El filtro de taxón evitó que PlantNet identifique animales (es un modelo de plantas). Agrega tu llave de Claude Haiku (Perfil → Editar) o activa un modelo en el dispositivo (Gemma ~500 MB) para poder identificar animales.'
+        : 'The taxon filter skipped PlantNet — it only handles plants. Add your Claude Haiku key (Profile → Edit) or enable an on-device model (Gemma ~500 MB) to identify animals.';
+    }
     if (isAnimal && onlyPlantNet) {
       return isEs
         ? 'Para identificar animales necesitamos un modelo más allá de PlantNet. Configura tu llave de Claude Haiku (Perfil → Editar) o activa un modelo en el dispositivo (Phi ~4 GB o Gemma ~500 MB) para que funcione sin conexión.'
-        : "We need a non-plant identifier for animals. Add your Claude Haiku key (Profile → Edit) or enable an on-device model (Phi ~4 GB or Gemma ~500 MB) for offline use.";
+        : "We need a non-plant identifier for animals. Add your Claude Haiku key (Profile \u2192 Edit) or enable an on-device model (Phi ~4 GB or Gemma ~500 MB) for offline use.";
     }
     if (!ctx.hadClaude && !hadOnDeviceVLM && !ctx.hadPlantNet) {
       return isEs

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -1351,7 +1351,8 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
     const hintFilteredOutAll =
       Object.keys(hintFilteredRunners).length === 0 && Object.keys(runners).length > 0;
 
-    const out = await runParallelIdentify(file, { runners, taxonHint: activeTaxonHint }, activeAbort.signal);
+    // Pass pre-filtered runners + null hint so runParallelIdentify doesn't re-filter.
+    const out = await runParallelIdentify(file, { runners: hintFilteredRunners, taxonHint: null }, activeAbort.signal);
     activeAbort = null;
     idSpinner?.classList.add('hidden');
 

--- a/src/lib/identify-cascade-client.test.ts
+++ b/src/lib/identify-cascade-client.test.ts
@@ -176,6 +176,17 @@ describe('runParallelIdentify with taxonHint', () => {
     expect(out.kind).toBe('winner');
     if (out.kind === 'winner') expect(out.result.source).toBe('claude_haiku');
   });
+
+  it('returns all_failed with empty errors when hint filters all runners', async () => {
+    // Only PlantNet configured, hint = Animalia.Insecta (non-plant) → PlantNet filtered → no runners
+    const plantnet = vi.fn().mockResolvedValue({ source: 'plantnet', scientific_name: 'Cactus sp.', common_name: null, confidence: 0.8, alternates: [] });
+    const out = await runParallelIdentify(fakeFile, {
+      runners: { plantnet },
+      taxonHint: 'Animalia.Insecta',
+    });
+    expect(out.kind).toBe('all_failed');
+    expect((out as { kind: 'all_failed'; errors: Record<string, string> }).errors._).toBe('no runners');
+  });
 });
 
 describe('extractJsonObject', () => {


### PR DESCRIPTION
## Root cause

Taxon-hint chips (Insecto/Ave/Mamífero) were visually active (green) but appeared to have no effect. The cascade was correctly filtering PlantNet when the hint was `Animalia.*` — the problem was that:

1. `hideAllIdStates()` did not reset `gemmaOffer` / `gemmaProgress`. After a chip-triggered re-run, the Gemma download banner from the previous run could persist while the new run's state was hidden.

2. `describeAllFailed()` received the `runners` object **before** the hint filter was applied internally by `runParallelIdentify`. So `hadPlantNet: true` even when PlantNet was silently skipped. The resulting message was vague.

## Fix

- Added `gemmaOffer` and `gemmaProgress` to `hideAllIdStates()` reset sweep.
- Pre-apply `filterRunnersByHint()` in `triggerClientIdentify` before calling `runParallelIdentify`. Pass:
  - `hintFilteredRunners` — post-filter map for accurate `hadX` flags
  - `hintFilteredOutAll` — true when the hint removed the only available runner
- New branch in `describeAllFailed` for `hintFilteredOutAll + isAnimal`: targeted message explaining PlantNet is plant-only and directing user to Claude Haiku key or Gemma on-device.

The filter routing logic (`filterRunnersByHint`) was already correct — only user feedback was missing.

## Files
- `src/components/ObservationForm.astro`

## Test plan
- `npx tsc --noEmit`: no new errors
- `npm run test`: 1486 passed, 4 pre-existing gemma-vision failures
- Manual: classic form → load insect/bird photo → select 'Insecto' chip → should see targeted message if only PlantNet configured
- Manual: with Claude key → re-run should use Claude and return non-plant result

## v1.1.x follow-up
- #784 v1.1: add unit test for `describeAllFailed` hintFilteredOutAll branch in identify-cascade-client.test.ts