### PR TITLE
test(home): E2E tests for greeting time-bucket (#864)

### DIFF
--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -33,7 +33,7 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
   aria-live="polite"
 >
   <div class="home-widgets-greeting flex items-center justify-between flex-wrap gap-3">
-    <p class="hw-greeting-text text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100" role="status" aria-live="polite"></p>
+    <p class="hw-greeting-text text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100" role="status" aria-live="polite" data-testid="home-greeting"></p>
     <span
       class="hw-streak hidden inline-flex items-center gap-1.5 rounded-full border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-950/40 px-3 py-1.5 text-sm font-semibold text-amber-900 dark:text-amber-200"
       role="status"

--- a/tests/e2e/home-greeting.spec.ts
+++ b/tests/e2e/home-greeting.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * E2E: greeting time-bucket flip at 06:00 / 12:00 / 19:00
+ *
+ * Tests the greeting text rendered in `.hw-greeting-text[data-testid="home-greeting"]`
+ * for all four time buckets in both EN and ES. Date is mocked via addInitScript
+ * so the test is deterministic regardless of when it runs.
+ *
+ * Spec: tests/unit/home-greeting.test.ts covers the pure helper (bucketForHour);
+ * this suite covers the rendered DOM end-to-end.
+ *
+ * Note: the greeting element is populated client-side after Supabase session probe.
+ * For signed-out visitors the greeting phrase still renders (no-name form) using
+ * the time-bucket label from the data-attributes on the widget root.
+ */
+import { test, expect } from '@playwright/test';
+
+type GreetingCase = {
+  hour: number;
+  locale: 'en' | 'es';
+  path: string;
+  expected: string;
+};
+
+const CASES: GreetingCase[] = [
+  // ES — four buckets
+  { hour: 5,  locale: 'es', path: '/es/', expected: 'Buenas madrugadas' },
+  { hour: 9,  locale: 'es', path: '/es/', expected: 'Buenos días' },
+  { hour: 13, locale: 'es', path: '/es/', expected: 'Buenas tardes' },
+  { hour: 21, locale: 'es', path: '/es/', expected: 'Buenas noches' },
+  // EN — four buckets
+  { hour: 5,  locale: 'en', path: '/en/', expected: 'Up late' },
+  { hour: 9,  locale: 'en', path: '/en/', expected: 'Good morning' },
+  { hour: 13, locale: 'en', path: '/en/', expected: 'Good afternoon' },
+  { hour: 21, locale: 'en', path: '/en/', expected: 'Good evening' },
+];
+
+for (const { hour, locale, path, expected } of CASES) {
+  test(`greeting at ${hour}:00 (${locale}): "${expected}"`, async ({ page }) => {
+    // Mock Date.now() and `new Date()` before any page scripts run.
+    // Use a fixed UTC timestamp at the given hour (UTC). Since
+    // HomeWidgets reads `.getHours()` which is local-time, CI machines
+    // in UTC will get the right bucket directly. Tests that care about
+    // TZ differences belong to unit coverage.
+    const isoTs = `2026-05-09T${String(hour).padStart(2, '0')}:30:00.000Z`;
+    await page.addInitScript((ts: string) => {
+      const fixed = new Date(ts).valueOf();
+      const Orig = Date;
+      // @ts-ignore
+      class MockDate extends Orig {
+        constructor(...args: unknown[]) {
+          if (args.length === 0) { super(fixed); return; }
+          // @ts-ignore
+          super(...args);
+        }
+        static now() { return fixed; }
+        static parse(s: string) { return Orig.parse(s); }
+        static UTC(...args: Parameters<typeof Date.UTC>) { return Orig.UTC(...args); }
+      }
+      // @ts-ignore
+      globalThis.Date = MockDate;
+    }, isoTs);
+
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+    // The greeting element is hydrated synchronously once the script runs.
+    // Wait up to 5 s for the text to appear.
+    const greetingEl = page.locator('[data-testid="home-greeting"]').first();
+    await expect(greetingEl).toContainText(expected, { timeout: 5_000 });
+  });
+}


### PR DESCRIPTION
## Scope

8 Playwright tests (4 time-buckets × 2 locales) that verify the home greeting renders the correct phrase at:

| Hour | ES | EN |
|---|---|---|
| 05:30 | Buenas madrugadas | Up late |
| 09:30 | Buenos días | Good morning |
| 13:30 | Buenas tardes | Good afternoon |
| 21:30 | Buenas noches | Good evening |

## Technique

`page.addInitScript` overrides `Date` before page scripts run — this is the same approach used in other temporal E2E tests in the suite.

## Stability hook

Added `data-testid="home-greeting"` to the `.hw-greeting-text` element so the test selector is independent of copy changes.

## Test plan
- `npm run test`: 1486 passed, 4 pre-existing failures (unchanged)
- `npx tsc --noEmit`: clean (3 pre-existing @huggingface/transformers only)
- Playwright: `npm run test:e2e -- home-greeting` — requires a running dev server

## v1.1.x follow-up
- Add TZ-aware bucket tests once the greeting localizes bucket boundaries per user timezone

Closes #864