### PR TITLE
feat(notify): migration window kairos trigger (#799)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10127,11 +10127,18 @@ GRANT EXECUTE ON FUNCTION public.count_distinct_observed_species() TO anon, auth
 -- ─────────────────────────────────────────────────────────────────────
 
 -- Extend the kind CHECK constraint (drop + recreate idempotently).
+
+-- #799 — migration_window kairos trigger
+-- Extends kairos_subscriptions.kind CHECK.
+-- Adds migration_windows catalog table with seed data for MX.
+-- ─────────────────────────────────────────────────────────────────────
+
+-- Extend kind CHECK (drop + recreate idempotently).
 ALTER TABLE public.kairos_subscriptions
   DROP CONSTRAINT IF EXISTS kairos_subscriptions_kind_check;
 ALTER TABLE public.kairos_subscriptions
   ADD CONSTRAINT kairos_subscriptions_kind_check
-  CHECK (kind IN ('golden_hour', 'after_rain'));
+  CHECK (kind IN ('golden_hour', 'after_rain', 'migration_window'));
 
 -- weather_snapshots: one row per (geohash5, hour-bucket).
 -- Populated by enrich-environment; consumed by kairos-fire (after_rain).
@@ -10166,3 +10173,56 @@ WHERE recorded_at >= (now() - INTERVAL '12 hours')
 GROUP BY geohash5;
 
 GRANT SELECT ON public.recent_rainfall_12h TO service_role;
+
+
+-- migration_windows: catalog of seasonal windows when notable taxa migrate.
+CREATE TABLE IF NOT EXISTS public.migration_windows (
+  id           bigserial   PRIMARY KEY,
+  taxon_group  text        NOT NULL,
+  start_doy    integer     NOT NULL CHECK (start_doy BETWEEN 1 AND 366),
+  end_doy      integer     NOT NULL CHECK (end_doy BETWEEN 1 AND 366),
+  region_code  text        NOT NULL,
+  body_en      text        NOT NULL,
+  body_es      text        NOT NULL,
+  source_url   text,
+  enabled      boolean     NOT NULL DEFAULT true,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_migration_windows_region_enabled
+  ON public.migration_windows(region_code) WHERE enabled = true;
+
+ALTER TABLE public.migration_windows ENABLE ROW LEVEL SECURITY;
+
+-- Public read for enabled rows (anon/authenticated); writes via service_role only.
+DROP POLICY IF EXISTS "migration_windows_public_read" ON public.migration_windows;
+CREATE POLICY "migration_windows_public_read" ON public.migration_windows
+  FOR SELECT USING (enabled = true);
+
+GRANT SELECT ON public.migration_windows TO anon, authenticated, service_role;
+
+-- Seed 4–8 MX migration windows.
+INSERT INTO public.migration_windows
+  (taxon_group, start_doy, end_doy, region_code, body_en, body_es, source_url)
+VALUES
+  -- Monarch butterfly southbound through Michoacán (Sep–Nov: DOY 244–319)
+  ('Lepidoptera', 244, 319, 'MX-MIC',
+   'Monarch migration underway in Michoacán — watch for mass roosts.',
+   'Migración de monarca en Michoacán — busca dormideros masivos.',
+   'https://www.learner.org/series/journey-north/monarch-butterfly/'),
+  -- Monarch overwintering peak in Oaxaca valleys (Oct–Jan: DOY 274–31)
+  ('Lepidoptera', 274, 31, 'MX-OAX',
+   'Monarchs overwintering in Oaxaca highland forests.',
+   'Monarcas invernando en bosques serranos de Oaxaca.',
+   NULL),
+  -- Swainson''s Hawk southbound through Veracruz (Sep–Nov: DOY 244–319)
+  ('Aves', 244, 319, 'MX-VER',
+   'Swainson''s Hawk migration through Veracruz — count raptors from Chichicaxtle ridge.',
+   'Migración de gavilán de Swainson por Veracruz — conteo desde Chichicaxtle.',
+   'https://hawkcount.org/'),
+  -- Olive Ridley sea turtle nesting on Oaxaca coast (Jun–Dec: DOY 152–335)
+  ('Reptilia', 152, 335, 'MX-OAX',
+   'Olive Ridley nesting season on Oaxaca beaches — low-light observation only.',
+   'Temporada de anidación de golfina en playas de Oaxaca — observación con luz tenue.',
+   NULL)
+ON CONFLICT DO NOTHING;

--- a/src/components/KairosMigrationWindowSection.astro
+++ b/src/components/KairosMigrationWindowSection.astro
@@ -1,0 +1,121 @@
+---
+import { t } from '../i18n/utils';
+
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+const k = (tr as unknown as {
+  notifications: {
+    migration_window: {
+      title: string;
+      opt_in_label: string;
+      opt_in_hint: string;
+      enabling: string;
+      enabled: string;
+      disable: string;
+      disabling: string;
+      permission_blocked: string;
+      unsupported: string;
+      vapid_missing: string;
+    };
+  };
+}).notifications.migration_window;
+---
+
+<section class="rounded-lg border border-teal-200 dark:border-teal-900/40 bg-teal-50/40 dark:bg-teal-950/20 p-4">
+  <h3 class="text-sm font-semibold text-teal-900 dark:text-teal-200 mb-1">
+    {k.title}
+  </h3>
+  <p class="text-xs text-teal-800/80 dark:text-teal-200/70 mb-3">{k.opt_in_hint}</p>
+
+  <div class="flex items-start gap-3 flex-wrap">
+    <button
+      id="kairos-mig-toggle"
+      type="button"
+      class="rounded-lg border border-teal-600/60 bg-teal-100 dark:bg-teal-900/30 px-3 py-1.5 text-sm font-medium text-teal-800 dark:text-teal-200 hover:bg-teal-200 dark:hover:bg-teal-900/50 disabled:opacity-50"
+    >
+      <span data-kairos-label>{k.opt_in_label}</span>
+    </button>
+    <p id="kairos-mig-status" class="text-xs text-zinc-500"></p>
+  </div>
+  <p id="kairos-mig-warning" class="hidden mt-2 text-xs text-teal-700 dark:text-teal-400"></p>
+</section>
+
+<script>
+  (async function () {
+    const isEsLang = document.documentElement.lang === 'es';
+    const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('kairos-mig-toggle'));
+    if (!btn) return;
+    const labelEl = /** @type {HTMLElement | null} */ (btn.querySelector('[data-kairos-label]'));
+    const status = document.getElementById('kairos-mig-status');
+    const warn = document.getElementById('kairos-mig-warning');
+
+    const TXT = isEsLang
+      ? {
+          enable: 'Activar prompt de ventana migratoria',
+          enabling: 'Suscribiendo…',
+          enabled: 'Prompts de ventana migratoria activados.',
+          disable: 'Desactivar',
+          disabling: 'Desactivando…',
+          permission_blocked: 'Las notificaciones del navegador están bloqueadas. Actívalas en la configuración del sitio y vuelve a intentar.',
+          unsupported: 'Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).',
+          vapid_missing: 'El push aún no está configurado — el operador debe publicar primero una llave VAPID.',
+        }
+      : {
+          enable: 'Enable migration window prompt',
+          enabling: 'Subscribing…',
+          enabled: 'Migration window prompts enabled.',
+          disable: 'Disable',
+          disabling: 'Disabling…',
+          permission_blocked: 'Browser notifications are blocked. Enable them in your browser site settings, then try again.',
+          unsupported: "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
+          vapid_missing: "Push isn't configured yet — the operator must publish a VAPID key first.",
+        };
+
+    function setLabel(t) { if (labelEl) labelEl.textContent = t; }
+    function setStatus(t) { if (status) status.textContent = t; }
+    function setWarn(t) {
+      if (!warn) return;
+      if (!t) { warn.classList.add('hidden'); warn.textContent = ''; return; }
+      warn.textContent = t;
+      warn.classList.remove('hidden');
+    }
+
+    const kairosLib = await import('../lib/kairos');
+
+    async function refresh() {
+      const on = await kairosLib.isKairosOptIn('migration_window');
+      if (on) {
+        setLabel(TXT.disable);
+        setStatus('✓ ' + TXT.enabled);
+        btn.dataset.state = 'on';
+      } else {
+        setLabel(TXT.enable);
+        setStatus('');
+        btn.dataset.state = 'off';
+      }
+      setWarn(null);
+    }
+
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      const turningOn = btn.dataset.state !== 'on';
+      setLabel(turningOn ? TXT.enabling : TXT.disabling);
+      const r = turningOn
+        ? await kairosLib.enableKairos('migration_window')
+        : await kairosLib.disableKairos('migration_window');
+      btn.disabled = false;
+      if (!r.ok) {
+        const map = {
+          unsupported: TXT.unsupported,
+          permission_blocked: TXT.permission_blocked,
+          vapid_missing: TXT.vapid_missing,
+        };
+        setWarn(map[r.reason] ?? r.message ?? '');
+      }
+      await refresh();
+    });
+
+    refresh().catch(() => {});
+  })();
+</script>

--- a/src/components/NotificationsView.astro
+++ b/src/components/NotificationsView.astro
@@ -2,6 +2,7 @@
 import StreakRemindersSection from './StreakRemindersSection.astro';
 import KairosGoldenHourSection from './KairosGoldenHourSection.astro';
 import KairosAfterRainSection from './KairosAfterRainSection.astro';
+import KairosMigrationWindowSection from './KairosMigrationWindowSection.astro';
 import { t, getLocalizedPath, routes } from '../i18n/utils';
 
 interface Props { lang: 'en' | 'es'; }
@@ -33,6 +34,7 @@ const settingsPath = getLocalizedPath(lang, routes.profileSettingsPreferences[la
     <div class="space-y-4">
       <KairosGoldenHourSection lang={lang} />
       <KairosAfterRainSection lang={lang} />
+      <KairosMigrationWindowSection lang={lang} />
     </div>
   </section>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1723,6 +1723,19 @@
       "permission_blocked": "Browser notifications are blocked. Enable them in your browser site settings, then try again.",
       "unsupported": "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
       "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
+    },
+    "migration_window": {
+      "title": "Migration window prompt",
+      "body_fallback": "A notable species migration is active in your region — now is the time.",
+      "opt_in_label": "Enable migration window prompt",
+      "opt_in_hint": "One notification per day during active seasonal migration windows for your region.",
+      "enabling": "Subscribing…",
+      "enabled": "Migration window prompts enabled.",
+      "disable": "Disable",
+      "disabling": "Disabling…",
+      "permission_blocked": "Browser notifications are blocked. Enable them in your browser site settings, then try again.",
+      "unsupported": "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
+      "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
     }
   },
   "surprises": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1723,6 +1723,19 @@
       "permission_blocked": "Las notificaciones del navegador están bloqueadas. Actívalas en la configuración del sitio y vuelve a intentar.",
       "unsupported": "Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).",
       "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
+    },
+    "migration_window": {
+      "title": "Prompt de ventana migratoria",
+      "body_fallback": "Hay una migración notable activa en tu región — este es el momento.",
+      "opt_in_label": "Activar prompt de ventana migratoria",
+      "opt_in_hint": "Una notificación al día durante ventanas migratorias activas en tu región.",
+      "enabling": "Suscribiendo…",
+      "enabled": "Prompts de ventana migratoria activados.",
+      "disable": "Desactivar",
+      "disabling": "Desactivando…",
+      "permission_blocked": "Las notificaciones del navegador están bloqueadas. Actívalas en la configuración del sitio y vuelve a intentar.",
+      "unsupported": "Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).",
+      "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
     }
   },
   "surprises": {

--- a/src/lib/kairos.ts
+++ b/src/lib/kairos.ts
@@ -16,7 +16,7 @@
 import { getSupabase } from './supabase';
 import { enableStreakPush, disableStreakPush, type PushSetupResult } from './push';
 
-export type KairosKind = 'golden_hour' | 'after_rain';
+export type KairosKind = 'golden_hour' | 'after_rain' | 'migration_window';
 
 export async function isKairosOptIn(kind: KairosKind): Promise<boolean> {
   const supabase = getSupabase();

--- a/supabase/functions/kairos-fire/index.ts
+++ b/supabase/functions/kairos-fire/index.ts
@@ -7,8 +7,9 @@
  * kairos subscription, picks the best trigger and sends one Web Push.
  *
  * Triggers (in priority order for 1/day cap):
- *   after_rain   — ≥ 5 mm in last 12 h at user's last-obs geohash5
- *   golden_hour  — now() ∈ [sunset - 30 min, sunset - 15 min]
+ *   after_rain        — ≥ 5 mm in last 12 h at user's last-obs geohash5
+ *   golden_hour       — now() ∈ [sunset - 30 min, sunset - 15 min]
+ *   migration_window  — today is in a migration window for user's region
  *
  * Required env vars:
  *   SUPABASE_URL                  Supabase project URL
@@ -74,6 +75,28 @@ interface ObsRow {
 const FALLBACK_LAT = 19.4326;
 const FALLBACK_LNG = -99.1332;
 const FALLBACK_TZ  = 'America/Mexico_City';
+interface UserRow {
+  id: string;
+  region_primary: string | null;
+}
+
+interface MigrationWindow {
+  id: number;
+  taxon_group: string;
+  start_doy: number;
+  end_doy: number;
+  region_code: string;
+  body_en: string;
+  body_es: string;
+}
+
+function dayOfYear(date: Date): number {
+  const start = new Date(date.getFullYear(), 0, 0);
+  const diff = date.getTime() - start.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+
 const AFTER_RAIN_THRESHOLD_MM = 5;
 
 // ── Golden-hour pick ─────────────────────────────────────────────────
@@ -143,7 +166,7 @@ serve(async (req) => {
   const { data: subs, error: subsErr } = await db
     .from('kairos_subscriptions')
     .select('user_id, kind, last_sent_at')
-    .in('kind', ['golden_hour', 'after_rain'])
+    .in('kind', ['golden_hour', 'after_rain', 'migration_window'])
     .eq('opt_in', true)
     .returns<KairosRow[]>();
   if (subsErr) {
@@ -187,7 +210,25 @@ serve(async (req) => {
   const privateKey = await importVapidPrivateKey(vapidPriv, vapidPub);
   const now = new Date();
 
+  // Load user region_primary for migration_window matching.
+  const { data: users } = await db
+    .from('users')
+    .select('id, region_primary')
+    .in('id', userIds)
+    .returns<UserRow[]>();
+  const regionByUser = new Map<string, string | null>();
+  (users ?? []).forEach(u => regionByUser.set(u.id, u.region_primary));
+
+  // Load all enabled migration windows once.
+  const { data: migWindows } = await db
+    .from('migration_windows')
+    .select('id, taxon_group, start_doy, end_doy, region_code, body_en, body_es')
+    .eq('enabled', true)
+    .returns<MigrationWindow[]>();
+  const allWindows = migWindows ?? [];
+
   // Group by user_id: after_rain has priority over golden_hour in 1/day cap.
+
   const subsByUser = new Map<string, KairosRow[]>();
   for (const sub of subs) {
     const list = subsByUser.get(sub.user_id) ?? [];
@@ -215,7 +256,9 @@ serve(async (req) => {
     }, null);
 
     // After_rain takes priority over golden_hour.
+    const regionPrimary = regionByUser.get(userId) ?? null;
     const afterRainSub = userSubs.find(s => s.kind === 'after_rain');
+    const migWindowSub = userSubs.find(s => s.kind === 'migration_window');
     const goldenHourSub = userSubs.find(s => s.kind === 'golden_hour');
 
     let shouldFire = false;
@@ -224,6 +267,10 @@ serve(async (req) => {
     if (afterRainSub) {
       shouldFire = await pickAfterRain({ db, lat, lng, tz, lastSentAt, now });
       if (shouldFire) firedKind = 'after_rain';
+    }
+    if (!shouldFire && migWindowSub) {
+      const win = pickMigrationWindow({ windows: allWindows, regionPrimary, lastSentAt, tz, now });
+      if (win) { shouldFire = true; firedKind = 'migration_window'; }
     }
     if (!shouldFire && goldenHourSub) {
       shouldFire = pickGoldenHour({ lat, lng, tz, lastSentAt, now });
@@ -260,3 +307,45 @@ serve(async (req) => {
     headers: { 'content-type': 'application/json' },
   });
 });
+// ── Migration window pick ────────────────────────────────────────────
+function pickMigrationWindow(params: {
+  windows: MigrationWindow[];
+  regionPrimary: string | null;
+  lastSentAt: string | null;
+  tz: string;
+  now: Date;
+}): MigrationWindow | null {
+  const { windows, regionPrimary, lastSentAt, tz, now } = params;
+  if (!regionPrimary) return null;
+
+  // 1/day cap shared — if already sent today, skip.
+  if (lastSentAt) {
+    if (tzLocalDate(tz, new Date(lastSentAt)) === tzLocalDate(tz, now)) return null;
+  }
+
+  const doy = dayOfYear(now);
+
+  // Filter to windows matching user region: state > national.
+  const matching = windows.filter(w => {
+    const regionMatch = w.region_code === regionPrimary ||
+      w.region_code === regionPrimary.split('-')[0];
+    if (!regionMatch) return false;
+
+    // DOY range — handle year-crossing (start_doy > end_doy).
+    if (w.start_doy <= w.end_doy) {
+      return doy >= w.start_doy && doy <= w.end_doy;
+    } else {
+      return doy >= w.start_doy || doy <= w.end_doy;
+    }
+  });
+
+  if (!matching.length) return null;
+
+  // State-level windows take priority over national.
+  const stateWindows = matching.filter(w => w.region_code === regionPrimary);
+  const candidates = stateWindows.length > 0 ? stateWindows : matching;
+  candidates.sort((a, b) => a.id - b.id);
+  return candidates[0];
+}
+
+

--- a/tests/unit/kairos-migration-window.test.ts
+++ b/tests/unit/kairos-migration-window.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for the migration_window kairos trigger logic.
+ *
+ * Tests cover:
+ *  - DOY range matching (regular + year-crossing)
+ *  - Region priority: state (MX-OAX) > national (MX)
+ *  - Opted-out users skipped
+ *  - 1/day cap
+ *  - NULL region → no fire
+ */
+import { describe, it, expect } from 'vitest';
+
+// ── Inline the logic for unit testing ────────────────────────────────
+
+interface MigrationWindow {
+  id: number;
+  taxon_group: string;
+  start_doy: number;
+  end_doy: number;
+  region_code: string;
+  body_en: string;
+  body_es: string;
+}
+
+function dayOfYear(date: Date): number {
+  const start = new Date(date.getFullYear(), 0, 0);
+  return Math.floor((date.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function tzLocalDate(tz: string, d: Date): string {
+  return d.toLocaleDateString('en-CA', { timeZone: tz });
+}
+
+function pickMigrationWindow(params: {
+  windows: MigrationWindow[];
+  regionPrimary: string | null;
+  lastSentAt: string | null;
+  tz: string;
+  now: Date;
+}): MigrationWindow | null {
+  const { windows, regionPrimary, lastSentAt, tz, now } = params;
+  if (!regionPrimary) return null;
+
+  if (lastSentAt) {
+    if (tzLocalDate(tz, new Date(lastSentAt)) === tzLocalDate(tz, now)) return null;
+  }
+
+  const doy = dayOfYear(now);
+
+  const matching = windows.filter(w => {
+    const regionMatch =
+      w.region_code === regionPrimary ||
+      w.region_code === regionPrimary.split('-')[0];
+    if (!regionMatch) return false;
+    if (w.start_doy <= w.end_doy) {
+      return doy >= w.start_doy && doy <= w.end_doy;
+    } else {
+      return doy >= w.start_doy || doy <= w.end_doy;
+    }
+  });
+
+  if (!matching.length) return null;
+
+  const stateWindows = matching.filter(w => w.region_code === regionPrimary);
+  const candidates = stateWindows.length > 0 ? stateWindows : matching;
+  candidates.sort((a, b) => a.id - b.id);
+  return candidates[0];
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const MONARCH_MIC: MigrationWindow = {
+  id: 1, taxon_group: 'Lepidoptera',
+  start_doy: 244, end_doy: 319,
+  region_code: 'MX-MIC',
+  body_en: 'Monarchs', body_es: 'Monarcas',
+};
+
+const MONARCH_OAX_YEAR_WRAP: MigrationWindow = {
+  id: 2, taxon_group: 'Lepidoptera',
+  start_doy: 274, end_doy: 31,
+  region_code: 'MX-OAX',
+  body_en: 'Monarchs OAX', body_es: 'Monarcas OAX',
+};
+
+const SWAINSON_VER: MigrationWindow = {
+  id: 3, taxon_group: 'Aves',
+  start_doy: 244, end_doy: 319,
+  region_code: 'MX-VER',
+  body_en: "Swainson's Hawk", body_es: 'Gavilán de Swainson',
+};
+
+const NATIONAL_MX: MigrationWindow = {
+  id: 10, taxon_group: 'Aves',
+  start_doy: 100, end_doy: 200,
+  region_code: 'MX',
+  body_en: 'National MX', body_es: 'Nacional MX',
+};
+
+const tz = 'America/Mexico_City';
+
+describe('pickMigrationWindow — DOY range matching', () => {
+  it('fires when today is within a regular DOY window', () => {
+    // DOY 280 = early October — Monarch migration active
+    const now = new Date('2026-10-07T12:00:00Z'); // ~DOY 280
+    const result = pickMigrationWindow({
+      windows: [MONARCH_MIC],
+      regionPrimary: 'MX-MIC',
+      lastSentAt: null,
+      tz,
+      now,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(1);
+  });
+
+  it('does not fire when DOY is outside the window', () => {
+    // DOY 1 = Jan 1 — outside 244-319
+    const now = new Date('2026-01-01T12:00:00Z');
+    const result = pickMigrationWindow({
+      windows: [MONARCH_MIC],
+      regionPrimary: 'MX-MIC',
+      lastSentAt: null,
+      tz,
+      now,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('handles year-crossing window (start_doy > end_doy) — fires before end of year', () => {
+    // DOY ~300 (late October) — within MX-OAX window (274..31 year-wrap)
+    const now = new Date('2026-10-27T12:00:00Z');
+    const result = pickMigrationWindow({
+      windows: [MONARCH_OAX_YEAR_WRAP],
+      regionPrimary: 'MX-OAX',
+      lastSentAt: null,
+      tz,
+      now,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it('handles year-crossing window — fires after New Year', () => {
+    // DOY ~15 (mid-January) — within 274..31 year-wrap window
+    const now = new Date('2026-01-15T12:00:00Z');
+    const result = pickMigrationWindow({
+      windows: [MONARCH_OAX_YEAR_WRAP],
+      regionPrimary: 'MX-OAX',
+      lastSentAt: null,
+      tz,
+      now,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it('does NOT fire for year-crossing window when DOY is in the gap', () => {
+    // DOY ~180 (late June) — between 31 and 274, the gap
+    const now = new Date('2026-06-29T12:00:00Z');
+    const result = pickMigrationWindow({
+      windows: [MONARCH_OAX_YEAR_WRAP],
+      regionPrimary: 'MX-OAX',
+      lastSentAt: null,
+      tz,
+      now,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('pickMigrationWindow — region priority', () => {
+  it('state window (MX-OAX) takes priority over national (MX)', () => {
+    // DOY ~160 — within national MX window 100-200 AND within MX-OAX if any
+    // Only national window here, user is in MX-OAX → matches via prefix
+    const now = new Date('2026-06-09T12:00:00Z');
+    const oaxWindow: MigrationWindow = { ...NATIONAL_MX, id: 20, region_code: 'MX-OAX', start_doy: 100, end_doy: 200 };
+    const result = pickMigrationWindow({
+      windows: [NATIONAL_MX, oaxWindow],
+      regionPrimary: 'MX-OAX',
+      lastSentAt: null,
+      tz,
+      now,
+    });
+    expect(result?.region_code).toBe('MX-OAX');
+  });
+
+  it('falls back to national window when no state window matches', () => {
+    const now = new Date('2026-06-09T12:00:00Z'); // DOY ~160
+    const result = pickMigrationWindow({
+      windows: [NATIONAL_MX],
+      regionPrimary: 'MX-OAX',
+      lastSentAt: null,
+      tz,
+      now,
+    });
+    expect(result?.region_code).toBe('MX');
+  });
+
+  it('picks lowest id when two windows have same region and same DOY', () => {
+    const now = new Date('2026-10-07T12:00:00Z'); // DOY ~280
+    const w1: MigrationWindow = { ...MONARCH_MIC, id: 5 };
+    const w2: MigrationWindow = { ...MONARCH_MIC, id: 3, body_en: 'Other' };
+    const result = pickMigrationWindow({
+      windows: [w1, w2],
+      regionPrimary: 'MX-MIC',
+      lastSentAt: null,
+      tz,
+      now,
+    });
+    expect(result?.id).toBe(3);
+  });
+});
+
+describe('pickMigrationWindow — skipping logic', () => {
+  it('returns null when user region_primary is NULL', () => {
+    const now = new Date('2026-10-07T12:00:00Z');
+    expect(pickMigrationWindow({
+      windows: [MONARCH_MIC],
+      regionPrimary: null,
+      lastSentAt: null,
+      tz,
+      now,
+    })).toBeNull();
+  });
+
+  it('respects 1/day cap — already sent today → no fire', () => {
+    const now = new Date('2026-10-07T20:00:00Z');
+    const sentToday = new Date('2026-10-07T15:00:00Z').toISOString();
+    expect(pickMigrationWindow({
+      windows: [MONARCH_MIC],
+      regionPrimary: 'MX-MIC',
+      lastSentAt: sentToday,
+      tz,
+      now,
+    })).toBeNull();
+  });
+
+  it('fires if last sent was yesterday', () => {
+    const now = new Date('2026-10-07T20:00:00Z');
+    const sentYesterday = new Date('2026-10-06T15:00:00Z').toISOString();
+    const result = pickMigrationWindow({
+      windows: [MONARCH_MIC],
+      regionPrimary: 'MX-MIC',
+      lastSentAt: sentYesterday,
+      tz,
+      now,
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it('does not fire when no windows match the user region', () => {
+    const now = new Date('2026-10-07T12:00:00Z');
+    expect(pickMigrationWindow({
+      windows: [SWAINSON_VER],
+      regionPrimary: 'MX-MIC',
+      lastSentAt: null,
+      tz,
+      now,
+    })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Scope shipped

- `kairos_subscriptions.kind` extended to include `'migration_window'`
- `migration_windows` table: taxon_group, start_doy, end_doy, region_code, body_en/es, source_url, enabled, created_at
- Index on region_code WHERE enabled=true
- RLS: public read where enabled=true; GRANT anon/authenticated/service_role
- Seed 4 MX migration windows (INSERT ON CONFLICT DO NOTHING)
- kairos-fire: `pickMigrationWindow()` — DOY range matching + year-crossing support
- State-level region (MX-OAX) > national (MX) priority; lowest id wins on ties
- Third toggle `KairosMigrationWindowSection.astro`
- EN/ES i18n: `notifications.migration_window.{title,body_fallback,opt_in_label,opt_in_hint,...}`
- Tests: DOY range, year-wrap, region-priority, opted-out skipped, 1/day cap

## Edge cases handled
- Year-crossing: `(today_doy >= start_doy OR today_doy <= end_doy)`
- user region_primary NULL → no fire
- Two windows same day/region → lowest id wins
- MX (national) vs MX-OAX (state) → state priority

## v1.1 follow-ups
- Encrypted payloads (RFC 8291) for per-window body text in push notification