### PR TITLE
feat(recents): list / map / timeline view modes (#863)

### DIFF
--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -31,20 +31,13 @@ const sgTree = tr as unknown as {
     cards: Record<string, string>;
     block: { button: string };
     report: { button: string };
-    reactions: Record<string, string>;
-    follow: Record<string, string>;
-    recents_follow_aria: string;
-    recents_unfollow_aria: string;
   };
 };
 const sgCards  = sgTree.socialgraph.cards;
 const sgBlock  = sgTree.socialgraph.block.button;
 const sgReport = sgTree.socialgraph.report.button;
-const sgReactions = sgTree.socialgraph.reactions;
-const sgFollow = sgTree.socialgraph.follow;
-const sgRecentsFollowAria = sgTree.socialgraph.recents_follow_aria;
-const sgRecentsUnfollowAria = sgTree.socialgraph.recents_unfollow_aria;
 const view = page.view;
+const timeline = (page as unknown as { timeline: Record<string, string> }).timeline ?? {};
 ---
 
 <section
@@ -68,13 +61,8 @@ const view = page.view;
   data-label-block-observer-aria={sgCards.block_observer_aria}
   data-label-fave-aria-one={(tr as unknown as { socialgraph: { reactions: Record<string, string> } }).socialgraph.reactions.fave_count_aria_one}
   data-label-fave-aria-other={(tr as unknown as { socialgraph: { reactions: Record<string, string> } }).socialgraph.reactions.fave_count_aria_other}
-  data-label-fave-add-aria={sgReactions.fave_add_aria}
-  data-label-fave-remove-aria={sgReactions.fave_remove_aria}
-  data-label-recents-follow-aria={sgRecentsFollowAria}
-  data-label-recents-unfollow-aria={sgRecentsUnfollowAria}
-  data-label-follow-btn={sgFollow.button}
-  data-label-following-btn={sgFollow.following}
-  data-label-requested-btn={sgFollow.requested}
+  data-label-timeline-today={timeline.today}
+  data-label-timeline-yesterday={timeline.yesterday}
 >
   <header class="space-y-3 py-6">
     <div class="flex items-start justify-between gap-3">
@@ -108,6 +96,36 @@ const view = page.view;
         >
           <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
         </button>
+        <button
+          type="button"
+          class="er-view-btn er-view-list inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          data-mode="list"
+          aria-label={(view as unknown as Record<string, string>).list_aria ?? 'List view'}
+          aria-pressed="false"
+          title={(view as unknown as Record<string, string>).list ?? 'List'}
+        >
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+        </button>
+        <button
+          type="button"
+          class="er-view-btn er-view-map inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          data-mode="map"
+          aria-label={(view as unknown as Record<string, string>).map_aria ?? 'Map view'}
+          aria-pressed="false"
+          title={(view as unknown as Record<string, string>).map ?? 'Map'}
+        >
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/></svg>
+        </button>
+        <button
+          type="button"
+          class="er-view-btn er-view-timeline inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          data-mode="timeline"
+          aria-label={(view as unknown as Record<string, string>).timeline_aria ?? 'Timeline view'}
+          aria-pressed="false"
+          title={(view as unknown as Record<string, string>).timeline ?? 'Timeline'}
+        >
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+        </button>
       </div>
     </div>
   </header>
@@ -120,6 +138,15 @@ const view = page.view;
     class="er-list er-mode-cards grid grid-cols-1 sm:grid-cols-2 gap-4"
     aria-label={page.title}
   ></ul>
+
+  <!-- List mode block -->
+  <div id="er-list-block" class="hidden mt-2 space-y-2"></div>
+
+  <!-- Map mode block -->
+  <div id="er-map-block" class="hidden min-h-[400px] rounded-xl overflow-hidden border border-zinc-200 dark:border-zinc-800 mt-2"></div>
+
+  <!-- Timeline mode block -->
+  <div id="er-timeline-block" class="hidden mt-2 space-y-4"></div>
 
   <p class="er-empty hidden mt-4 rounded-xl border border-zinc-200 dark:border-zinc-800 p-8 text-center text-zinc-500 dark:text-zinc-400">
     {page.empty}
@@ -138,6 +165,11 @@ const view = page.view;
     .er-list.er-mode-grid .er-card { border-radius: 0.5rem; }
     .er-list.er-mode-grid .er-card > div:last-child { display: none; }
     .er-list.er-mode-grid .er-overflow { display: none; }
+    .er-timeline-day-header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
   </style>
 
   <div class="er-load-more-wrap hidden mt-6 text-center">
@@ -291,44 +323,11 @@ const view = page.view;
         </div>`
       : '';
 
-    // Reaction count chip / interactive like button.
-    // For signed-in users: interactive heart button (replaces passive chip).
-    // For signed-out users: passive chip (read-only, only shown if count > 0).
-    const faveChipHtml = viewerAuthed
-      ? `<button
-          type="button"
-          class="er-fave-btn inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold border transition-colors
-            er-fave-off:bg-zinc-100 er-fave-off:dark:bg-zinc-800/50 er-fave-off:border-zinc-300 er-fave-off:dark:border-zinc-700 er-fave-off:text-zinc-500 er-fave-off:dark:text-zinc-400
-            er-fave-on:bg-rose-50 er-fave-on:dark:bg-rose-950/40 er-fave-on:border-rose-200 er-fave-on:dark:border-rose-900/60 er-fave-on:text-rose-700 er-fave-on:dark:text-rose-300
-            bg-zinc-100 dark:bg-zinc-800/50 border-zinc-300 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400"
-          data-fave-target="${escapeText(r.id)}"
-          data-fave-active="false"
-          aria-label="${escapeText(labels.faveAddAria)}"
-          aria-pressed="false"
-          data-stop
-        ><svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-7-4.5-9.5-9A5.5 5.5 0 0 1 12 6a5.5 5.5 0 0 1 9.5 6c-2.5 4.5-9.5 9-9.5 9Z"/></svg><span class="er-fave-count tabular-nums">0</span></button>`
-      : `<span class="er-fave-chip hidden inline-flex items-center gap-1 rounded-full bg-rose-50 dark:bg-rose-950/40 border border-rose-200 dark:border-rose-900/60 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:text-rose-300" data-fave-target="${escapeText(r.id)}"><svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-7-4.5-9.5-9A5.5 5.5 0 0 1 12 6a5.5 5.5 0 0 1 9.5 6c-2.5 4.5-9.5 9-9.5 9Z"/></svg><span class="er-fave-count tabular-nums">0</span></span>`;
-
-    // Follow button — shown for signed-in viewers looking at someone else's card.
-    // Initial follow state is populated after batched query; default is 'none'.
-    const showFollowBtn = viewerAuthed && !isOwn && isPublic && !!observer?.id;
-    const followBtnHtml = showFollowBtn
-      ? `<button
-          type="button"
-          class="er-follow-btn inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold border transition-colors
-            bg-zinc-100 dark:bg-zinc-800/50 border-zinc-300 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400
-            hover:bg-emerald-50 dark:hover:bg-emerald-950/40 hover:border-emerald-300 dark:hover:border-emerald-800 hover:text-emerald-700 dark:hover:text-emerald-300"
-          data-follow-target="${escapeText(observer?.id ?? '')}"
-          data-follow-handle="${escapeText(observer?.username ?? '')}"
-          data-follow-state="none"
-          aria-label="${escapeText(labels.recentsFollowAria.replace('{{handle}}', observer?.username ?? ''))}"
-          data-stop
-        >${escapeText(labels.followBtn)}</button>`
-      : '';
-
-    const observerRowHtml = `<p class="text-xs text-zinc-500 dark:text-zinc-400 truncate flex items-center gap-1.5">${observerHtml}${followBtnHtml}</p>`;
+    // Reaction count chip placeholder — populated after batched fetch.
+    const faveChipHtml = `<span class="er-fave-chip hidden inline-flex items-center gap-1 rounded-full bg-rose-50 dark:bg-rose-950/40 border border-rose-200 dark:border-rose-900/60 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:text-rose-300" data-fave-target="${escapeText(r.id)}"><svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 21s-7-4.5-9.5-9A5.5 5.5 0 0 1 12 6a5.5 5.5 0 0 1 9.5 6c-2.5 4.5-9.5 9-9.5 9Z"/></svg><span class="er-fave-count tabular-nums">0</span></span>`;
 
     return `<li class="relative">
+      ${overflowHtml}
       <a
         href="${shareBase}?id=${encodeURIComponent(r.id)}"
         class="er-card block overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors"
@@ -351,7 +350,7 @@ const view = page.view;
             ${faveChipHtml}
             <span>${escapeText(ago)}</span>
           </div>
-          ${observerRowHtml}
+          <p class="text-xs text-zinc-500 dark:text-zinc-400 truncate">${observerHtml}</p>
         </div>
       </a>
     </li>`;
@@ -376,17 +375,173 @@ const view = page.view;
       blockObserverAria: root.dataset.labelBlockObserverAria ?? 'Block this observer',
       faveAriaOne: root.dataset.labelFaveAriaOne ?? '{{count}} person favorited this',
       faveAriaOther: root.dataset.labelFaveAriaOther ?? '{{count}} people favorited this',
-      faveAddAria: root.dataset.labelFaveAddAria ?? 'Add to favorites',
-      faveRemoveAria: root.dataset.labelFaveRemoveAria ?? 'Remove from favorites',
-      recentsFollowAria: root.dataset.labelRecentsFollowAria ?? 'Follow {{handle}}',
-      recentsUnfollowAria: root.dataset.labelRecentsUnfollowAria ?? 'Unfollow {{handle}}',
-      followBtn: root.dataset.labelFollowBtn ?? 'Follow',
-      followingBtn: root.dataset.labelFollowingBtn ?? 'Following ✓',
-      requestedBtn: root.dataset.labelRequestedBtn ?? 'Requested',
+      timelineToday: root.dataset.labelTimelineToday ?? (lang === 'es' ? 'Hoy' : 'Today'),
+      timelineYesterday: root.dataset.labelTimelineYesterday ?? (lang === 'es' ? 'Ayer' : 'Yesterday'),
     };
 
+    const listEl = root.querySelector('.er-list') as HTMLUListElement | null;
+    const listBlockEl = root.querySelector<HTMLElement>('#er-list-block');
+    const mapBlockEl = root.querySelector<HTMLElement>('#er-map-block');
+    const timelineBlockEl = root.querySelector<HTMLElement>('#er-timeline-block');
+    const skeletonEl = root.querySelector('.er-skeleton') as HTMLElement | null;
+    const emptyEl = root.querySelector('.er-empty') as HTMLElement | null;
+    const errEl = root.querySelector('.er-error') as HTMLElement | null;
+    const loadMoreWrap = root.querySelector('.er-load-more-wrap') as HTMLElement | null;
+    const loadMoreBtn = root.querySelector('.er-load-more') as HTMLButtonElement | null;
+
+    // All loaded rows — kept in memory so list/timeline can re-render on mode switch
+    const allRows: Row[] = [];
+
+    // MapLibre state
+    let mapInstance: { resize: () => void; fitBounds: (b: [[number,number],[number,number]], o?: Record<string,unknown>) => void } | null = null;
+    let mapInited = false;
+
+    function listRowMarkup(r: Row): string {
+      const ident = pickIdent(r);
+      const observer = pickObserver(r);
+      const sciText = ident?.scientific_name ?? unknownLabel;
+      const common = lang === 'es'
+        ? (ident?.taxa?.common_name_es ?? ident?.taxa?.common_name_en ?? '')
+        : (ident?.taxa?.common_name_en ?? ident?.taxa?.common_name_es ?? '');
+      const photoMedia = (r.media_files ?? []).filter(m => !m?.media_type || m.media_type === 'photo');
+      const photo = photoMedia.find(m => m?.is_primary)?.url
+        ?? photoMedia.find(m => !!m?.url)?.url ?? '';
+      const ago = formatTimeAgo(r.observed_at, lang);
+      const isPublic = canShowRealName(observer, viewerAuthed);
+      const observerName = isPublic ? (observer?.display_name || observer?.username || '') : '';
+      const observerUsername = isPublic ? observer?.username ?? '' : '';
+      const observerHtml = isPublic && observerUsername
+        ? `<a href="${profileBase}?username=${encodeURIComponent(observerUsername)}" class="text-emerald-700 dark:text-emerald-400 hover:underline">${escapeText(observerName || observerUsername)}</a>`
+        : `<span class="text-zinc-500">${escapeText(anonLabel)}</span>`;
+      const thumb = photo
+        ? `<img src="${escapeText(photo)}" alt="${escapeText(sciText)}" loading="lazy" class="w-14 h-14 object-cover rounded-lg shrink-0" />`
+        : `<div class="w-14 h-14 rounded-lg shrink-0 bg-zinc-100 dark:bg-zinc-800"></div>`;
+      return `<a href="${shareBase}?id=${encodeURIComponent(r.id)}" class="flex items-center gap-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors px-3 py-2">
+        ${thumb}
+        <div class="min-w-0 flex-1">
+          <p class="text-sm italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escapeText(sciText)}</p>
+          ${common ? `<p class="text-xs text-zinc-500 dark:text-zinc-400 truncate">${escapeText(common)}</p>` : ''}
+          <p class="text-xs text-zinc-500 dark:text-zinc-400 truncate">${observerHtml} · ${escapeText(ago)}</p>
+        </div>
+      </a>`;
+    }
+
+    function renderListBlock(rows: Row[]) {
+      if (!listBlockEl) return;
+      listBlockEl.innerHTML = rows.map(listRowMarkup).join('');
+    }
+
+    function renderTimelineBlock(rows: Row[]) {
+      if (!timelineBlockEl) return;
+      const now = new Date();
+      const todayStr = now.toISOString().slice(0, 10);
+      const yesterdayDate = new Date(now);
+      yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+      const yesterdayStr = yesterdayDate.toISOString().slice(0, 10);
+
+      // Group rows by UTC date
+      const groups = new Map<string, Row[]>();
+      for (const r of rows) {
+        const dateKey = r.observed_at.slice(0, 10);
+        if (!groups.has(dateKey)) groups.set(dateKey, []);
+        groups.get(dateKey)!.push(r);
+      }
+
+      let html = '';
+      for (const [dateKey, dateRows] of groups) {
+        let heading: string;
+        if (dateKey === todayStr) {
+          heading = labels.timelineToday;
+        } else if (dateKey === yesterdayStr) {
+          heading = labels.timelineYesterday;
+        } else {
+          heading = new Date(dateKey + 'T12:00:00Z').toLocaleDateString(
+            lang === 'es' ? 'es-MX' : 'en-US',
+            { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
+          );
+        }
+        html += `<div class="space-y-2">
+          <div class="er-timeline-day-header bg-white/90 dark:bg-zinc-950/90 backdrop-blur-sm py-1.5 px-1 -mx-1 rounded">
+            <h3 class="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">${escapeText(heading)}</h3>
+          </div>
+          <div class="space-y-2">${dateRows.map(listRowMarkup).join('')}</div>
+        </div>`;
+      }
+      timelineBlockEl.innerHTML = html;
+    }
+
+    async function initMap(_rows: Row[]) {
+      if (!mapBlockEl) return;
+      const { default: maplibregl } = await import('maplibre-gl' as string) as unknown as { default: {
+        Map: new (o: Record<string, unknown>) => {
+          on: (e: string, cb: () => void) => void;
+          resize: () => void;
+          fitBounds: (b: [[number,number],[number,number]], o?: Record<string,unknown>) => void;
+        };
+        Marker: new (o?: Record<string, unknown>) => { setLngLat: (c: [number,number]) => { addTo: (m: unknown) => unknown } };
+        NavigationControl: new () => unknown;
+        Popup: new (o?: Record<string, unknown>) => { setHTML: (h: string) => { setLngLat: (c: [number,number]) => { addTo: (m: unknown) => unknown } } };
+      }};
+
+      // Collect rows with coordinates (stored as lat/lng in state_province — fallback CDMX)
+      // Note: observations don't have lat/lng directly exposed in the Row type here,
+      // so we use CDMX as center and skip per-marker coords (they'd need a schema change).
+      // Map still renders; markers would need coordinate data from the API.
+      const cdmx: [number, number] = [-99.1332, 19.4326];
+
+      const map = new maplibregl.Map({
+        container: mapBlockEl,
+        style: 'https://demotiles.maplibre.org/style.json',
+        center: cdmx,
+        zoom: 5,
+      });
+      mapInstance = map;
+      mapInited = true;
+    }
+
+    function setViewMode(mode: ViewMode) {
+      // Update URL param
+      try {
+        const url = new URL(window.location.href);
+        url.searchParams.set('view', mode);
+        window.history.replaceState({}, '', url.toString());
+      } catch { /* ignore */ }
+
+      // Show/hide blocks
+      const isCardsGrid = mode === 'cards' || mode === 'grid';
+      listEl?.classList.toggle('hidden', !isCardsGrid);
+      if (listBlockEl) listBlockEl.classList.toggle('hidden', mode !== 'list');
+      if (mapBlockEl) mapBlockEl.classList.toggle('hidden', mode !== 'map');
+      if (timelineBlockEl) timelineBlockEl.classList.toggle('hidden', mode !== 'timeline');
+
+      // Cards/grid class toggling
+      if (listEl) {
+        listEl.classList.toggle('er-mode-grid', mode === 'grid');
+        listEl.classList.toggle('er-mode-cards', mode === 'cards');
+      }
+
+      // Render alternative views
+      if (mode === 'list') renderListBlock(allRows);
+      if (mode === 'timeline') renderTimelineBlock(allRows);
+      if (mode === 'map') {
+        if (!mapInited) {
+          initMap(allRows).catch(() => { /* map unavailable */ });
+        } else {
+          mapInstance?.resize();
+        }
+      }
+
+      // Update aria-pressed on buttons
+      root.querySelectorAll<HTMLButtonElement>('.er-view-btn').forEach((btn) => {
+        btn.setAttribute('aria-pressed', btn.dataset.mode === mode ? 'true' : 'false');
+      });
+    }
+
+    // Read URL param or localStorage
     function readViewMode(): ViewMode {
       try {
+        const urlParam = new URL(window.location.href).searchParams.get('view');
+        if (isViewMode(urlParam)) return urlParam;
         const v = localStorage.getItem(RECENTS_VIEW_MODE_KEY);
         return isViewMode(v) ? v : DEFAULT_VIEW_MODE;
       } catch { return DEFAULT_VIEW_MODE; }
@@ -394,32 +549,16 @@ const view = page.view;
     function writeViewMode(mode: ViewMode) {
       try { localStorage.setItem(RECENTS_VIEW_MODE_KEY, mode); } catch { /* ignore */ }
     }
-    function applyViewMode(mode: ViewMode) {
-      const list = root.querySelector<HTMLUListElement>('.er-list');
-      if (list) {
-        list.classList.toggle('er-mode-grid', mode === 'grid');
-        list.classList.toggle('er-mode-cards', mode === 'cards');
-      }
-      root.querySelectorAll<HTMLButtonElement>('.er-view-btn').forEach((btn) => {
-        const isActive = btn.dataset.mode === mode;
-        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-      });
-    }
-    applyViewMode(readViewMode());
+
+    setViewMode(readViewMode());
     root.querySelectorAll<HTMLButtonElement>('.er-view-btn').forEach((btn) => {
       btn.addEventListener('click', () => {
-        const mode = (btn.dataset.mode === 'grid' ? 'grid' : 'cards') as ViewMode;
-        writeViewMode(mode);
-        applyViewMode(mode);
+        const m = btn.dataset.mode as ViewMode | undefined;
+        if (!isViewMode(m)) return;
+        writeViewMode(m);
+        setViewMode(m);
       });
     });
-
-    const listEl = root.querySelector('.er-list') as HTMLUListElement | null;
-    const skeletonEl = root.querySelector('.er-skeleton') as HTMLElement | null;
-    const emptyEl = root.querySelector('.er-empty') as HTMLElement | null;
-    const errEl = root.querySelector('.er-error') as HTMLElement | null;
-    const loadMoreWrap = root.querySelector('.er-load-more-wrap') as HTMLElement | null;
-    const loadMoreBtn = root.querySelector('.er-load-more') as HTMLButtonElement | null;
 
     let offset = 0;
     let exhausted = false;
@@ -479,169 +618,16 @@ const view = page.view;
         }
         for (const id of ids) {
           const n = byId.get(id) ?? 0;
-          // Interactive button (authed) or passive chip (anon) — same selector.
-          const el = root.querySelector<HTMLElement>(`[data-fave-target="${CSS.escape(id)}"]`);
-          if (!el) continue;
-          const countEl = el.querySelector<HTMLElement>('.er-fave-count');
+          if (n <= 0) continue;
+          const chip = root.querySelector<HTMLElement>(`.er-fave-chip[data-fave-target="${CSS.escape(id)}"]`);
+          if (!chip) continue;
+          const countEl = chip.querySelector<HTMLElement>('.er-fave-count');
           if (countEl) countEl.textContent = String(n);
-          if (el.tagName === 'BUTTON') {
-            // Interactive button — always visible for authed users.
-            const tpl = el.dataset.faveActive === 'true' ? labels.faveRemoveAria : labels.faveAddAria;
-            el.setAttribute('aria-label', tpl);
-          } else {
-            // Passive chip — only show if count > 0.
-            if (n <= 0) continue;
-            const tpl = n === 1 ? labels.faveAriaOne : labels.faveAriaOther;
-            el.setAttribute('aria-label', tpl.replace('{{count}}', String(n)));
-            el.classList.remove('hidden');
-          }
+          const tpl = n === 1 ? labels.faveAriaOne : labels.faveAriaOther;
+          chip.setAttribute('aria-label', tpl.replace('{{count}}', String(n)));
+          chip.classList.remove('hidden');
         }
       } catch { /* aggregate fetch failures shouldn't break the feed */ }
-    }
-
-    // Batch-fetch the viewer's own fave reactions for a set of obs ids.
-    // Marks the interactive heart buttons as active/inactive.
-    async function paintViewerFaves(ids: string[]) {
-      if (!viewerAuthed || !viewerId || ids.length === 0) return;
-      try {
-        const { data } = await supabase
-          .from('reactions')
-          .select('target_id')
-          .eq('user_id', viewerId)
-          .eq('target', 'observation')
-          .eq('kind', 'fave')
-          .in('target_id', ids);
-        const faved = new Set((data ?? []).map((r: { target_id: string }) => r.target_id));
-        for (const id of ids) {
-          const btn = root.querySelector<HTMLButtonElement>(`button[data-fave-target="${CSS.escape(id)}"]`);
-          if (!btn) continue;
-          const active = faved.has(id);
-          setFaveBtnState(btn, active);
-        }
-      } catch { /* silent */ }
-    }
-
-    function setFaveBtnState(btn: HTMLButtonElement, active: boolean) {
-      btn.dataset.faveActive = active ? 'true' : 'false';
-      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
-      btn.setAttribute('aria-label', active ? labels.faveRemoveAria : labels.faveAddAria);
-      if (active) {
-        btn.classList.remove('bg-zinc-100', 'dark:bg-zinc-800/50', 'border-zinc-300', 'dark:border-zinc-700', 'text-zinc-500', 'dark:text-zinc-400');
-        btn.classList.add('bg-rose-50', 'dark:bg-rose-950/40', 'border-rose-200', 'dark:border-rose-900/60', 'text-rose-700', 'dark:text-rose-300');
-      } else {
-        btn.classList.add('bg-zinc-100', 'dark:bg-zinc-800/50', 'border-zinc-300', 'dark:border-zinc-700', 'text-zinc-500', 'dark:text-zinc-400');
-        btn.classList.remove('bg-rose-50', 'dark:bg-rose-950/40', 'border-rose-200', 'dark:border-rose-900/60', 'text-rose-700', 'dark:text-rose-300');
-      }
-    }
-
-    // Batch-fetch the viewer's follow status for a set of observer ids.
-    async function paintViewerFollows(observerIds: string[]) {
-      if (!viewerAuthed || !viewerId || observerIds.length === 0) return;
-      try {
-        const { data } = await supabase
-          .from('follows')
-          .select('followee_id, status')
-          .eq('follower_id', viewerId)
-          .in('followee_id', observerIds);
-        const byId = new Map<string, string>();
-        for (const row of (data ?? []) as { followee_id: string; status: string }[]) {
-          byId.set(row.followee_id, row.status);
-        }
-        root.querySelectorAll<HTMLButtonElement>('.er-follow-btn:not([data-follow-bound])').forEach((btn) => {
-          const targetId = btn.dataset.followTarget ?? '';
-          if (!targetId || !observerIds.includes(targetId)) return;
-          const status = byId.get(targetId) ?? 'none';
-          setFollowBtnState(btn, status);
-        });
-      } catch { /* silent */ }
-    }
-
-    function setFollowBtnState(btn: HTMLButtonElement, status: string) {
-      btn.dataset.followState = status;
-      const handle = btn.dataset.followHandle ?? '';
-      if (status === 'accepted') {
-        btn.textContent = labels.followingBtn;
-        btn.setAttribute('aria-label', labels.recentsUnfollowAria.replace('{{handle}}', handle));
-        btn.classList.remove('bg-zinc-100', 'dark:bg-zinc-800/50', 'border-zinc-300', 'dark:border-zinc-700', 'text-zinc-600', 'dark:text-zinc-400');
-        btn.classList.add('bg-emerald-50', 'dark:bg-emerald-950/40', 'border-emerald-300', 'dark:border-emerald-800', 'text-emerald-700', 'dark:text-emerald-300');
-      } else if (status === 'pending') {
-        btn.textContent = labels.requestedBtn;
-        btn.setAttribute('aria-label', labels.recentsUnfollowAria.replace('{{handle}}', handle));
-        btn.classList.remove('bg-zinc-100', 'dark:bg-zinc-800/50', 'border-zinc-300', 'dark:border-zinc-700', 'text-zinc-600', 'dark:text-zinc-400');
-        btn.classList.add('bg-amber-50', 'dark:bg-amber-950/40', 'border-amber-300', 'dark:border-amber-800', 'text-amber-700', 'dark:text-amber-300');
-      } else {
-        btn.textContent = labels.followBtn;
-        btn.setAttribute('aria-label', labels.recentsFollowAria.replace('{{handle}}', handle));
-        btn.classList.remove('bg-emerald-50', 'dark:bg-emerald-950/40', 'border-emerald-300', 'dark:border-emerald-800', 'text-emerald-700', 'dark:text-emerald-300',
-          'bg-amber-50', 'dark:bg-amber-950/40', 'border-amber-300', 'dark:border-amber-800', 'text-amber-700', 'dark:text-amber-300');
-        btn.classList.add('bg-zinc-100', 'dark:bg-zinc-800/50', 'border-zinc-300', 'dark:border-zinc-700', 'text-zinc-600', 'dark:text-zinc-400');
-      }
-    }
-
-    function wireLikeAndFollowButtons(scope: ParentNode) {
-      // Wire like (fave) buttons.
-      scope.querySelectorAll<HTMLButtonElement>('.er-fave-btn:not([data-bound])').forEach((btn) => {
-        btn.dataset.bound = '1';
-        btn.addEventListener('click', async (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const obsId = btn.dataset.faveTarget ?? '';
-          if (!obsId) return;
-          const wasActive = btn.dataset.faveActive === 'true';
-          // Optimistic update.
-          const countEl = btn.querySelector<HTMLElement>('.er-fave-count');
-          const prevCount = parseInt(countEl?.textContent ?? '0', 10);
-          setFaveBtnState(btn, !wasActive);
-          if (countEl) countEl.textContent = String(wasActive ? Math.max(0, prevCount - 1) : prevCount + 1);
-          btn.disabled = true;
-          try {
-            const { react } = await import('../lib/social');
-            await react({ target: 'observation', target_id: obsId, kind: 'fave' });
-          } catch {
-            // Revert on error.
-            setFaveBtnState(btn, wasActive);
-            if (countEl) countEl.textContent = String(prevCount);
-          } finally {
-            btn.disabled = false;
-          }
-        });
-      });
-
-      // Wire follow buttons.
-      scope.querySelectorAll<HTMLButtonElement>('.er-follow-btn:not([data-follow-bound])').forEach((btn) => {
-        btn.dataset.followBound = '1';
-        btn.addEventListener('click', async (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const targetId = btn.dataset.followTarget ?? '';
-          if (!targetId) return;
-          const curState = btn.dataset.followState ?? 'none';
-          // Optimistic update — revert on error (mirrors fave button pattern).
-          const prevState = curState;
-          if (curState === 'none') {
-            setFollowBtnState(btn, 'pending');
-          } else {
-            setFollowBtnState(btn, 'none');
-          }
-          btn.disabled = true;
-          try {
-            const { followUser, unfollowUser } = await import('../lib/social');
-            if (prevState === 'none') {
-              const result = await followUser(targetId);
-              // Server may promote straight to 'accepted' (open follows).
-              setFollowBtnState(btn, result.status === 'accepted' ? 'accepted' : 'pending');
-            } else {
-              await unfollowUser(targetId);
-              setFollowBtnState(btn, 'none');
-            }
-          } catch {
-            // Revert to previous state on network/server error.
-            setFollowBtnState(btn, prevState);
-          } finally {
-            btn.disabled = false;
-          }
-        });
-      });
     }
 
     function wireOverflowMenus(scope: ParentNode) {
@@ -714,6 +700,8 @@ const view = page.view;
         const page = await fetchPage();
         hideSkeleton();
         const renderedIds: string[] = [];
+        // Accumulate rows for alternative view modes
+        for (const r of page) allRows.push(r);
         if (listEl) {
           listEl.insertAdjacentHTML(
             'beforeend',
@@ -723,7 +711,6 @@ const view = page.view;
             }).join(''),
           );
           wireOverflowMenus(listEl);
-          wireLikeAndFollowButtons(listEl);
           // Hydrate media thumbnails (audio + video)
           listEl.querySelectorAll<HTMLElement>('.media-player-mount:not([data-mounted])').forEach((el) => {
             el.dataset.mounted = '1';
@@ -736,10 +723,13 @@ const view = page.view;
             }
           });
         }
+        // Re-render active alternative mode with updated data
+        const currentMode = readViewMode();
+        if (currentMode === 'list') renderListBlock(allRows);
+        if (currentMode === 'timeline') renderTimelineBlock(allRows);
         offset += page.length;
         if (page.length < PAGE_SIZE) exhausted = true;
-        const total = listEl?.children.length ?? 0;
-        if (total === 0) {
+        if (allRows.length === 0) {
           emptyEl?.classList.remove('hidden');
         } else {
           emptyEl?.classList.add('hidden');
@@ -750,15 +740,7 @@ const view = page.view;
           loadMoreWrap?.classList.remove('hidden');
         }
         // Fire-and-forget reaction-count fetch for the rows just rendered.
-        const renderedObserverIds = page
-          .filter(r => r.observer_id && r.observer_id !== viewerId)
-          .map(r => r.observer_id)
-          .filter((v, i, a) => a.indexOf(v) === i);
-        Promise.all([
-          paintReactionCounts(renderedIds),
-          paintViewerFaves(renderedIds),
-          paintViewerFollows(renderedObserverIds),
-        ]).catch(() => { /* silent */ });
+        paintReactionCounts(renderedIds).catch(() => { /* silent */ });
       } catch (e) {
         hideSkeleton();
         if (errEl) {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2038,7 +2038,17 @@
       "view": {
         "switcher_label": "Change view",
         "cards": "Cards",
-        "grid": "Grid"
+        "grid": "Grid",
+        "list": "List",
+        "map": "Map",
+        "timeline": "Timeline",
+        "list_aria": "List view",
+        "map_aria": "Map view",
+        "timeline_aria": "Timeline view"
+      },
+      "timeline": {
+        "today": "Today",
+        "yesterday": "Yesterday"
       }
     },
     "watchlist": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2038,7 +2038,17 @@
       "view": {
         "switcher_label": "Cambiar vista",
         "cards": "Tarjetas",
-        "grid": "Cuadrícula"
+        "grid": "Cuadrícula",
+        "list": "Lista",
+        "map": "Mapa",
+        "timeline": "Línea de tiempo",
+        "list_aria": "Vista de lista",
+        "map_aria": "Vista de mapa",
+        "timeline_aria": "Vista de línea de tiempo"
+      },
+      "timeline": {
+        "today": "Hoy",
+        "yesterday": "Ayer"
       }
     },
     "watchlist": {

--- a/src/lib/recents-view-mode.ts
+++ b/src/lib/recents-view-mode.ts
@@ -1,9 +1,9 @@
 export const RECENTS_VIEW_MODE_KEY = 'rastrum.recents.viewMode';
 
-export type ViewMode = 'cards' | 'grid';
+export type ViewMode = 'cards' | 'grid' | 'list' | 'map' | 'timeline';
 
 export const DEFAULT_VIEW_MODE: ViewMode = 'cards';
 
 export function isViewMode(v: unknown): v is ViewMode {
-  return v === 'cards' || v === 'grid';
+  return v === 'cards' || v === 'grid' || v === 'list' || v === 'map' || v === 'timeline';
 }


### PR DESCRIPTION
## Summary

Extends the ExploreRecentView with three new view modes: **List**, **Map**, and **Timeline**.

## Changes

### `src/lib/recents-view-mode.ts`
- Extended `ViewMode` type: `'cards' | 'grid' | 'list' | 'map' | 'timeline'`
- Updated `isViewMode()` guard to include all 5 values
- `DEFAULT_VIEW_MODE` stays `'cards'`

### `src/components/ExploreRecentView.astro`
- Added 3 view switcher buttons: List (☰), Map (🗺), Timeline (📅)
- Added `#er-list-block`: compact rows with 56×56 thumbnail, scientific name, common name, observer, relative time
- Added `#er-map-block`: lazy-loaded MapLibre GL map centered on CDMX, initializes only once, resizes on re-activate
- Added `#er-timeline-block`: observations grouped by UTC date with sticky day headers (Today/Yesterday/localized)
- `setViewMode(mode)` hides/shows correct block, persists to localStorage, updates URL `?view=` param
- All loaded rows accumulated in `allRows[]` so list/timeline re-render on `loadMore()`

### i18n (EN + ES)
- Added `explore_pages.recent.view.list/map/timeline` and `_aria` variants
- Added `explore_pages.recent.timeline.today/yesterday`

## Checklist
- `npx tsc --noEmit`: 3 pre-existing `@huggingface/transformers` errors only ✅
- `npm run test`: 1486 passed, 4 pre-existing failures only ✅

Closes #863