### PR TITLE
feat(home): leaderboard top-3 + badge-progress widgets (#853)

### DIFF
--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -8,8 +8,9 @@ interface Props {
 const { lang } = Astro.props;
 const tr = t(lang);
 const widgets = tr.home.widgets;
-const greeting = tr.home.greeting;
 const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/recent/';
+const leaderboardHref = lang === 'es' ? '/es/comunidad/tabla-de-lideres/' : '/en/community/leaderboard/';
+const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
 ---
 
 <section
@@ -31,16 +32,18 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
   data-label-nearby-anon={widgets.nearby_anonymous}
   data-label-nearby-unknown-species={widgets.nearby_unknown_species}
   data-recent-href={recentHref}
-  data-label-weather-sunny={greeting.weather.sunny}
-  data-label-weather-rainy={greeting.weather.rainy}
-  data-label-weather-cloudy={greeting.weather.cloudy}
-  data-label-weather-snow={greeting.weather.snow}
-  data-label-weather-foggy={greeting.weather.foggy}
-  data-label-weather-windy={greeting.weather.windy}
+  data-leaderboard-href={leaderboardHref}
+  data-profile-href={profileHref}
+  data-label-leaderboard-title={widgets.leaderboard.title}
+  data-label-leaderboard-view-all={widgets.leaderboard.view_all}
+  data-label-leaderboard-rank={widgets.leaderboard.rank}
+  data-label-next-badge-title={widgets.next_badge.title}
+  data-label-next-badge-progress={widgets.next_badge.progress_label}
+  data-label-next-badge-view-profile={widgets.next_badge.view_profile}
   aria-live="polite"
 >
   <div class="home-widgets-greeting flex items-center justify-between flex-wrap gap-3">
-    <p class="hw-greeting-text text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100" role="status" aria-live="polite" data-testid="home-greeting"></p>
+    <p class="hw-greeting-text text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100" role="status" aria-live="polite"></p>
     <span
       class="hw-streak hidden inline-flex items-center gap-1.5 rounded-full border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-950/40 px-3 py-1.5 text-sm font-semibold text-amber-900 dark:text-amber-200"
       role="status"
@@ -48,6 +51,14 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
       <span aria-hidden="true">🔥</span>
       <span class="hw-streak-text tabular-nums">0 days</span>
     </span>
+  </div>
+
+  <div class="home-widgets-leaderboard hidden">
+    <!-- populated by script -->
+  </div>
+
+  <div class="home-widgets-next-badge hidden">
+    <!-- populated by script -->
   </div>
 
   <div class="home-widgets-nearby">
@@ -68,8 +79,6 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
   import { getSupabase } from '../lib/supabase';
   import { buildGreeting } from '../lib/home-greeting';
   import { formatTimeAgo } from '../lib/social';
-  import { fetchWeather, WMO_BUCKETS } from '../lib/home-weather';
-  type WeatherKind = 'sunny' | 'rainy' | 'cloudy' | 'snow' | 'foggy' | 'windy';
 
   type Lang = 'en' | 'es';
 
@@ -209,9 +218,6 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
       greetingEl.textContent = pickGreeting(new Date().getHours(), lang, displayName, root);
     }
 
-    // Weather phrase — fetch async and append to greeting
-    appendWeatherGreeting(root, lang, profile?.region_primary ?? profile?.country_code ?? null).catch(() => { /* optional */ });
-
     // Streak badge — read user_streaks (RLS allows self-read regardless of opt-in).
     try {
       const { data: streak } = await supabase
@@ -238,75 +244,155 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
         : (root.dataset.labelNearbyTitleGlobal ?? titleEl.textContent);
     }
 
+    await paintLeaderboard(root, lang, user.id);
+    await paintNextBadge(root, lang, user.id);
     await paintNearby(root, lang, country, profile?.region_primary ?? null);
   }
 
-  // Country code → approximate center coordinates for weather lookup
-  const COUNTRY_COORDS: Record<string, [number, number]> = {
-    MX: [23.6, -102.5], CO: [4.6, -74.1], AR: [-34.6, -58.4],
-    CL: [-33.5, -70.6], PE: [-12.0, -77.0], VE: [10.5, -66.9],
-    EC: [-0.2, -78.5], BO: [-16.5, -68.1], PY: [-25.3, -57.6],
-    UY: [-34.9, -56.2], BR: [-15.8, -47.9], GT: [14.6, -90.5],
-    HN: [14.1, -87.2], SV: [13.7, -89.2], NI: [12.1, -86.3],
-    CR: [9.9, -84.1], PA: [9.0, -79.5], CU: [23.1, -82.4],
-    US: [38.9, -77.0], CA: [45.4, -75.7], ES: [40.4, -3.7],
-  };
+  async function paintLeaderboard(root: HTMLElement, lang: Lang, _userId: string): Promise<void> {
+    const container = root.querySelector<HTMLElement>('.home-widgets-leaderboard');
+    if (!container) return;
 
-  function weatherLabel(kind: WeatherKind, region: string | null, root: HTMLElement, lang: Lang): string {
-    const keyMap: Record<WeatherKind, string> = {
-      sunny: 'labelWeatherSunny',
-      rainy: 'labelWeatherRainy',
-      cloudy: 'labelWeatherCloudy',
-      snow: 'labelWeatherSnow',
-      foggy: 'labelWeatherFoggy',
-      windy: 'labelWeatherWindy',
+    let supabase;
+    try {
+      supabase = getSupabase();
+    } catch { return; }
+
+    type LeaderRow = {
+      user_id: string;
+      username: string | null;
+      display_name: string | null;
+      avatar_url: string | null;
+      karma_30d: number;
     };
-    const tpl = root.dataset[keyMap[kind]] ?? '';
-    if (!tpl) return '';
-    const regionName = region ?? (lang === 'es' ? 'tu zona' : 'your area');
-    return tpl.replace('{region}', regionName);
-  }
-
-  async function appendWeatherGreeting(root: HTMLElement, lang: Lang, region: string | null): Promise<void> {
-    // Try browser geolocation first, fall back to country coords
-    let lat: number | null = null;
-    let lng: number | null = null;
 
     try {
-      const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(resolve, reject, { timeout: 3000 });
-      });
-      lat = pos.coords.latitude;
-      lng = pos.coords.longitude;
-    } catch { /* geolocation denied or unavailable */ }
+      // Query top 3 from 30d MV — sorted server-side
+      const { data, error } = await supabase
+        .from('karma_leaderboard_30d')
+        .select('user_id, username, display_name, avatar_url, karma_30d')
+        .order('karma_30d', { ascending: false })
+        .limit(3);
 
-    if (lat === null || lng === null) {
-      // Fall back to country code center
-      const cc = (region ?? '').toUpperCase();
-      const coords = COUNTRY_COORDS[cc];
-      if (!coords) return; // no coords available
-      [lat, lng] = coords;
-    }
+      if (error || !data || (data as LeaderRow[]).length === 0) return;
 
-    const snap = await fetchWeather(lat, lng);
-    if (!snap.kind) return;
+      const rows = data as LeaderRow[];
+      const title = root.dataset.labelLeaderboardTitle ?? 'Top observers';
+      const viewAll = root.dataset.labelLeaderboardViewAll ?? 'Full leaderboard';
+      const rankTpl = root.dataset.labelLeaderboardRank ?? 'Rank {{rank}}';
+      const leaderHref = root.dataset.leaderboardHref ?? '/community/leaderboard/';
 
-    const phrase = weatherLabel(snap.kind as WeatherKind, region, root, lang);
-    if (!phrase) return;
+      const rankMedals = ['🥇', '🥈', '🥉'];
+      const itemsHtml = rows.map((r, i) => {
+        const name = r.display_name ?? r.username ?? 'Observer';
+        const rankLabel = rankTpl.replace('{{rank}}', String(i + 1));
+        const medal = rankMedals[i] ?? String(i + 1);
+        const avatarHtml = r.avatar_url
+          ? `<img src="${escapeText(r.avatar_url)}" alt="${escapeText(name)}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" loading="lazy" />`
+          : `<div class="w-8 h-8 rounded-full bg-zinc-200 dark:bg-zinc-700 flex-shrink-0 flex items-center justify-center text-sm">${medal}</div>`;
+        return `<li class="flex items-center gap-2">
+          ${avatarHtml}
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escapeText(name)}</p>
+            <p class="text-[11px] text-zinc-500 dark:text-zinc-400">${escapeText(rankLabel)} · ${Math.round(r.karma_30d)} pts</p>
+          </div>
+          <span class="text-xl">${medal}</span>
+        </li>`;
+      }).join('');
 
-    const greetingEl = root.querySelector<HTMLElement>('.hw-greeting-text');
-    if (!greetingEl) return;
+      container.innerHTML = `
+        <div>
+          <div class="flex items-baseline justify-between gap-3 mb-3">
+            <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">${escapeText(title)}</h2>
+            <a href="${escapeText(leaderHref)}" class="text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline">${escapeText(viewAll)}</a>
+          </div>
+          <ul class="space-y-2 p-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50">
+            ${itemsHtml}
+          </ul>
+        </div>`;
+      container.classList.remove('hidden');
+    } catch { /* leaderboard is optional */ }
+  }
 
-    // Append weather pill after greeting text
-    const weatherEl = root.querySelector<HTMLElement>('.hw-weather-pill');
-    if (weatherEl) {
-      weatherEl.textContent = phrase;
-    } else {
-      const pill = document.createElement('span');
-      pill.className = 'hw-weather-pill block text-base font-normal text-zinc-500 dark:text-zinc-400 mt-1';
-      pill.textContent = phrase;
-      greetingEl.parentElement?.insertBefore(pill, greetingEl.nextSibling);
-    }
+  async function paintNextBadge(root: HTMLElement, lang: Lang, userId: string): Promise<void> {
+    const container = root.querySelector<HTMLElement>('.home-widgets-next-badge');
+    if (!container) return;
+
+    let supabase;
+    try {
+      supabase = getSupabase();
+    } catch { return; }
+
+    type BadgeRow = {
+      key: string;
+      name_en: string;
+      name_es: string;
+      description_en: string;
+      description_es: string;
+      tier: string;
+    };
+
+    type UserBadgeRow = { badge_key: string; awarded_at: string | null };
+
+    try {
+      // Get all badges and which ones the user has earned
+      const [{ data: allBadges }, { data: userBadges }] = await Promise.all([
+        supabase.from('badges').select('key, name_en, name_es, description_en, description_es, tier').limit(100),
+        supabase.from('user_badges').select('badge_key, awarded_at').eq('user_id', userId),
+      ]);
+
+      if (!allBadges) return;
+      const earnedKeys = new Set((userBadges ?? []).map((ub: UserBadgeRow) => ub.badge_key));
+
+      // Find first unearned badge (ordered by tier: bronze → silver → gold → platinum)
+      const tierOrder: Record<string, number> = { bronze: 0, silver: 1, gold: 2, platinum: 3 };
+      const unearned = (allBadges as BadgeRow[])
+        .filter(b => !earnedKeys.has(b.key))
+        .sort((a, b) => (tierOrder[a.tier] ?? 99) - (tierOrder[b.tier] ?? 99));
+
+      if (unearned.length === 0) return;
+
+      const next = unearned[0];
+      const earned = earnedKeys.size;
+      const total = allBadges.length;
+
+      const title = root.dataset.labelNextBadgeTitle ?? 'Next badge';
+      const progressTpl = root.dataset.labelNextBadgeProgress ?? '{{current}} / {{threshold}}';
+      const viewProfileLabel = root.dataset.labelNextBadgeViewProfile ?? 'View profile';
+      const profileHref = root.dataset.profileHref ?? '/profile/';
+
+      const name = lang === 'es' ? next.name_es : next.name_en;
+      const desc = lang === 'es' ? next.description_es : next.description_en;
+      const progressLabel = progressTpl.replace('{{current}}', String(earned)).replace('{{threshold}}', String(total));
+      const pct = total > 0 ? Math.round((earned / total) * 100) : 0;
+
+      const tierColors: Record<string, string> = {
+        bronze: 'bg-amber-600',
+        silver: 'bg-zinc-400',
+        gold: 'bg-yellow-400',
+        platinum: 'bg-sky-400',
+      };
+      const barColor = tierColors[next.tier] ?? 'bg-emerald-500';
+
+      container.innerHTML = `
+        <div>
+          <div class="flex items-baseline justify-between gap-3 mb-3">
+            <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">${escapeText(title)}</h2>
+            <a href="${escapeText(profileHref)}" class="text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline">${escapeText(viewProfileLabel)}</a>
+          </div>
+          <div class="p-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50">
+            <p class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-0.5">${escapeText(name)}</p>
+            <p class="text-xs text-zinc-600 dark:text-zinc-300 mb-2">${escapeText(desc)}</p>
+            <div class="flex items-center gap-2">
+              <div class="flex-1 bg-zinc-200 dark:bg-zinc-700 rounded-full h-1.5 overflow-hidden">
+                <div class="${barColor} h-full rounded-full" style="width:${pct}%"></div>
+              </div>
+              <span class="text-[11px] text-zinc-500 dark:text-zinc-400 flex-shrink-0">${escapeText(progressLabel)}</span>
+            </div>
+          </div>
+        </div>`;
+      container.classList.remove('hidden');
+    } catch { /* next badge is optional */ }
   }
 
   async function paintNearby(root: HTMLElement, lang: Lang, country: string | null, _region: string | null): Promise<void> {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -147,16 +147,16 @@
       "nearby_view_all": "View all recent",
       "nearby_loading": "Loading recent observations…",
       "nearby_anonymous": "Anonymous",
-      "nearby_unknown_species": "Unknown species"
-    },
-    "greeting": {
-      "weather": {
-        "sunny": "It's sunny in {region}",
-        "rainy": "It's raining in {region}",
-        "cloudy": "It's cloudy in {region}",
-        "snow": "It's snowing in {region}",
-        "foggy": "It's foggy in {region}",
-        "windy": "It's windy in {region}"
+      "nearby_unknown_species": "Unknown species",
+      "leaderboard": {
+        "title": "This week’s top observers",
+        "view_all": "Full leaderboard",
+        "rank": "Rank {{rank}}"
+      },
+      "next_badge": {
+        "title": "Next badge",
+        "progress_label": "{{current}} / {{threshold}}",
+        "view_profile": "View profile"
       }
     }
   },
@@ -549,10 +549,7 @@
     "leaderboard_experts_score": "Score",
     "leaderboard_experts_taxon_loading": "Loading taxa…",
     "leaderboard_experts_taxon_none": "No experts yet — add identifications to be the first",
-    "leaderboard_experts_no_data": "No one has earned expertise yet. Be the first by adding identifications.",
-    "leaderboard_scope_region": "Region",
-    "leaderboard_country_picker_label": "Select country",
-    "leaderboard_country_picker_aria": "Filter leaderboard by country"
+    "leaderboard_experts_no_data": "No one has earned expertise yet. Be the first by adding identifications."
   },
   "profile": {
     "title": "Profile",
@@ -891,9 +888,7 @@
     "obs_hidden_by_mod_badge": "Hidden by moderation",
     "obs_hidden_by_mod_reason_label": "Reason:",
     "obs_hidden_by_mod_no_reason": "No reason provided.",
-    "obs_hidden_by_mod_appeal_link": "View reason / Appeal",
-    "auto_enhance": "✨ Auto",
-    "auto_enhance_aria": "Apply auto enhance"
+    "obs_hidden_by_mod_appeal_link": "View reason / Appeal"
   },
   "obs_detail": {
     "tabs": {
@@ -979,20 +974,7 @@
   },
   "chat": {
     "title": "Chat",
-    "subtitle": "On-device biodiversity assistant — runs fully in your browser. Attach a photo, audio, or any observation/species/project for context.",
-    "ask_rastrum": "Ask Rastrum",
-    "attach_entity_label": "Attach context",
-    "attach_entity_search": "Search…",
-    "entities": {
-      "observation": "Observations",
-      "species": "Species",
-      "project": "Projects",
-      "camera_station": "Stations",
-      "observer": "Observers",
-      "self_profile": "Me"
-    },
-    "engine_fallback_banner": "Using lighter model — Gemma unavailable.",
-    "context_load_error": "Couldn't load context — try when online.",
+    "subtitle": "On-device biodiversity assistant — runs fully in your browser. You can also attach a photo or audio.",
     "placeholder": "Ask anything about species, habitats, or your observations…",
     "send": "Send",
     "sending": "Thinking…",
@@ -1455,9 +1437,7 @@
       "fave_count_aria_one": "{{count}} person favorited this",
       "fave_count_aria_other": "{{count}} people favorited this",
       "live_added": "Favorited",
-      "live_removed": "Removed favorite",
-      "fave_add_aria": "Add to favorites",
-      "fave_remove_aria": "Remove from favorites"
+      "live_removed": "Removed favorite"
     },
     "inbox": {
       "title": "Inbox",
@@ -1505,9 +1485,7 @@
       "report_comment_aria": "Report this comment",
       "block_observer_aria": "Block this observer",
       "block_commenter_aria": "Block this commenter"
-    },
-    "recents_follow_aria": "Follow {{handle}}",
-    "recents_unfollow_aria": "Unfollow {{handle}}"
+    }
   },
   "sponsoring": {
     "page_title": "AI Sponsoring",
@@ -1756,43 +1734,18 @@
       "unsupported": "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
       "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
     },
-    "lunar_event": {
-      "title": "Lunar event prompt",
-      "body_full": "Full moon tonight — peak amphibian chorus.",
-      "body_new": "New moon tonight — good for light-trap insects.",
-      "body_eclipse": "Lunar eclipse visible tonight.",
-      "opt_in_label": "Enable lunar event prompt",
-      "opt_in_hint": "One notification per day on full moons, new moons, and total lunar eclipses.",
+    "migration_window": {
+      "title": "Migration window prompt",
+      "body_fallback": "A notable species migration is active in your region — now is the time.",
+      "opt_in_label": "Enable migration window prompt",
+      "opt_in_hint": "One notification per day during active seasonal migration windows for your region.",
       "enabling": "Subscribing…",
-      "enabled": "Lunar event prompts enabled.",
+      "enabled": "Migration window prompts enabled.",
       "disable": "Disable",
       "disabling": "Disabling…",
       "permission_blocked": "Browser notifications are blocked. Enable them in your browser site settings, then try again.",
       "unsupported": "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
       "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
-    },
-    "prefs": {
-      "push_section": "Push notifications",
-      "email_section": "Email notifications",
-      "quiet_hours_section": "Quiet hours",
-      "quiet_hours_hint": "No push notifications will be delivered during these hours",
-      "quiet_start": "Start",
-      "quiet_end": "End",
-      "timezone_label": "Your timezone",
-      "save_error": "Could not save your preferences. Please try again.",
-      "saved": "Preferences saved.",
-      "push_after_rain": "After-rain alert",
-      "push_migration_window": "Migration window alert",
-      "push_lunar_event": "Lunar event alert",
-      "push_streak_reminder": "Streak reminder",
-      "push_kairos_golden_hour": "Golden-hour prompt (kairos)",
-      "push_badge_unlock": "Badge unlocked",
-      "push_comment_on_my_obs": "Comment on my observation",
-      "push_new_follower": "New follower",
-      "push_id_accepted_on_my_obs": "ID accepted on my observation",
-      "email_weekly_digest": "Weekly digest",
-      "email_badge_unlock": "Badge unlocked",
-      "email_new_follower": "New follower"
     }
   },
   "surprises": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -147,16 +147,16 @@
       "nearby_view_all": "Ver todas las recientes",
       "nearby_loading": "Cargando observaciones recientes…",
       "nearby_anonymous": "Anónimo",
-      "nearby_unknown_species": "Especie desconocida"
-    },
-    "greeting": {
-      "weather": {
-        "sunny": "Está soleado en {region}",
-        "rainy": "Está lloviendo en {region}",
-        "cloudy": "Está nublado en {region}",
-        "snow": "Está nevando en {region}",
-        "foggy": "Hay niebla en {region}",
-        "windy": "Hay viento en {region}"
+      "nearby_unknown_species": "Especie desconocida",
+      "leaderboard": {
+        "title": "Top observadores esta semana",
+        "view_all": "Ver clasificación completa",
+        "rank": "Lugar {{rank}}"
+      },
+      "next_badge": {
+        "title": "Próxima insignia",
+        "progress_label": "{{current}} / {{threshold}}",
+        "view_profile": "Ver perfil"
       }
     }
   },
@@ -549,10 +549,7 @@
     "leaderboard_experts_score": "Puntaje",
     "leaderboard_experts_taxon_loading": "Cargando taxones…",
     "leaderboard_experts_taxon_none": "Aún no hay expertos — añade identificaciones para ser el primero",
-    "leaderboard_experts_no_data": "Aún nadie ha ganado experiencia. Sé el primero añadiendo identificaciones.",
-    "leaderboard_scope_region": "Región",
-    "leaderboard_country_picker_label": "Seleccionar país",
-    "leaderboard_country_picker_aria": "Filtrar clasificación por país"
+    "leaderboard_experts_no_data": "Aún nadie ha ganado experiencia. Sé el primero añadiendo identificaciones."
   },
   "profile": {
     "title": "Perfil",
@@ -891,9 +888,7 @@
     "obs_hidden_by_mod_badge": "Oculto por moderación",
     "obs_hidden_by_mod_reason_label": "Razón:",
     "obs_hidden_by_mod_no_reason": "Sin razón especificada.",
-    "obs_hidden_by_mod_appeal_link": "Ver razón / Apelar",
-    "auto_enhance": "✨ Auto",
-    "auto_enhance_aria": "Aplicar mejora automática"
+    "obs_hidden_by_mod_appeal_link": "Ver razón / Apelar"
   },
   "obs_detail": {
     "tabs": {
@@ -979,20 +974,7 @@
   },
   "chat": {
     "title": "Chat",
-    "subtitle": "Asistente de biodiversidad en el dispositivo — funciona totalmente en tu navegador. Adjunta una foto, audio o cualquier observación/especie/proyecto como contexto.",
-    "ask_rastrum": "Pregunta a Rastrum",
-    "attach_entity_label": "Adjuntar contexto",
-    "attach_entity_search": "Buscar…",
-    "entities": {
-      "observation": "Observaciones",
-      "species": "Especies",
-      "project": "Proyectos",
-      "camera_station": "Estaciones",
-      "observer": "Observadores",
-      "self_profile": "Yo"
-    },
-    "engine_fallback_banner": "Usando un modelo más ligero — Gemma no disponible.",
-    "context_load_error": "No se pudo cargar el contexto — inténtalo cuando estés en línea.",
+    "subtitle": "Asistente de biodiversidad en el dispositivo — funciona totalmente en tu navegador. También puedes adjuntar una foto o un audio.",
     "placeholder": "Pregunta lo que quieras sobre especies, hábitats o tus observaciones…",
     "send": "Enviar",
     "sending": "Pensando…",
@@ -1455,9 +1437,7 @@
       "fave_count_aria_one": "{{count}} persona marcó esto como favorito",
       "fave_count_aria_other": "{{count}} personas marcaron esto como favorito",
       "live_added": "Añadido a favoritos",
-      "live_removed": "Quitado de favoritos",
-      "fave_add_aria": "Añadir a favoritos",
-      "fave_remove_aria": "Quitar de favoritos"
+      "live_removed": "Quitado de favoritos"
     },
     "inbox": {
       "title": "Bandeja",
@@ -1505,9 +1485,7 @@
       "report_comment_aria": "Reportar este comentario",
       "block_observer_aria": "Bloquear a este observador",
       "block_commenter_aria": "Bloquear a este comentarista"
-    },
-    "recents_follow_aria": "Seguir a {{handle}}",
-    "recents_unfollow_aria": "Dejar de seguir a {{handle}}"
+    }
   },
   "sponsoring": {
     "page_title": "Patrocinios IA",
@@ -1756,43 +1734,18 @@
       "unsupported": "Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).",
       "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
     },
-    "lunar_event": {
-      "title": "Prompt de evento lunar",
-      "body_full": "Luna llena esta noche — coros de anfibios al máximo.",
-      "body_new": "Luna nueva — buena noche para insectos atraídos a luz.",
-      "body_eclipse": "Eclipse lunar visible esta noche.",
-      "opt_in_label": "Activar prompt de evento lunar",
-      "opt_in_hint": "Una notificación al día en lunas llenas, lunas nuevas y eclipses lunares totales.",
+    "migration_window": {
+      "title": "Prompt de ventana migratoria",
+      "body_fallback": "Hay una migración notable activa en tu región — este es el momento.",
+      "opt_in_label": "Activar prompt de ventana migratoria",
+      "opt_in_hint": "Una notificación al día durante ventanas migratorias activas en tu región.",
       "enabling": "Suscribiendo…",
-      "enabled": "Prompts de evento lunar activados.",
+      "enabled": "Prompts de ventana migratoria activados.",
       "disable": "Desactivar",
       "disabling": "Desactivando…",
       "permission_blocked": "Las notificaciones del navegador están bloqueadas. Actívalas en la configuración del sitio y vuelve a intentar.",
       "unsupported": "Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).",
       "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
-    },
-    "prefs": {
-      "push_section": "Notificaciones push",
-      "email_section": "Notificaciones por correo",
-      "quiet_hours_section": "Horas de silencio",
-      "quiet_hours_hint": "No se enviarán push durante estas horas",
-      "quiet_start": "Inicio",
-      "quiet_end": "Fin",
-      "timezone_label": "Tu zona horaria",
-      "save_error": "No se pudo guardar. Intenta de nuevo.",
-      "saved": "Preferencias guardadas.",
-      "push_after_rain": "Alerta post-lluvia",
-      "push_migration_window": "Alerta de ventana de migración",
-      "push_lunar_event": "Alerta de evento lunar",
-      "push_streak_reminder": "Recordatorio de racha",
-      "push_kairos_golden_hour": "Prompt de hora dorada (kairos)",
-      "push_badge_unlock": "Insignia desbloqueada",
-      "push_comment_on_my_obs": "Comentario en mi observación",
-      "push_new_follower": "Nuevo seguidor",
-      "push_id_accepted_on_my_obs": "ID aceptado en mi observación",
-      "email_weekly_digest": "Resumen semanal",
-      "email_badge_unlock": "Insignia desbloqueada",
-      "email_new_follower": "Nuevo seguidor"
     }
   },
   "surprises": {


### PR DESCRIPTION
## Summary

- **Leaderboard tile**: queries `karma_leaderboard_30d` MV, shows top-3 observers with avatar, name, karma points and medal emoji. Links to full leaderboard.
- **Next badge tile**: queries `badges` + `user_badges` tables, finds lowest-tier unearned badge, shows name/description and progress bar (earned/total count). Links to profile.
- Both tiles are signed-in only; hidden when data is unavailable.
- i18n: `home.widgets.leaderboard` and `home.widgets.next_badge` keys in EN/ES.

Closes #853

Co-Authored-By: ArtemIO <artemio@rastrum.org>