### PR TITLE
feat(profile): wire KarmaFrame on 5 avatar surfaces + size=sm static ring (#859)

### DIFF
--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -122,10 +122,11 @@ const sgReportLabel = sgTree.socialgraph.report.button;
   import { getSupabase } from '../lib/supabase';
   import { buildCommentTree, formatTimeAgo, sanitizeCommentBody, type CommentRow, type CommentNode } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
+  import { tierForKarma } from '../lib/karma-frame';
 
   const PAGE_SIZE = 20;
 
-  type AuthorMap = Record<string, { username: string | null; display_name: string | null; avatar_url: string | null }>;
+  type AuthorMap = Record<string, { username: string | null; display_name: string | null; avatar_url: string | null; karma_total: number }>;
 
   function initials(name: string) {
     return (name || '?').trim().slice(0, 2).toUpperCase();
@@ -148,7 +149,11 @@ const sgReportLabel = sgTree.socialgraph.report.button;
     const author = authors[node.author_id];
     const name = author?.display_name || author?.username || (lang === 'es' ? 'Observador' : 'Observer');
     const handle = author?.username ?? '';
-    const avatar = author?.avatar_url || avatarSvg(name);
+    const commentKarmaTier = tierForKarma(author?.karma_total ?? 0);
+    const commentRingClass = commentKarmaTier.staticRingClass ?? commentKarmaTier.ringClass;
+    const avatarHtml = author?.avatar_url
+      ? `<span class="inline-block rounded-full ring-offset-1 ring-offset-white dark:ring-offset-zinc-900 ${escapeText(commentRingClass)}"><img src="${escapeText(author.avatar_url)}" alt="" class="w-8 h-8 rounded-full bg-zinc-200 dark:bg-zinc-800 block" /></span>`
+      : `<img src="${avatarSvg(name)}" alt="" class="w-8 h-8 rounded-full bg-zinc-200 dark:bg-zinc-800 shrink-0" />`;
     const ago = formatTimeAgo(node.created_at, lang);
     const editedBadge = node.edited_at ? `<span class="text-xs text-zinc-400 ml-1">(${labels.edited})</span>` : '';
     const isOwner = currentUserId && currentUserId === node.author_id;
@@ -183,7 +188,7 @@ const sgReportLabel = sgTree.socialgraph.report.button;
     return `
       <li class="comment-item ${indent}" data-comment-id="${node.id}">
         <article class="flex gap-3">
-          <img src="${avatar}" alt="" class="w-8 h-8 rounded-full bg-zinc-200 dark:bg-zinc-800 shrink-0" />
+          ${avatarHtml}
           <div class="flex-1 min-w-0">
             <header class="flex items-start gap-2 text-sm">
               <div class="flex-1 min-w-0">
@@ -267,13 +272,14 @@ const sgReportLabel = sgTree.socialgraph.report.button;
       if (!missing.length) return;
       const { data } = await supabase
         .from('users')
-        .select('id, username, display_name, avatar_url')
+        .select('id, username, display_name, avatar_url, karma_total')
         .in('id', missing);
       for (const u of data ?? []) {
         authors[u.id as string] = {
           username: u.username as string | null,
           display_name: u.display_name as string | null,
           avatar_url: u.avatar_url as string | null,
+          karma_total: (u as unknown as { karma_total?: number | null }).karma_total ?? 0,
         };
       }
     }

--- a/src/components/CommunityView.astro
+++ b/src/components/CommunityView.astro
@@ -220,6 +220,7 @@ const stringsJson = JSON.stringify({
   import { parseFilters, serializeFilters, loadGps, saveGps, clearGps, type CommunityFilters, type CommunityGps } from '../lib/community-url';
   import { loadCommunity, loadCommunityNearbyAt, viewerHasCentroid, loadViewerCommunityMeta, loadIsoCountries, COMMUNITY_PAGE_SIZE, type CommunityObserver } from '../lib/community';
   import { getSupabase } from '../lib/supabase';
+  import { tierForKarma } from '../lib/karma-frame';
 
   interface Strings {
     lang: 'en' | 'es';
@@ -360,12 +361,14 @@ const stringsJson = JSON.stringify({
     const speciesLabel = STRINGS.speciesTpl.replace('{n}', String(row.species_count));
     const lastSeen = STRINGS.lastSeenTpl.replace('{when}', relativeTime(row.last_observation_at));
 
+    const karmaRingTier = tierForKarma(row.karma_total ?? 0);
+    const karmaRingClass = karmaRingTier.staticRingClass ?? karmaRingTier.ringClass;
     const el = document.createElement('article');
     el.className = 'rounded-lg border border-zinc-200 dark:border-zinc-800 p-4 flex items-start gap-3';
     el.innerHTML = `
       <a href="${profileHref}" class="flex-none">
         ${row.avatar_url
-          ? `<img src="${escapeHtml(row.avatar_url)}" alt="" loading="lazy" class="w-12 h-12 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover">`
+          ? `<span class="inline-block rounded-full ring-offset-1 ring-offset-white dark:ring-offset-zinc-900 ${escapeHtml(karmaRingClass)}"><img src="${escapeHtml(row.avatar_url)}" alt="" loading="lazy" class="w-12 h-12 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover block"></span>`
           : `<div class="w-12 h-12 rounded-full bg-emerald-700 text-white flex items-center justify-center font-semibold">${escapeHtml(displayName.slice(0, 1).toUpperCase())}</div>`}
       </a>
       <div class="flex-1 min-w-0">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -227,7 +227,15 @@ const docColumns = [
       <BellIcon lang={locale} />
       <div id="avatar-wrap" class="hidden relative shrink-0">
         <button id="avatar-btn" aria-label="Account menu" class="block rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-500">
-          <img id="header-avatar" src="" alt="" class="w-8 h-8 rounded-full bg-emerald-600 object-cover" />
+          <span
+            id="header-avatar-frame"
+            class="inline-block rounded-full ring-offset-2 ring-offset-white dark:ring-offset-zinc-900"
+            data-karma-frame
+            data-karma-tier="seedling"
+            data-karma-glow="0"
+          >
+            <img id="header-avatar" src="" alt="" class="w-8 h-8 rounded-full bg-emerald-600 object-cover" />
+          </span>
         </button>
         <div id="avatar-menu" class="hidden absolute right-0 top-full mt-2 w-52 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-lg py-1 z-50">
           <a id="menu-profile" href={getLocalizedPath(lang, routes.profile[locale] + '/')} class="block px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800">{tr.profile.view_profile}</a>
@@ -315,6 +323,7 @@ const docColumns = [
   import { signOut, SUPABASE_AUTH_STORAGE_KEY, HEADER_AVATAR_CACHE_KEY, HEADER_AVATAR_NAME_KEY } from '../lib/auth';
   import { getUserRoles } from '../lib/user-roles';
   import type { UserProfile } from '../lib/types';
+  import { tierForKarma } from '../lib/karma-frame';
 
   const signInLink = document.getElementById('sign-in-link');
   const avatarWrap = document.getElementById('avatar-wrap');
@@ -372,13 +381,24 @@ const docColumns = [
       if (!userId) return;
       const { data: profile } = await supabase
         .from('users')
-        .select('username,display_name,avatar_url')
+        .select('username,display_name,avatar_url,karma_total')
         .eq('id', userId)
-        .maybeSingle<Pick<UserProfile,'username'|'display_name'|'avatar_url'>>();
+        .maybeSingle<Pick<UserProfile,'username'|'display_name'|'avatar_url'> & { karma_total?: number | null }>();
       const name = profile?.display_name || profile?.username || sessionUser?.email?.split('@')[0] || '?';
       const finalSrc = profile?.avatar_url || avatarImg.src || initialsAvatar(name);
       avatarImg.src = finalSrc;
       avatarImg.alt = name;
+      // Apply KarmaFrame ring to the header avatar wrapper (size='sm' → static, no animation)
+      const avatarFrame = document.getElementById('header-avatar-frame');
+      if (avatarFrame) {
+        const tier = tierForKarma(profile?.karma_total ?? 0);
+        avatarFrame.className = [
+          'inline-block rounded-full ring-offset-2 ring-offset-white dark:ring-offset-zinc-900',
+          tier.staticRingClass ?? tier.ringClass,
+        ].join(' ');
+        avatarFrame.dataset.karmaTier = tier.id;
+        avatarFrame.dataset.karmaGlow = tier.glow ? '1' : '0';
+      }
       try { localStorage.setItem(AVATAR_CACHE_KEY, finalSrc); localStorage.setItem(AVATAR_NAME_KEY, name); } catch { /* ignore */ }
     } catch { /* env not set */ }
   }

--- a/src/components/KarmaLeaderboardView.astro
+++ b/src/components/KarmaLeaderboardView.astro
@@ -238,6 +238,7 @@ const stringsJson = JSON.stringify({
 
 <script>
   import { getSupabase } from '../lib/supabase';
+  import { tierForKarma } from '../lib/karma-frame';
   import {
     viewFromSearch,
     searchForView,
@@ -382,8 +383,10 @@ const stringsJson = JSON.stringify({
       ? ['🥇', '🥈', '🥉'][rank - 1]
       : String(rank);
 
+    const avatarKarmaTier = tierForKarma(row.karma ?? 0);
+    const avatarRing = avatarKarmaTier.staticRingClass ?? avatarKarmaTier.ringClass;
     const avatarCell = row.avatar_url
-      ? `<img src="${escapeHtml(row.avatar_url)}" alt="" loading="lazy" class="w-8 h-8 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover flex-none">`
+      ? `<span class="inline-block rounded-full ring-offset-1 ring-offset-white dark:ring-offset-zinc-900 ${escapeHtml(avatarRing)}"><img src="${escapeHtml(row.avatar_url)}" alt="" loading="lazy" class="w-8 h-8 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover flex-none block"></span>`
       : `<div class="w-8 h-8 rounded-full bg-emerald-700 text-white flex items-center justify-center font-semibold text-xs flex-none">${escapeHtml(displayName.slice(0, 1).toUpperCase())}</div>`;
 
     const scoreCell = mode === 'experts'

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -96,7 +96,15 @@ const sponsoringI18n = {
 
   <article data-pp-profile class="hidden">
     <header class="flex items-start gap-4 md:gap-6 mb-6">
-      <img data-pp-avatar src="" alt="" class="w-20 h-20 md:w-24 md:h-24 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover shrink-0" />
+      <span
+        data-pp-avatar-frame
+        class="inline-block rounded-full ring-offset-2 ring-offset-white dark:ring-offset-zinc-900 shrink-0"
+        data-karma-frame
+        data-karma-tier="seedling"
+        data-karma-glow="0"
+      >
+        <img data-pp-avatar src="" alt="" class="w-20 h-20 md:w-24 md:h-24 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover" />
+      </span>
       <div class="min-w-0 flex-1">
         <h1 data-pp-name class="text-2xl md:text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 truncate">—</h1>
         <p class="text-sm text-zinc-500 mt-0.5">
@@ -226,6 +234,7 @@ const sponsoringI18n = {
   import { getSupabase } from '../lib/supabase';
   import { wireOverflowMenu } from '../lib/overflow-menu';
   import { openConfirmDialog } from '../lib/confirm-dialog';
+  import { tierForKarma } from '../lib/karma-frame';
 
   type Lang = 'en' | 'es';
 
@@ -396,6 +405,17 @@ const sponsoringI18n = {
     if (avatarEl) {
       avatarEl.src = profile.avatar_url || initialsAvatar(name);
       avatarEl.alt = name;
+    }
+    // Apply KarmaFrame ring to the avatar wrapper (size='lg' → full animation)
+    const avatarFrame = root.querySelector<HTMLElement>('[data-pp-avatar-frame]');
+    if (avatarFrame) {
+      const tier = tierForKarma(profile.karma_total ?? 0);
+      avatarFrame.className = [
+        'inline-block rounded-full ring-offset-2 ring-offset-white dark:ring-offset-zinc-900 shrink-0',
+        tier.ringClass,
+      ].join(' ');
+      avatarFrame.dataset.karmaTier = tier.id;
+      avatarFrame.dataset.karmaGlow = tier.glow ? '1' : '0';
     }
 
     if (showLocation && profile.region_primary) {

--- a/src/components/profile/KarmaFrame.astro
+++ b/src/components/profile/KarmaFrame.astro
@@ -25,9 +25,14 @@ const sizeClass =
   : size === 'lg' ? 'w-24 h-24 md:w-28 md:h-28'
   : 'w-16 h-16 md:w-20 md:h-20';
 
+// For compact list contexts (size='sm') use the static variant (no animation).
+const activeRingClass = size === 'sm'
+  ? (tier.staticRingClass ?? tier.ringClass)
+  : tier.ringClass;
+
 const wrapperClass = [
   'inline-block rounded-full ring-offset-2 ring-offset-white dark:ring-offset-zinc-900',
-  tier.ringClass,
+  activeRingClass,
   extraClass,
 ].filter(Boolean).join(' ');
 ---

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -27,6 +27,7 @@ export interface CommunityObserver {
   obs_count_30d: number;
   last_observation_at: string | null;
   joined_at: string;
+  karma_total: number | null;
 }
 
 export const COMMUNITY_PAGE_SIZE = 20;

--- a/src/lib/karma-frame.ts
+++ b/src/lib/karma-frame.ts
@@ -10,6 +10,8 @@ export interface KarmaTier {
   id: KarmaTierId;
   min: number;
   ringClass: string;
+  /** Ring class without animation — used for `size='sm'` compact/list contexts. */
+  staticRingClass?: string;
   glow?: boolean;
 }
 
@@ -33,18 +35,21 @@ const TIERS: readonly KarmaTier[] = [
     id: 'expert',
     min: 1000,
     ringClass: 'ring-2 ring-sky-500 motion-safe:animate-pulse',
+    staticRingClass: 'ring-2 ring-sky-500',
     glow: true,
   },
   {
     id: 'master',
     min: 5000,
     ringClass: 'ring-4 ring-yellow-400 shadow-[0_0_12px_rgba(250,204,21,0.6)] motion-safe:animate-pulse',
+    staticRingClass: 'ring-4 ring-yellow-400 shadow-[0_0_12px_rgba(250,204,21,0.6)]',
     glow: true,
   },
   {
     id: 'legend',
     min: 10000,
     ringClass: 'ring-4 ring-fuchsia-500 shadow-[0_0_16px_rgba(217,70,239,0.7)] motion-safe:animate-rastrum-legend-spin',
+    staticRingClass: 'ring-4 ring-fuchsia-500 shadow-[0_0_16px_rgba(217,70,239,0.7)]',
     glow: true,
   },
 ];


### PR DESCRIPTION
## Scope shipped

Implements the Option C decision from #861: KarmaFrame everywhere, `size='sm'` skips animations for dense list contexts.

### Core change
- `karma-frame.ts`: added `staticRingClass` to `expert`/`master`/`legend` tiers — same colors but without `motion-safe:animate-*`
- `KarmaFrame.astro`: when `size='sm'`, picks `staticRingClass ?? ringClass`

### 5 surfaces wired

| Surface | Component | Size | Animation |
|---|---|---|---|
| Public profile hero | PublicProfileViewV2.astro | lg | ✅ full |
| Header dropdown | Header.astro | sm | ❌ static |
| Leaderboard rows | KarmaLeaderboardView.astro | sm (inline) | ❌ static |
| Community cards | CommunityView.astro | sm (inline) | ❌ static |
| Comment author | Comments.astro | sm (inline) | ❌ static |

### No new queries
All surfaces reuse `karma_total` already in their selects. `CommunityObserver` TypeScript interface updated to include the field (was already returned by `SELECT *` from `community_observers` view).

## Test plan
- `npx tsc --noEmit`: clean (3 pre-existing @huggingface/transformers errors only)
- `npm run test`: 1486 passed, 4 pre-existing failures
- Manual: leaderboard top-20 scrolls smoothly; expert users show ring without pulse

## v1.1.x follow-up
- Add visual smoke test that a legend-tier user shows fuchsia ring on profile page
- Consider opt-out toggle per user (v1.5)

Closes #859