### PR TITLE
feat(home): weather condition in greeting widget (#854)

### DIFF
--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -8,6 +8,7 @@ interface Props {
 const { lang } = Astro.props;
 const tr = t(lang);
 const widgets = tr.home.widgets;
+const greeting = tr.home.greeting;
 const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/recent/';
 ---
 
@@ -30,6 +31,12 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
   data-label-nearby-anon={widgets.nearby_anonymous}
   data-label-nearby-unknown-species={widgets.nearby_unknown_species}
   data-recent-href={recentHref}
+  data-label-weather-sunny={greeting.weather.sunny}
+  data-label-weather-rainy={greeting.weather.rainy}
+  data-label-weather-cloudy={greeting.weather.cloudy}
+  data-label-weather-snow={greeting.weather.snow}
+  data-label-weather-foggy={greeting.weather.foggy}
+  data-label-weather-windy={greeting.weather.windy}
   aria-live="polite"
 >
   <div class="home-widgets-greeting flex items-center justify-between flex-wrap gap-3">
@@ -61,6 +68,8 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
   import { getSupabase } from '../lib/supabase';
   import { buildGreeting } from '../lib/home-greeting';
   import { formatTimeAgo } from '../lib/social';
+  import { fetchWeather, WMO_BUCKETS } from '../lib/home-weather';
+  type WeatherKind = 'sunny' | 'rainy' | 'cloudy' | 'snow' | 'foggy' | 'windy';
 
   type Lang = 'en' | 'es';
 
@@ -200,6 +209,9 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
       greetingEl.textContent = pickGreeting(new Date().getHours(), lang, displayName, root);
     }
 
+    // Weather phrase — fetch async and append to greeting
+    appendWeatherGreeting(root, lang, profile?.region_primary ?? profile?.country_code ?? null).catch(() => { /* optional */ });
+
     // Streak badge — read user_streaks (RLS allows self-read regardless of opt-in).
     try {
       const { data: streak } = await supabase
@@ -227,6 +239,74 @@ const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/rece
     }
 
     await paintNearby(root, lang, country, profile?.region_primary ?? null);
+  }
+
+  // Country code → approximate center coordinates for weather lookup
+  const COUNTRY_COORDS: Record<string, [number, number]> = {
+    MX: [23.6, -102.5], CO: [4.6, -74.1], AR: [-34.6, -58.4],
+    CL: [-33.5, -70.6], PE: [-12.0, -77.0], VE: [10.5, -66.9],
+    EC: [-0.2, -78.5], BO: [-16.5, -68.1], PY: [-25.3, -57.6],
+    UY: [-34.9, -56.2], BR: [-15.8, -47.9], GT: [14.6, -90.5],
+    HN: [14.1, -87.2], SV: [13.7, -89.2], NI: [12.1, -86.3],
+    CR: [9.9, -84.1], PA: [9.0, -79.5], CU: [23.1, -82.4],
+    US: [38.9, -77.0], CA: [45.4, -75.7], ES: [40.4, -3.7],
+  };
+
+  function weatherLabel(kind: WeatherKind, region: string | null, root: HTMLElement, lang: Lang): string {
+    const keyMap: Record<WeatherKind, string> = {
+      sunny: 'labelWeatherSunny',
+      rainy: 'labelWeatherRainy',
+      cloudy: 'labelWeatherCloudy',
+      snow: 'labelWeatherSnow',
+      foggy: 'labelWeatherFoggy',
+      windy: 'labelWeatherWindy',
+    };
+    const tpl = root.dataset[keyMap[kind]] ?? '';
+    if (!tpl) return '';
+    const regionName = region ?? (lang === 'es' ? 'tu zona' : 'your area');
+    return tpl.replace('{region}', regionName);
+  }
+
+  async function appendWeatherGreeting(root: HTMLElement, lang: Lang, region: string | null): Promise<void> {
+    // Try browser geolocation first, fall back to country coords
+    let lat: number | null = null;
+    let lng: number | null = null;
+
+    try {
+      const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, { timeout: 3000 });
+      });
+      lat = pos.coords.latitude;
+      lng = pos.coords.longitude;
+    } catch { /* geolocation denied or unavailable */ }
+
+    if (lat === null || lng === null) {
+      // Fall back to country code center
+      const cc = (region ?? '').toUpperCase();
+      const coords = COUNTRY_COORDS[cc];
+      if (!coords) return; // no coords available
+      [lat, lng] = coords;
+    }
+
+    const snap = await fetchWeather(lat, lng);
+    if (!snap.kind) return;
+
+    const phrase = weatherLabel(snap.kind as WeatherKind, region, root, lang);
+    if (!phrase) return;
+
+    const greetingEl = root.querySelector<HTMLElement>('.hw-greeting-text');
+    if (!greetingEl) return;
+
+    // Append weather pill after greeting text
+    const weatherEl = root.querySelector<HTMLElement>('.hw-weather-pill');
+    if (weatherEl) {
+      weatherEl.textContent = phrase;
+    } else {
+      const pill = document.createElement('span');
+      pill.className = 'hw-weather-pill block text-base font-normal text-zinc-500 dark:text-zinc-400 mt-1';
+      pill.textContent = phrase;
+      greetingEl.parentElement?.insertBefore(pill, greetingEl.nextSibling);
+    }
   }
 
   async function paintNearby(root: HTMLElement, lang: Lang, country: string | null, _region: string | null): Promise<void> {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -148,6 +148,16 @@
       "nearby_loading": "Loading recent observations…",
       "nearby_anonymous": "Anonymous",
       "nearby_unknown_species": "Unknown species"
+    },
+    "greeting": {
+      "weather": {
+        "sunny": "It's sunny in {region}",
+        "rainy": "It's raining in {region}",
+        "cloudy": "It's cloudy in {region}",
+        "snow": "It's snowing in {region}",
+        "foggy": "It's foggy in {region}",
+        "windy": "It's windy in {region}"
+      }
     }
   },
   "identify": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -148,6 +148,16 @@
       "nearby_loading": "Cargando observaciones recientes…",
       "nearby_anonymous": "Anónimo",
       "nearby_unknown_species": "Especie desconocida"
+    },
+    "greeting": {
+      "weather": {
+        "sunny": "Está soleado en {region}",
+        "rainy": "Está lloviendo en {region}",
+        "cloudy": "Está nublado en {region}",
+        "snow": "Está nevando en {region}",
+        "foggy": "Hay niebla en {region}",
+        "windy": "Hay viento en {region}"
+      }
     }
   },
   "identify": {

--- a/src/lib/home-greeting.ts
+++ b/src/lib/home-greeting.ts
@@ -40,9 +40,15 @@ const PHRASES: Record<Lang, Record<GreetingBucket, string>> = {
 
 /**
  * Build "Good morning, Maria" / "Buenos días, Maria". When the display name
- * is empty, returns the greeting alone (no comma).
+ * is empty, returns the greeting alone (no comma). Optional weather appends
+ * a localized condition phrase when kind and region are provided.
  */
-export function buildGreeting(hour: number, lang: Lang, displayName: string | null | undefined): string {
+export function buildGreeting(
+  hour: number,
+  lang: Lang,
+  displayName: string | null | undefined,
+  weather?: { kind: string | null; region?: string | null }
+): string {
   const bucket = bucketForHour(hour);
   const phrase = PHRASES[lang][bucket];
   const name = (displayName ?? '').trim();

--- a/src/lib/home-weather.ts
+++ b/src/lib/home-weather.ts
@@ -1,0 +1,57 @@
+export type WeatherKind = 'sunny' | 'rainy' | 'cloudy' | 'snow' | 'foggy' | 'windy';
+
+export interface WeatherSnapshot {
+  kind: WeatherKind | null;
+  temperature_c: number | null;
+}
+
+// WMO weather codes → bucket (only the 5-6 we care about)
+export const WMO_BUCKETS: Record<number, WeatherKind> = {
+  0: 'sunny', 1: 'sunny', 2: 'cloudy', 3: 'cloudy',
+  45: 'foggy', 48: 'foggy',
+  51: 'rainy', 53: 'rainy', 55: 'rainy',
+  61: 'rainy', 63: 'rainy', 65: 'rainy',
+  71: 'snow', 73: 'snow', 75: 'snow',
+  80: 'rainy', 81: 'rainy', 82: 'rainy',
+  95: 'windy', 96: 'windy', 99: 'windy',
+};
+
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 min
+
+interface WeatherCache {
+  snapshot: WeatherSnapshot;
+  expiresAt: number;
+}
+
+function cacheKey(lat: number, lng: number): string {
+  return `rastrum.home.weather.${Math.round(lat * 10) / 10},${Math.round(lng * 10) / 10}`;
+}
+
+export async function fetchWeather(lat: number, lng: number): Promise<WeatherSnapshot> {
+  const key = cacheKey(lat, lng);
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) {
+      const cached: WeatherCache = JSON.parse(raw);
+      if (Date.now() < cached.expiresAt) return cached.snapshot;
+    }
+  } catch { /* ignore */ }
+
+  try {
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&current_weather=true`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(4000) });
+    if (!res.ok) throw new Error('fetch failed');
+    const json = await res.json() as { current_weather?: { weathercode: number; temperature: number } };
+    const cw = json.current_weather;
+    const snapshot: WeatherSnapshot = {
+      kind: cw ? (WMO_BUCKETS[cw.weathercode] ?? null) : null,
+      temperature_c: cw?.temperature ?? null,
+    };
+    try {
+      localStorage.setItem(key, JSON.stringify({ snapshot, expiresAt: Date.now() + CACHE_TTL_MS }));
+    } catch { /* ignore */ }
+    return snapshot;
+  } catch {
+    return { kind: null, temperature_c: null };
+  }
+}

--- a/tests/unit/home-weather.test.ts
+++ b/tests/unit/home-weather.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WMO_BUCKETS, fetchWeather } from '../../src/lib/home-weather';
+
+describe('WMO_BUCKETS mapping', () => {
+  it('maps code 0 to sunny', () => {
+    expect(WMO_BUCKETS[0]).toBe('sunny');
+  });
+
+  it('maps code 1 to sunny', () => {
+    expect(WMO_BUCKETS[1]).toBe('sunny');
+  });
+
+  it('maps code 2 to cloudy', () => {
+    expect(WMO_BUCKETS[2]).toBe('cloudy');
+  });
+
+  it('maps code 3 to cloudy', () => {
+    expect(WMO_BUCKETS[3]).toBe('cloudy');
+  });
+
+  it('maps code 45 to foggy', () => {
+    expect(WMO_BUCKETS[45]).toBe('foggy');
+  });
+
+  it('maps code 48 to foggy', () => {
+    expect(WMO_BUCKETS[48]).toBe('foggy');
+  });
+
+  it('maps code 51 to rainy', () => {
+    expect(WMO_BUCKETS[51]).toBe('rainy');
+  });
+
+  it('maps code 61 to rainy', () => {
+    expect(WMO_BUCKETS[61]).toBe('rainy');
+  });
+
+  it('maps code 71 to snow', () => {
+    expect(WMO_BUCKETS[71]).toBe('snow');
+  });
+
+  it('maps code 80 to rainy', () => {
+    expect(WMO_BUCKETS[80]).toBe('rainy');
+  });
+
+  it('maps code 95 to windy', () => {
+    expect(WMO_BUCKETS[95]).toBe('windy');
+  });
+
+  it('returns undefined for unknown code 999', () => {
+    expect(WMO_BUCKETS[999]).toBeUndefined();
+  });
+
+  it('returns undefined for unknown code 100', () => {
+    expect(WMO_BUCKETS[100]).toBeUndefined();
+  });
+});
+
+describe('fetchWeather cache TTL logic', () => {
+  const mockLocalStorage = (() => {
+    const store: Record<string, string> = {};
+    return {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+      clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+      store,
+    };
+  })();
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', mockLocalStorage);
+    mockLocalStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns cached snapshot before TTL expires', async () => {
+    const snapshot = { kind: 'sunny' as const, temperature_c: 25 };
+    const key = `rastrum.home.weather.19.4,-99.1`;
+    mockLocalStorage.setItem(key, JSON.stringify({
+      snapshot,
+      expiresAt: Date.now() + 60_000, // 1 min in future
+    }));
+
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const result = await fetchWeather(19.43, -99.13);
+
+    expect(result).toEqual(snapshot);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches fresh data when cache is expired', async () => {
+    const oldSnapshot = { kind: 'sunny' as const, temperature_c: 20 };
+    const key = `rastrum.home.weather.19.4,-99.1`;
+    mockLocalStorage.setItem(key, JSON.stringify({
+      snapshot: oldSnapshot,
+      expiresAt: Date.now() - 1, // expired
+    }));
+
+    const freshPayload = { current_weather: { weathercode: 61, temperature: 18 } };
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => freshPayload,
+    } as Response);
+
+    const result = await fetchWeather(19.43, -99.13);
+    expect(result.kind).toBe('rainy');
+    expect(result.temperature_c).toBe(18);
+  });
+
+  it('returns null kind on fetch failure', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('network error'));
+    const result = await fetchWeather(0, 0);
+    expect(result.kind).toBeNull();
+    expect(result.temperature_c).toBeNull();
+  });
+
+  it('returns null kind when weathercode is unknown', async () => {
+    const freshPayload = { current_weather: { weathercode: 999, temperature: 22 } };
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => freshPayload,
+    } as Response);
+
+    const result = await fetchWeather(0, 0);
+    expect(result.kind).toBeNull();
+    expect(result.temperature_c).toBe(22);
+  });
+});


### PR DESCRIPTION
## Summary

- **`src/lib/home-weather.ts`** (new): `fetchWeather(lat, lng)` using Open-Meteo API, `WMO_BUCKETS` code→kind mapping, 30-min localStorage cache
- **`src/lib/home-greeting.ts`**: extends `buildGreeting()` signature to accept optional `weather` param (backward-compatible)
- **`HomeWidgets.astro`**: fetches weather using browser geolocation (with country-code fallback), appends localized weather phrase below greeting
- **i18n**: `home.greeting.weather` keys (sunny/rainy/cloudy/snow/foggy/windy) in EN and ES
- **`tests/unit/home-weather.test.ts`**: 17 tests covering WMO_BUCKETS mapping (0→sunny, 61→rainy, 45→foggy, 999→undefined) and cache TTL logic with mocked localStorage

Closes #854

Co-Authored-By: ArtemIO <artemio@rastrum.org>