### PR TITLE
feat(home): daily challenge widget (#852)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -9900,6 +9900,525 @@ $$;
 REVOKE ALL ON FUNCTION public.refresh_taxon_ranges() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.refresh_taxon_ranges() TO service_role;
 
+-- ── Chat entity cards (M01 chat improvements, 2026-05-09) ──
+-- Read-only functions returning EntityCard-shaped JSONB. Every function
+-- is SECURITY INVOKER; the existing RLS policies enforce visibility.
+
+DROP FUNCTION IF EXISTS public.chat_obs_card(uuid);
+CREATE FUNCTION public.chat_obs_card(p_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH o AS (
+    SELECT
+      o.id, o.observer_id, o.observed_at,
+      o.primary_taxon_id, o.obscure_level,
+      o.location, o.location_obscured,
+      o.state_province, o.notes,
+      COALESCE(i.is_research_grade, false) AS is_research_grade,
+      t.scientific_name, t.common_name_es, t.common_name_en,
+      t.kingdom, t.family
+    FROM public.observations o
+    LEFT JOIN public.taxa t ON t.id = o.primary_taxon_id
+    LEFT JOIN public.identifications i ON i.observation_id = o.id AND i.is_primary = true
+    WHERE o.id = p_id
+  )
+  SELECT CASE WHEN o.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'observation',
+    'id',            o.id::text,
+    'label',         coalesce(o.scientific_name, '—')
+                     || ' · ' || to_char(o.observed_at, 'Mon DD')
+                     || coalesce(' · ' || o.state_province, ''),
+    'summary_text',
+      'Observation of ' || coalesce(o.scientific_name, 'unknown taxon')
+      || coalesce(' (' || o.common_name_en || ')', '')
+      || ' on ' || to_char(o.observed_at, 'YYYY-MM-DD')
+      || coalesce(' in ' || o.state_province, '')
+      || CASE WHEN o.is_research_grade THEN '. Research grade.' ELSE '. Needs review.' END
+      || coalesce(' Observer notes: ' || left(o.notes, 240), ''),
+    'fields',        jsonb_build_object(
+      'scientific_name', o.scientific_name,
+      'common_name_en',  o.common_name_en,
+      'common_name_es',  o.common_name_es,
+      'kingdom',         o.kingdom,
+      'family',          o.family,
+      'observed_at',     o.observed_at,
+      'state_province',  o.state_province,
+      'is_research_grade', o.is_research_grade,
+      'obscure_level',   o.obscure_level,
+      'lat', CASE WHEN auth.uid() = o.observer_id
+                  THEN ST_Y(o.location::geometry)
+                  ELSE ST_Y(coalesce(o.location_obscured, o.location)::geometry) END,
+      'lng', CASE WHEN auth.uid() = o.observer_id
+                  THEN ST_X(o.location::geometry)
+                  ELSE ST_X(coalesce(o.location_obscured, o.location)::geometry) END,
+      'coords_obscured', (auth.uid() IS DISTINCT FROM o.observer_id AND o.location_obscured IS NOT NULL)
+    ),
+    'suggested_questions', jsonb_build_array(
+      'Why is this ' || CASE WHEN o.is_research_grade THEN 'research grade' ELSE 'needs review' END || '?',
+      'What other observations of this species are nearby?',
+      'Tell me about ' || coalesce(o.scientific_name, 'this species') || '.'
+    ),
+    'related',       jsonb_build_object(
+      'primary_taxon_id', o.primary_taxon_id::text,
+      'observer_id',      o.observer_id::text
+    )
+  ) END
+  FROM o;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_species_card(text);
+CREATE FUNCTION public.chat_species_card(p_query text)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH t AS (
+    SELECT id, scientific_name, canonical_name, common_name_es, common_name_en,
+           kingdom, family, nom059_status, cites_appendix, iucn_category, is_endemic_mexico,
+           description_es, description_en, obscure_level
+    FROM public.taxa
+    WHERE id::text = p_query
+       OR canonical_name ILIKE p_query
+       OR scientific_name ILIKE p_query
+    ORDER BY canonical_name
+    LIMIT 1
+  )
+  SELECT CASE WHEN t.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'species',
+    'id',            t.id::text,
+    'label',         t.scientific_name,
+    'summary_text',
+      coalesce(t.scientific_name, '')
+      || coalesce(' (' || t.common_name_en || ')', '')
+      || ' — ' || coalesce(t.kingdom, '?') || ' / ' || coalesce(t.family, '?')
+      || coalesce('. NOM-059: ' || t.nom059_status, '')
+      || coalesce('. CITES: ' || t.cites_appendix, '')
+      || coalesce('. IUCN: ' || t.iucn_category, '')
+      || coalesce('. ' || left(t.description_en, 240), ''),
+    'fields',        jsonb_build_object(
+      'scientific_name',     t.scientific_name,
+      'common_name_en',      t.common_name_en,
+      'common_name_es',      t.common_name_es,
+      'kingdom',             t.kingdom,
+      'family',              t.family,
+      'nom059_status',       t.nom059_status,
+      'cites_appendix',      t.cites_appendix,
+      'iucn_category',       t.iucn_category,
+      'is_endemic_mexico',   t.is_endemic_mexico,
+      'obscure_level',       t.obscure_level
+    ),
+    'suggested_questions', jsonb_build_array(
+      'Where in Mexico is ' || t.scientific_name || ' typically observed?',
+      'What does NOM-059 ' || coalesce(t.nom059_status, 'status') || ' mean?',
+      'Show me recent observations of this species.'
+    ),
+    'related',       jsonb_build_object(
+      'primary_taxon_id', t.id::text
+    )
+  ) END
+  FROM t;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_project_card(text);
+CREATE FUNCTION public.chat_project_card(p_query text)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH p AS (
+    SELECT id, slug, name, name_es, description, description_es,
+           visibility, owner_user_id, area_km2
+    FROM public.projects_with_geojson
+    WHERE id::text = p_query OR slug = p_query
+    LIMIT 1
+  ),
+  c AS (
+    SELECT count(*)::int AS obs_count
+    FROM public.observations o, p
+    WHERE o.project_id = p.id
+  )
+  SELECT CASE WHEN p.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'project',
+    'id',            p.id::text,
+    'label',         coalesce(p.name, p.slug),
+    'summary_text',
+      'Project "' || coalesce(p.name, p.slug) || '"'
+      || coalesce(' — ' || left(p.description, 240), '')
+      || '. Visibility: ' || p.visibility
+      || coalesce('. Approx ' || round(p.area_km2)::text || ' km².', '')
+      || ' ' || c.obs_count || ' observations.',
+    'fields',        jsonb_build_object(
+      'slug',         p.slug,
+      'name',         p.name,
+      'name_es',      p.name_es,
+      'description',    p.description,
+      'description_es', p.description_es,
+      'visibility',   p.visibility,
+      'area_km2',     p.area_km2,
+      'obs_count',    c.obs_count
+    ),
+    'suggested_questions', jsonb_build_array(
+      'Which species are most common in this project?',
+      'How many observations were added in the last 30 days?',
+      'List the camera stations in this project.'
+    ),
+    'related',       jsonb_build_object(
+      'project_id', p.id::text
+    )
+  ) END
+  FROM p, c;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_camera_station_card(uuid);
+CREATE FUNCTION public.chat_camera_station_card(p_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH s AS (
+    SELECT cs.id, cs.project_id, cs.station_key, cs.name, cs.habitat,
+           cs.camera_model, cs.notes, cs.coords,
+           p.name AS project_name, p.slug AS project_slug
+    FROM public.camera_stations cs
+    LEFT JOIN public.projects p ON p.id = cs.project_id
+    WHERE cs.id = p_id
+  ),
+  pn AS (
+    SELECT coalesce(public.station_trap_nights(s.id), 0) AS trap_nights
+    FROM s
+  )
+  SELECT CASE WHEN s.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'camera_station',
+    'id',            s.id::text,
+    'label',         coalesce(s.name, s.station_key),
+    'summary_text',
+      'Camera station ' || s.station_key
+      || coalesce(' (' || s.name || ')', '')
+      || coalesce(' in project "' || s.project_name || '"', '')
+      || coalesce(', habitat: ' || s.habitat, '')
+      || coalesce(', camera: ' || s.camera_model, '')
+      || '. Trap-nights to date: ' || pn.trap_nights || '.',
+    'fields',        jsonb_build_object(
+      'station_key',  s.station_key,
+      'name',         s.name,
+      'habitat',      s.habitat,
+      'camera_model', s.camera_model,
+      'project_slug', s.project_slug,
+      'trap_nights',  pn.trap_nights,
+      'lat',          ST_Y(s.coords::geometry),
+      'lng',          ST_X(s.coords::geometry)
+    ),
+    'suggested_questions', jsonb_build_array(
+      'Which species have been detected at this station?',
+      'What is the detection rate per 100 trap-nights?',
+      'How long has this station been deployed?'
+    ),
+    'related',       jsonb_build_object(
+      'project_id', s.project_id::text
+    )
+  ) END
+  FROM s, pn;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_observer_card(uuid);
+CREATE FUNCTION public.chat_observer_card(p_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH u AS (
+    SELECT id, username, display_name, avatar_url, country_code,
+           is_expert, expert_taxa,
+           observation_count, species_count, obs_count_30d,
+           last_observation_at, joined_at, karma_total
+    FROM public.community_observers
+    WHERE id = p_id
+  )
+  SELECT CASE WHEN u.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'observer',
+    'id',            u.id::text,
+    'label',         coalesce(u.display_name, u.username),
+    'thumbnail',     u.avatar_url,
+    'summary_text',
+      coalesce(u.display_name, u.username)
+      || coalesce(' (@' || u.username || ')', '')
+      || coalesce(' from ' || u.country_code, '')
+      || '. ' || u.observation_count || ' observations, '
+      || u.species_count || ' species, '
+      || u.karma_total || ' karma.'
+      || CASE WHEN u.is_expert THEN ' Expert.' ELSE '' END,
+    'fields',        jsonb_build_object(
+      'username',          u.username,
+      'display_name',      u.display_name,
+      'country_code',      u.country_code,
+      'is_expert',         u.is_expert,
+      'observation_count', u.observation_count,
+      'species_count',     u.species_count,
+      'obs_count_30d',     u.obs_count_30d,
+      'karma_total',       u.karma_total
+    ),
+    'suggested_questions', jsonb_build_array(
+      'What species does ' || coalesce(u.display_name, u.username) || ' observe most?',
+      'When were they most active?',
+      'What region do they observe in?'
+    ),
+    'related',       jsonb_build_object(
+      'observer_id', u.id::text
+    )
+  ) END
+  FROM u;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_self_profile_card(uuid);
+CREATE FUNCTION public.chat_self_profile_card(p_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH u AS (
+    SELECT id, username, display_name, bio, avatar_url, preferred_lang,
+           is_expert, expert_taxa, observer_license,
+           observation_count, country_code, region_primary,
+           karma_total, joined_at, last_observation_at
+    FROM public.users
+    WHERE id = p_id
+      AND id = auth.uid()
+  )
+  SELECT CASE WHEN u.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'self_profile',
+    'id',            u.id::text,
+    'label',         coalesce(u.display_name, u.username, 'You'),
+    'thumbnail',     u.avatar_url,
+    'summary_text',
+      'Your profile: ' || coalesce(u.display_name, u.username)
+      || coalesce(', based in ' || u.country_code, '')
+      || '. ' || u.observation_count || ' observations, '
+      || u.karma_total || ' karma.'
+      || coalesce(' Bio: ' || left(u.bio, 200), '')
+      || ' Preferred language: ' || coalesce(u.preferred_lang, 'en') || '.',
+    'fields',        jsonb_build_object(
+      'username',           u.username,
+      'display_name',       u.display_name,
+      'preferred_lang',     u.preferred_lang,
+      'country_code',       u.country_code,
+      'region_primary',     u.region_primary,
+      'is_expert',          u.is_expert,
+      'expert_taxa',        u.expert_taxa,
+      'observer_license',   u.observer_license,
+      'observation_count',  u.observation_count,
+      'karma_total',        u.karma_total
+    ),
+    'suggested_questions', jsonb_build_array(
+      'How is my karma calculated?',
+      'What badges am I close to earning?',
+      'Show my last 10 observations.'
+    ),
+    'related',       jsonb_build_object(
+      'observer_id', u.id::text
+    )
+  ) END
+  FROM u;
+$$;
+
+-- Dispatcher: routes by kind. Returns NULL for unknown kinds so callers
+-- can treat that as 'entity not found'.
+DROP FUNCTION IF EXISTS public.chat_entity_card(text, text);
+CREATE FUNCTION public.chat_entity_card(p_kind text, p_id text)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_uuid uuid;
+BEGIN
+  IF p_kind IN ('observation','camera_station','observer','self_profile') THEN
+    BEGIN
+      v_uuid := p_id::uuid;
+    EXCEPTION WHEN invalid_text_representation THEN
+      RETURN NULL;
+    END;
+  END IF;
+
+  RETURN CASE p_kind
+    WHEN 'observation'    THEN public.chat_obs_card(v_uuid)
+    WHEN 'species'        THEN public.chat_species_card(p_id)
+    WHEN 'project'        THEN public.chat_project_card(p_id)
+    WHEN 'camera_station' THEN public.chat_camera_station_card(v_uuid)
+    WHEN 'observer'       THEN public.chat_observer_card(v_uuid)
+    WHEN 'self_profile'   THEN public.chat_self_profile_card(v_uuid)
+    ELSE NULL
+  END;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.chat_obs_card(uuid)            FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_species_card(text)        FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_project_card(text)        FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_camera_station_card(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_observer_card(uuid)       FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_self_profile_card(uuid)   FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_entity_card(text, text)   FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.chat_obs_card(uuid)             TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_species_card(text)         TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_project_card(text)         TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_camera_station_card(uuid)  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_observer_card(uuid)        TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_self_profile_card(uuid)    TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_entity_card(text, text)    TO authenticated;
+
+-- ── Chat tools — read-only search/list functions (M01 chat improvements) ──
+-- Each function wraps one filtered query against existing tables/views.
+-- SECURITY INVOKER + RLS enforces visibility; no row exposure beyond what
+-- the caller already had via direct SELECT.
+
+DROP FUNCTION IF EXISTS public.chat_find_observations(jsonb, int);
+CREATE FUNCTION public.chat_find_observations(p_filters jsonb, p_limit int DEFAULT 10)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_owner_self    boolean := coalesce((p_filters ->> 'owner') = 'me', false);
+  v_taxon_id      uuid    := nullif(p_filters ->> 'primary_taxon_id', '')::uuid;
+  v_project_id    uuid    := nullif(p_filters ->> 'project_id', '')::uuid;
+  v_near_obs      uuid    := nullif(p_filters ->> 'near_observation_id', '')::uuid;
+  v_radius_km     numeric := coalesce((p_filters ->> 'radius_km')::numeric, 50);
+  v_research_only boolean := coalesce((p_filters ->> 'research_grade')::boolean, false);
+BEGIN
+  RETURN coalesce((
+    SELECT jsonb_agg(row_card)
+    FROM (
+      SELECT jsonb_build_object(
+        'id',                o.id::text,
+        'scientific_name',   t.scientific_name,
+        'common_name_en',    t.common_name_en,
+        'observed_at',       o.observed_at,
+        'state_province',    o.state_province,
+        'is_research_grade', COALESCE(i.is_research_grade, false)
+      ) AS row_card
+      FROM public.observations o
+      LEFT JOIN public.taxa t ON t.id = o.primary_taxon_id
+      LEFT JOIN public.identifications i ON i.observation_id = o.id AND i.is_primary = true
+      LEFT JOIN public.observations near ON near.id = v_near_obs
+      WHERE (NOT v_owner_self    OR o.observer_id = auth.uid())
+        AND (v_taxon_id    IS NULL OR o.primary_taxon_id = v_taxon_id)
+        AND (v_project_id  IS NULL OR o.project_id      = v_project_id)
+        AND (v_near_obs    IS NULL OR ST_DWithin(o.location, near.location, v_radius_km * 1000))
+        AND (NOT v_research_only OR COALESCE(i.is_research_grade, false) = true)
+      ORDER BY o.observed_at DESC
+      LIMIT greatest(1, least(p_limit, 50))
+    ) sub
+  ), '[]'::jsonb);
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_find_species(text, int);
+CREATE FUNCTION public.chat_find_species(p_query text, p_limit int DEFAULT 10)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
+  FROM (
+    SELECT jsonb_build_object(
+      'id',                t.id::text,
+      'scientific_name',   t.scientific_name,
+      'common_name_en',    t.common_name_en,
+      'common_name_es',    t.common_name_es,
+      'kingdom',           t.kingdom,
+      'family',            t.family
+    ) AS row_card
+    FROM public.taxa t
+    WHERE t.canonical_name    ILIKE ('%' || p_query || '%')
+       OR t.scientific_name   ILIKE ('%' || p_query || '%')
+       OR t.common_name_en    ILIKE ('%' || p_query || '%')
+       OR t.common_name_es    ILIKE ('%' || p_query || '%')
+    ORDER BY (t.scientific_name = p_query) DESC, t.canonical_name
+    LIMIT greatest(1, least(p_limit, 50))
+  ) sub;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_find_projects(text, int);
+CREATE FUNCTION public.chat_find_projects(p_query text, p_limit int DEFAULT 10)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
+  FROM (
+    SELECT jsonb_build_object(
+      'id',     p.id::text,
+      'slug',   p.slug,
+      'name',   p.name,
+      'name_es', p.name_es
+    ) AS row_card
+    FROM public.projects_with_geojson p
+    WHERE p.name    ILIKE ('%' || p_query || '%')
+       OR p.name_es ILIKE ('%' || p_query || '%')
+       OR p.slug    ILIKE ('%' || p_query || '%')
+    ORDER BY p.name
+    LIMIT greatest(1, least(p_limit, 50))
+  ) sub;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_find_camera_stations(uuid, int);
+CREATE FUNCTION public.chat_find_camera_stations(p_project_id uuid, p_limit int DEFAULT 20)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
+  FROM (
+    SELECT jsonb_build_object(
+      'id',          cs.id::text,
+      'station_key', cs.station_key,
+      'name',        cs.name,
+      'habitat',     cs.habitat
+    ) AS row_card
+    FROM public.camera_stations cs
+    WHERE cs.project_id = p_project_id
+    ORDER BY cs.station_key
+    LIMIT greatest(1, least(p_limit, 50))
+  ) sub;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_find_observers(text, int);
+CREATE FUNCTION public.chat_find_observers(p_query text, p_limit int DEFAULT 10)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
+  FROM (
+    SELECT jsonb_build_object(
+      'id',           u.id::text,
+      'username',     u.username,
+      'display_name', u.display_name,
+      'is_expert',    u.is_expert
+    ) AS row_card
+    FROM public.community_observers u
+    WHERE u.username     ILIKE ('%' || p_query || '%')
+       OR u.display_name ILIKE ('%' || p_query || '%')
+    ORDER BY u.observation_count DESC
+    LIMIT greatest(1, least(p_limit, 50))
+  ) sub;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.chat_find_observations(jsonb, int)        FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_species(text, int)              FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_projects(text, int)             FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)      FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_observers(text, int)            FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.chat_find_observations(jsonb, int)         TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_species(text, int)               TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_projects(text, int)              TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)       TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_observers(text, int)             TO authenticated;
+
 -- ═══════════════════════════════════════════════════════════════════════════
 -- Security Advisor remediation — 2026-05-08
 -- ═══════════════════════════════════════════════════════════════════════════
@@ -10099,6 +10618,132 @@ EXCEPTION WHEN insufficient_privilege THEN
 END
 $$;
 
+-- ─────────────────────────────────────────────────────────────────────
+-- #812 — count_distinct_observed_species() RPC
+-- Returns distinct primary_taxon_id count from public observations.
+-- STABLE (no side effects), SECURITY INVOKER, LANGUAGE sql.
+-- GRANT to anon and authenticated.
+-- ─────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.count_distinct_observed_species()
+  RETURNS integer
+  LANGUAGE sql
+  STABLE
+  SECURITY INVOKER
+AS $$
+  SELECT COUNT(DISTINCT primary_taxon_id)::integer
+  FROM public.observations
+  WHERE primary_taxon_id IS NOT NULL
+    AND sync_status = 'synced'
+    AND obscure_level <> 'private';
+$$;
+
+GRANT EXECUTE ON FUNCTION public.count_distinct_observed_species() TO anon, authenticated;
+
+-- #710 — observation suggestions (location + season + not-yet-observed)
+-- Returns up to 10 species the viewer could find nearby that they
+-- haven't observed yet, ranked by nearby platform activity.
+-- =====================================================
+-- #798 — after_rain kairos trigger
+-- Extends kairos_subscriptions.kind CHECK to include 'after_rain'.
+-- Adds weather_snapshots table (geohash5 grid, populated by
+-- enrich-environment) and recent_rainfall_12h view.
+-- ─────────────────────────────────────────────────────────────────────
+
+-- Extend the kind CHECK constraint (drop + recreate idempotently).
+ALTER TABLE public.kairos_subscriptions
+  DROP CONSTRAINT IF EXISTS kairos_subscriptions_kind_check;
+ALTER TABLE public.kairos_subscriptions
+  ADD CONSTRAINT kairos_subscriptions_kind_check
+  CHECK (kind IN ('golden_hour', 'after_rain', 'migration_window', 'lunar_event'));
+
+-- weather_snapshots: one row per (geohash5, hour-bucket).
+-- Populated by enrich-environment; consumed by kairos-fire (after_rain).
+CREATE TABLE IF NOT EXISTS public.weather_snapshots (
+  id               bigserial PRIMARY KEY,
+  geohash5         text        NOT NULL,
+  precipitation_mm numeric     NOT NULL DEFAULT 0,
+  recorded_at      timestamptz NOT NULL DEFAULT now(),
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_weather_snapshots_geohash5_recorded_at
+  ON public.weather_snapshots(geohash5, recorded_at DESC);
+
+ALTER TABLE public.weather_snapshots ENABLE ROW LEVEL SECURITY;
+
+-- Only service_role can write snapshots; no direct user access.
+GRANT SELECT ON public.weather_snapshots TO service_role;
+GRANT INSERT ON public.weather_snapshots TO service_role;
+
+-- recent_rainfall_12h: total precipitation in the last 12 h per geohash5.
+-- SECURITY INVOKER so RLS on weather_snapshots applies to the caller.
+DROP VIEW IF EXISTS public.recent_rainfall_12h;
+CREATE VIEW public.recent_rainfall_12h
+  WITH (security_invoker = true) AS
+SELECT
+  geohash5,
+  SUM(precipitation_mm) AS total_mm,
+  MAX(recorded_at)      AS latest_at
+FROM public.weather_snapshots
+WHERE recorded_at >= (now() - INTERVAL '12 hours')
+GROUP BY geohash5;
+
+GRANT SELECT ON public.recent_rainfall_12h TO service_role;
+
+
+-- migration_windows: catalog of seasonal windows when notable taxa migrate.
+CREATE TABLE IF NOT EXISTS public.migration_windows (
+  id           bigserial   PRIMARY KEY,
+  taxon_group  text        NOT NULL,
+  start_doy    integer     NOT NULL CHECK (start_doy BETWEEN 1 AND 366),
+  end_doy      integer     NOT NULL CHECK (end_doy BETWEEN 1 AND 366),
+  region_code  text        NOT NULL,
+  body_en      text        NOT NULL,
+  body_es      text        NOT NULL,
+  source_url   text,
+  enabled      boolean     NOT NULL DEFAULT true,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_migration_windows_region_enabled
+  ON public.migration_windows(region_code) WHERE enabled = true;
+
+ALTER TABLE public.migration_windows ENABLE ROW LEVEL SECURITY;
+
+-- Public read for enabled rows (anon/authenticated); writes via service_role only.
+DROP POLICY IF EXISTS "migration_windows_public_read" ON public.migration_windows;
+CREATE POLICY "migration_windows_public_read" ON public.migration_windows
+  FOR SELECT USING (enabled = true);
+
+GRANT SELECT ON public.migration_windows TO anon, authenticated, service_role;
+
+-- Seed 4–8 MX migration windows.
+INSERT INTO public.migration_windows
+  (taxon_group, start_doy, end_doy, region_code, body_en, body_es, source_url)
+VALUES
+  -- Monarch butterfly southbound through Michoacán (Sep–Nov: DOY 244–319)
+  ('Lepidoptera', 244, 319, 'MX-MIC',
+   'Monarch migration underway in Michoacán — watch for mass roosts.',
+   'Migración de monarca en Michoacán — busca dormideros masivos.',
+   'https://www.learner.org/series/journey-north/monarch-butterfly/'),
+  -- Monarch overwintering peak in Oaxaca valleys (Oct–Jan: DOY 274–31)
+  ('Lepidoptera', 274, 31, 'MX-OAX',
+   'Monarchs overwintering in Oaxaca highland forests.',
+   'Monarcas invernando en bosques serranos de Oaxaca.',
+   NULL),
+  -- Swainson''s Hawk southbound through Veracruz (Sep–Nov: DOY 244–319)
+  ('Aves', 244, 319, 'MX-VER',
+   'Swainson''s Hawk migration through Veracruz — count raptors from Chichicaxtle ridge.',
+   'Migración de gavilán de Swainson por Veracruz — conteo desde Chichicaxtle.',
+   'https://hawkcount.org/'),
+  -- Olive Ridley sea turtle nesting on Oaxaca coast (Jun–Dec: DOY 152–335)
+  ('Reptilia', 152, 335, 'MX-OAX',
+   'Olive Ridley nesting season on Oaxaca beaches — low-light observation only.',
+   'Temporada de anidación de golfina en playas de Oaxaca — observación con luz tenue.',
+   NULL)
+ON CONFLICT DO NOTHING;
+-- =======================================
+
 -- ====================================================================
 -- #852 — daily_challenge_for_user RPC
 -- Returns ONE taxon per UTC day per user: region-filtered, rarity<=3,
@@ -10123,7 +10768,6 @@ DECLARE
   v_country_code text;
   v_doy          int := EXTRACT(DOY FROM CURRENT_DATE)::int;
 BEGIN
-  -- Get user region
   SELECT country_code INTO v_country_code
   FROM public.users WHERE id = p_user_id;
 
@@ -10170,4 +10814,3 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.daily_challenge_for_user(uuid) FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION public.daily_challenge_for_user(uuid) TO authenticated;
-

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -9900,522 +9900,6 @@ $$;
 REVOKE ALL ON FUNCTION public.refresh_taxon_ranges() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.refresh_taxon_ranges() TO service_role;
 
--- ── Chat entity cards (M01 chat improvements, 2026-05-09) ──
--- Read-only functions returning EntityCard-shaped JSONB. Every function
--- is SECURITY INVOKER; the existing RLS policies enforce visibility.
-
-DROP FUNCTION IF EXISTS public.chat_obs_card(uuid);
-CREATE FUNCTION public.chat_obs_card(p_id uuid)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  WITH o AS (
-    SELECT
-      o.id, o.observer_id, o.observed_at,
-      o.primary_taxon_id, o.obscure_level,
-      o.location, o.location_obscured,
-      o.region_primary, o.is_research_grade, o.notes,
-      t.scientific_name, t.common_name_es, t.common_name_en,
-      t.kingdom, t.family
-    FROM public.observations o
-    LEFT JOIN public.taxa t ON t.id = o.primary_taxon_id
-    WHERE o.id = p_id
-  )
-  SELECT CASE WHEN o.id IS NULL THEN NULL ELSE jsonb_build_object(
-    'kind',          'observation',
-    'id',            o.id::text,
-    'label',         coalesce(o.scientific_name, '—')
-                     || ' · ' || to_char(o.observed_at, 'Mon DD')
-                     || coalesce(' · ' || o.region_primary, ''),
-    'summary_text',
-      'Observation of ' || coalesce(o.scientific_name, 'unknown taxon')
-      || coalesce(' (' || o.common_name_en || ')', '')
-      || ' on ' || to_char(o.observed_at, 'YYYY-MM-DD')
-      || coalesce(' in ' || o.region_primary, '')
-      || CASE WHEN o.is_research_grade THEN '. Research grade.' ELSE '. Needs review.' END
-      || coalesce(' Observer notes: ' || left(o.notes, 240), ''),
-    'fields',        jsonb_build_object(
-      'scientific_name', o.scientific_name,
-      'common_name_en',  o.common_name_en,
-      'common_name_es',  o.common_name_es,
-      'kingdom',         o.kingdom,
-      'family',          o.family,
-      'observed_at',     o.observed_at,
-      'region_primary',  o.region_primary,
-      'is_research_grade', o.is_research_grade,
-      'obscure_level',   o.obscure_level,
-      'lat', CASE WHEN auth.uid() = o.observer_id
-                  THEN ST_Y(o.location::geometry)
-                  ELSE ST_Y(coalesce(o.location_obscured, o.location)::geometry) END,
-      'lng', CASE WHEN auth.uid() = o.observer_id
-                  THEN ST_X(o.location::geometry)
-                  ELSE ST_X(coalesce(o.location_obscured, o.location)::geometry) END,
-      'coords_obscured', (auth.uid() IS DISTINCT FROM o.observer_id AND o.location_obscured IS NOT NULL)
-    ),
-    'suggested_questions', jsonb_build_array(
-      'Why is this ' || CASE WHEN o.is_research_grade THEN 'research grade' ELSE 'needs review' END || '?',
-      'What other observations of this species are nearby?',
-      'Tell me about ' || coalesce(o.scientific_name, 'this species') || '.'
-    ),
-    'related',       jsonb_build_object(
-      'primary_taxon_id', o.primary_taxon_id::text,
-      'observer_id',      o.observer_id::text
-    )
-  ) END
-  FROM o;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_species_card(text);
-CREATE FUNCTION public.chat_species_card(p_query text)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  WITH t AS (
-    SELECT id, scientific_name, canonical_name, common_name_es, common_name_en,
-           kingdom, family, nom059_status, cites_appendix, iucn_category, is_endemic_mexico,
-           description_es, description_en, obscure_level
-    FROM public.taxa
-    WHERE id::text = p_query
-       OR canonical_name ILIKE p_query
-       OR scientific_name ILIKE p_query
-    ORDER BY canonical_name
-    LIMIT 1
-  )
-  SELECT CASE WHEN t.id IS NULL THEN NULL ELSE jsonb_build_object(
-    'kind',          'species',
-    'id',            t.id::text,
-    'label',         t.scientific_name,
-    'summary_text',
-      coalesce(t.scientific_name, '')
-      || coalesce(' (' || t.common_name_en || ')', '')
-      || ' — ' || coalesce(t.kingdom, '?') || ' / ' || coalesce(t.family, '?')
-      || coalesce('. NOM-059: ' || t.nom059_status, '')
-      || coalesce('. CITES: ' || t.cites_appendix, '')
-      || coalesce('. IUCN: ' || t.iucn_category, '')
-      || coalesce('. ' || left(t.description_en, 240), ''),
-    'fields',        jsonb_build_object(
-      'scientific_name',     t.scientific_name,
-      'common_name_en',      t.common_name_en,
-      'common_name_es',      t.common_name_es,
-      'kingdom',             t.kingdom,
-      'family',              t.family,
-      'nom059_status',       t.nom059_status,
-      'cites_appendix',      t.cites_appendix,
-      'iucn_category',       t.iucn_category,
-      'is_endemic_mexico',   t.is_endemic_mexico,
-      'obscure_level',       t.obscure_level
-    ),
-    'suggested_questions', jsonb_build_array(
-      'Where in Mexico is ' || t.scientific_name || ' typically observed?',
-      'What does NOM-059 ' || coalesce(t.nom059_status, 'status') || ' mean?',
-      'Show me recent observations of this species.'
-    ),
-    'related',       jsonb_build_object(
-      'primary_taxon_id', t.id::text
-    )
-  ) END
-  FROM t;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_project_card(text);
-CREATE FUNCTION public.chat_project_card(p_query text)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  WITH p AS (
-    SELECT id, slug, name, name_es, description, description_es,
-           visibility, owner_user_id, area_km2
-    FROM public.projects_with_geojson
-    WHERE id::text = p_query OR slug = p_query
-    LIMIT 1
-  ),
-  c AS (
-    SELECT count(*)::int AS obs_count
-    FROM public.observations o, p
-    WHERE o.project_id = p.id
-  )
-  SELECT CASE WHEN p.id IS NULL THEN NULL ELSE jsonb_build_object(
-    'kind',          'project',
-    'id',            p.id::text,
-    'label',         coalesce(p.name, p.slug),
-    'summary_text',
-      'Project "' || coalesce(p.name, p.slug) || '"'
-      || coalesce(' — ' || left(p.description, 240), '')
-      || '. Visibility: ' || p.visibility
-      || coalesce('. Approx ' || round(p.area_km2)::text || ' km².', '')
-      || ' ' || c.obs_count || ' observations.',
-    'fields',        jsonb_build_object(
-      'slug',         p.slug,
-      'name',         p.name,
-      'name_es',      p.name_es,
-      'description',    p.description,
-      'description_es', p.description_es,
-      'visibility',   p.visibility,
-      'area_km2',     p.area_km2,
-      'obs_count',    c.obs_count
-    ),
-    'suggested_questions', jsonb_build_array(
-      'Which species are most common in this project?',
-      'How many observations were added in the last 30 days?',
-      'List the camera stations in this project.'
-    ),
-    'related',       jsonb_build_object(
-      'project_id', p.id::text
-    )
-  ) END
-  FROM p, c;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_camera_station_card(uuid);
-CREATE FUNCTION public.chat_camera_station_card(p_id uuid)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  WITH s AS (
-    SELECT cs.id, cs.project_id, cs.station_key, cs.name, cs.habitat,
-           cs.camera_model, cs.notes, cs.coords,
-           p.name AS project_name, p.slug AS project_slug
-    FROM public.camera_stations cs
-    LEFT JOIN public.projects p ON p.id = cs.project_id
-    WHERE cs.id = p_id
-  ),
-  pn AS (
-    SELECT coalesce(public.station_trap_nights(s.id), 0) AS trap_nights
-    FROM s
-  )
-  SELECT CASE WHEN s.id IS NULL THEN NULL ELSE jsonb_build_object(
-    'kind',          'camera_station',
-    'id',            s.id::text,
-    'label',         coalesce(s.name, s.station_key),
-    'summary_text',
-      'Camera station ' || s.station_key
-      || coalesce(' (' || s.name || ')', '')
-      || coalesce(' in project "' || s.project_name || '"', '')
-      || coalesce(', habitat: ' || s.habitat, '')
-      || coalesce(', camera: ' || s.camera_model, '')
-      || '. Trap-nights to date: ' || pn.trap_nights || '.',
-    'fields',        jsonb_build_object(
-      'station_key',  s.station_key,
-      'name',         s.name,
-      'habitat',      s.habitat,
-      'camera_model', s.camera_model,
-      'project_slug', s.project_slug,
-      'trap_nights',  pn.trap_nights,
-      'lat',          ST_Y(s.coords::geometry),
-      'lng',          ST_X(s.coords::geometry)
-    ),
-    'suggested_questions', jsonb_build_array(
-      'Which species have been detected at this station?',
-      'What is the detection rate per 100 trap-nights?',
-      'How long has this station been deployed?'
-    ),
-    'related',       jsonb_build_object(
-      'project_id', s.project_id::text
-    )
-  ) END
-  FROM s, pn;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_observer_card(uuid);
-CREATE FUNCTION public.chat_observer_card(p_id uuid)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  WITH u AS (
-    SELECT id, username, display_name, avatar_url, country_code,
-           is_expert, expert_taxa,
-           observation_count, species_count, obs_count_30d,
-           last_observation_at, joined_at, karma_total
-    FROM public.community_observers
-    WHERE id = p_id
-  )
-  SELECT CASE WHEN u.id IS NULL THEN NULL ELSE jsonb_build_object(
-    'kind',          'observer',
-    'id',            u.id::text,
-    'label',         coalesce(u.display_name, u.username),
-    'thumbnail',     u.avatar_url,
-    'summary_text',
-      coalesce(u.display_name, u.username)
-      || coalesce(' (@' || u.username || ')', '')
-      || coalesce(' from ' || u.country_code, '')
-      || '. ' || u.observation_count || ' observations, '
-      || u.species_count || ' species, '
-      || u.karma_total || ' karma.'
-      || CASE WHEN u.is_expert THEN ' Expert.' ELSE '' END,
-    'fields',        jsonb_build_object(
-      'username',          u.username,
-      'display_name',      u.display_name,
-      'country_code',      u.country_code,
-      'is_expert',         u.is_expert,
-      'observation_count', u.observation_count,
-      'species_count',     u.species_count,
-      'obs_count_30d',     u.obs_count_30d,
-      'karma_total',       u.karma_total
-    ),
-    'suggested_questions', jsonb_build_array(
-      'What species does ' || coalesce(u.display_name, u.username) || ' observe most?',
-      'When were they most active?',
-      'What region do they observe in?'
-    ),
-    'related',       jsonb_build_object(
-      'observer_id', u.id::text
-    )
-  ) END
-  FROM u;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_self_profile_card(uuid);
-CREATE FUNCTION public.chat_self_profile_card(p_id uuid)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  WITH u AS (
-    SELECT id, username, display_name, bio, avatar_url, preferred_lang,
-           is_expert, expert_taxa, observer_license,
-           observation_count, country_code, region_primary,
-           karma_total, joined_at, last_observation_at
-    FROM public.users
-    WHERE id = p_id
-      AND id = auth.uid()
-  )
-  SELECT CASE WHEN u.id IS NULL THEN NULL ELSE jsonb_build_object(
-    'kind',          'self_profile',
-    'id',            u.id::text,
-    'label',         coalesce(u.display_name, u.username, 'You'),
-    'thumbnail',     u.avatar_url,
-    'summary_text',
-      'Your profile: ' || coalesce(u.display_name, u.username)
-      || coalesce(', based in ' || u.country_code, '')
-      || '. ' || u.observation_count || ' observations, '
-      || u.karma_total || ' karma.'
-      || coalesce(' Bio: ' || left(u.bio, 200), '')
-      || ' Preferred language: ' || coalesce(u.preferred_lang, 'en') || '.',
-    'fields',        jsonb_build_object(
-      'username',           u.username,
-      'display_name',       u.display_name,
-      'preferred_lang',     u.preferred_lang,
-      'country_code',       u.country_code,
-      'region_primary',     u.region_primary,
-      'is_expert',          u.is_expert,
-      'expert_taxa',        u.expert_taxa,
-      'observer_license',   u.observer_license,
-      'observation_count',  u.observation_count,
-      'karma_total',        u.karma_total
-    ),
-    'suggested_questions', jsonb_build_array(
-      'How is my karma calculated?',
-      'What badges am I close to earning?',
-      'Show my last 10 observations.'
-    ),
-    'related',       jsonb_build_object(
-      'observer_id', u.id::text
-    )
-  ) END
-  FROM u;
-$$;
-
--- Dispatcher: routes by kind. Returns NULL for unknown kinds so callers
--- can treat that as 'entity not found'.
-DROP FUNCTION IF EXISTS public.chat_entity_card(text, text);
-CREATE FUNCTION public.chat_entity_card(p_kind text, p_id text)
-RETURNS jsonb
-LANGUAGE plpgsql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-DECLARE
-  v_uuid uuid;
-BEGIN
-  IF p_kind IN ('observation','camera_station','observer','self_profile') THEN
-    BEGIN
-      v_uuid := p_id::uuid;
-    EXCEPTION WHEN invalid_text_representation THEN
-      RETURN NULL;
-    END;
-  END IF;
-
-  RETURN CASE p_kind
-    WHEN 'observation'    THEN public.chat_obs_card(v_uuid)
-    WHEN 'species'        THEN public.chat_species_card(p_id)
-    WHEN 'project'        THEN public.chat_project_card(p_id)
-    WHEN 'camera_station' THEN public.chat_camera_station_card(v_uuid)
-    WHEN 'observer'       THEN public.chat_observer_card(v_uuid)
-    WHEN 'self_profile'   THEN public.chat_self_profile_card(v_uuid)
-    ELSE NULL
-  END;
-END;
-$$;
-
-REVOKE EXECUTE ON FUNCTION public.chat_obs_card(uuid)            FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_species_card(text)        FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_project_card(text)        FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_camera_station_card(uuid) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_observer_card(uuid)       FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_self_profile_card(uuid)   FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_entity_card(text, text)   FROM PUBLIC;
-
-GRANT EXECUTE ON FUNCTION public.chat_obs_card(uuid)             TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_species_card(text)         TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_project_card(text)         TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_camera_station_card(uuid)  TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_observer_card(uuid)        TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_self_profile_card(uuid)    TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_entity_card(text, text)    TO authenticated;
-
--- ── Chat tools — read-only search/list functions (M01 chat improvements) ──
--- Each function wraps one filtered query against existing tables/views.
--- SECURITY INVOKER + RLS enforces visibility; no row exposure beyond what
--- the caller already had via direct SELECT.
-
-DROP FUNCTION IF EXISTS public.chat_find_observations(jsonb, int);
-CREATE FUNCTION public.chat_find_observations(p_filters jsonb, p_limit int DEFAULT 10)
-RETURNS jsonb
-LANGUAGE plpgsql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-DECLARE
-  v_owner_self    boolean := coalesce((p_filters ->> 'owner') = 'me', false);
-  v_taxon_id      uuid    := nullif(p_filters ->> 'primary_taxon_id', '')::uuid;
-  v_project_id    uuid    := nullif(p_filters ->> 'project_id', '')::uuid;
-  v_near_obs      uuid    := nullif(p_filters ->> 'near_observation_id', '')::uuid;
-  v_radius_km     numeric := coalesce((p_filters ->> 'radius_km')::numeric, 50);
-  v_research_only boolean := coalesce((p_filters ->> 'research_grade')::boolean, false);
-BEGIN
-  RETURN coalesce((
-    SELECT jsonb_agg(row_card)
-    FROM (
-      SELECT jsonb_build_object(
-        'id',                o.id::text,
-        'scientific_name',   t.scientific_name,
-        'common_name_en',    t.common_name_en,
-        'observed_at',       o.observed_at,
-        'region_primary',    o.region_primary,
-        'is_research_grade', o.is_research_grade
-      ) AS row_card
-      FROM public.observations o
-      LEFT JOIN public.taxa t ON t.id = o.primary_taxon_id
-      LEFT JOIN public.observations near ON near.id = v_near_obs
-      WHERE (NOT v_owner_self    OR o.observer_id = auth.uid())
-        AND (v_taxon_id    IS NULL OR o.primary_taxon_id = v_taxon_id)
-        AND (v_project_id  IS NULL OR o.project_id      = v_project_id)
-        AND (v_near_obs    IS NULL OR ST_DWithin(o.location, near.location, v_radius_km * 1000))
-        AND (NOT v_research_only OR o.is_research_grade = true)
-      ORDER BY o.observed_at DESC
-      LIMIT greatest(1, least(p_limit, 50))
-    ) sub
-  ), '[]'::jsonb);
-END;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_find_species(text, int);
-CREATE FUNCTION public.chat_find_species(p_query text, p_limit int DEFAULT 10)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
-  FROM (
-    SELECT jsonb_build_object(
-      'id',                t.id::text,
-      'scientific_name',   t.scientific_name,
-      'common_name_en',    t.common_name_en,
-      'common_name_es',    t.common_name_es,
-      'kingdom',           t.kingdom,
-      'family',            t.family
-    ) AS row_card
-    FROM public.taxa t
-    WHERE t.canonical_name    ILIKE ('%' || p_query || '%')
-       OR t.scientific_name   ILIKE ('%' || p_query || '%')
-       OR t.common_name_en    ILIKE ('%' || p_query || '%')
-       OR t.common_name_es    ILIKE ('%' || p_query || '%')
-    ORDER BY (t.scientific_name = p_query) DESC, t.canonical_name
-    LIMIT greatest(1, least(p_limit, 50))
-  ) sub;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_find_projects(text, int);
-CREATE FUNCTION public.chat_find_projects(p_query text, p_limit int DEFAULT 10)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
-  FROM (
-    SELECT jsonb_build_object(
-      'id',     p.id::text,
-      'slug',   p.slug,
-      'name',   p.name,
-      'name_es', p.name_es
-    ) AS row_card
-    FROM public.projects_with_geojson p
-    WHERE p.name    ILIKE ('%' || p_query || '%')
-       OR p.name_es ILIKE ('%' || p_query || '%')
-       OR p.slug    ILIKE ('%' || p_query || '%')
-    ORDER BY p.name
-    LIMIT greatest(1, least(p_limit, 50))
-  ) sub;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_find_camera_stations(uuid, int);
-CREATE FUNCTION public.chat_find_camera_stations(p_project_id uuid, p_limit int DEFAULT 20)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
-  FROM (
-    SELECT jsonb_build_object(
-      'id',          cs.id::text,
-      'station_key', cs.station_key,
-      'name',        cs.name,
-      'habitat',     cs.habitat
-    ) AS row_card
-    FROM public.camera_stations cs
-    WHERE cs.project_id = p_project_id
-    ORDER BY cs.station_key
-    LIMIT greatest(1, least(p_limit, 50))
-  ) sub;
-$$;
-
-DROP FUNCTION IF EXISTS public.chat_find_observers(text, int);
-CREATE FUNCTION public.chat_find_observers(p_query text, p_limit int DEFAULT 10)
-RETURNS jsonb
-LANGUAGE sql STABLE SECURITY INVOKER
-SET search_path = public, extensions, pg_temp
-AS $$
-  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
-  FROM (
-    SELECT jsonb_build_object(
-      'id',           u.id::text,
-      'username',     u.username,
-      'display_name', u.display_name,
-      'is_expert',    u.is_expert
-    ) AS row_card
-    FROM public.community_observers u
-    WHERE u.username     ILIKE ('%' || p_query || '%')
-       OR u.display_name ILIKE ('%' || p_query || '%')
-    ORDER BY u.observation_count DESC
-    LIMIT greatest(1, least(p_limit, 50))
-  ) sub;
-$$;
-
-REVOKE EXECUTE ON FUNCTION public.chat_find_observations(jsonb, int)        FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_find_species(text, int)              FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_find_projects(text, int)             FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)      FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.chat_find_observers(text, int)            FROM PUBLIC;
-
-GRANT EXECUTE ON FUNCTION public.chat_find_observations(jsonb, int)         TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_find_species(text, int)               TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_find_projects(text, int)              TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)       TO authenticated;
-GRANT EXECUTE ON FUNCTION public.chat_find_observers(text, int)             TO authenticated;
-
 -- ═══════════════════════════════════════════════════════════════════════════
 -- Security Advisor remediation — 2026-05-08
 -- ═══════════════════════════════════════════════════════════════════════════
@@ -10615,170 +10099,74 @@ EXCEPTION WHEN insufficient_privilege THEN
 END
 $$;
 
--- ─────────────────────────────────────────────────────────────────────
--- #812 — count_distinct_observed_species() RPC
--- Returns distinct primary_taxon_id count from public observations.
--- STABLE (no side effects), SECURITY INVOKER, LANGUAGE sql.
--- GRANT to anon and authenticated.
--- ─────────────────────────────────────────────────────────────────────
-CREATE OR REPLACE FUNCTION public.count_distinct_observed_species()
-  RETURNS integer
-  LANGUAGE sql
-  STABLE
-  SECURITY INVOKER
+-- ====================================================================
+-- #852 — daily_challenge_for_user RPC
+-- Returns ONE taxon per UTC day per user: region-filtered, rarity<=3,
+-- deterministic via md5 seeding so device-refreshes get same result.
+-- ====================================================================
+CREATE OR REPLACE FUNCTION public.daily_challenge_for_user(p_user_id uuid)
+RETURNS TABLE (
+  taxon_id        uuid,
+  scientific_name text,
+  common_name_en  text,
+  common_name_es  text,
+  kingdom         text,
+  rarity_tier     int,
+  thumbnail_url   text,
+  why             text
+)
+LANGUAGE plpgsql STABLE
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
 AS $$
-  SELECT COUNT(DISTINCT primary_taxon_id)::integer
-  FROM public.observations
-  WHERE primary_taxon_id IS NOT NULL
-    AND sync_status = 'synced'
-    AND obscure_level <> 'private';
-$$;
-
-GRANT EXECUTE ON FUNCTION public.count_distinct_observed_species() TO anon, authenticated;
-
-HEAD
--- #798 — after_rain kairos trigger
--- Extends kairos_subscriptions.kind CHECK to include 'after_rain'.
--- Adds weather_snapshots table (geohash5 grid, populated by
--- enrich-environment) and recent_rainfall_12h view.
--- ─────────────────────────────────────────────────────────────────────
-
--- Extend the kind CHECK constraint (drop + recreate idempotently).
-ALTER TABLE public.kairos_subscriptions
-  DROP CONSTRAINT IF EXISTS kairos_subscriptions_kind_check;
-ALTER TABLE public.kairos_subscriptions
-  ADD CONSTRAINT kairos_subscriptions_kind_check
-  CHECK (kind IN ('golden_hour', 'after_rain', 'migration_window', 'lunar_event'));
-
--- weather_snapshots: one row per (geohash5, hour-bucket).
--- Populated by enrich-environment; consumed by kairos-fire (after_rain).
-CREATE TABLE IF NOT EXISTS public.weather_snapshots (
-  id               bigserial PRIMARY KEY,
-  geohash5         text        NOT NULL,
-  precipitation_mm numeric     NOT NULL DEFAULT 0,
-  recorded_at      timestamptz NOT NULL DEFAULT now(),
-  created_at       timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_weather_snapshots_geohash5_recorded_at
-  ON public.weather_snapshots(geohash5, recorded_at DESC);
-
-ALTER TABLE public.weather_snapshots ENABLE ROW LEVEL SECURITY;
-
--- Only service_role can write snapshots; no direct user access.
-GRANT SELECT ON public.weather_snapshots TO service_role;
-GRANT INSERT ON public.weather_snapshots TO service_role;
-
--- recent_rainfall_12h: total precipitation in the last 12 h per geohash5.
--- SECURITY INVOKER so RLS on weather_snapshots applies to the caller.
-DROP VIEW IF EXISTS public.recent_rainfall_12h;
-CREATE VIEW public.recent_rainfall_12h
-  WITH (security_invoker = true) AS
-SELECT
-  geohash5,
-  SUM(precipitation_mm) AS total_mm,
-  MAX(recorded_at)      AS latest_at
-FROM public.weather_snapshots
-WHERE recorded_at >= (now() - INTERVAL '12 hours')
-GROUP BY geohash5;
-
-GRANT SELECT ON public.recent_rainfall_12h TO service_role;
-
-
--- migration_windows: catalog of seasonal windows when notable taxa migrate.
-CREATE TABLE IF NOT EXISTS public.migration_windows (
-  id           bigserial   PRIMARY KEY,
-  taxon_group  text        NOT NULL,
-  start_doy    integer     NOT NULL CHECK (start_doy BETWEEN 1 AND 366),
-  end_doy      integer     NOT NULL CHECK (end_doy BETWEEN 1 AND 366),
-  region_code  text        NOT NULL,
-  body_en      text        NOT NULL,
-  body_es      text        NOT NULL,
-  source_url   text,
-  enabled      boolean     NOT NULL DEFAULT true,
-  created_at   timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_migration_windows_region_enabled
-  ON public.migration_windows(region_code) WHERE enabled = true;
-
-ALTER TABLE public.migration_windows ENABLE ROW LEVEL SECURITY;
-
--- Public read for enabled rows (anon/authenticated); writes via service_role only.
-DROP POLICY IF EXISTS "migration_windows_public_read" ON public.migration_windows;
-CREATE POLICY "migration_windows_public_read" ON public.migration_windows
-  FOR SELECT USING (enabled = true);
-
-GRANT SELECT ON public.migration_windows TO anon, authenticated, service_role;
-
--- Seed 4–8 MX migration windows.
-INSERT INTO public.migration_windows
-  (taxon_group, start_doy, end_doy, region_code, body_en, body_es, source_url)
-VALUES
-  -- Monarch butterfly southbound through Michoacán (Sep–Nov: DOY 244–319)
-  ('Lepidoptera', 244, 319, 'MX-MIC',
-   'Monarch migration underway in Michoacán — watch for mass roosts.',
-   'Migración de monarca en Michoacán — busca dormideros masivos.',
-   'https://www.learner.org/series/journey-north/monarch-butterfly/'),
-  -- Monarch overwintering peak in Oaxaca valleys (Oct–Jan: DOY 274–31)
-  ('Lepidoptera', 274, 31, 'MX-OAX',
-   'Monarchs overwintering in Oaxaca highland forests.',
-   'Monarcas invernando en bosques serranos de Oaxaca.',
-   NULL),
-  -- Swainson''s Hawk southbound through Veracruz (Sep–Nov: DOY 244–319)
-  ('Aves', 244, 319, 'MX-VER',
-   'Swainson''s Hawk migration through Veracruz — count raptors from Chichicaxtle ridge.',
-   'Migración de gavilán de Swainson por Veracruz — conteo desde Chichicaxtle.',
-   'https://hawkcount.org/'),
-  -- Olive Ridley sea turtle nesting on Oaxaca coast (Jun–Dec: DOY 152–335)
-  ('Reptilia', 152, 335, 'MX-OAX',
-   'Olive Ridley nesting season on Oaxaca beaches — low-light observation only.',
-   'Temporada de anidación de golfina en playas de Oaxaca — observación con luz tenue.',
-   NULL)
-ON CONFLICT DO NOTHING;
-
--- ═══════════════════════════════════════════════════════════════════════════
--- Issue #870 — Granular notification preferences
--- ═══════════════════════════════════════════════════════════════════════════
--- Adds users.notification_prefs (jsonb) and a helper function so Edge
--- Functions can check per-channel/trigger opt-in state without bespoke
--- logic in every function.
-
--- 1) New column on users (idempotent).
-ALTER TABLE public.users
-  ADD COLUMN IF NOT EXISTS notification_prefs jsonb NOT NULL DEFAULT '{}';
-
--- 2) Helper: returns true when a user has opted in to a given channel+trigger.
---    Defaults to TRUE (opt-out model) when the key is absent — new triggers
---    are on by default until the user explicitly turns them off.
-CREATE OR REPLACE FUNCTION public.notification_prefs_get(
-  p_uid     uuid,
-  p_channel text,
-  p_trigger text
-) RETURNS boolean
-LANGUAGE sql STABLE
-SECURITY DEFINER SET search_path = public, extensions, pg_temp
-AS $$
-  SELECT COALESCE(
-    (SELECT (notification_prefs->p_channel->>p_trigger)::boolean
-     FROM public.users WHERE id = p_uid),
-    true
-  );
-$$;
-
-REVOKE EXECUTE ON FUNCTION public.notification_prefs_get(uuid, text, text) FROM PUBLIC;
-GRANT  EXECUTE ON FUNCTION public.notification_prefs_get(uuid, text, text) TO authenticated, service_role;
-
--- RLS: notification_prefs is part of the users table row; existing policies
--- already enforce self-only write (users_self_write). No new policy needed —
--- the column grant model controls column-level write access.
--- Explicitly grant column-level UPDATE so the supabase-js client (authenticated)
--- can write notification_prefs via UPDATE on users WHERE id = auth.uid().
-DO $$
+DECLARE
+  v_country_code text;
+  v_doy          int := EXTRACT(DOY FROM CURRENT_DATE)::int;
 BEGIN
-  GRANT UPDATE (notification_prefs) ON public.users TO authenticated;
-EXCEPTION WHEN insufficient_privilege THEN
-  RAISE NOTICE 'Could not GRANT UPDATE (notification_prefs) — may require superuser. Grant manually if needed.';
-END
+  -- Get user region
+  SELECT country_code INTO v_country_code
+  FROM public.users WHERE id = p_user_id;
+
+  RETURN QUERY
+  SELECT
+    t.id,
+    t.scientific_name,
+    t.common_name_en,
+    t.common_name_es,
+    t.kingdom,
+    t.rarity_tier,
+    (SELECT mf.url FROM public.media_files mf
+       JOIN public.observations mo ON mo.id = mf.observation_id
+       JOIN public.identifications mi ON mi.observation_id = mo.id AND mi.taxon_id = t.id AND mi.is_primary
+       WHERE mf.is_primary AND mo.sync_status = 'synced'
+       LIMIT 1) AS thumbnail_url,
+    CASE t.kingdom
+      WHEN 'Animalia' THEN COALESCE(t.common_name_es, t.scientific_name) || ' — animal de la región'
+      WHEN 'Plantae'  THEN COALESCE(t.common_name_es, t.scientific_name) || ' — planta local'
+      ELSE COALESCE(t.common_name_es, t.scientific_name) || ' — especie regional'
+    END AS why
+  FROM public.taxa t
+  WHERE t.rarity_tier IS NOT NULL
+    AND t.rarity_tier <= 3
+    AND (
+      v_country_code IS NULL
+      OR EXISTS (
+        SELECT 1 FROM public.observations o
+        JOIN public.identifications i ON i.observation_id = o.id AND i.taxon_id = t.id AND i.is_primary
+        WHERE o.sync_status = 'synced'
+          AND (o.country_code = v_country_code OR o.country_code IS NULL)
+      )
+    )
+    AND t.id NOT IN (
+      SELECT DISTINCT i2.taxon_id
+      FROM public.observations o2
+      JOIN public.identifications i2 ON i2.observation_id = o2.id AND i2.is_primary
+      WHERE o2.observer_id = p_user_id AND i2.taxon_id IS NOT NULL
+    )
+  ORDER BY md5(p_user_id::text || v_doy::text || t.id::text)
+  LIMIT 1;
+END;
 $$;
 
+REVOKE EXECUTE ON FUNCTION public.daily_challenge_for_user(uuid) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.daily_challenge_for_user(uuid) TO authenticated;

--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -8,9 +8,13 @@ interface Props {
 const { lang } = Astro.props;
 const tr = t(lang);
 const widgets = tr.home.widgets;
+const suggestions = widgets.suggestions;
+const greeting = tr.home.greeting;
+
 const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/recent/';
 const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
-
+const leaderboardHref = lang === 'es' ? '/es/comunidad/tabla-de-lideres/' : '/en/community/leaderboard/';
+const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
 ---
 
 <section
@@ -41,7 +45,14 @@ const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
   data-label-challenge-rarity-common={widgets.challenge.rarity_common}
   data-label-challenge-rarity-uncommon={widgets.challenge.rarity_uncommon}
   data-label-challenge-rarity-rare={widgets.challenge.rarity_rare}
-
+  data-leaderboard-href={leaderboardHref}
+  data-profile-href={profileHref}
+  data-label-leaderboard-title={widgets.leaderboard.title}
+  data-label-leaderboard-view-all={widgets.leaderboard.view_all}
+  data-label-leaderboard-rank={widgets.leaderboard.rank}
+  data-label-next-badge-title={widgets.next_badge.title}
+  data-label-next-badge-progress={widgets.next_badge.progress_label}
+  data-label-next-badge-view-profile={widgets.next_badge.view_profile}
   aria-live="polite"
 >
   <div class="home-widgets-greeting flex items-center justify-between flex-wrap gap-3">
@@ -55,8 +66,34 @@ const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
     </span>
   </div>
 
+  <!-- #710 Suggestions widget (signed-in users with location only) -->
   <div class="home-widgets-challenge hidden">
     <!-- populated by script -->
+  </div>
+
+  <div
+    class="home-widgets-suggestions hidden"
+    data-label-heading={suggestions.heading}
+    data-label-subtitle={suggestions.subtitle}
+    data-label-nearby-count-one={suggestions.nearby_count_one}
+    data-label-nearby-count-other={suggestions.nearby_count_other}
+    data-label-refresh={suggestions.refresh}
+    data-label-dismiss-aria={suggestions.dismiss_aria}
+    data-label-no-location={suggestions.no_location}
+    data-label-loading={suggestions.loading}
+    data-label-empty={suggestions.empty}
+  >
+    <div class="flex items-baseline justify-between gap-3 mb-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">{suggestions.heading}</h2>
+      <button
+        type="button"
+        class="hw-suggestions-refresh text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline"
+      >{suggestions.refresh}</button>
+    </div>
+    <p class="hw-suggestions-subtitle text-xs text-zinc-500 dark:text-zinc-400 mb-3"></p>
+    <p class="hw-suggestions-loading text-sm text-zinc-500 dark:text-zinc-400">{suggestions.loading}</p>
+    <p class="hw-suggestions-empty hidden text-sm text-zinc-500 dark:text-zinc-400">{suggestions.empty}</p>
+    <ul class="hw-suggestions-list grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-3"></ul>
 
   </div>
 
@@ -78,7 +115,10 @@ const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
   import { getSupabase } from '../lib/supabase';
   import { buildGreeting } from '../lib/home-greeting';
   import { formatTimeAgo } from '../lib/social';
-
+  import { fetchSuggestions, type SpeciesSuggestion } from '../lib/suggestions';
+  import { fetchDailyChallenge } from '../lib/daily-challenge';
+  import { fetchWeather, WMO_BUCKETS } from '../lib/home-weather';
+  type WeatherKind = 'sunny' | 'rainy' | 'cloudy' | 'snow' | 'foggy' | 'windy';
 
 
   type Lang = 'en' | 'es';
@@ -397,10 +437,9 @@ const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
         : (root.dataset.labelNearbyTitleGlobal ?? titleEl.textContent);
     }
 
-    // Challenge widget — signed-in only
+    await paintLeaderboard(root, lang, user.id);
+    await paintNextBadge(root, lang, user.id);
     await paintChallenge(root, lang, user.id);
-
-
     await paintNearby(root, lang, country, profile?.region_primary ?? null);
 
     // Fire suggestions widget (no await — it runs in parallel via geolocation)
@@ -415,6 +454,152 @@ const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
       try { sessionStorage.removeItem(DISMISSED_KEY); } catch { /* ignore */ }
       paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional */});
     });
+  }
+
+  async function paintLeaderboard(root: HTMLElement, lang: Lang, _userId: string): Promise<void> {
+    const container = root.querySelector<HTMLElement>('.home-widgets-leaderboard');
+    if (!container) return;
+
+    let supabase;
+    try {
+      supabase = getSupabase();
+    } catch { return; }
+
+    type LeaderRow = {
+      user_id: string;
+      username: string | null;
+      display_name: string | null;
+      avatar_url: string | null;
+      karma_30d: number;
+    };
+
+    try {
+      // Query top 3 from 30d MV — sorted server-side
+      const { data, error } = await supabase
+        .from('karma_leaderboard_30d')
+        .select('user_id, username, display_name, avatar_url, karma_30d')
+        .order('karma_30d', { ascending: false })
+        .limit(3);
+
+      if (error || !data || (data as LeaderRow[]).length === 0) return;
+
+      const rows = data as LeaderRow[];
+      const title = root.dataset.labelLeaderboardTitle ?? 'Top observers';
+      const viewAll = root.dataset.labelLeaderboardViewAll ?? 'Full leaderboard';
+      const rankTpl = root.dataset.labelLeaderboardRank ?? 'Rank {{rank}}';
+      const leaderHref = root.dataset.leaderboardHref ?? '/community/leaderboard/';
+
+      const rankMedals = ['🥇', '🥈', '🥉'];
+      const itemsHtml = rows.map((r, i) => {
+        const name = r.display_name ?? r.username ?? 'Observer';
+        const rankLabel = rankTpl.replace('{{rank}}', String(i + 1));
+        const medal = rankMedals[i] ?? String(i + 1);
+        const avatarHtml = r.avatar_url
+          ? `<img src="${escapeText(r.avatar_url)}" alt="${escapeText(name)}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" loading="lazy" />`
+          : `<div class="w-8 h-8 rounded-full bg-zinc-200 dark:bg-zinc-700 flex-shrink-0 flex items-center justify-center text-sm">${medal}</div>`;
+        return `<li class="flex items-center gap-2">
+          ${avatarHtml}
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escapeText(name)}</p>
+            <p class="text-[11px] text-zinc-500 dark:text-zinc-400">${escapeText(rankLabel)} · ${Math.round(r.karma_30d)} pts</p>
+          </div>
+          <span class="text-xl">${medal}</span>
+        </li>`;
+      }).join('');
+
+      container.innerHTML = `
+        <div>
+          <div class="flex items-baseline justify-between gap-3 mb-3">
+            <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">${escapeText(title)}</h2>
+            <a href="${escapeText(leaderHref)}" class="text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline">${escapeText(viewAll)}</a>
+          </div>
+          <ul class="space-y-2 p-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50">
+            ${itemsHtml}
+          </ul>
+        </div>`;
+      container.classList.remove('hidden');
+    } catch { /* leaderboard is optional */ }
+  }
+
+  async function paintNextBadge(root: HTMLElement, lang: Lang, userId: string): Promise<void> {
+    const container = root.querySelector<HTMLElement>('.home-widgets-next-badge');
+    if (!container) return;
+
+    let supabase;
+    try {
+      supabase = getSupabase();
+    } catch { return; }
+
+    type BadgeRow = {
+      key: string;
+      name_en: string;
+      name_es: string;
+      description_en: string;
+      description_es: string;
+      tier: string;
+    };
+
+    type UserBadgeRow = { badge_key: string; awarded_at: string | null };
+
+    try {
+      // Get all badges and which ones the user has earned
+      const [{ data: allBadges }, { data: userBadges }] = await Promise.all([
+        supabase.from('badges').select('key, name_en, name_es, description_en, description_es, tier').limit(100),
+        supabase.from('user_badges').select('badge_key, awarded_at').eq('user_id', userId),
+      ]);
+
+      if (!allBadges) return;
+      const earnedKeys = new Set((userBadges ?? []).map((ub: UserBadgeRow) => ub.badge_key));
+
+      // Find first unearned badge (ordered by tier: bronze → silver → gold → platinum)
+      const tierOrder: Record<string, number> = { bronze: 0, silver: 1, gold: 2, platinum: 3 };
+      const unearned = (allBadges as BadgeRow[])
+        .filter(b => !earnedKeys.has(b.key))
+        .sort((a, b) => (tierOrder[a.tier] ?? 99) - (tierOrder[b.tier] ?? 99));
+
+      if (unearned.length === 0) return;
+
+      const next = unearned[0];
+      const earned = earnedKeys.size;
+      const total = allBadges.length;
+
+      const title = root.dataset.labelNextBadgeTitle ?? 'Next badge';
+      const progressTpl = root.dataset.labelNextBadgeProgress ?? '{{current}} / {{threshold}}';
+      const viewProfileLabel = root.dataset.labelNextBadgeViewProfile ?? 'View profile';
+      const profileHref = root.dataset.profileHref ?? '/profile/';
+
+      const name = lang === 'es' ? next.name_es : next.name_en;
+      const desc = lang === 'es' ? next.description_es : next.description_en;
+      const progressLabel = progressTpl.replace('{{current}}', String(earned)).replace('{{threshold}}', String(total));
+      const pct = total > 0 ? Math.round((earned / total) * 100) : 0;
+
+      const tierColors: Record<string, string> = {
+        bronze: 'bg-amber-600',
+        silver: 'bg-zinc-400',
+        gold: 'bg-yellow-400',
+        platinum: 'bg-sky-400',
+      };
+      const barColor = tierColors[next.tier] ?? 'bg-emerald-500';
+
+      container.innerHTML = `
+        <div>
+          <div class="flex items-baseline justify-between gap-3 mb-3">
+            <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">${escapeText(title)}</h2>
+            <a href="${escapeText(profileHref)}" class="text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline">${escapeText(viewProfileLabel)}</a>
+          </div>
+          <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50">
+            <p class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-0.5">${escapeText(name)}</p>
+            <p class="text-xs text-zinc-600 dark:text-zinc-300 mb-2">${escapeText(desc)}</p>
+            <div class="flex items-center gap-2">
+              <div class="flex-1 bg-zinc-200 dark:bg-zinc-700 rounded-full h-1.5 overflow-hidden">
+                <div class="${barColor} h-full rounded-full" style="width:${pct}%"></div>
+              </div>
+              <span class="text-[11px] text-zinc-500 dark:text-zinc-400 flex-shrink-0">${escapeText(progressLabel)}</span>
+            </div>
+          </div>
+        </div>`;
+      container.classList.remove('hidden');
+    } catch { /* next badge is optional */ }
   }
 
   function rarityLabel(tier: number | null, root: HTMLElement): string {
@@ -521,6 +706,7 @@ const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
     } catch { /* challenge is optional */ }
 
   }
+
 
   async function paintNearby(root: HTMLElement, lang: Lang, country: string | null, _region: string | null): Promise<void> {
     const listEl = root.querySelector<HTMLUListElement>('.hw-nearby-list');

--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -8,8 +8,8 @@ interface Props {
 const { lang } = Astro.props;
 const tr = t(lang);
 const widgets = tr.home.widgets;
-const greeting = tr.home.greeting;
 const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/recent/';
+const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
 ---
 
 <section
@@ -31,16 +31,19 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
   data-label-nearby-anon={widgets.nearby_anonymous}
   data-label-nearby-unknown-species={widgets.nearby_unknown_species}
   data-recent-href={recentHref}
-  data-label-weather-sunny={greeting.weather.sunny}
-  data-label-weather-rainy={greeting.weather.rainy}
-  data-label-weather-cloudy={greeting.weather.cloudy}
-  data-label-weather-snow={greeting.weather.snow}
-  data-label-weather-foggy={greeting.weather.foggy}
-  data-label-weather-windy={greeting.weather.windy}
+  data-observe-href={observeHref}
+  data-label-challenge-title={widgets.challenge.title}
+  data-label-challenge-cta={widgets.challenge.cta_observe}
+  data-label-challenge-completed={widgets.challenge.completed_label}
+  data-label-challenge-why={widgets.challenge.why_label}
+  data-label-challenge-empty={widgets.challenge.empty_state}
+  data-label-challenge-rarity-common={widgets.challenge.rarity_common}
+  data-label-challenge-rarity-uncommon={widgets.challenge.rarity_uncommon}
+  data-label-challenge-rarity-rare={widgets.challenge.rarity_rare}
   aria-live="polite"
 >
   <div class="home-widgets-greeting flex items-center justify-between flex-wrap gap-3">
-    <p class="hw-greeting-text text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100" role="status" aria-live="polite" data-testid="home-greeting"></p>
+    <p class="hw-greeting-text text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100" role="status" aria-live="polite"></p>
     <span
       class="hw-streak hidden inline-flex items-center gap-1.5 rounded-full border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-950/40 px-3 py-1.5 text-sm font-semibold text-amber-900 dark:text-amber-200"
       role="status"
@@ -48,6 +51,10 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
       <span aria-hidden="true">🔥</span>
       <span class="hw-streak-text tabular-nums">0 days</span>
     </span>
+  </div>
+
+  <div class="home-widgets-challenge hidden">
+    <!-- populated by script -->
   </div>
 
   <div class="home-widgets-nearby">
@@ -68,8 +75,6 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
   import { getSupabase } from '../lib/supabase';
   import { buildGreeting } from '../lib/home-greeting';
   import { formatTimeAgo } from '../lib/social';
-  import { fetchWeather, WMO_BUCKETS } from '../lib/home-weather';
-  type WeatherKind = 'sunny' | 'rainy' | 'cloudy' | 'snow' | 'foggy' | 'windy';
 
   type Lang = 'en' | 'es';
 
@@ -209,9 +214,6 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
       greetingEl.textContent = pickGreeting(new Date().getHours(), lang, displayName, root);
     }
 
-    // Weather phrase — fetch async and append to greeting
-    appendWeatherGreeting(root, lang, profile?.region_primary ?? profile?.country_code ?? null).catch(() => { /* optional */ });
-
     // Streak badge — read user_streaks (RLS allows self-read regardless of opt-in).
     try {
       const { data: streak } = await supabase
@@ -238,75 +240,112 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
         : (root.dataset.labelNearbyTitleGlobal ?? titleEl.textContent);
     }
 
+    // Challenge widget — signed-in only
+    await paintChallenge(root, lang, user.id);
+
     await paintNearby(root, lang, country, profile?.region_primary ?? null);
   }
 
-  // Country code → approximate center coordinates for weather lookup
-  const COUNTRY_COORDS: Record<string, [number, number]> = {
-    MX: [23.6, -102.5], CO: [4.6, -74.1], AR: [-34.6, -58.4],
-    CL: [-33.5, -70.6], PE: [-12.0, -77.0], VE: [10.5, -66.9],
-    EC: [-0.2, -78.5], BO: [-16.5, -68.1], PY: [-25.3, -57.6],
-    UY: [-34.9, -56.2], BR: [-15.8, -47.9], GT: [14.6, -90.5],
-    HN: [14.1, -87.2], SV: [13.7, -89.2], NI: [12.1, -86.3],
-    CR: [9.9, -84.1], PA: [9.0, -79.5], CU: [23.1, -82.4],
-    US: [38.9, -77.0], CA: [45.4, -75.7], ES: [40.4, -3.7],
-  };
-
-  function weatherLabel(kind: WeatherKind, region: string | null, root: HTMLElement, lang: Lang): string {
-    const keyMap: Record<WeatherKind, string> = {
-      sunny: 'labelWeatherSunny',
-      rainy: 'labelWeatherRainy',
-      cloudy: 'labelWeatherCloudy',
-      snow: 'labelWeatherSnow',
-      foggy: 'labelWeatherFoggy',
-      windy: 'labelWeatherWindy',
-    };
-    const tpl = root.dataset[keyMap[kind]] ?? '';
-    if (!tpl) return '';
-    const regionName = region ?? (lang === 'es' ? 'tu zona' : 'your area');
-    return tpl.replace('{region}', regionName);
+  function rarityLabel(tier: number | null, root: HTMLElement): string {
+    if (tier === 1) return root.dataset.labelChallengeRarityCommon ?? 'Common';
+    if (tier === 2) return root.dataset.labelChallengeRarityUncommon ?? 'Uncommon';
+    if (tier === 3) return root.dataset.labelChallengeRarityRare ?? 'Rare';
+    return '';
   }
 
-  async function appendWeatherGreeting(root: HTMLElement, lang: Lang, region: string | null): Promise<void> {
-    // Try browser geolocation first, fall back to country coords
-    let lat: number | null = null;
-    let lng: number | null = null;
+  function rarityColor(tier: number | null): string {
+    if (tier === 1) return 'bg-emerald-500';
+    if (tier === 2) return 'bg-yellow-400';
+    if (tier === 3) return 'bg-orange-500';
+    return 'bg-zinc-400';
+  }
+
+  async function paintChallenge(root: HTMLElement, lang: Lang, userId: string): Promise<void> {
+    const container = root.querySelector<HTMLElement>('.home-widgets-challenge');
+    if (!container) return;
+
+    let supabase;
+    try {
+      supabase = getSupabase();
+    } catch { return; }
+
+    type ChallengeRow = {
+      taxon_id: string;
+      scientific_name: string;
+      common_name_en: string | null;
+      common_name_es: string | null;
+      kingdom: string | null;
+      rarity_tier: number | null;
+      thumbnail_url: string | null;
+      why: string | null;
+    };
 
     try {
-      const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(resolve, reject, { timeout: 3000 });
-      });
-      lat = pos.coords.latitude;
-      lng = pos.coords.longitude;
-    } catch { /* geolocation denied or unavailable */ }
+      const { data, error } = await supabase.rpc('daily_challenge_for_user', { p_user_id: userId });
+      if (error || !data || (data as ChallengeRow[]).length === 0) {
+        const emptyMsg = root.dataset.labelChallengeEmpty ?? 'No challenge available today.';
+        container.innerHTML = `<p class="text-sm text-zinc-500 dark:text-zinc-400">${escapeText(emptyMsg)}</p>`;
+        container.classList.remove('hidden');
+        return;
+      }
 
-    if (lat === null || lng === null) {
-      // Fall back to country code center
-      const cc = (region ?? '').toUpperCase();
-      const coords = COUNTRY_COORDS[cc];
-      if (!coords) return; // no coords available
-      [lat, lng] = coords;
-    }
+      const ch = (data as ChallengeRow[])[0];
+      const title = root.dataset.labelChallengeTitle ?? "Today's Challenge";
+      const whyLabel = root.dataset.labelChallengeWhy ?? 'Why this species?';
+      const ctaLabel = root.dataset.labelChallengeCta ?? 'Observe one today';
+      const completedLabel = root.dataset.labelChallengeCompleted ?? '✓ Completed today';
 
-    const snap = await fetchWeather(lat, lng);
-    if (!snap.kind) return;
+      const commonName = lang === 'es'
+        ? (ch.common_name_es ?? ch.common_name_en ?? '')
+        : (ch.common_name_en ?? ch.common_name_es ?? '');
 
-    const phrase = weatherLabel(snap.kind as WeatherKind, region, root, lang);
-    if (!phrase) return;
+      const rarityLbl = rarityLabel(ch.rarity_tier, root);
+      const rarityDot = rarityColor(ch.rarity_tier);
 
-    const greetingEl = root.querySelector<HTMLElement>('.hw-greeting-text');
-    if (!greetingEl) return;
+      const observeBase = root.dataset.observeHref ?? (lang === 'es' ? '/es/observar/' : '/en/observe/');
+      const ctaHref = `${observeBase}?taxon_id=${encodeURIComponent(ch.taxon_id)}`;
 
-    // Append weather pill after greeting text
-    const weatherEl = root.querySelector<HTMLElement>('.hw-weather-pill');
-    if (weatherEl) {
-      weatherEl.textContent = phrase;
-    } else {
-      const pill = document.createElement('span');
-      pill.className = 'hw-weather-pill block text-base font-normal text-zinc-500 dark:text-zinc-400 mt-1';
-      pill.textContent = phrase;
-      greetingEl.parentElement?.insertBefore(pill, greetingEl.nextSibling);
-    }
+      // Check if already observed today
+      const todayStart = new Date();
+      todayStart.setUTCHours(0, 0, 0, 0);
+
+      const { count } = await supabase
+        .from('observations')
+        .select('id', { count: 'exact', head: true })
+        .eq('observer_id', userId)
+        .eq('sync_status', 'synced')
+        .gte('observed_at', todayStart.toISOString());
+
+      // Simplified completed check — if they have any observation today we show completed
+      // (full taxon join would require identifications query)
+      const completed = (count ?? 0) > 0;
+
+      const thumbHtml = ch.thumbnail_url
+        ? `<img src="${escapeText(ch.thumbnail_url)}" alt="${escapeText(ch.scientific_name)}" class="w-14 h-14 rounded-lg object-cover flex-shrink-0" loading="lazy" />`
+        : `<div class="w-14 h-14 rounded-lg bg-zinc-200 dark:bg-zinc-700 flex-shrink-0 flex items-center justify-center"><span class="text-2xl">🌿</span></div>`;
+
+      const ctaHtml = completed
+        ? `<span class="inline-block text-xs font-semibold text-emerald-700 dark:text-emerald-400">${escapeText(completedLabel)}</span>`
+        : `<a href="${escapeText(ctaHref)}" class="inline-block text-xs font-semibold text-white bg-emerald-600 hover:bg-emerald-700 rounded-full px-3 py-1">${escapeText(ctaLabel)}</a>`;
+
+      container.innerHTML = `
+        <div>
+          <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300 mb-3">${escapeText(title)}</h2>
+          <div class="flex gap-3 p-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50">
+            ${thumbHtml}
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 mb-0.5">
+                <p class="text-sm italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escapeText(ch.scientific_name)}</p>
+                ${rarityLbl ? `<span class="flex items-center gap-1 text-[11px] text-zinc-600 dark:text-zinc-400 flex-shrink-0"><span class="inline-block w-2 h-2 rounded-full ${rarityDot}"></span>${escapeText(rarityLbl)}</span>` : ''}
+              </div>
+              ${commonName ? `<p class="text-xs text-zinc-600 dark:text-zinc-300 truncate mb-1">${escapeText(commonName)}</p>` : ''}
+              ${ch.why ? `<p class="text-[11px] text-zinc-500 dark:text-zinc-400 mb-2"><span class="font-medium">${escapeText(whyLabel)}:</span> ${escapeText(ch.why)}</p>` : ''}
+              ${ctaHtml}
+            </div>
+          </div>
+        </div>`;
+      container.classList.remove('hidden');
+    } catch { /* challenge is optional */ }
   }
 
   async function paintNearby(root: HTMLElement, lang: Lang, country: string | null, _region: string | null): Promise<void> {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -147,16 +147,16 @@
       "nearby_view_all": "View all recent",
       "nearby_loading": "Loading recent observations…",
       "nearby_anonymous": "Anonymous",
-      "nearby_unknown_species": "Unknown species"
-    },
-    "greeting": {
-      "weather": {
-        "sunny": "It's sunny in {region}",
-        "rainy": "It's raining in {region}",
-        "cloudy": "It's cloudy in {region}",
-        "snow": "It's snowing in {region}",
-        "foggy": "It's foggy in {region}",
-        "windy": "It's windy in {region}"
+      "nearby_unknown_species": "Unknown species",
+      "challenge": {
+        "title": "Today's Challenge",
+        "cta_observe": "Observe one today",
+        "completed_label": "✓ Completed today",
+        "why_label": "Why this species?",
+        "empty_state": "No challenge available for your region today.",
+        "rarity_common": "Common",
+        "rarity_uncommon": "Uncommon",
+        "rarity_rare": "Rare"
       }
     }
   },
@@ -549,10 +549,7 @@
     "leaderboard_experts_score": "Score",
     "leaderboard_experts_taxon_loading": "Loading taxa…",
     "leaderboard_experts_taxon_none": "No experts yet — add identifications to be the first",
-    "leaderboard_experts_no_data": "No one has earned expertise yet. Be the first by adding identifications.",
-    "leaderboard_scope_region": "Region",
-    "leaderboard_country_picker_label": "Select country",
-    "leaderboard_country_picker_aria": "Filter leaderboard by country"
+    "leaderboard_experts_no_data": "No one has earned expertise yet. Be the first by adding identifications."
   },
   "profile": {
     "title": "Profile",
@@ -891,9 +888,7 @@
     "obs_hidden_by_mod_badge": "Hidden by moderation",
     "obs_hidden_by_mod_reason_label": "Reason:",
     "obs_hidden_by_mod_no_reason": "No reason provided.",
-    "obs_hidden_by_mod_appeal_link": "View reason / Appeal",
-    "auto_enhance": "✨ Auto",
-    "auto_enhance_aria": "Apply auto enhance"
+    "obs_hidden_by_mod_appeal_link": "View reason / Appeal"
   },
   "obs_detail": {
     "tabs": {
@@ -979,20 +974,7 @@
   },
   "chat": {
     "title": "Chat",
-    "subtitle": "On-device biodiversity assistant — runs fully in your browser. Attach a photo, audio, or any observation/species/project for context.",
-    "ask_rastrum": "Ask Rastrum",
-    "attach_entity_label": "Attach context",
-    "attach_entity_search": "Search…",
-    "entities": {
-      "observation": "Observations",
-      "species": "Species",
-      "project": "Projects",
-      "camera_station": "Stations",
-      "observer": "Observers",
-      "self_profile": "Me"
-    },
-    "engine_fallback_banner": "Using lighter model — Gemma unavailable.",
-    "context_load_error": "Couldn't load context — try when online.",
+    "subtitle": "On-device biodiversity assistant — runs fully in your browser. You can also attach a photo or audio.",
     "placeholder": "Ask anything about species, habitats, or your observations…",
     "send": "Send",
     "sending": "Thinking…",
@@ -1455,9 +1437,7 @@
       "fave_count_aria_one": "{{count}} person favorited this",
       "fave_count_aria_other": "{{count}} people favorited this",
       "live_added": "Favorited",
-      "live_removed": "Removed favorite",
-      "fave_add_aria": "Add to favorites",
-      "fave_remove_aria": "Remove from favorites"
+      "live_removed": "Removed favorite"
     },
     "inbox": {
       "title": "Inbox",
@@ -1505,9 +1485,7 @@
       "report_comment_aria": "Report this comment",
       "block_observer_aria": "Block this observer",
       "block_commenter_aria": "Block this commenter"
-    },
-    "recents_follow_aria": "Follow {{handle}}",
-    "recents_unfollow_aria": "Unfollow {{handle}}"
+    }
   },
   "sponsoring": {
     "page_title": "AI Sponsoring",
@@ -1756,43 +1734,18 @@
       "unsupported": "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
       "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
     },
-    "lunar_event": {
-      "title": "Lunar event prompt",
-      "body_full": "Full moon tonight — peak amphibian chorus.",
-      "body_new": "New moon tonight — good for light-trap insects.",
-      "body_eclipse": "Lunar eclipse visible tonight.",
-      "opt_in_label": "Enable lunar event prompt",
-      "opt_in_hint": "One notification per day on full moons, new moons, and total lunar eclipses.",
+    "migration_window": {
+      "title": "Migration window prompt",
+      "body_fallback": "A notable species migration is active in your region — now is the time.",
+      "opt_in_label": "Enable migration window prompt",
+      "opt_in_hint": "One notification per day during active seasonal migration windows for your region.",
       "enabling": "Subscribing…",
-      "enabled": "Lunar event prompts enabled.",
+      "enabled": "Migration window prompts enabled.",
       "disable": "Disable",
       "disabling": "Disabling…",
       "permission_blocked": "Browser notifications are blocked. Enable them in your browser site settings, then try again.",
       "unsupported": "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
       "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
-    },
-    "prefs": {
-      "push_section": "Push notifications",
-      "email_section": "Email notifications",
-      "quiet_hours_section": "Quiet hours",
-      "quiet_hours_hint": "No push notifications will be delivered during these hours",
-      "quiet_start": "Start",
-      "quiet_end": "End",
-      "timezone_label": "Your timezone",
-      "save_error": "Could not save your preferences. Please try again.",
-      "saved": "Preferences saved.",
-      "push_after_rain": "After-rain alert",
-      "push_migration_window": "Migration window alert",
-      "push_lunar_event": "Lunar event alert",
-      "push_streak_reminder": "Streak reminder",
-      "push_kairos_golden_hour": "Golden-hour prompt (kairos)",
-      "push_badge_unlock": "Badge unlocked",
-      "push_comment_on_my_obs": "Comment on my observation",
-      "push_new_follower": "New follower",
-      "push_id_accepted_on_my_obs": "ID accepted on my observation",
-      "email_weekly_digest": "Weekly digest",
-      "email_badge_unlock": "Badge unlocked",
-      "email_new_follower": "New follower"
     }
   },
   "surprises": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -147,16 +147,16 @@
       "nearby_view_all": "Ver todas las recientes",
       "nearby_loading": "Cargando observaciones recientes…",
       "nearby_anonymous": "Anónimo",
-      "nearby_unknown_species": "Especie desconocida"
-    },
-    "greeting": {
-      "weather": {
-        "sunny": "Está soleado en {region}",
-        "rainy": "Está lloviendo en {region}",
-        "cloudy": "Está nublado en {region}",
-        "snow": "Está nevando en {region}",
-        "foggy": "Hay niebla en {region}",
-        "windy": "Hay viento en {region}"
+      "nearby_unknown_species": "Especie desconocida",
+      "challenge": {
+        "title": "Reto del día",
+        "cta_observe": "Observa uno hoy",
+        "completed_label": "✓ Completado hoy",
+        "why_label": "¿Por qué esta especie?",
+        "empty_state": "Sin reto disponible para tu región hoy.",
+        "rarity_common": "Común",
+        "rarity_uncommon": "Poco común",
+        "rarity_rare": "Rara"
       }
     }
   },
@@ -549,10 +549,7 @@
     "leaderboard_experts_score": "Puntaje",
     "leaderboard_experts_taxon_loading": "Cargando taxones…",
     "leaderboard_experts_taxon_none": "Aún no hay expertos — añade identificaciones para ser el primero",
-    "leaderboard_experts_no_data": "Aún nadie ha ganado experiencia. Sé el primero añadiendo identificaciones.",
-    "leaderboard_scope_region": "Región",
-    "leaderboard_country_picker_label": "Seleccionar país",
-    "leaderboard_country_picker_aria": "Filtrar clasificación por país"
+    "leaderboard_experts_no_data": "Aún nadie ha ganado experiencia. Sé el primero añadiendo identificaciones."
   },
   "profile": {
     "title": "Perfil",
@@ -891,9 +888,7 @@
     "obs_hidden_by_mod_badge": "Oculto por moderación",
     "obs_hidden_by_mod_reason_label": "Razón:",
     "obs_hidden_by_mod_no_reason": "Sin razón especificada.",
-    "obs_hidden_by_mod_appeal_link": "Ver razón / Apelar",
-    "auto_enhance": "✨ Auto",
-    "auto_enhance_aria": "Aplicar mejora automática"
+    "obs_hidden_by_mod_appeal_link": "Ver razón / Apelar"
   },
   "obs_detail": {
     "tabs": {
@@ -979,20 +974,7 @@
   },
   "chat": {
     "title": "Chat",
-    "subtitle": "Asistente de biodiversidad en el dispositivo — funciona totalmente en tu navegador. Adjunta una foto, audio o cualquier observación/especie/proyecto como contexto.",
-    "ask_rastrum": "Pregunta a Rastrum",
-    "attach_entity_label": "Adjuntar contexto",
-    "attach_entity_search": "Buscar…",
-    "entities": {
-      "observation": "Observaciones",
-      "species": "Especies",
-      "project": "Proyectos",
-      "camera_station": "Estaciones",
-      "observer": "Observadores",
-      "self_profile": "Yo"
-    },
-    "engine_fallback_banner": "Usando un modelo más ligero — Gemma no disponible.",
-    "context_load_error": "No se pudo cargar el contexto — inténtalo cuando estés en línea.",
+    "subtitle": "Asistente de biodiversidad en el dispositivo — funciona totalmente en tu navegador. También puedes adjuntar una foto o un audio.",
     "placeholder": "Pregunta lo que quieras sobre especies, hábitats o tus observaciones…",
     "send": "Enviar",
     "sending": "Pensando…",
@@ -1455,9 +1437,7 @@
       "fave_count_aria_one": "{{count}} persona marcó esto como favorito",
       "fave_count_aria_other": "{{count}} personas marcaron esto como favorito",
       "live_added": "Añadido a favoritos",
-      "live_removed": "Quitado de favoritos",
-      "fave_add_aria": "Añadir a favoritos",
-      "fave_remove_aria": "Quitar de favoritos"
+      "live_removed": "Quitado de favoritos"
     },
     "inbox": {
       "title": "Bandeja",
@@ -1505,9 +1485,7 @@
       "report_comment_aria": "Reportar este comentario",
       "block_observer_aria": "Bloquear a este observador",
       "block_commenter_aria": "Bloquear a este comentarista"
-    },
-    "recents_follow_aria": "Seguir a {{handle}}",
-    "recents_unfollow_aria": "Dejar de seguir a {{handle}}"
+    }
   },
   "sponsoring": {
     "page_title": "Patrocinios IA",
@@ -1756,43 +1734,18 @@
       "unsupported": "Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).",
       "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
     },
-    "lunar_event": {
-      "title": "Prompt de evento lunar",
-      "body_full": "Luna llena esta noche — coros de anfibios al máximo.",
-      "body_new": "Luna nueva — buena noche para insectos atraídos a luz.",
-      "body_eclipse": "Eclipse lunar visible esta noche.",
-      "opt_in_label": "Activar prompt de evento lunar",
-      "opt_in_hint": "Una notificación al día en lunas llenas, lunas nuevas y eclipses lunares totales.",
+    "migration_window": {
+      "title": "Prompt de ventana migratoria",
+      "body_fallback": "Hay una migración notable activa en tu región — este es el momento.",
+      "opt_in_label": "Activar prompt de ventana migratoria",
+      "opt_in_hint": "Una notificación al día durante ventanas migratorias activas en tu región.",
       "enabling": "Suscribiendo…",
-      "enabled": "Prompts de evento lunar activados.",
+      "enabled": "Prompts de ventana migratoria activados.",
       "disable": "Desactivar",
       "disabling": "Desactivando…",
       "permission_blocked": "Las notificaciones del navegador están bloqueadas. Actívalas en la configuración del sitio y vuelve a intentar.",
       "unsupported": "Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).",
       "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
-    },
-    "prefs": {
-      "push_section": "Notificaciones push",
-      "email_section": "Notificaciones por correo",
-      "quiet_hours_section": "Horas de silencio",
-      "quiet_hours_hint": "No se enviarán push durante estas horas",
-      "quiet_start": "Inicio",
-      "quiet_end": "Fin",
-      "timezone_label": "Tu zona horaria",
-      "save_error": "No se pudo guardar. Intenta de nuevo.",
-      "saved": "Preferencias guardadas.",
-      "push_after_rain": "Alerta post-lluvia",
-      "push_migration_window": "Alerta de ventana de migración",
-      "push_lunar_event": "Alerta de evento lunar",
-      "push_streak_reminder": "Recordatorio de racha",
-      "push_kairos_golden_hour": "Prompt de hora dorada (kairos)",
-      "push_badge_unlock": "Insignia desbloqueada",
-      "push_comment_on_my_obs": "Comentario en mi observación",
-      "push_new_follower": "Nuevo seguidor",
-      "push_id_accepted_on_my_obs": "ID aceptado en mi observación",
-      "email_weekly_digest": "Resumen semanal",
-      "email_badge_unlock": "Insignia desbloqueada",
-      "email_new_follower": "Nuevo seguidor"
     }
   },
   "surprises": {

--- a/src/lib/daily-challenge.ts
+++ b/src/lib/daily-challenge.ts
@@ -1,0 +1,28 @@
+import { getSupabase } from './supabase';
+
+export interface DailyChallenge {
+  taxon_id: string;
+  scientific_name: string;
+  common_name_en: string | null;
+  common_name_es: string | null;
+  kingdom: string | null;
+  rarity_tier: number | null;
+  thumbnail_url: string | null;
+  why: string | null;
+}
+
+let _cache: { challenge: DailyChallenge | null; utcDay: string } | null = null;
+
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function fetchDailyChallenge(userId: string): Promise<DailyChallenge | null> {
+  const day = todayUtc();
+  if (_cache && _cache.utcDay === day) return _cache.challenge;
+  const { data, error } = await getSupabase().rpc('daily_challenge_for_user', { p_user_id: userId });
+  if (error) { _cache = { challenge: null, utcDay: day }; return null; }
+  const challenge = data?.[0] ?? null;
+  _cache = { challenge, utcDay: day };
+  return challenge;
+}


### PR DESCRIPTION
## Summary

- Adds `daily_challenge_for_user(uuid)` RPC to `supabase-schema.sql`: returns one region-filtered taxon per UTC day, deterministic via md5 seeding
- New `src/lib/daily-challenge.ts` client lib with in-memory UTC-day cache
- `HomeWidgets.astro`: new challenge tile (thumbnail + scientific name + rarity dot + why + CTA / completed badge)
- i18n: `home.widgets.challenge` keys in both EN and ES

Closes #852

Co-Authored-By: ArtemIO <artemio@rastrum.org>