### PR TITLE
ci(mobile): cargo clippy + fmt --check on tauri workflow (#872)

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -1,0 +1,44 @@
+name: Rust lint (clippy + fmt)
+
+# Path-filtered: only runs when src-tauri/ changes, so most PRs don't pay the cost.
+on:
+  pull_request:
+    paths:
+      - 'src-tauri/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src-tauri/**'
+
+permissions:
+  contents: read
+
+jobs:
+  rust-lint:
+    name: cargo fmt --check + cargo clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Cargo registry + build artefacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+          # Warm-cache runtime target: < 60 s for this minimal crate.
+
+      - name: cargo fmt --check
+        working-directory: src-tauri
+        run: cargo fmt --check
+
+      - name: cargo clippy — deny warnings
+        working-directory: src-tauri
+        run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## Scope shipped

Adds `.github/workflows/rust-lint.yml` — a path-filtered CI job that runs on any PR (or `main` push) touching `src-tauri/**`.

### Two jobs
- `cargo fmt --check` — fails if any Rust source is unformatted
- `cargo clippy --all-targets --all-features -- -D warnings` — fails on any lint warning

### Path filter
```yaml
on:
  pull_request:
    paths:
      - 'src-tauri/**'
```
PRs that don't touch the Tauri crate pay zero cost.

### Caching
Uses `Swatinem/rust-cache@v2` with `workspaces: src-tauri -> target`. Warm-cache runtime target: < 60 s for this minimal crate.

### Relationship to existing tauri-android.yml
That workflow is `workflow_dispatch`-only (heavy AAB build). This lint job is a cheap path-gated complement, not a replacement.

## Out of scope (v1.5+)
- `cargo audit` for vulnerability scanning
- `cargo deny` for license compliance
- Cross-compile checks for Android targets (covered by the build job)

## Test plan
- [x] `npx tsc --noEmit` clean (no Rust/TS coupling)
- [x] `npm run test` green (no change to test suite)
- [x] `npm run build` succeeds
- [ ] Operator smoke: introduce a deliberate fmt error in `src-tauri/src/main.rs`, push to a branch touching `src-tauri/`, confirm the lint job fails

Closes #872

🤖 Generated with Claude Sonnet 4.5