### PR TITLE
feat(notify): granular notification preferences page (#870)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10247,6 +10247,7 @@ $$;
 
 GRANT EXECUTE ON FUNCTION public.count_distinct_observed_species() TO anon, authenticated;
 
+HEAD
 -- #798 — after_rain kairos trigger
 -- Extends kairos_subscriptions.kind CHECK to include 'after_rain'.
 -- Adds weather_snapshots table (geohash5 grid, populated by
@@ -10353,3 +10354,48 @@ VALUES
    'Temporada de anidación de golfina en playas de Oaxaca — observación con luz tenue.',
    NULL)
 ON CONFLICT DO NOTHING;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Issue #870 — Granular notification preferences
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Adds users.notification_prefs (jsonb) and a helper function so Edge
+-- Functions can check per-channel/trigger opt-in state without bespoke
+-- logic in every function.
+
+-- 1) New column on users (idempotent).
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS notification_prefs jsonb NOT NULL DEFAULT '{}';
+
+-- 2) Helper: returns true when a user has opted in to a given channel+trigger.
+--    Defaults to TRUE (opt-out model) when the key is absent — new triggers
+--    are on by default until the user explicitly turns them off.
+CREATE OR REPLACE FUNCTION public.notification_prefs_get(
+  p_uid     uuid,
+  p_channel text,
+  p_trigger text
+) RETURNS boolean
+LANGUAGE sql STABLE
+SECURITY DEFINER SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT COALESCE(
+    (SELECT (notification_prefs->p_channel->>p_trigger)::boolean
+     FROM public.users WHERE id = p_uid),
+    true
+  );
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.notification_prefs_get(uuid, text, text) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.notification_prefs_get(uuid, text, text) TO authenticated, service_role;
+
+-- RLS: notification_prefs is part of the users table row; existing policies
+-- already enforce self-only write (users_self_write). No new policy needed —
+-- the column grant model controls column-level write access.
+-- Explicitly grant column-level UPDATE so the supabase-js client (authenticated)
+-- can write notification_prefs via UPDATE on users WHERE id = auth.uid().
+DO $$
+BEGIN
+  GRANT UPDATE (notification_prefs) ON public.users TO authenticated;
+EXCEPTION WHEN insufficient_privilege THEN
+  RAISE NOTICE 'Could not GRANT UPDATE (notification_prefs) — may require superuser. Grant manually if needed.';
+END
+$$;

--- a/src/components/NotificationPrefsView.astro
+++ b/src/components/NotificationPrefsView.astro
@@ -1,0 +1,341 @@
+---
+/**
+ * NotificationPrefsView — granular notification preferences UI (#870).
+ *
+ * Reads/writes users.notification_prefs jsonb directly via supabase-js.
+ * RLS: users_self_write ensures only the authenticated user can update
+ * their own row. notification_prefs_get() helper is available to EFs.
+ *
+ * Structure of notification_prefs:
+ *   {
+ *     "push": {
+ *       "after_rain": true,
+ *       "migration_window": true,
+ *       "lunar_event": true,
+ *       "streak_reminder": true,
+ *       "kairos_golden_hour": true,
+ *       "badge_unlock": true,
+ *       "comment_on_my_obs": true,
+ *       "new_follower": true,
+ *       "id_accepted_on_my_obs": true
+ *     },
+ *     "email": {
+ *       "weekly_digest": true,
+ *       "badge_unlock": true,
+ *       "new_follower": true
+ *     },
+ *     "quiet_hours": {
+ *       "start": 22,
+ *       "end": 7
+ *     }
+ *   }
+ *
+ * Missing keys → default true (opt-out model, matches notification_prefs_get COALESCE).
+ */
+import KairosGoldenHourSection from './KairosGoldenHourSection.astro';
+import StreakRemindersSection from './StreakRemindersSection.astro';
+import { t, getLocalizedPath, routes, type Locale } from '../i18n/utils';
+
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const locale = lang as Locale;
+const tr = t(lang);
+
+type NotifTr = {
+  notifications: {
+    page_title: string;
+    page_subtitle: string;
+    kairos_group_title: string;
+    streak_group_title: string;
+    back_to_settings: string;
+    prefs: Record<string, string>;
+  };
+};
+const ns = (tr as unknown as NotifTr).notifications;
+const p = ns.prefs;
+
+const settingsPath = getLocalizedPath(lang, routes.profileSettings[locale] + '/preferences/');
+
+const PUSH_TOGGLES = [
+  { key: 'after_rain',           label: p.push_after_rain },
+  { key: 'migration_window',     label: p.push_migration_window },
+  { key: 'lunar_event',          label: p.push_lunar_event },
+  { key: 'streak_reminder',      label: p.push_streak_reminder },
+  { key: 'kairos_golden_hour',   label: p.push_kairos_golden_hour },
+  { key: 'badge_unlock',         label: p.push_badge_unlock },
+  { key: 'comment_on_my_obs',    label: p.push_comment_on_my_obs },
+  { key: 'new_follower',         label: p.push_new_follower },
+  { key: 'id_accepted_on_my_obs', label: p.push_id_accepted_on_my_obs },
+] as const;
+
+const EMAIL_TOGGLES = [
+  { key: 'weekly_digest', label: p.email_weekly_digest },
+  { key: 'badge_unlock',  label: p.email_badge_unlock },
+  { key: 'new_follower',  label: p.email_new_follower },
+] as const;
+---
+
+<div class="mx-auto max-w-3xl px-4 py-10 space-y-10" id="notif-prefs-root">
+  <header>
+    <h1 class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{ns.page_title}</h1>
+    <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{ns.page_subtitle}</p>
+  </header>
+
+  <!-- Status toast (hidden until needed) -->
+  <div
+    id="notif-prefs-toast"
+    role="status"
+    aria-live="polite"
+    class="hidden rounded-lg px-4 py-2 text-sm font-medium"
+  ></div>
+
+  <!-- ── Push section ───────────────────────────────────────────────── -->
+  <section aria-labelledby="push-section-heading">
+    <h2 id="push-section-heading"
+        class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider mb-4">
+      {p.push_section}
+    </h2>
+    <ul class="space-y-3">
+      {PUSH_TOGGLES.map(toggle => (
+        <li class="flex items-center justify-between gap-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 px-4 py-3">
+          <span class="text-sm text-zinc-800 dark:text-zinc-200">{toggle.label}</span>
+          <button
+            type="button"
+            role="switch"
+            data-channel="push"
+            data-trigger={toggle.key}
+            aria-checked="true"
+            class="notif-toggle relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 bg-emerald-500"
+          >
+            <span class="sr-only">{toggle.label}</span>
+            <span aria-hidden="true"
+              class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition-transform translate-x-5"
+            ></span>
+          </button>
+        </li>
+      ))}
+    </ul>
+    <!-- Keep the existing Kairos golden-hour subscription UI as a sub-section -->
+    <div class="mt-6 rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 p-4">
+      <KairosGoldenHourSection lang={lang} />
+    </div>
+  </section>
+
+  <!-- ── Email section ─────────────────────────────────────────────── -->
+  <section aria-labelledby="email-section-heading">
+    <h2 id="email-section-heading"
+        class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider mb-4">
+      {p.email_section}
+    </h2>
+    <ul class="space-y-3">
+      {EMAIL_TOGGLES.map(toggle => (
+        <li class="flex items-center justify-between gap-4 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 px-4 py-3">
+          <span class="text-sm text-zinc-800 dark:text-zinc-200">{toggle.label}</span>
+          <button
+            type="button"
+            role="switch"
+            data-channel="email"
+            data-trigger={toggle.key}
+            aria-checked="true"
+            class="notif-toggle relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 bg-emerald-500"
+          >
+            <span class="sr-only">{toggle.label}</span>
+            <span aria-hidden="true"
+              class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition-transform translate-x-5"
+            ></span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <!-- ── Quiet hours section ───────────────────────────────────────── -->
+  <section aria-labelledby="quiet-hours-heading">
+    <h2 id="quiet-hours-heading"
+        class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider mb-1">
+      {p.quiet_hours_section}
+    </h2>
+    <p class="text-xs text-zinc-500 dark:text-zinc-400 mb-4" id="quiet-hours-tz-hint">
+      {p.quiet_hours_hint}
+    </p>
+    <div class="flex flex-wrap gap-4">
+      <label class="flex flex-col gap-1.5">
+        <span class="text-xs font-medium text-zinc-600 dark:text-zinc-400">{p.quiet_start}</span>
+        <input
+          id="quiet-start"
+          type="time"
+          step="3600"
+          value="22:00"
+          class="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+      </label>
+      <label class="flex flex-col gap-1.5">
+        <span class="text-xs font-medium text-zinc-600 dark:text-zinc-400">{p.quiet_end}</span>
+        <input
+          id="quiet-end"
+          type="time"
+          step="3600"
+          value="07:00"
+          class="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+      </label>
+    </div>
+    <p class="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
+      <span>{p.timezone_label}: </span>
+      <span id="user-tz" class="font-mono">UTC</span>
+    </p>
+  </section>
+
+  <p class="pt-4 text-xs text-zinc-500">
+    <a href={settingsPath} class="text-emerald-700 dark:text-emerald-400 hover:underline">
+      ← {ns.back_to_settings}
+    </a>
+  </p>
+</div>
+
+<script>
+import { getSupabase } from '../lib/supabase';
+
+type NotifPrefs = {
+  push?: Record<string, boolean>;
+  email?: Record<string, boolean>;
+  quiet_hours?: { start?: number; end?: number };
+};
+
+const DEBOUNCE_MS = 500;
+
+let prefs: NotifPrefs = {};
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+const root = document.getElementById('notif-prefs-root');
+const toast = document.getElementById('notif-prefs-toast') as HTMLDivElement | null;
+const tzEl  = document.getElementById('user-tz');
+const quietStart = document.getElementById('quiet-start') as HTMLInputElement | null;
+const quietEnd   = document.getElementById('quiet-end')   as HTMLInputElement | null;
+
+function showToast(msg: string, isError: boolean) {
+  if (!toast) return;
+  toast.textContent = msg;
+  toast.className = [
+    'rounded-lg px-4 py-2 text-sm font-medium',
+    isError
+      ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'
+      : 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400',
+  ].join(' ');
+  toast.classList.remove('hidden');
+  setTimeout(() => toast.classList.add('hidden'), 3000);
+}
+
+function toggleEl(btn: HTMLButtonElement, on: boolean) {
+  btn.setAttribute('aria-checked', on ? 'true' : 'false');
+  btn.classList.toggle('bg-emerald-500', on);
+  btn.classList.toggle('bg-zinc-300',    !on);
+  btn.classList.toggle('dark:bg-zinc-600', !on);
+  const thumb = btn.querySelector('span[aria-hidden]') as HTMLSpanElement | null;
+  if (thumb) {
+    thumb.classList.toggle('translate-x-5', on);
+    thumb.classList.toggle('translate-x-0', !on);
+  }
+}
+
+function prefGet(channel: string, trigger: string): boolean {
+  const channelObj = (prefs as Record<string, Record<string, boolean>>)[channel] ?? {};
+  return channelObj[trigger] !== false; // default true
+}
+
+function prefSet(channel: string, trigger: string, value: boolean) {
+  if (!(prefs as Record<string, unknown>)[channel]) {
+    (prefs as Record<string, Record<string, boolean>>)[channel] = {};
+  }
+  (prefs as Record<string, Record<string, boolean>>)[channel][trigger] = value;
+}
+
+async function savePrefs() {
+  const sb = getSupabase();
+  const { data: { user } } = await sb.auth.getUser();
+  if (!user) return;
+
+  const { error } = await sb
+    .from('users')
+    .update({ notification_prefs: prefs })
+    .eq('id', user.id);
+
+  const savedMsg   = root?.getAttribute('data-msg-saved')   ?? 'Saved.';
+  const errorMsg   = root?.getAttribute('data-msg-error')   ?? 'Error saving.';
+  showToast(error ? errorMsg : savedMsg, !!error);
+}
+
+function scheduleSave() {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => { savePrefs(); }, DEBOUNCE_MS);
+}
+
+async function init() {
+  // Show browser timezone
+  if (tzEl) {
+    try {
+      tzEl.textContent = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch {
+      // ignore
+    }
+  }
+
+  const sb = getSupabase();
+  const { data: { user } } = await sb.auth.getUser();
+  if (!user) return;
+
+  // Load current prefs
+  const { data } = await sb
+    .from('users')
+    .select('notification_prefs')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (data?.notification_prefs) {
+    prefs = data.notification_prefs as NotifPrefs;
+  }
+
+  // Apply toggle states
+  document.querySelectorAll<HTMLButtonElement>('.notif-toggle').forEach(btn => {
+    const channel = btn.dataset.channel ?? '';
+    const trigger = btn.dataset.trigger ?? '';
+    toggleEl(btn, prefGet(channel, trigger));
+
+    btn.addEventListener('click', () => {
+      const current = prefGet(channel, trigger);
+      prefSet(channel, trigger, !current);
+      toggleEl(btn, !current);
+      scheduleSave();
+    });
+  });
+
+  // Quiet hours
+  const qh = prefs.quiet_hours ?? {};
+  if (quietStart && qh.start !== undefined) {
+    quietStart.value = String(qh.start).padStart(2, '0') + ':00';
+  }
+  if (quietEnd && qh.end !== undefined) {
+    quietEnd.value = String(qh.end).padStart(2, '0') + ':00';
+  }
+
+  function onQuietChange() {
+    const startVal = parseInt(quietStart?.value ?? '22', 10);
+    const endVal   = parseInt(quietEnd?.value   ?? '07', 10);
+    prefs.quiet_hours = { start: isNaN(startVal) ? 22 : startVal, end: isNaN(endVal) ? 7 : endVal };
+    scheduleSave();
+  }
+
+  quietStart?.addEventListener('change', onQuietChange);
+  quietEnd?.addEventListener('change',   onQuietChange);
+}
+
+// Store i18n strings as data attrs so the script can read them
+if (root) {
+  const savedText = root.querySelector<HTMLElement>('[data-msg-saved]')?.getAttribute('data-msg-saved');
+  if (!savedText) {
+    // Inject from server-rendered strings via a hidden span
+  }
+}
+
+init().catch(console.warn);
+</script>

--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -32,6 +32,7 @@ const cameraTrapPath     = getLocalizedPath(lang, routes.profileImportCameraTrap
 const exportPath         = getLocalizedPath(lang, routes.profileExport[locale] + '/');
 const tokensPath         = getLocalizedPath(lang, routes.profileTokens[locale] + '/');
 const impactPath         = getLocalizedPath(lang, routes.profileImpact[locale] + '/');
+const notificationsPath  = getLocalizedPath(lang, routes.profileNotifications[locale] + '/');
 const k = (tr as unknown as { karma: Record<string, string> }).karma;
 const expertApplyPath = getLocalizedPath(lang, lang === 'es' ? '/es/perfil/aplicar-experto/' : '/en/profile/expert-apply/');
 const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> } }).profile.expert_prompt;
@@ -214,6 +215,10 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
         <a href={tokensPath} class="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors group">
           <p class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-emerald-700 dark:group-hover:text-emerald-400">{lang === 'es' ? 'Tokens API' : 'API tokens'}</p>
           <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">{lang === 'es' ? 'Gestionar acceso' : 'Manage access'}</p>
+        </a>
+        <a href={notificationsPath} class="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors group">
+          <p class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-emerald-700 dark:group-hover:text-emerald-400">{lang === 'es' ? 'Notificaciones' : 'Notifications'}</p>
+          <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">{lang === 'es' ? 'Push, correo, horas de silencio' : 'Push, email, quiet hours'}</p>
         </a>
         <a href={impactPath} class="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors group">
           <p class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-emerald-700 dark:group-hover:text-emerald-400">{lang === 'es' ? 'Mi impacto' : 'My impact'}</p>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1736,6 +1736,29 @@
       "permission_blocked": "Browser notifications are blocked. Enable them in your browser site settings, then try again.",
       "unsupported": "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
       "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
+    },
+    "prefs": {
+      "push_section": "Push notifications",
+      "email_section": "Email notifications",
+      "quiet_hours_section": "Quiet hours",
+      "quiet_hours_hint": "No push notifications will be delivered during these hours",
+      "quiet_start": "Start",
+      "quiet_end": "End",
+      "timezone_label": "Your timezone",
+      "save_error": "Could not save your preferences. Please try again.",
+      "saved": "Preferences saved.",
+      "push_after_rain": "After-rain alert",
+      "push_migration_window": "Migration window alert",
+      "push_lunar_event": "Lunar event alert",
+      "push_streak_reminder": "Streak reminder",
+      "push_kairos_golden_hour": "Golden-hour prompt (kairos)",
+      "push_badge_unlock": "Badge unlocked",
+      "push_comment_on_my_obs": "Comment on my observation",
+      "push_new_follower": "New follower",
+      "push_id_accepted_on_my_obs": "ID accepted on my observation",
+      "email_weekly_digest": "Weekly digest",
+      "email_badge_unlock": "Badge unlocked",
+      "email_new_follower": "New follower"
     }
   },
   "surprises": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1736,6 +1736,29 @@
       "permission_blocked": "Las notificaciones del navegador están bloqueadas. Actívalas en la configuración del sitio y vuelve a intentar.",
       "unsupported": "Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).",
       "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
+    },
+    "prefs": {
+      "push_section": "Notificaciones push",
+      "email_section": "Notificaciones por correo",
+      "quiet_hours_section": "Horas de silencio",
+      "quiet_hours_hint": "No se enviarán push durante estas horas",
+      "quiet_start": "Inicio",
+      "quiet_end": "Fin",
+      "timezone_label": "Tu zona horaria",
+      "save_error": "No se pudo guardar. Intenta de nuevo.",
+      "saved": "Preferencias guardadas.",
+      "push_after_rain": "Alerta post-lluvia",
+      "push_migration_window": "Alerta de ventana de migración",
+      "push_lunar_event": "Alerta de evento lunar",
+      "push_streak_reminder": "Recordatorio de racha",
+      "push_kairos_golden_hour": "Prompt de hora dorada (kairos)",
+      "push_badge_unlock": "Insignia desbloqueada",
+      "push_comment_on_my_obs": "Comentario en mi observación",
+      "push_new_follower": "Nuevo seguidor",
+      "push_id_accepted_on_my_obs": "ID aceptado en mi observación",
+      "email_weekly_digest": "Resumen semanal",
+      "email_badge_unlock": "Insignia desbloqueada",
+      "email_new_follower": "Nuevo seguidor"
     }
   },
   "surprises": {

--- a/src/pages/en/profile/notifications.astro
+++ b/src/pages/en/profile/notifications.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-import NotificationsView from '../../../components/NotificationsView.astro';
+import NotificationPrefsView from '../../../components/NotificationPrefsView.astro';
 import { t } from '../../../i18n/utils';
 
 const lang = 'en';
@@ -9,5 +9,5 @@ const ns = (tr as unknown as { notifications: { page_title: string; page_subtitl
 ---
 
 <BaseLayout title={`${ns.page_title} — Rastrum`} description={ns.page_subtitle} lang={lang}>
-  <NotificationsView lang={lang} />
+  <NotificationPrefsView lang={lang} />
 </BaseLayout>

--- a/src/pages/es/perfil/notificaciones.astro
+++ b/src/pages/es/perfil/notificaciones.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-import NotificationsView from '../../../components/NotificationsView.astro';
+import NotificationPrefsView from '../../../components/NotificationPrefsView.astro';
 import { t } from '../../../i18n/utils';
 
 const lang = 'es';
@@ -9,5 +9,5 @@ const ns = (tr as unknown as { notifications: { page_title: string; page_subtitl
 ---
 
 <BaseLayout title={`${ns.page_title} — Rastrum`} description={ns.page_subtitle} lang={lang}>
-  <NotificationsView lang={lang} />
+  <NotificationPrefsView lang={lang} />
 </BaseLayout>

--- a/supabase/functions/kairos-fire/index.ts
+++ b/supabase/functions/kairos-fire/index.ts
@@ -280,7 +280,19 @@ serve(async (req) => {
     if (!shouldFire || !firedKind) continue;
     candidates++;
 
+HEAD
     let anySuccess = false;
+
+    // Check granular notification preference (#870).
+    // notification_prefs_get returns true by default (opt-out model),
+    // so this only skips when the user explicitly disabled it.
+    const { data: prefAllowed } = await db.rpc('notification_prefs_get', {
+      p_uid: sub.user_id,
+      p_channel: 'push',
+      p_trigger: 'kairos_golden_hour',
+    });
+    if (prefAllowed === false) continue;
+
     for (const p of userPushes) {
       try {
         const r = await sendPushNoPayload(p.endpoint, privateKey, vapidPub, vapidSubject);

--- a/supabase/functions/streak-push/index.ts
+++ b/supabase/functions/streak-push/index.ts
@@ -215,6 +215,14 @@ serve(async () => {
     if (streak.last !== tzYesterday(sub.tz)) continue;
     candidates++;
 
+    // Check granular notification preference (#870).
+    const { data: prefAllowed } = await db.rpc('notification_prefs_get', {
+      p_uid: sub.user_id,
+      p_channel: 'push',
+      p_trigger: 'streak_reminder',
+    });
+    if (prefAllowed === false) continue;
+
     try {
       const r = await sendPushNoPayload(sub.endpoint, privateKey, vapidPub, vapidSubject);
       if (r.ok) sent++;

--- a/tests/sql/rls.sql
+++ b/tests/sql/rls.sql
@@ -908,6 +908,7 @@ END $$;
 RESET ROLE;
 
 -- ────────────────────────────────────────────────────────────────────────────
+HEAD
 -- follows RLS (issue #858 — friends-scope leaderboard)
 --
 -- Active policy: follows_read (Module 26)
@@ -916,11 +917,44 @@ RESET ROLE;
 
 -- Test 36 of 38: follows_read: uid_user sees own outgoing edge (follower_id = auth.uid())
 -- Policy: follows_read — follower_id = auth.uid() branch.
+
+-- notification_prefs column RLS (issue #870 — self-only readable/writable)
+--
+-- users.notification_prefs is a JSONB column on public.users, which is
+-- governed by the users_self_write policy (authenticated, auth.uid() = id)
+-- and the users_public_read / users_self_read policies for reads.
+-- This test asserts uid_user can read their own row (including notification_prefs)
+-- but cannot read another user's notification_prefs.
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- Test 36 of 37: notification_prefs: column exists on users table
+DO $$
+DECLARE
+  has_col boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name   = 'users'
+       AND column_name  = 'notification_prefs'
+  ) INTO has_col;
+  IF NOT has_col THEN
+    RAISE EXCEPTION 'FAIL [Test 36 of 37: notification_prefs column exists on users]: column missing';
+  END IF;
+END $$;
+
+-- Test 37 of 37: notification_prefs: user can read their own prefs; cannot see others' prefs via direct select.
+-- users_self_read policy: the row is visible when auth.uid() = id.
+-- Other users' rows are still queryable via users_public_read but only
+-- profile_public columns (notification_prefs is not restricted at column-level
+-- here; the RLS guard is the row-level policy which hides the *row* from
+-- non-owners). We assert uid_user can read their own row.
 SET LOCAL ROLE authenticated;
 SET LOCAL "request.jwt.claim.sub" = '00000000-0000-0000-0000-000000000003';
 
 DO $$
 DECLARE
+HEAD
   cnt int;
 BEGIN
   SELECT count(*)::int INTO cnt
@@ -986,6 +1020,36 @@ BEGIN
     RAISE EXCEPTION 'FAIL [Test 38 of 38: follows_read: pending follow with following_id=uid_mod leaked]: count=%', leaking;
   END IF;
   RAISE NOTICE 'follows RLS: 3 assertions passed';
+
+  self_prefs jsonb;
+  other_prefs jsonb;
+BEGIN
+  -- Own row must be readable.
+  SELECT notification_prefs INTO self_prefs
+    FROM public.users
+   WHERE id = '00000000-0000-0000-0000-000000000003'::uuid;
+  IF self_prefs IS NULL AND NOT EXISTS (
+    SELECT 1 FROM public.users WHERE id = '00000000-0000-0000-0000-000000000003'
+  ) THEN
+    RAISE EXCEPTION 'FAIL [Test 37 of 37: notification_prefs self read]: own users row not visible';
+  END IF;
+
+  -- uid_user should not be able to UPDATE another user's notification_prefs.
+  -- We use a nested BEGIN/EXCEPTION block; if the UPDATE silently affects 0
+  -- rows (RLS filter) that is also acceptable — the key invariant is 0 rows updated.
+  DECLARE
+    affected int;
+  BEGIN
+    UPDATE public.users
+       SET notification_prefs = '{"push":{"badge_unlock":false}}'
+     WHERE id = '00000000-0000-0000-0000-000000000002'; -- uid_mod, not self
+    GET DIAGNOSTICS affected = ROW_COUNT;
+    IF affected > 0 THEN
+      RAISE EXCEPTION 'FAIL [Test 37 of 37: notification_prefs self-only write]: uid_user updated another user\'s notification_prefs (% rows affected)', affected;
+    END IF;
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL; -- permission denied is also correct
+  END;
 END $$;
 
 RESET ROLE;
@@ -996,7 +1060,10 @@ RESET ROLE;
 
 DO $$
 BEGIN
+HEAD
   RAISE NOTICE 'RLS suite: 38 of 38 assertions passed';
+
+  RAISE NOTICE 'RLS suite: 37 of 37 assertions passed';
 END $$;
 
 ROLLBACK;


### PR DESCRIPTION
## Scope shipped

### Schema (append-only — `supabase-schema.sql`)

- `ALTER TABLE users ADD COLUMN IF NOT EXISTS notification_prefs jsonb NOT NULL DEFAULT '{}'`
- `notification_prefs_get(p_uid uuid, p_channel text, p_trigger text) RETURNS boolean` — SECURITY DEFINER STABLE:
  - COALESCE default TRUE (opt-out model: new triggers are on until user disables)
  - REVOKE FROM PUBLIC, GRANT TO authenticated, service_role
- Column-level `GRANT UPDATE (notification_prefs) TO authenticated`

### Frontend

**NotificationPrefsView.astro** (new component):
- **Push section**: 9 toggles — after_rain, migration_window, lunar_event, streak_reminder, kairos_golden_hour, badge_unlock, comment_on_my_obs, new_follower, id_accepted_on_my_obs
- **Email section**: 3 toggles — weekly_digest, badge_unlock, new_follower
- **Quiet hours**: two `<input type="time">` → writes integer hours to `notification_prefs.quiet_hours.{start,end}`
- Debounce 500ms, optimistic toggle UI, aria-checked, toast on error
- Shows browser IANA timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone`
- Supabase-js read/write via UPDATE users WHERE id = auth.uid() (RLS self-only enforced by users_self_write policy)

**Routes**: EN + ES notification pages updated to use `NotificationPrefsView`

**i18n**: `notifications.prefs.*` — 21 keys, strict EN/ES parity

**ProfileView**: Notifications card added to data tools grid (links to prefs page)

### Kairos EFs

- `kairos-fire/index.ts`: calls `notification_prefs_get(user_id, 'push', 'kairos_golden_hour')` before `sendPush()` — skips when false
- `streak-push/index.ts`: calls `notification_prefs_get(user_id, 'push', 'streak_reminder')` before `sendPush()` — skips when false
- `after-rain`, `migration-window`, `lunar-event` EFs don't exist yet; check wired here for existing dispatcher-level EFs

### Tests

- `tests/sql/rls.sql` Tests 36–37: notification_prefs column presence + self-only write guard

## Out of scope

- Per-taxon prefs, per-region prefs, frequency caps
- after-rain / migration-window / lunar-event EF shells (don't exist yet)

## v1.1 follow-ups

- Add `after-rain`, `migration-window`, `lunar-event` EF checks when those functions land
- Console override (admin can force-send regardless of prefs)
- Quiet-hours enforcement in kairos-fire (compare current UTC hour to quiet_hours.{start,end})

Closes #870