### PR TITLE
fix(discover): month-boundary bug in suggest_nearby_species SQL + media index (#876 followup)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10104,6 +10104,14 @@ $$;
 -- Returns up to 10 species the viewer could find nearby that they
 -- haven't observed yet, ranked by nearby platform activity.
 -- ============================================================
+
+-- Supporting index: speeds up the correlated photo_url subquery inside
+-- suggest_nearby_species. Covers the common access pattern:
+-- media_files WHERE observation_id = X AND is_primary = true.
+CREATE INDEX IF NOT EXISTS idx_media_files_obs_primary
+  ON public.media_files(observation_id, is_primary)
+  WHERE is_primary = true;
+
 CREATE OR REPLACE FUNCTION public.suggest_nearby_species(
   p_user_id   uuid,
   p_lat       double precision,
@@ -10142,7 +10150,13 @@ RETURNS TABLE (
             ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
             p_radius_km * 1000
           )
-      AND EXTRACT(MONTH FROM o.observed_at) BETWEEN p_month - 1 AND p_month + 1
+      AND EXTRACT(MONTH FROM o.observed_at) = ANY(
+            ARRAY[
+              ((p_month - 2 + 12) % 12) + 1,
+              p_month,
+              (p_month % 12) + 1
+            ]
+          )
       AND i.taxon_id IS NOT NULL
       AND i.taxon_id NOT IN (SELECT taxon_id FROM user_observed)
     GROUP BY i.taxon_id

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10098,3 +10098,75 @@ EXCEPTION WHEN insufficient_privilege THEN
   RAISE NOTICE 'apply role cannot CREATE POLICY on spatial_ref_sys; advisor entry will persist.';
 END
 $$;
+
+-- ============================================================
+-- #710 — observation suggestions (location + season + not-yet-observed)
+-- Returns up to 10 species the viewer could find nearby that they
+-- haven't observed yet, ranked by nearby platform activity.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.suggest_nearby_species(
+  p_user_id   uuid,
+  p_lat       double precision,
+  p_lng       double precision,
+  p_month     integer,          -- 1–12 (current month, caller-supplied)
+  p_radius_km integer DEFAULT 50,
+  p_limit     integer DEFAULT 10
+)
+RETURNS TABLE (
+  taxon_id        uuid,
+  scientific_name text,
+  common_name_es  text,
+  common_name_en  text,
+  kingdom         text,
+  class           text,
+  nearby_count    bigint,
+  photo_url       text
+) LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  WITH user_observed AS (
+    SELECT DISTINCT i.taxon_id
+    FROM observations o
+    JOIN identifications i ON i.observation_id = o.id AND i.is_primary
+    WHERE o.observer_id = p_user_id
+      AND i.taxon_id IS NOT NULL
+  ),
+  nearby AS (
+    SELECT
+      i.taxon_id,
+      count(*) AS nearby_count
+    FROM observations o
+    JOIN identifications i ON i.observation_id = o.id AND i.is_primary
+    WHERE o.sync_status = 'synced'
+      AND o.location IS NOT NULL
+      AND ST_DWithin(
+            o.location::geography,
+            ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
+            p_radius_km * 1000
+          )
+      AND EXTRACT(MONTH FROM o.observed_at) BETWEEN p_month - 1 AND p_month + 1
+      AND i.taxon_id IS NOT NULL
+      AND i.taxon_id NOT IN (SELECT taxon_id FROM user_observed)
+    GROUP BY i.taxon_id
+    ORDER BY nearby_count DESC
+    LIMIT p_limit * 3   -- oversample before joining taxa
+  )
+  SELECT
+    t.id          AS taxon_id,
+    t.scientific_name,
+    t.common_name_es,
+    t.common_name_en,
+    t.kingdom,
+    t.class,
+    n.nearby_count,
+    (SELECT mf.url FROM media_files mf
+       JOIN observations mo ON mo.id = mf.observation_id
+       JOIN identifications mi ON mi.observation_id = mo.id AND mi.taxon_id = t.id AND mi.is_primary
+       WHERE mf.is_primary AND mo.sync_status = 'synced'
+       LIMIT 1) AS photo_url
+  FROM nearby n
+  JOIN taxa t ON t.id = n.taxon_id
+  ORDER BY n.nearby_count DESC
+  LIMIT p_limit;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.suggest_nearby_species FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.suggest_nearby_species TO authenticated;

--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -8,6 +8,7 @@ interface Props {
 const { lang } = Astro.props;
 const tr = t(lang);
 const widgets = tr.home.widgets;
+const suggestions = widgets.suggestions;
 const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/recent/';
 ---
 
@@ -43,6 +44,32 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
     </span>
   </div>
 
+  <!-- #710 Suggestions widget (signed-in users with location only) -->
+  <div
+    class="home-widgets-suggestions hidden"
+    data-label-heading={suggestions.heading}
+    data-label-subtitle={suggestions.subtitle}
+    data-label-nearby-count-one={suggestions.nearby_count_one}
+    data-label-nearby-count-other={suggestions.nearby_count_other}
+    data-label-refresh={suggestions.refresh}
+    data-label-dismiss-aria={suggestions.dismiss_aria}
+    data-label-no-location={suggestions.no_location}
+    data-label-loading={suggestions.loading}
+    data-label-empty={suggestions.empty}
+  >
+    <div class="flex items-baseline justify-between gap-3 mb-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">{suggestions.heading}</h2>
+      <button
+        type="button"
+        class="hw-suggestions-refresh text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline"
+      >{suggestions.refresh}</button>
+    </div>
+    <p class="hw-suggestions-subtitle text-xs text-zinc-500 dark:text-zinc-400 mb-3"></p>
+    <p class="hw-suggestions-loading text-sm text-zinc-500 dark:text-zinc-400">{suggestions.loading}</p>
+    <p class="hw-suggestions-empty hidden text-sm text-zinc-500 dark:text-zinc-400">{suggestions.empty}</p>
+    <ul class="hw-suggestions-list grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-3"></ul>
+  </div>
+
   <div class="home-widgets-nearby">
     <div class="flex items-baseline justify-between gap-3 mb-3">
       <h2 class="hw-nearby-title text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">{widgets.nearby_title_local}</h2>
@@ -61,6 +88,7 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
   import { getSupabase } from '../lib/supabase';
   import { buildGreeting } from '../lib/home-greeting';
   import { formatTimeAgo } from '../lib/social';
+  import { fetchSuggestions, type SpeciesSuggestion } from '../lib/suggestions';
 
   type Lang = 'en' | 'es';
 
@@ -159,6 +187,158 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
     return name ? `${localized}, ${name}` : localized;
   }
 
+  // ── Suggestions (issue #710) ─────────────────────────────────────────────
+
+  const DISMISSED_KEY = 'rastrum.suggestions.dismissed';
+
+  function getDismissed(): Set<string> {
+    try {
+      const raw = sessionStorage.getItem(DISMISSED_KEY);
+      return raw ? new Set<string>(JSON.parse(raw)) : new Set<string>();
+    } catch {
+      return new Set<string>();
+    }
+  }
+
+  function saveDismissed(set: Set<string>): void {
+    try {
+      sessionStorage.setItem(DISMISSED_KEY, JSON.stringify([...set]));
+    } catch { /* quota exceeded — ignore */ }
+  }
+
+  function suggestionCard(s: SpeciesSuggestion, lang: Lang, sugRoot: HTMLElement): string {
+    const dismissed = getDismissed();
+    if (dismissed.has(s.taxon_id)) return '';
+
+    const countTpl = s.nearby_count === 1
+      ? (sugRoot.dataset.labelNearbyCountOne ?? '{{count}} nearby observation')
+      : (sugRoot.dataset.labelNearbyCountOther ?? '{{count}} nearby observations');
+    const countLabel = countTpl.replace('{{count}}', String(s.nearby_count));
+
+    const dismissTpl = sugRoot.dataset.labelDismissAria ?? 'Not interested in {{name}}';
+    const dismissLabel = dismissTpl.replace('{{name}}', s.scientific_name);
+
+    const common = lang === 'es'
+      ? (s.common_name_es ?? s.common_name_en ?? '')
+      : (s.common_name_en ?? s.common_name_es ?? '');
+
+    const commonHtml = common
+      ? `<p class="text-xs text-zinc-600 dark:text-zinc-300 truncate">${escapeText(common)}</p>`
+      : '';
+
+    const imgHtml = s.photo_url
+      ? `<img src="${escapeText(s.photo_url)}" alt="${escapeText(s.scientific_name)}" loading="lazy" class="w-full h-full object-cover" />`
+      : '';
+
+    return `<li data-taxon-id="${escapeText(s.taxon_id)}">
+      <div class="relative overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 group">
+        <div class="aspect-square w-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
+          ${imgHtml}
+        </div>
+        <div class="p-2.5">
+          <p class="text-xs italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escapeText(s.scientific_name)}</p>
+          ${commonHtml}
+          <p class="text-[11px] text-emerald-700 dark:text-emerald-400 mt-1">${escapeText(countLabel)}</p>
+        </div>
+        <button
+          type="button"
+          data-dismiss="${escapeText(s.taxon_id)}"
+          aria-label="${escapeText(dismissLabel)}"
+          class="absolute top-1.5 right-1.5 rounded-full p-1 text-zinc-400 dark:text-zinc-500 bg-white/80 dark:bg-zinc-900/80 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity hover:text-zinc-700 dark:hover:text-zinc-200"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+            <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+          </svg>
+        </button>
+      </div>
+    </li>`;
+  }
+
+  function monthName(lang: Lang): string {
+    return new Date().toLocaleString(lang === 'es' ? 'es-MX' : 'en-US', { month: 'long' });
+  }
+
+  async function paintSuggestions(
+    root: HTMLElement,
+    lang: Lang,
+    userId: string,
+    seed: number
+  ): Promise<void> {
+    const sugRoot = root.querySelector<HTMLElement>('.home-widgets-suggestions');
+    if (!sugRoot) return;
+
+    const listEl = sugRoot.querySelector<HTMLUListElement>('.hw-suggestions-list');
+    const loadingEl = sugRoot.querySelector<HTMLElement>('.hw-suggestions-loading');
+    const emptyEl = sugRoot.querySelector<HTMLElement>('.hw-suggestions-empty');
+    const subtitleEl = sugRoot.querySelector<HTMLElement>('.hw-suggestions-subtitle');
+    if (!listEl) return;
+
+    // Update subtitle month name
+    if (subtitleEl) {
+      const tpl = sugRoot.dataset.labelSubtitle ?? '';
+      subtitleEl.textContent = tpl.replace('{{month}}', monthName(lang));
+    }
+
+    loadingEl?.classList.remove('hidden');
+    emptyEl?.classList.add('hidden');
+    listEl.innerHTML = '';
+
+    // Request geolocation
+    let lat: number, lng: number;
+    try {
+      const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, {
+          timeout: 8000,
+          maximumAge: 5 * 60 * 1000, // 5 min cache
+        });
+      });
+      lat = pos.coords.latitude;
+      lng = pos.coords.longitude;
+    } catch {
+      // Permission denied or unavailable — keep widget hidden
+      loadingEl?.classList.add('hidden');
+      return;
+    }
+
+    try {
+      // seed param forces a different result set on refresh (use limit oversample trick)
+      const limit = 10 + (seed % 5); // vary limit slightly to get different rows
+      const all = await fetchSuggestions(userId, lat, lng, { limit });
+      const dismissed = getDismissed();
+      const filtered = all.filter(s => !dismissed.has(s.taxon_id)).slice(0, 5);
+
+      loadingEl?.classList.add('hidden');
+
+      if (filtered.length === 0) {
+        emptyEl?.classList.remove('hidden');
+        return;
+      }
+
+      listEl.innerHTML = filtered.map(s => suggestionCard(s, lang, sugRoot)).join('');
+      sugRoot.classList.remove('hidden');
+
+      // Wire up dismiss buttons
+      listEl.querySelectorAll<HTMLButtonElement>('button[data-dismiss]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const taxonId = btn.dataset.dismiss ?? '';
+          const dismissed = getDismissed();
+          dismissed.add(taxonId);
+          saveDismissed(dismissed);
+          const li = btn.closest('li');
+          if (li) li.remove();
+          if (listEl.children.length === 0) {
+            emptyEl?.classList.remove('hidden');
+          }
+        });
+      });
+    } catch {
+      loadingEl?.classList.add('hidden');
+      emptyEl?.classList.remove('hidden');
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+
   async function init() {
     const root = document.querySelector<HTMLElement>('.home-widgets');
     if (!root) return;
@@ -227,6 +407,19 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
     }
 
     await paintNearby(root, lang, country, profile?.region_primary ?? null);
+
+    // Fire suggestions widget (no await — it runs in parallel via geolocation)
+    let suggestionSeed = 0;
+    paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional widget */});
+
+    // Wire up the Refresh button
+    const sugRoot = root.querySelector<HTMLElement>('.home-widgets-suggestions');
+    sugRoot?.querySelector<HTMLButtonElement>('.hw-suggestions-refresh')?.addEventListener('click', () => {
+      suggestionSeed = (suggestionSeed + 1) % 100;
+      // Clear dismissed on refresh
+      try { sessionStorage.removeItem(DISMISSED_KEY); } catch { /* ignore */ }
+      paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional */});
+    });
   }
 
   async function paintNearby(root: HTMLElement, lang: Lang, country: string | null, _region: string | null): Promise<void> {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -147,7 +147,18 @@
       "nearby_view_all": "View all recent",
       "nearby_loading": "Loading recent observations…",
       "nearby_anonymous": "Anonymous",
-      "nearby_unknown_species": "Unknown species"
+      "nearby_unknown_species": "Unknown species",
+      "suggestions": {
+        "heading": "Go find these",
+        "subtitle": "Species near you in {{month}} you haven't observed yet",
+        "nearby_count_one": "{{count}} nearby observation",
+        "nearby_count_other": "{{count}} nearby observations",
+        "refresh": "Show me different",
+        "dismiss_aria": "Not interested in {{name}}",
+        "no_location": "Allow location access to see suggestions",
+        "loading": "Finding species near you…",
+        "empty": "No new suggestions nearby. Check back next month."
+      }
     }
   },
   "identify": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -147,7 +147,18 @@
       "nearby_view_all": "Ver todas las recientes",
       "nearby_loading": "Cargando observaciones recientes…",
       "nearby_anonymous": "Anónimo",
-      "nearby_unknown_species": "Especie desconocida"
+      "nearby_unknown_species": "Especie desconocida",
+      "suggestions": {
+        "heading": "Ve a buscar estos",
+        "subtitle": "Especies cerca de ti en {{month}} que aún no has observado",
+        "nearby_count_one": "{{count}} observación cercana",
+        "nearby_count_other": "{{count}} observaciones cercanas",
+        "refresh": "Mostrar otras",
+        "dismiss_aria": "No me interesa {{name}}",
+        "no_location": "Permite el acceso a tu ubicación para ver sugerencias",
+        "loading": "Buscando especies cerca de ti…",
+        "empty": "Sin nuevas sugerencias cercanas. Vuelve el próximo mes."
+      }
     }
   },
   "identify": {

--- a/src/lib/suggestions.ts
+++ b/src/lib/suggestions.ts
@@ -1,0 +1,31 @@
+import { getSupabase } from './supabase';
+
+export interface SpeciesSuggestion {
+  taxon_id: string;
+  scientific_name: string;
+  common_name_es: string | null;
+  common_name_en: string | null;
+  kingdom: string | null;
+  class: string | null;
+  nearby_count: number;
+  photo_url: string | null;
+}
+
+export async function fetchSuggestions(
+  userId: string,
+  lat: number,
+  lng: number,
+  opts?: { limit?: number; radiusKm?: number }
+): Promise<SpeciesSuggestion[]> {
+  const month = new Date().getMonth() + 1;
+  const { data, error } = await getSupabase().rpc('suggest_nearby_species', {
+    p_user_id: userId,
+    p_lat: lat,
+    p_lng: lng,
+    p_month: month,
+    p_radius_km: opts?.radiusKm ?? 50,
+    p_limit: opts?.limit ?? 10,
+  });
+  if (error) throw error;
+  return (data ?? []) as SpeciesSuggestion[];
+}

--- a/tests/unit/suggestions.test.ts
+++ b/tests/unit/suggestions.test.ts
@@ -128,3 +128,50 @@ describe('fetchSuggestions', () => {
     expect(Number.isInteger(month)).toBe(true);
   });
 });
+
+// ── Month-boundary formula unit tests (#876 fix) ──────────────────────────
+// The SQL uses: ((p_month - 2 + 12) % 12) + 1, p_month, (p_month % 12) + 1
+// to compute prev/current/next month without BETWEEN (which broke at
+// Jan=1 → BETWEEN 0 AND 2, and Dec=12 → BETWEEN 11 AND 13).
+function monthWindow(m: number): [number, number, number] {
+  return [
+    ((m - 2 + 12) % 12) + 1,
+    m,
+    (m % 12) + 1,
+  ];
+}
+
+describe('monthWindow — boundary-safe month triplet', () => {
+  it('January wraps prev to December', () => {
+    expect(monthWindow(1)).toEqual([12, 1, 2]);
+  });
+
+  it('December wraps next to January', () => {
+    expect(monthWindow(12)).toEqual([11, 12, 1]);
+  });
+
+  it('mid-year produces consecutive months', () => {
+    expect(monthWindow(6)).toEqual([5, 6, 7]);
+    expect(monthWindow(7)).toEqual([6, 7, 8]);
+  });
+
+  it('all months produce values in [1..12]', () => {
+    for (let m = 1; m <= 12; m++) {
+      const [prev, cur, next] = monthWindow(m);
+      expect(prev).toBeGreaterThanOrEqual(1);
+      expect(prev).toBeLessThanOrEqual(12);
+      expect(cur).toBe(m);
+      expect(next).toBeGreaterThanOrEqual(1);
+      expect(next).toBeLessThanOrEqual(12);
+    }
+  });
+
+  it('never produces 0 or 13 (which BETWEEN p_month±1 would generate)', () => {
+    // This was the original bug: BETWEEN 0 AND 2 in January, BETWEEN 11 AND 13 in December.
+    for (let m = 1; m <= 12; m++) {
+      const window = monthWindow(m);
+      expect(window).not.toContain(0);
+      expect(window).not.toContain(13);
+    }
+  });
+});

--- a/tests/unit/suggestions.test.ts
+++ b/tests/unit/suggestions.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We mock the supabase module before importing the module under test
+const mockRpc = vi.fn();
+
+vi.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => ({
+    rpc: mockRpc,
+  }),
+}));
+
+// Import after mock is set up
+const { fetchSuggestions } = await import('../../src/lib/suggestions');
+
+const FAKE_USER_ID = '00000000-0000-0000-0000-000000000001';
+const FAKE_LAT = 19.43;
+const FAKE_LNG = -99.13;
+
+describe('fetchSuggestions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('happy path: returns 3 suggestions', async () => {
+    const mockData = [
+      {
+        taxon_id: 'taxon-1',
+        scientific_name: 'Quercus rugosa',
+        common_name_es: 'Encino',
+        common_name_en: 'Netleaf Oak',
+        kingdom: 'Plantae',
+        class: 'Magnoliopsida',
+        nearby_count: 42,
+        photo_url: 'https://example.com/quercus.jpg',
+      },
+      {
+        taxon_id: 'taxon-2',
+        scientific_name: 'Piranga rubra',
+        common_name_es: 'Cardenal veranero',
+        common_name_en: 'Summer Tanager',
+        kingdom: 'Animalia',
+        class: 'Aves',
+        nearby_count: 17,
+        photo_url: 'https://example.com/piranga.jpg',
+      },
+      {
+        taxon_id: 'taxon-3',
+        scientific_name: 'Bufo valliceps',
+        common_name_es: 'Sapo del golfo',
+        common_name_en: 'Gulf Coast Toad',
+        kingdom: 'Animalia',
+        class: 'Amphibia',
+        nearby_count: 5,
+        photo_url: null,
+      },
+    ];
+
+    mockRpc.mockResolvedValueOnce({ data: mockData, error: null });
+
+    const result = await fetchSuggestions(FAKE_USER_ID, FAKE_LAT, FAKE_LNG);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].scientific_name).toBe('Quercus rugosa');
+    expect(result[1].common_name_en).toBe('Summer Tanager');
+    expect(result[2].photo_url).toBeNull();
+
+    expect(mockRpc).toHaveBeenCalledOnce();
+    expect(mockRpc).toHaveBeenCalledWith('suggest_nearby_species', {
+      p_user_id: FAKE_USER_ID,
+      p_lat: FAKE_LAT,
+      p_lng: FAKE_LNG,
+      p_month: expect.any(Number),
+      p_radius_km: 50,
+      p_limit: 10,
+    });
+  });
+
+  it('empty result: returns []', async () => {
+    mockRpc.mockResolvedValueOnce({ data: [], error: null });
+
+    const result = await fetchSuggestions(FAKE_USER_ID, FAKE_LAT, FAKE_LNG);
+
+    expect(result).toEqual([]);
+    expect(mockRpc).toHaveBeenCalledOnce();
+  });
+
+  it('null data: returns []', async () => {
+    mockRpc.mockResolvedValueOnce({ data: null, error: null });
+
+    const result = await fetchSuggestions(FAKE_USER_ID, FAKE_LAT, FAKE_LNG);
+
+    expect(result).toEqual([]);
+  });
+
+  it('error: throws', async () => {
+    const mockError = new Error('RPC error: permission denied');
+    mockRpc.mockResolvedValueOnce({ data: null, error: mockError });
+
+    await expect(fetchSuggestions(FAKE_USER_ID, FAKE_LAT, FAKE_LNG)).rejects.toThrow(
+      'RPC error: permission denied'
+    );
+  });
+
+  it('passes custom opts (limit, radiusKm) to the RPC', async () => {
+    mockRpc.mockResolvedValueOnce({ data: [], error: null });
+
+    await fetchSuggestions(FAKE_USER_ID, FAKE_LAT, FAKE_LNG, { limit: 5, radiusKm: 25 });
+
+    expect(mockRpc).toHaveBeenCalledWith('suggest_nearby_species', {
+      p_user_id: FAKE_USER_ID,
+      p_lat: FAKE_LAT,
+      p_lng: FAKE_LNG,
+      p_month: expect.any(Number),
+      p_radius_km: 25,
+      p_limit: 5,
+    });
+  });
+
+  it('p_month is the current month (1-based)', async () => {
+    mockRpc.mockResolvedValueOnce({ data: [], error: null });
+
+    await fetchSuggestions(FAKE_USER_ID, FAKE_LAT, FAKE_LNG);
+
+    const call = mockRpc.mock.calls[0][1] as Record<string, unknown>;
+    const month = call.p_month as number;
+    expect(month).toBeGreaterThanOrEqual(1);
+    expect(month).toBeLessThanOrEqual(12);
+    expect(Number.isInteger(month)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixup for #876 — two issues caught in cross-review by Nyx.

## Bug 1: BETWEEN p_month ± 1 breaks at year boundaries

`BETWEEN p_month - 1 AND p_month + 1` generates:
- January: `BETWEEN 0 AND 2` — `EXTRACT(MONTH)` never returns 0, December observations invisible
- December: `BETWEEN 11 AND 13` — 13 never exists, January observations invisible

**Fix:** `= ANY(ARRAY[prev, cur, next])` with modular arithmetic:
```sql
= ANY(ARRAY[((p_month - 2 + 12) % 12) + 1, p_month, (p_month % 12) + 1])
```

## Bug 2: Missing index on media_files for photo_url subquery

Added `idx_media_files_obs_primary ON media_files(observation_id, is_primary) WHERE is_primary = true` — the correlated subquery for photo_url was scanning on `observation_id` only.

## Tests
5 new unit tests in `tests/unit/suggestions.test.ts` (monthWindow boundary suite) — all 11 tests green.