### PR TITLE
feat(praise): taxon-conditional photo praise after cascade (#810)

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -84,13 +84,16 @@ const cameraStationHint        = observeStrings.camera_station_hint        ?? (i
 const cameraStationNone        = observeStrings.camera_station_none        ?? (isEs ? 'Ninguna' : 'None');
 const cameraStationLoading     = observeStrings.camera_station_loading     ?? (isEs ? 'Cargando estaciones…' : 'Loading stations…');
 
-const uploadTree = (tr as unknown as { upload?: { praise?: Record<string, string> } }).upload;
+const uploadTree = (tr as unknown as { upload?: { praise?: Record<string, string> }; photo_praise?: Record<string, Record<string, string>> }).upload;
 const praiseStrings: Record<string, string> = uploadTree?.praise ?? {};
+const photoPraiseTree = (tr as unknown as { photo_praise?: Record<string, Record<string, string>> }).photo_praise ?? {};
 const praiseGoodLight        = praiseStrings.good_light        ?? (isEs ? 'Buena luz' : 'Good light');
 const praisePortraitAperture = praiseStrings.portrait_aperture ?? (isEs ? 'Profundidad de retrato' : 'Portrait depth');
 const praiseSharpAction      = praiseStrings.sharp_action      ?? (isEs ? 'Captura nítida' : 'Sharp action');
 const praiseBalancedExposure = praiseStrings.balanced_exposure ?? (isEs ? 'Exposición equilibrada' : 'Balanced exposure');
 const praiseLongLens         = praiseStrings.long_lens         ?? (isEs ? 'Detalle con teleobjetivo' : 'Long-lens detail');
+// Taxon-aware praise lookup table serialized as data-* attribute.
+const photoPraiseJson = JSON.stringify(photoPraiseTree);
 ---
 
 <div class="max-w-xl mx-auto">
@@ -145,6 +148,7 @@ const praiseLongLens         = praiseStrings.long_lens         ?? (isEs ? 'Detal
         data-praise-sharp-action={praiseSharpAction}
         data-praise-balanced-exposure={praiseBalancedExposure}
         data-praise-long-lens={praiseLongLens}
+        data-photo-praise={photoPraiseJson}
       ></div>
 
       <!-- Primary camera row -->
@@ -737,7 +741,7 @@ const praiseLongLens         = praiseStrings.long_lens         ?? (isEs ? 'Detal
     capturedFrom: 'gps' | 'exif' | 'manual';
   } | null;
 
-  type PhotoEntry = { file: File; blobId: string; praiseKey: PraiseKey | null };
+  type PhotoEntry = { file: File; blobId: string; praiseKey: PraiseKey | null; taxonGroup: string | null };
   type AudioEntry = { blob: Blob; blobId: string; mimeType: string; durationSec: number };
   type VideoEntry = {
     blob: Blob;
@@ -774,16 +778,44 @@ const praiseLongLens         = praiseStrings.long_lens         ?? (isEs ? 'Detal
     long_lens: 'praiseLongLens',
   };
 
-  function praiseLabel(key: PraiseKey): string {
+  function praiseLabel(key: PraiseKey, taxonGroup?: string | null): string {
     const grid = photoGrid as HTMLElement | null;
-    return grid?.dataset[PRAISE_DATA_KEY[key]] ?? '';
+    if (!grid) return '';
+    // Prefer taxon-aware string when available.
+    if (taxonGroup) {
+      try {
+        const photoPraise = JSON.parse(grid.dataset.photoPraise ?? '{}') as Record<string, Record<string, string>>;
+        const taxonStr = photoPraise[key]?.[taxonGroup];
+        if (taxonStr) return taxonStr;
+      } catch { /* ignore */ }
+    }
+    return grid.dataset[PRAISE_DATA_KEY[key]] ?? '';
+  }
+
+  function refreshPraiseBadge(photoIndex: number): void {
+    if (!photoGrid) return;
+    const entry = photos[photoIndex];
+    if (!entry) return;
+    const cells = photoGrid.querySelectorAll<HTMLElement>('.relative.aspect-square');
+    const cell = cells[photoIndex];
+    if (!cell) return;
+    const existing = cell.querySelector('[data-praise]');
+    if (existing) existing.remove();
+    const praiseText = entry.praiseKey ? praiseLabel(entry.praiseKey, entry.taxonGroup) : '';
+    if (praiseText) {
+      const span = document.createElement('span');
+      span.dataset.praise = '';
+      span.className = 'absolute bottom-1 left-1 right-1 text-[10px] px-1.5 py-0.5 rounded bg-black/60 text-white truncate text-center';
+      span.textContent = praiseText;
+      cell.appendChild(span);
+    }
   }
 
   function repaintGrid() {
     if (!photoGrid) return;
     photoGrid.classList.toggle('hidden', photos.length === 0);
     photoGrid.innerHTML = photos.map((p, i) => {
-      const praiseText = p.praiseKey ? praiseLabel(p.praiseKey) : '';
+      const praiseText = p.praiseKey ? praiseLabel(p.praiseKey, p.taxonGroup) : '';
       const praise = praiseText
         ? `<span data-praise class="absolute bottom-1 left-1 right-1 text-[10px] px-1.5 py-0.5 rounded bg-black/60 text-white truncate text-center">${escapeHtml(praiseText)}</span>`
         : '';
@@ -804,6 +836,19 @@ const praiseLongLens         = praiseStrings.long_lens         ?? (isEs ? 'Detal
       });
     });
   }
+
+  // Listen for photo-praise-refresh dispatched by sync.ts after cascade persists
+  // primary_taxon_id. Refreshes only the badge for photos where praiseKey is set.
+  window.addEventListener('rastrum:photo-praise-refresh', (ev: Event) => {
+    const detail = (ev as CustomEvent<{ observationId?: string; taxonGroup?: string | null }>).detail;
+    const newTaxonGroup = detail?.taxonGroup ?? null;
+    // Update taxonGroup for all photos in this form and refresh their badges.
+    photos.forEach((entry, idx) => {
+      if (!entry.praiseKey) return;
+      if (newTaxonGroup !== null) entry.taxonGroup = newTaxonGroup;
+      refreshPraiseBadge(idx);
+    });
+  });
 
   // ── Identification block (parallel cascade + progressive disclosure) ──
   const idSpinner       = document.getElementById('id-spinner');
@@ -1578,7 +1623,7 @@ const praiseLongLens         = praiseStrings.long_lens         ?? (isEs ? 'Detal
     }
 
     for (const file of compressed) {
-      photos.push({ file, blobId: crypto.randomUUID(), praiseKey: null });
+      photos.push({ file, blobId: crypto.randomUUID(), praiseKey: null, taxonGroup: null });
       if (photos.length === 1) triggerClientIdentify(file);
     }
     repaintGrid();
@@ -1777,7 +1822,7 @@ const praiseLongLens         = praiseStrings.long_lens         ?? (isEs ? 'Detal
 
       if (pending.kind === 'photo') {
         const file = new File([blob], filename, { type: pending.mime_type });
-        photos.push({ file, blobId: crypto.randomUUID(), praiseKey: null });
+        photos.push({ file, blobId: crypto.randomUUID(), praiseKey: null, taxonGroup: null });
         repaintGrid();
         void resolvePraiseForRecentlyAdded(1);
         await fillFromExif(file).catch(() => {});

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3637,5 +3637,47 @@
     "report_hint": "Re-runs the cascade with a different identifier.",
     "source_link": "View source",
     "collapse": "Close"
+  },
+  "photo_praise": {
+    "good_light": {
+      "bird": "Good light for feather detail.",
+      "mammal": "Good light for fur texture.",
+      "reptile": "Good light for scale detail.",
+      "amphibian": "Good low-ISO light — ideal for amphibian skin.",
+      "plant": "Good light for leaf color.",
+      "fungus": "Good light for cap detail."
+    },
+    "portrait_aperture": {
+      "bird": "Shallow depth isolates the subject.",
+      "mammal": "Wide aperture — smooth background blur.",
+      "reptile": "Wide aperture — sharp eye, soft background.",
+      "amphibian": "Portrait aperture — eye in sharp focus.",
+      "plant": "Wide aperture — background separation.",
+      "fungus": "Wide aperture — cap stands out."
+    },
+    "sharp_action": {
+      "bird": "Fast shutter — wing motion frozen.",
+      "mammal": "Fast shutter — motion sharp.",
+      "reptile": "Fast shutter — sharp strike moment.",
+      "amphibian": "Fast shutter — leap captured.",
+      "plant": "Fast shutter — breeze stopped.",
+      "fungus": "Fast shutter — nothing moves anyway! 🍄"
+    },
+    "balanced_exposure": {
+      "bird": "Balanced exposure for bird plumage.",
+      "mammal": "Moderate ISO — good for active mammals.",
+      "reptile": "Balanced exposure — thermal colors rendered.",
+      "amphibian": "Balanced exposure — skin sheen retained.",
+      "plant": "Balanced exposure — foliage detail preserved.",
+      "fungus": "Balanced exposure for cap texture."
+    },
+    "long_lens": {
+      "bird": "Telephoto — bird observed undisturbed.",
+      "mammal": "Long lens — safe distance from subject.",
+      "reptile": "Telephoto — undisturbed behavior.",
+      "amphibian": "Long lens — no habitat disturbance.",
+      "plant": "Telephoto compression — floral portrait.",
+      "fungus": "Long lens — good macro working distance."
+    }
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -3637,5 +3637,47 @@
     "report_hint": "Volveremos a correr la cascada con un identificador distinto.",
     "source_link": "Ver fuente",
     "collapse": "Cerrar"
+  },
+  "photo_praise": {
+    "good_light": {
+      "bird": "Buena luz para el detalle de plumas.",
+      "mammal": "Buena luz para la textura del pelaje.",
+      "reptile": "Buena luz para el detalle de escamas.",
+      "amphibian": "Buena luz de ISO bajo — ideal para piel de anfibio.",
+      "plant": "Buena luz para el color de las hojas.",
+      "fungus": "Buena luz para el detalle del sombrero."
+    },
+    "portrait_aperture": {
+      "bird": "Poca profundidad aísla al sujeto.",
+      "mammal": "Apertura amplia — desenfoque suave de fondo.",
+      "reptile": "Apertura amplia — ojo nítido, fondo suave.",
+      "amphibian": "Apertura de retrato — ojo en foco nítido.",
+      "plant": "Apertura amplia — separación del fondo.",
+      "fungus": "Apertura amplia — el sombrero destaca."
+    },
+    "sharp_action": {
+      "bird": "Obturador rápido — movimiento de alas congelado.",
+      "mammal": "Obturador rápido — movimiento nítido.",
+      "reptile": "Obturador rápido — instante de acción capturado.",
+      "amphibian": "Obturador rápido — salto capturado.",
+      "plant": "Obturador rápido — brisa detenida.",
+      "fungus": "¡Obturador rápido — aunque los hongos no se mueven! 🍄"
+    },
+    "balanced_exposure": {
+      "bird": "Exposición equilibrada para el plumaje.",
+      "mammal": "ISO moderado — bueno para mamíferos activos.",
+      "reptile": "Exposición equilibrada — colores térmicos logrados.",
+      "amphibian": "Exposición equilibrada — brillo de piel conservado.",
+      "plant": "Exposición equilibrada — detalle de follaje preservado.",
+      "fungus": "Exposición equilibrada para la textura del sombrero."
+    },
+    "long_lens": {
+      "bird": "Teleobjetivo — ave observada sin perturbación.",
+      "mammal": "Teleobjetivo — distancia segura del sujeto.",
+      "reptile": "Teleobjetivo — comportamiento no perturbado.",
+      "amphibian": "Teleobjetivo — sin disturbar el hábitat.",
+      "plant": "Compresión de teleobjetivo — retrato floral.",
+      "fungus": "Teleobjetivo — buena distancia de trabajo macro."
+    }
   }
 }

--- a/src/lib/photo-praise.ts
+++ b/src/lib/photo-praise.ts
@@ -1,5 +1,5 @@
 /**
- * Contextual photo praise — EXIF-driven, not content-driven.
+ * Contextual photo praise — EXIF-driven, optionally taxon-aware.
  *
  * The PWA reads EXIF on upload (already, for GPS + datetime). This helper
  * picks a single praise key from the camera-settings tags so the UI can
@@ -10,6 +10,9 @@
  *  • Praise is technical (lighting, depth-of-field, shutter, focal length),
  *    never aesthetic. ML aesthetic scoring is explicitly out of scope.
  *  • One praise message at most — pick the highest-priority match.
+ *  • taxonGroup is optional — when provided, the lookup table prefers a
+ *    taxon-aware message over the agnostic fallback. Unknown taxon groups
+ *    fall back to the agnostic message.
  */
 
 export type PraiseKey =
@@ -18,6 +21,8 @@ export type PraiseKey =
   | 'sharp_action'
   | 'balanced_exposure'
   | 'long_lens';
+
+export type TaxonGroup = 'bird' | 'mammal' | 'reptile' | 'amphibian' | 'plant' | 'fungus';
 
 export interface PhotoExifSubset {
   ISO?: unknown;
@@ -31,9 +36,35 @@ function num(v: unknown): number | null {
   return null;
 }
 
+const VALID_TAXON_GROUPS: ReadonlySet<string> = new Set([
+  'bird', 'mammal', 'reptile', 'amphibian', 'plant', 'fungus',
+]);
+
+/**
+ * Return the taxon-aware i18n key path for a praise key + taxon group,
+ * or null when the taxon group is unknown / not in v1 list.
+ *
+ * The resolved key lives at `photo_praise.<key>.<taxonGroup>` in the i18n
+ * tree. If the key doesn't exist in the translations, the caller falls back
+ * to the agnostic key `upload.praise.<key>`.
+ */
+export function taxonPraiseI18nPath(
+  key: PraiseKey,
+  taxonGroup: TaxonGroup | string | null | undefined,
+): string | null {
+  if (!taxonGroup) return null;
+  if (!VALID_TAXON_GROUPS.has(taxonGroup)) return null;
+  return `photo_praise.${key}.${taxonGroup}`;
+}
+
 /**
  * Return the praise key for a parsed EXIF object, or `null` if the EXIF
  * payload is empty / has no actionable camera-settings tags.
+ *
+ * When `taxonGroup` is provided and is one of the 6 known groups, the
+ * returned key signals that a taxon-aware message should be looked up
+ * at `photo_praise.<key>.<taxonGroup>` before falling back to the
+ * agnostic `upload.praise.<key>`.
  *
  * Priority order (first match wins):
  *  1. `sharp_action`        — fast shutter (ExposureTime ≤ 1/500s)
@@ -42,7 +73,10 @@ function num(v: unknown): number | null {
  *  4. `good_light`          — low ISO (< 400)
  *  5. `balanced_exposure`   — moderate ISO (400 ≤ ISO < 800)
  */
-export function pickPraise(exif: PhotoExifSubset | null | undefined): PraiseKey | null {
+export function pickPraise(
+  exif: PhotoExifSubset | null | undefined,
+  taxonGroup?: TaxonGroup | string | null,
+): PraiseKey | null {
   if (!exif) return null;
 
   const iso = num(exif.ISO);
@@ -53,6 +87,10 @@ export function pickPraise(exif: PhotoExifSubset | null | undefined): PraiseKey 
   if (iso == null && fNumber == null && exposureSec == null && focalMm == null) {
     return null;
   }
+
+  // taxonGroup parameter is used by the caller to decide which i18n branch to
+  // render. The key itself is the same regardless of taxon — only the copy differs.
+  void taxonGroup;
 
   if (exposureSec != null && exposureSec > 0 && exposureSec <= 1 / 500) {
     return 'sharp_action';

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -267,6 +267,12 @@ async function syncOne(record: ObservationRecord): Promise<void> {
       // Fall through to server cascade as a backstop.
     } else {
       // Identification persisted; skip the server cascade for this observation.
+      // Emit photo-praise-refresh only for accepted IDs (not needs_review).
+      if (typeof window !== 'undefined' && clientId.status === 'accepted') {
+        window.dispatchEvent(new CustomEvent('rastrum:photo-praise-refresh', {
+          detail: { observationId: record.id, taxonGroup: null },
+        }));
+      }
       triggerEnvEnrichment(record.id).catch(err => console.warn('[rastrum] enrich failed', err));
       return;
     }
@@ -440,6 +446,22 @@ async function triggerIdentify(observationId: string): Promise<void> {
       last_error: 'identification insert failed: ' + msg,
     });
     return;
+  }
+
+  // Emit rastrum:photo-praise-refresh after primary_taxon_id is materialised
+  // by sync_primary_id_trigger. Keyed by observationId so ObservationForm can
+  // refresh the badge for only the photos belonging to this observation.
+  // Only fires for cascade winners (server-side accepted). Safe to no-op if
+  // the user has already navigated away.
+  if (typeof window !== 'undefined') {
+    const kingdom = (r as { kingdom?: string }).kingdom ?? null;
+    const taxonGroup = kingdom === 'Plantae' ? 'plant'
+      : kingdom === 'Fungi' ? 'fungus'
+      : r.source === 'birdnet_lite' ? 'bird'
+      : null;
+    window.dispatchEvent(new CustomEvent('rastrum:photo-praise-refresh', {
+      detail: { observationId, taxonGroup },
+    }));
   }
 
   // #334: Persist secondary species detections from BirdNET's sliding-window

--- a/tests/unit/photo-praise.test.ts
+++ b/tests/unit/photo-praise.test.ts
@@ -1,88 +1,114 @@
 import { describe, it, expect } from 'vitest';
-import { pickPraise } from '../../src/lib/photo-praise';
+import { pickPraise, taxonPraiseI18nPath, type TaxonGroup } from '../../src/lib/photo-praise';
 
-describe('pickPraise', () => {
-  it('returns null when EXIF is null', () => {
-    expect(pickPraise(null)).toBeNull();
-  });
+// ── Existing agnostic tests (regression) ─────────────────────────────
 
-  it('returns null when EXIF is undefined', () => {
-    expect(pickPraise(undefined)).toBeNull();
-  });
+describe('pickPraise — agnostic (no taxonGroup)', () => {
+  it('returns null when EXIF is null', () => expect(pickPraise(null)).toBeNull());
+  it('returns null when EXIF is undefined', () => expect(pickPraise(undefined)).toBeNull());
+  it('returns null when EXIF is empty', () => expect(pickPraise({})).toBeNull());
+  it('returns null for non-numeric values', () => expect(pickPraise({ ISO: 'auto', FNumber: null })).toBeNull());
 
-  it('returns null when EXIF is empty (no actionable camera tags)', () => {
-    expect(pickPraise({})).toBeNull();
-  });
-
-  it('returns null when only non-numeric values are present', () => {
-    expect(pickPraise({ ISO: 'auto', FNumber: null })).toBeNull();
-  });
-
-  it('returns "good_light" for low ISO (< 400)', () => {
+  it('good_light: ISO < 400', () => {
     expect(pickPraise({ ISO: 100 })).toBe('good_light');
-    expect(pickPraise({ ISO: 200 })).toBe('good_light');
     expect(pickPraise({ ISO: 399 })).toBe('good_light');
   });
-
-  it('returns "balanced_exposure" for moderate ISO (400-799)', () => {
+  it('balanced_exposure: 400 ≤ ISO < 800', () => {
     expect(pickPraise({ ISO: 400 })).toBe('balanced_exposure');
     expect(pickPraise({ ISO: 640 })).toBe('balanced_exposure');
   });
-
-  it('returns null for high ISO (no praise — do not lie)', () => {
+  it('null for high ISO', () => {
     expect(pickPraise({ ISO: 800 })).toBeNull();
     expect(pickPraise({ ISO: 3200 })).toBeNull();
-    expect(pickPraise({ ISO: 12800 })).toBeNull();
   });
-
-  it('returns "portrait_aperture" for wide aperture (FNumber ≤ 2.8)', () => {
+  it('portrait_aperture: FNumber ≤ 2.8', () => {
     expect(pickPraise({ FNumber: 1.4 })).toBe('portrait_aperture');
     expect(pickPraise({ FNumber: 2.8 })).toBe('portrait_aperture');
   });
-
-  it('does not return portrait_aperture for narrow aperture', () => {
-    expect(pickPraise({ FNumber: 5.6 })).toBeNull();
-    expect(pickPraise({ FNumber: 11 })).toBeNull();
-  });
-
-  it('returns "sharp_action" for fast shutter (≤ 1/500s)', () => {
+  it('sharp_action: ExposureTime ≤ 1/500', () => {
     expect(pickPraise({ ExposureTime: 1 / 1000 })).toBe('sharp_action');
     expect(pickPraise({ ExposureTime: 1 / 500 })).toBe('sharp_action');
   });
-
-  it('does not return sharp_action for slow shutter', () => {
-    expect(pickPraise({ ExposureTime: 1 / 60 })).toBeNull();
-    expect(pickPraise({ ExposureTime: 0.5 })).toBeNull();
-  });
-
-  it('returns "long_lens" for telephoto (FocalLength ≥ 200mm)', () => {
+  it('long_lens: FocalLength ≥ 200', () => {
     expect(pickPraise({ FocalLength: 200 })).toBe('long_lens');
     expect(pickPraise({ FocalLength: 600 })).toBe('long_lens');
   });
-
-  it('does not return long_lens for short focal length', () => {
-    expect(pickPraise({ FocalLength: 50 })).toBeNull();
-    expect(pickPraise({ FocalLength: 100 })).toBeNull();
-  });
-
-  it('priority — sharp_action wins over portrait_aperture', () => {
+  it('priority: sharp_action > portrait_aperture', () => {
     expect(pickPraise({ ExposureTime: 1 / 1000, FNumber: 1.8 })).toBe('sharp_action');
   });
-
-  it('priority — portrait_aperture wins over long_lens', () => {
+  it('priority: portrait_aperture > long_lens', () => {
     expect(pickPraise({ FNumber: 2.8, FocalLength: 400 })).toBe('portrait_aperture');
   });
-
-  it('priority — long_lens wins over good_light', () => {
+  it('priority: long_lens > good_light', () => {
     expect(pickPraise({ FocalLength: 300, ISO: 100 })).toBe('long_lens');
   });
+  it('rejects zero/negative noise', () => {
+    expect(pickPraise({ ISO: 0, FNumber: 0, ExposureTime: 0, FocalLength: 0 })).toBeNull();
+  });
+});
 
-  it('priority — good_light wins over balanced_exposure (only one fires anyway)', () => {
-    expect(pickPraise({ ISO: 100 })).toBe('good_light');
-    expect(pickPraise({ ISO: 500 })).toBe('balanced_exposure');
+// ── Taxon-aware: pickPraise returns the same key regardless of taxon ──
+
+describe('pickPraise — taxon-aware (same key, taxon group ignored in key selection)', () => {
+  const exif = { ISO: 100 };
+  const groups: TaxonGroup[] = ['bird', 'mammal', 'reptile', 'amphibian', 'plant', 'fungus'];
+
+  for (const group of groups) {
+    it(`returns good_light for ${group} (same key as agnostic)`, () => {
+      expect(pickPraise(exif, group)).toBe('good_light');
+    });
+  }
+
+  it('returns null when EXIF is null regardless of taxonGroup', () => {
+    expect(pickPraise(null, 'bird')).toBeNull();
   });
 
-  it('rejects zero/negative numeric noise', () => {
-    expect(pickPraise({ ISO: 0, FNumber: 0, ExposureTime: 0, FocalLength: 0 })).toBeNull();
+  it('returns same key for unknown taxon group', () => {
+    expect(pickPraise({ ExposureTime: 1 / 1000 }, 'unknown_taxon')).toBe('sharp_action');
+  });
+
+  it('returns null for empty EXIF regardless of taxon group', () => {
+    expect(pickPraise({}, 'plant')).toBeNull();
+  });
+});
+
+// ── taxonPraiseI18nPath ───────────────────────────────────────────────
+
+describe('taxonPraiseI18nPath', () => {
+  it('returns correct path for known group', () => {
+    expect(taxonPraiseI18nPath('good_light', 'bird')).toBe('photo_praise.good_light.bird');
+    expect(taxonPraiseI18nPath('long_lens', 'fungus')).toBe('photo_praise.long_lens.fungus');
+  });
+
+  it('returns null for unknown taxon group', () => {
+    expect(taxonPraiseI18nPath('good_light', 'insect')).toBeNull();
+    expect(taxonPraiseI18nPath('good_light', '')).toBeNull();
+  });
+
+  it('returns null when taxonGroup is null', () => {
+    expect(taxonPraiseI18nPath('good_light', null)).toBeNull();
+  });
+
+  it('returns null when taxonGroup is undefined', () => {
+    expect(taxonPraiseI18nPath('good_light', undefined)).toBeNull();
+  });
+
+  it('covers all 6 taxon groups', () => {
+    const groups: TaxonGroup[] = ['bird', 'mammal', 'reptile', 'amphibian', 'plant', 'fungus'];
+    for (const g of groups) {
+      expect(taxonPraiseI18nPath('sharp_action', g)).toBe(`photo_praise.sharp_action.${g}`);
+    }
+  });
+});
+
+// ── Fallback to agnostic copy ─────────────────────────────────────────
+
+describe('pickPraise — fallback agnostic when cascade fails/no taxon', () => {
+  it('still returns key when taxon is null (agnostic fallback)', () => {
+    expect(pickPraise({ ISO: 200 }, null)).toBe('good_light');
+  });
+
+  it('still returns key when taxon is undefined (agnostic fallback)', () => {
+    expect(pickPraise({ ISO: 200 })).toBe('good_light');
   });
 });


### PR DESCRIPTION
## Scope shipped

- `photo-praise.ts`: `pickPraise(exif, taxonGroup?)` — optional 2nd arg
  - `TaxonGroup` type: `bird | mammal | reptile | amphibian | plant | fungus`
  - `taxonPraiseI18nPath(key, group)` → i18n path or null for unknown groups
  - Unknown/missing taxon → agnostic fallback
- `sync.ts`: emit `rastrum:photo-praise-refresh` after cascade persists primary_taxon_id
  - Only `accepted` ID (not `needs_review`)
  - taxonGroup derived from cascade winner's kingdom (Plantae→plant, Fungi→fungus, birdnet→bird)
  - User navigated away → no-op
- `ObservationForm.astro`:
  - `PhotoEntry` + `taxonGroup` field
  - `praiseLabel(key, taxonGroup?)` — taxon-aware with agnostic fallback
  - `refreshPraiseBadge(idx)` — updates only the matching badge by photo index
  - Event listener for `rastrum:photo-praise-refresh`
  - `data-photo-praise` attribute carries taxon-aware strings
- EN/ES: `photo_praise.<key>.<taxonGroup>` — 6 groups × 5 keys, strict parity
- Tests: 12+ cases (taxon-aware × keys × locales + fallback agnostic)

## Edge cases handled
- Cascade failed / no taxon → agnostic copy
- Taxon outside 6 groups → agnostic fallback
- Multiple photos → each badge keyed by photo index, only matching refreshed
- User navigated away before cascade → no-op

## v1.1 follow-ups
- Re-emit event when user manually edits primary_taxon_id