### PR TITLE
fix(home): strip HomeWidgets to stop production 400

### DIFF
--- a/docs/superpowers/plans/2026-05-09-chat-improvements.md
+++ b/docs/superpowers/plans/2026-05-09-chat-improvements.md
@@ -1,0 +1,3486 @@
+# Chat Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Gemma 4 E2B as a text-chat backbone, a generic chat-entity registry covering 6 entity kinds (observations, species, projects, camera stations, observers, self-profile), a typed JSON tool layer over Supabase RPCs, and decompose `ChatView.astro` (1,441 LOC) into a slim orchestrator + four sibling components.
+
+**Architecture:** ChatView orchestrator → ChatComposer + ChatBubble + ChatEntityChip + ChatEntityPicker. Engine layer (`chat-engine.ts`) dispatches between Gemma 4 (default) and Llama-3.2-1B (fallback) and runs a 1-round tool-call loop. Entity layer (`chat-entities/`) mirrors the existing `identifiers/` plugin registry. Five client-side tools call SECURITY INVOKER Supabase RPCs (`chat_entity_card` + 5 `chat_find_*`).
+
+**Tech Stack:** Astro, TypeScript (strict), Tailwind, Vitest + happy-dom, Playwright, Supabase (Postgres + PostGIS + RLS), Dexie (IndexedDB), `@mlc-ai/web-llm` (Llama), `@huggingface/transformers` + ONNX Runtime Web (Gemma).
+
+**Spec:** `docs/superpowers/specs/2026-05-09-chat-improvements-design.md`
+
+**Worktree:** Implementation runs in a worktree per the user's earlier directive. Create with the `superpowers:using-git-worktrees` skill at execution time.
+
+---
+
+## Sequencing
+
+The plan has 7 phases. Each phase ends in a green CI state and a meaningful commit. A reader could pause after any phase and the chat would still work.
+
+- **Phase 1 — SQL (no UI changes).** Add the 6 new RPCs + SQL regression tests.
+- **Phase 2 — Entity registry + Specs.** Generic `EntitySpec` + 6 built-in specs + unit tests.
+- **Phase 3 — Tool layer.** `chat-tools.ts` + 5 tools + unit tests.
+- **Phase 4 — Engine layer.** `loadGemmaTextEngine` + `chat-engine.ts` (tool-call loop) + ProfileEditForm download card.
+- **Phase 5 — UI decomposition.** Extract ChatBubble / ChatComposer / ChatEntityChip / ChatEntityPicker; slim ChatView; wire chat-engine + entity attach handler.
+- **Phase 6 — Deep links.** `AskRastrumButton` + drop into 5 entity surfaces.
+- **Phase 7 — i18n + telemetry + E2E + runbook.**
+
+Each task ends with a commit. `npm run typecheck && npm run test` must be green before each commit.
+
+---
+
+## File Structure
+
+### New files
+
+```
+src/lib/chat-entities/
+├── types.ts                       # EntityKind, EntityCard, EntitySpec
+├── registry.ts                    # singleton, mirrors identifiers/registry.ts
+├── index.ts                       # bootstrapChatEntities()
+├── observation.ts                 # EntitySpec for kind='observation'
+├── species.ts                     # EntitySpec for kind='species'
+├── project.ts                     # EntitySpec for kind='project'
+├── camera-station.ts              # EntitySpec for kind='camera_station'
+├── observer.ts                    # EntitySpec for kind='observer'
+└── self-profile.ts                # EntitySpec for kind='self_profile'
+
+src/lib/chat-entities/*.test.ts    # one .test.ts per source file above (excl. index.ts)
+
+src/lib/chat-tools.ts              # tool registry + dispatcher + 5 tools
+src/lib/chat-tools.test.ts
+
+src/lib/chat-engine.ts             # streamChat() with tool-call loop
+src/lib/chat-engine.test.ts
+
+src/lib/parse-attach-querystring.ts        # ?attach=kind:id parser
+src/lib/parse-attach-querystring.test.ts
+
+src/components/ChatComposer.astro
+src/components/ChatEntityChip.astro
+src/components/ChatEntityPicker.astro
+src/components/ChatBubble.astro
+src/components/AskRastrumButton.astro
+
+tests/unit/chat-composer.test.ts
+tests/unit/chat-entity-picker.test.ts
+tests/unit/ask-rastrum-button.test.ts
+
+tests/e2e/chat-deep-link.spec.ts
+tests/e2e/chat-entity-picker.spec.ts
+
+tests/sql/chat.sql                 # SQL regression assertions
+
+docs/runbooks/chat-improvements.md
+```
+
+### Modified files
+
+```
+docs/specs/infra/supabase-schema.sql  # append 6 new functions + grants
+src/lib/local-ai.ts                   # add loadGemmaTextEngine + cancel/clear
+src/components/ChatView.astro         # slim from 1,441 → ~400 LOC
+src/components/ProfileEditForm.astro  # add Gemma 4 (text) download card
+src/components/ShareObsView.astro     # mount AskRastrumButton
+src/components/MyObservationsView.astro     # mount AskRastrumButton
+src/components/SpeciesProfileView.astro     # mount AskRastrumButton
+src/components/ProjectDetailView.astro      # mount AskRastrumButton
+src/components/PublicProfileView.astro      # mount AskRastrumButton
+src/components/CameraStationItem.astro      # mount AskRastrumButton (if exists; verify in Task 23)
+src/lib/db.ts                          # extend ChatTurnRecord type
+src/i18n/en.json                       # add chat.entities.*, chat.tools.*, chat.attach_entity_*
+src/i18n/es.json                       # mirror
+.github/workflows/db-validate.yml      # wire tests/sql/chat.sql
+docs/runbooks/00-index.md              # link new runbook
+```
+
+---
+
+# Phase 1 — SQL Layer
+
+The chat surface needs read-only Postgres functions to fetch entity cards and search relations. All functions are `SECURITY INVOKER` (RLS does the gating), `SET search_path = public, extensions, pg_temp` (per the lint guard), `LANGUAGE plpgsql` or `LANGUAGE sql STABLE`, and `REVOKE EXECUTE … FROM PUBLIC` + `GRANT EXECUTE … TO authenticated`.
+
+The dispatcher `chat_entity_card(p_kind, p_id)` accepts a kind string and an id (uuid for db rows; slug for species/projects), and returns one JSONB row matching the `EntityCard` shape from the spec.
+
+---
+
+### Task 1: Add the per-kind card builders + dispatcher
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql` (append to end, before any "remediation" block at the bottom)
+
+- [ ] **Step 1: Read the relevant schema sections to confirm column names**
+
+Run:
+```bash
+grep -n "CREATE TABLE IF NOT EXISTS public.observations" docs/specs/infra/supabase-schema.sql
+grep -n "CREATE TABLE IF NOT EXISTS public.taxa" docs/specs/infra/supabase-schema.sql
+grep -n "CREATE TABLE IF NOT EXISTS public.projects" docs/specs/infra/supabase-schema.sql
+grep -n "CREATE TABLE IF NOT EXISTS public.camera_stations" docs/specs/infra/supabase-schema.sql
+grep -n "CREATE OR REPLACE VIEW public.community_observers" docs/specs/infra/supabase-schema.sql
+```
+
+Expected: Five line numbers. Read 30 lines starting at each to confirm column names. Note any drift from the assumptions in this plan; if a column you expected doesn't exist, stop and ask.
+
+- [ ] **Step 2: Append the dispatcher + per-kind card builders**
+
+Append the following at the end of `docs/specs/infra/supabase-schema.sql`, before any post-creation remediation block (search for "remediation" near the end of the file):
+
+```sql
+-- ── Chat entity cards (M01 chat improvements, 2026-05-09) ──
+-- Read-only functions returning EntityCard-shaped JSONB. Every function
+-- is SECURITY INVOKER; the existing RLS policies enforce visibility.
+
+DROP FUNCTION IF EXISTS public.chat_obs_card(uuid);
+CREATE FUNCTION public.chat_obs_card(p_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH o AS (
+    SELECT
+      o.id, o.observer_user_id, o.observed_at,
+      o.primary_taxon_id, o.obscure_level,
+      o.location, o.location_obscured,
+      o.region_primary, o.is_research_grade, o.notes,
+      t.scientific_name, t.common_name_es, t.common_name_en,
+      t.kingdom, t.family
+    FROM public.observations o
+    LEFT JOIN public.taxa t ON t.id = o.primary_taxon_id
+    WHERE o.id = p_id
+  )
+  SELECT CASE WHEN o.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'observation',
+    'id',            o.id::text,
+    'label',         coalesce(o.scientific_name, '—')
+                     || ' · ' || to_char(o.observed_at, 'Mon DD')
+                     || coalesce(' · ' || o.region_primary, ''),
+    'summary_text',
+      'Observation of ' || coalesce(o.scientific_name, 'unknown taxon')
+      || coalesce(' (' || o.common_name_en || ')', '')
+      || ' on ' || to_char(o.observed_at, 'YYYY-MM-DD')
+      || coalesce(' in ' || o.region_primary, '')
+      || CASE WHEN o.is_research_grade THEN '. Research grade.' ELSE '. Needs review.' END
+      || coalesce(' Observer notes: ' || left(o.notes, 240), ''),
+    'fields',        jsonb_build_object(
+      'scientific_name', o.scientific_name,
+      'common_name_en',  o.common_name_en,
+      'common_name_es',  o.common_name_es,
+      'kingdom',         o.kingdom,
+      'family',          o.family,
+      'observed_at',     o.observed_at,
+      'region_primary',  o.region_primary,
+      'is_research_grade', o.is_research_grade,
+      'obscure_level',   o.obscure_level,
+      'lat', CASE WHEN auth.uid() = o.observer_user_id
+                  THEN ST_Y(o.location::geometry)
+                  ELSE ST_Y(coalesce(o.location_obscured, o.location)::geometry) END,
+      'lng', CASE WHEN auth.uid() = o.observer_user_id
+                  THEN ST_X(o.location::geometry)
+                  ELSE ST_X(coalesce(o.location_obscured, o.location)::geometry) END,
+      'coords_obscured', (auth.uid() <> o.observer_user_id AND o.location_obscured IS NOT NULL)
+    ),
+    'suggested_questions', jsonb_build_array(
+      'Why is this ' || CASE WHEN o.is_research_grade THEN 'research grade' ELSE 'needs review' END || '?',
+      'What other observations of this species are nearby?',
+      'Tell me about ' || coalesce(o.scientific_name, 'this species') || '.'
+    ),
+    'related',       jsonb_build_object(
+      'primary_taxon_id', o.primary_taxon_id::text,
+      'observer_id',      o.observer_user_id::text
+    )
+  ) END
+  FROM o;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_species_card(text);
+CREATE FUNCTION public.chat_species_card(p_query text)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH t AS (
+    SELECT id, scientific_name, canonical_name, common_name_es, common_name_en,
+           kingdom, family, nom059_status, cites_appendix, iucn_category, is_endemic_mexico,
+           description_es, description_en, obscure_level
+    FROM public.taxa
+    WHERE id::text = p_query
+       OR canonical_name ILIKE p_query
+       OR scientific_name ILIKE p_query
+    ORDER BY canonical_name
+    LIMIT 1
+  )
+  SELECT CASE WHEN t.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'species',
+    'id',            t.id::text,
+    'label',         t.scientific_name,
+    'summary_text',
+      coalesce(t.scientific_name, '')
+      || coalesce(' (' || t.common_name_en || ')', '')
+      || ' — ' || coalesce(t.kingdom, '?') || ' / ' || coalesce(t.family, '?')
+      || coalesce('. NOM-059: ' || t.nom059_status, '')
+      || coalesce('. CITES: ' || t.cites_appendix, '')
+      || coalesce('. IUCN: ' || t.iucn_category, '')
+      || coalesce('. ' || left(t.description_en, 240), ''),
+    'fields',        jsonb_build_object(
+      'scientific_name',     t.scientific_name,
+      'common_name_en',      t.common_name_en,
+      'common_name_es',      t.common_name_es,
+      'kingdom',             t.kingdom,
+      'family',              t.family,
+      'nom059_status',       t.nom059_status,
+      'cites_appendix',      t.cites_appendix,
+      'iucn_category',       t.iucn_category,
+      'is_endemic_mexico',   t.is_endemic_mexico,
+      'obscure_level',       t.obscure_level
+    ),
+    'suggested_questions', jsonb_build_array(
+      'Where in Mexico is ' || t.scientific_name || ' typically observed?',
+      'What does NOM-059 ' || coalesce(t.nom059_status, 'status') || ' mean?',
+      'Show me recent observations of this species.'
+    ),
+    'related',       jsonb_build_object(
+      'primary_taxon_id', t.id::text
+    )
+  ) END
+  FROM t;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_project_card(text);
+CREATE FUNCTION public.chat_project_card(p_query text)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH p AS (
+    SELECT id, slug, name, name_es, description, description_es,
+           visibility, owner_user_id, area_km2
+    FROM public.projects_with_geojson
+    WHERE id::text = p_query OR slug = p_query
+    LIMIT 1
+  ),
+  c AS (
+    SELECT count(*)::int AS obs_count
+    FROM public.observations o, p
+    WHERE o.project_id = p.id
+  )
+  SELECT CASE WHEN p.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'project',
+    'id',            p.id::text,
+    'label',         coalesce(p.name, p.slug),
+    'summary_text',
+      'Project "' || coalesce(p.name, p.slug) || '"'
+      || coalesce(' — ' || left(p.description, 240), '')
+      || '. Visibility: ' || p.visibility
+      || coalesce('. Approx ' || round(p.area_km2)::text || ' km².', '')
+      || ' ' || c.obs_count || ' observations.',
+    'fields',        jsonb_build_object(
+      'slug',         p.slug,
+      'name',         p.name,
+      'name_es',      p.name_es,
+      'visibility',   p.visibility,
+      'area_km2',     p.area_km2,
+      'obs_count',    c.obs_count
+    ),
+    'suggested_questions', jsonb_build_array(
+      'Which species are most common in this project?',
+      'How many observations were added in the last 30 days?',
+      'List the camera stations in this project.'
+    ),
+    'related',       jsonb_build_object(
+      'project_id', p.id::text
+    )
+  ) END
+  FROM p, c;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_camera_station_card(uuid);
+CREATE FUNCTION public.chat_camera_station_card(p_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH s AS (
+    SELECT cs.id, cs.project_id, cs.station_key, cs.name, cs.habitat,
+           cs.camera_model, cs.notes, cs.coords,
+           p.name AS project_name, p.slug AS project_slug
+    FROM public.camera_stations cs
+    LEFT JOIN public.projects p ON p.id = cs.project_id
+    WHERE cs.id = p_id
+  ),
+  pn AS (
+    SELECT coalesce(sum(extract(day from coalesce(end_date::timestamp, now()) - start_date::timestamp))::int, 0) AS trap_nights
+    FROM public.camera_station_periods, s
+    WHERE camera_station_periods.station_id = s.id
+  )
+  SELECT CASE WHEN s.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'camera_station',
+    'id',            s.id::text,
+    'label',         coalesce(s.name, s.station_key),
+    'summary_text',
+      'Camera station ' || s.station_key
+      || coalesce(' (' || s.name || ')', '')
+      || coalesce(' in project "' || s.project_name || '"', '')
+      || coalesce(', habitat: ' || s.habitat, '')
+      || coalesce(', camera: ' || s.camera_model, '')
+      || '. Trap-nights to date: ' || pn.trap_nights || '.',
+    'fields',        jsonb_build_object(
+      'station_key',  s.station_key,
+      'name',         s.name,
+      'habitat',      s.habitat,
+      'camera_model', s.camera_model,
+      'project_slug', s.project_slug,
+      'trap_nights',  pn.trap_nights,
+      'lat',          ST_Y(s.coords::geometry),
+      'lng',          ST_X(s.coords::geometry)
+    ),
+    'suggested_questions', jsonb_build_array(
+      'Which species have been detected at this station?',
+      'What is the detection rate per 100 trap-nights?',
+      'How long has this station been deployed?'
+    ),
+    'related',       jsonb_build_object(
+      'project_id', s.project_id::text
+    )
+  ) END
+  FROM s, pn;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_observer_card(uuid);
+CREATE FUNCTION public.chat_observer_card(p_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  -- community_observers is the public view (no centroid, no email).
+  -- It already filters out hide_from_leaderboards = true.
+  WITH u AS (
+    SELECT id, username, display_name, avatar_url, country_code,
+           is_expert, expert_taxa,
+           observation_count, species_count, obs_count_30d,
+           last_observation_at, joined_at, karma_total
+    FROM public.community_observers
+    WHERE id = p_id
+  )
+  SELECT CASE WHEN u.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'observer',
+    'id',            u.id::text,
+    'label',         coalesce(u.display_name, u.username),
+    'thumbnail',     u.avatar_url,
+    'summary_text',
+      coalesce(u.display_name, u.username)
+      || coalesce(' (@' || u.username || ')', '')
+      || coalesce(' from ' || u.country_code, '')
+      || '. ' || u.observation_count || ' observations, '
+      || u.species_count || ' species, '
+      || u.karma_total || ' karma.'
+      || CASE WHEN u.is_expert THEN ' Expert.' ELSE '' END,
+    'fields',        jsonb_build_object(
+      'username',          u.username,
+      'display_name',      u.display_name,
+      'country_code',      u.country_code,
+      'is_expert',         u.is_expert,
+      'observation_count', u.observation_count,
+      'species_count',     u.species_count,
+      'obs_count_30d',     u.obs_count_30d,
+      'karma_total',       u.karma_total
+    ),
+    'suggested_questions', jsonb_build_array(
+      'What species does ' || coalesce(u.display_name, u.username) || ' observe most?',
+      'When were they most active?',
+      'What region do they observe in?'
+    ),
+    'related',       jsonb_build_object(
+      'observer_id', u.id::text
+    )
+  ) END
+  FROM u;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_self_profile_card(uuid);
+CREATE FUNCTION public.chat_self_profile_card(p_id uuid)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH u AS (
+    SELECT id, username, display_name, bio, avatar_url, preferred_lang,
+           is_expert, expert_taxa, observer_license,
+           observation_count, country_code, region_primary,
+           karma_total, joined_at, last_observation_at
+    FROM public.users
+    WHERE id = p_id
+      AND id = auth.uid()  -- self only
+  )
+  SELECT CASE WHEN u.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'kind',          'self_profile',
+    'id',            u.id::text,
+    'label',         coalesce(u.display_name, u.username, 'You'),
+    'thumbnail',     u.avatar_url,
+    'summary_text',
+      'Your profile: ' || coalesce(u.display_name, u.username)
+      || coalesce(', based in ' || u.country_code, '')
+      || '. ' || u.observation_count || ' observations, '
+      || u.karma_total || ' karma.'
+      || coalesce(' Bio: ' || left(u.bio, 200), '')
+      || ' Preferred language: ' || coalesce(u.preferred_lang, 'en') || '.',
+    'fields',        jsonb_build_object(
+      'username',           u.username,
+      'display_name',       u.display_name,
+      'preferred_lang',     u.preferred_lang,
+      'country_code',       u.country_code,
+      'region_primary',     u.region_primary,
+      'is_expert',          u.is_expert,
+      'expert_taxa',        u.expert_taxa,
+      'observer_license',   u.observer_license,
+      'observation_count',  u.observation_count,
+      'karma_total',        u.karma_total
+    ),
+    'suggested_questions', jsonb_build_array(
+      'How is my karma calculated?',
+      'What badges am I close to earning?',
+      'Show my last 10 observations.'
+    ),
+    'related',       jsonb_build_object(
+      'observer_id', u.id::text
+    )
+  ) END
+  FROM u;
+$$;
+
+-- Dispatcher: routes by kind. Returns NULL for unknown kinds so callers
+-- can treat that as 'entity not found'.
+DROP FUNCTION IF EXISTS public.chat_entity_card(text, text);
+CREATE FUNCTION public.chat_entity_card(p_kind text, p_id text)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_uuid uuid;
+BEGIN
+  IF p_kind IN ('observation','camera_station','observer','self_profile') THEN
+    BEGIN
+      v_uuid := p_id::uuid;
+    EXCEPTION WHEN invalid_text_representation THEN
+      RETURN NULL;
+    END;
+  END IF;
+
+  RETURN CASE p_kind
+    WHEN 'observation'    THEN public.chat_obs_card(v_uuid)
+    WHEN 'species'        THEN public.chat_species_card(p_id)
+    WHEN 'project'        THEN public.chat_project_card(p_id)
+    WHEN 'camera_station' THEN public.chat_camera_station_card(v_uuid)
+    WHEN 'observer'       THEN public.chat_observer_card(v_uuid)
+    WHEN 'self_profile'   THEN public.chat_self_profile_card(v_uuid)
+    ELSE NULL
+  END;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.chat_obs_card(uuid)            FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_species_card(text)        FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_project_card(text)        FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_camera_station_card(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_observer_card(uuid)       FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_self_profile_card(uuid)   FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_entity_card(text, text)   FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.chat_obs_card(uuid)             TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_species_card(text)         TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_project_card(text)         TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_camera_station_card(uuid)  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_observer_card(uuid)        TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_self_profile_card(uuid)    TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_entity_card(text, text)    TO authenticated;
+```
+
+- [ ] **Step 3: Apply the schema and verify**
+
+Run:
+```bash
+make db-apply
+make db-verify
+```
+
+Expected: `db-apply` exits 0; `db-verify` shows the new functions in its output.
+
+- [ ] **Step 4: Replay to confirm idempotency**
+
+Run: `make db-apply`
+
+Expected: exits 0 (the `DROP … IF EXISTS` + `CREATE` pattern is replay-safe).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(chat): chat_entity_card dispatcher + 6 per-kind card builders"
+```
+
+---
+
+### Task 2: Add the find_* search functions
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql` (append after the card builders from Task 1)
+
+These are read-only filtered queries the chat tools call when the model wants follow-up data.
+
+- [ ] **Step 1: Append the five find_* functions**
+
+Append to the same file, after the dispatcher:
+
+```sql
+-- ── Chat tools — read-only search/list functions ──
+
+DROP FUNCTION IF EXISTS public.chat_find_observations(jsonb, int);
+CREATE FUNCTION public.chat_find_observations(p_filters jsonb, p_limit int DEFAULT 10)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_owner_self    boolean := coalesce((p_filters ->> 'owner') = 'me', false);
+  v_taxon_id      uuid    := nullif(p_filters ->> 'primary_taxon_id', '')::uuid;
+  v_project_id    uuid    := nullif(p_filters ->> 'project_id', '')::uuid;
+  v_near_obs      uuid    := nullif(p_filters ->> 'near_observation_id', '')::uuid;
+  v_radius_km     numeric := coalesce((p_filters ->> 'radius_km')::numeric, 50);
+  v_research_only boolean := coalesce((p_filters ->> 'research_grade')::boolean, false);
+BEGIN
+  RETURN coalesce((
+    SELECT jsonb_agg(row_card)
+    FROM (
+      SELECT jsonb_build_object(
+        'id',                o.id::text,
+        'scientific_name',   t.scientific_name,
+        'common_name_en',    t.common_name_en,
+        'observed_at',       o.observed_at,
+        'region_primary',    o.region_primary,
+        'is_research_grade', o.is_research_grade
+      ) AS row_card
+      FROM public.observations o
+      LEFT JOIN public.taxa t ON t.id = o.primary_taxon_id
+      LEFT JOIN public.observations near ON near.id = v_near_obs
+      WHERE (NOT v_owner_self    OR o.observer_user_id = auth.uid())
+        AND (v_taxon_id    IS NULL OR o.primary_taxon_id = v_taxon_id)
+        AND (v_project_id  IS NULL OR o.project_id      = v_project_id)
+        AND (v_near_obs    IS NULL OR ST_DWithin(o.location, near.location, v_radius_km * 1000))
+        AND (NOT v_research_only OR o.is_research_grade = true)
+      ORDER BY o.observed_at DESC
+      LIMIT greatest(1, least(p_limit, 50))
+    ) sub
+  ), '[]'::jsonb);
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_find_species(text, int);
+CREATE FUNCTION public.chat_find_species(p_query text, p_limit int DEFAULT 10)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
+  FROM (
+    SELECT jsonb_build_object(
+      'id',                t.id::text,
+      'scientific_name',   t.scientific_name,
+      'common_name_en',    t.common_name_en,
+      'common_name_es',    t.common_name_es,
+      'kingdom',           t.kingdom,
+      'family',            t.family
+    ) AS row_card
+    FROM public.taxa t
+    WHERE t.canonical_name    ILIKE ('%' || p_query || '%')
+       OR t.scientific_name   ILIKE ('%' || p_query || '%')
+       OR t.common_name_en    ILIKE ('%' || p_query || '%')
+       OR t.common_name_es    ILIKE ('%' || p_query || '%')
+    ORDER BY (t.scientific_name = p_query) DESC, t.canonical_name
+    LIMIT greatest(1, least(p_limit, 50))
+  ) sub;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_find_projects(text, int);
+CREATE FUNCTION public.chat_find_projects(p_query text, p_limit int DEFAULT 10)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
+  FROM (
+    SELECT jsonb_build_object(
+      'id',     p.id::text,
+      'slug',   p.slug,
+      'name',   p.name,
+      'name_es', p.name_es
+    ) AS row_card
+    FROM public.projects_with_geojson p
+    WHERE p.name    ILIKE ('%' || p_query || '%')
+       OR p.name_es ILIKE ('%' || p_query || '%')
+       OR p.slug    ILIKE ('%' || p_query || '%')
+    ORDER BY p.name
+    LIMIT greatest(1, least(p_limit, 50))
+  ) sub;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_find_camera_stations(uuid, int);
+CREATE FUNCTION public.chat_find_camera_stations(p_project_id uuid, p_limit int DEFAULT 20)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
+  FROM (
+    SELECT jsonb_build_object(
+      'id',          cs.id::text,
+      'station_key', cs.station_key,
+      'name',        cs.name,
+      'habitat',     cs.habitat
+    ) AS row_card
+    FROM public.camera_stations cs
+    WHERE cs.project_id = p_project_id
+    ORDER BY cs.station_key
+    LIMIT greatest(1, least(p_limit, 50))
+  ) sub;
+$$;
+
+DROP FUNCTION IF EXISTS public.chat_find_observers(text, int);
+CREATE FUNCTION public.chat_find_observers(p_query text, p_limit int DEFAULT 10)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT coalesce(jsonb_agg(row_card), '[]'::jsonb)
+  FROM (
+    SELECT jsonb_build_object(
+      'id',           u.id::text,
+      'username',     u.username,
+      'display_name', u.display_name,
+      'is_expert',    u.is_expert
+    ) AS row_card
+    FROM public.community_observers u
+    WHERE u.username     ILIKE ('%' || p_query || '%')
+       OR u.display_name ILIKE ('%' || p_query || '%')
+    ORDER BY u.observation_count DESC
+    LIMIT greatest(1, least(p_limit, 50))
+  ) sub;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.chat_find_observations(jsonb, int)        FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_species(text, int)              FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_projects(text, int)             FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)      FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_observers(text, int)            FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.chat_find_observations(jsonb, int)         TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_species(text, int)               TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_projects(text, int)              TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)       TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_observers(text, int)             TO authenticated;
+```
+
+- [ ] **Step 2: Apply + replay**
+
+Run:
+```bash
+make db-apply
+make db-apply  # idempotency check
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(chat): add chat_find_* read-only search RPCs"
+```
+
+---
+
+### Task 3: SQL regression tests for chat functions
+
+**Files:**
+- Create: `tests/sql/chat.sql`
+- Modify: `.github/workflows/db-validate.yml` (add the new test file to the run step)
+
+- [ ] **Step 1: Read the existing rls.sql to mirror the assertion style**
+
+Run: `head -80 tests/sql/rls.sql`
+
+Note the `DO $$ BEGIN ... ASSERT ...; EXCEPTION WHEN OTHERS THEN ... END $$;` pattern.
+
+- [ ] **Step 2: Create `tests/sql/chat.sql`**
+
+Write `tests/sql/chat.sql`:
+
+```sql
+-- Chat function regression tests (M01 chat improvements).
+-- Mirrors the style of tests/sql/rls.sql — plain DO blocks with ASSERT.
+
+\set ON_ERROR_STOP on
+\timing off
+
+BEGIN;
+
+-- Seed: one observer + one observation with a sensitive species.
+INSERT INTO public.users (id, username) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'chat_test_user_1')
+ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.users (id, username) VALUES
+  ('22222222-2222-2222-2222-222222222222', 'chat_test_user_2')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.taxa (id, scientific_name, canonical_name, kingdom, family, obscure_level)
+VALUES (
+  '33333333-3333-3333-3333-333333333333',
+  'Test sensitivus',
+  'Test sensitivus',
+  'Animalia',
+  'Testidae',
+  'obscured'
+)
+ON CONFLICT (id) DO UPDATE SET obscure_level = EXCLUDED.obscure_level;
+
+INSERT INTO public.observations (
+  id, observer_user_id, primary_taxon_id, observed_at,
+  location, location_obscured, obscure_level, region_primary, is_research_grade
+)
+VALUES (
+  '44444444-4444-4444-4444-444444444444',
+  '11111111-1111-1111-1111-111111111111',
+  '33333333-3333-3333-3333-333333333333',
+  '2026-05-01T12:00:00Z',
+  ST_SetSRID(ST_MakePoint(-99.13, 19.43), 4326),
+  ST_SetSRID(ST_MakePoint(-99.10, 19.40), 4326),
+  'obscured',
+  'CDMX',
+  false
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Test 1: chat_obs_card returns NULL for unknown id.
+DO $$
+BEGIN
+  ASSERT public.chat_obs_card('00000000-0000-0000-0000-000000000000') IS NULL,
+    'chat_obs_card returned non-NULL for unknown id';
+END $$;
+
+-- Test 2: chat_obs_card returns owner-precise coords when auth.uid() = observer.
+SET LOCAL "request.jwt.claims" = '{"sub":"11111111-1111-1111-1111-111111111111"}';
+DO $$
+DECLARE
+  card jsonb := public.chat_obs_card('44444444-4444-4444-4444-444444444444');
+BEGIN
+  ASSERT (card -> 'fields' ->> 'coords_obscured')::boolean = false,
+    'owner-self should see coords_obscured=false';
+  ASSERT abs((card -> 'fields' ->> 'lat')::numeric - 19.43) < 0.01,
+    'owner-self should see precise lat ~19.43';
+END $$;
+
+-- Test 3: chat_obs_card returns obscured coords for non-owner.
+SET LOCAL "request.jwt.claims" = '{"sub":"22222222-2222-2222-2222-222222222222"}';
+DO $$
+DECLARE
+  card jsonb := public.chat_obs_card('44444444-4444-4444-4444-444444444444');
+BEGIN
+  ASSERT (card -> 'fields' ->> 'coords_obscured')::boolean = true,
+    'non-owner should see coords_obscured=true';
+  ASSERT abs((card -> 'fields' ->> 'lat')::numeric - 19.40) < 0.01,
+    'non-owner should see obscured lat ~19.40';
+END $$;
+
+-- Test 4: chat_self_profile_card refuses other-user lookup.
+SET LOCAL "request.jwt.claims" = '{"sub":"22222222-2222-2222-2222-222222222222"}';
+DO $$
+DECLARE
+  card jsonb := public.chat_self_profile_card('11111111-1111-1111-1111-111111111111');
+BEGIN
+  ASSERT card IS NULL,
+    'chat_self_profile_card should return NULL when auth.uid() != p_id';
+END $$;
+
+-- Test 5: chat_self_profile_card returns the row when auth.uid() = p_id.
+SET LOCAL "request.jwt.claims" = '{"sub":"11111111-1111-1111-1111-111111111111"}';
+DO $$
+DECLARE
+  card jsonb := public.chat_self_profile_card('11111111-1111-1111-1111-111111111111');
+BEGIN
+  ASSERT card IS NOT NULL,
+    'chat_self_profile_card should return a row for self';
+  ASSERT (card ->> 'kind') = 'self_profile',
+    'card.kind must be self_profile';
+END $$;
+
+-- Test 6: chat_entity_card dispatcher routes to the right per-kind function.
+DO $$
+DECLARE
+  card jsonb := public.chat_entity_card('observation', '44444444-4444-4444-4444-444444444444');
+BEGIN
+  ASSERT (card ->> 'kind') = 'observation', 'dispatcher should route observation';
+END $$;
+
+-- Test 7: chat_entity_card returns NULL for unknown kind.
+DO $$
+BEGIN
+  ASSERT public.chat_entity_card('not_a_kind', 'anything') IS NULL,
+    'dispatcher must return NULL for unknown kind';
+END $$;
+
+-- Test 8: chat_entity_card returns NULL for invalid uuid on uuid-typed kinds.
+DO $$
+BEGIN
+  ASSERT public.chat_entity_card('observation', 'not-a-uuid') IS NULL,
+    'dispatcher must swallow invalid_text_representation and return NULL';
+END $$;
+
+-- Test 9: chat_find_observations respects owner=me filter.
+SET LOCAL "request.jwt.claims" = '{"sub":"11111111-1111-1111-1111-111111111111"}';
+DO $$
+DECLARE
+  rows jsonb := public.chat_find_observations('{"owner":"me"}'::jsonb, 10);
+BEGIN
+  ASSERT jsonb_array_length(rows) >= 1,
+    'find_observations(owner=me) should return at least the seeded row';
+END $$;
+
+-- Test 10: chat_find_observers excludes hide_from_leaderboards users
+-- (community_observers view already enforces this).
+DO $$
+DECLARE
+  rows jsonb := public.chat_find_observers('chat_test_user', 10);
+BEGIN
+  ASSERT rows IS NOT NULL, 'find_observers must return at least an empty array';
+END $$;
+
+-- Cleanup.
+ROLLBACK;
+
+\echo 'tests/sql/chat.sql passed'
+```
+
+- [ ] **Step 3: Wire the new test into `db-validate.yml`**
+
+Read `.github/workflows/db-validate.yml` and find the step that runs `tests/sql/rls.sql`. Add a sibling step for `tests/sql/chat.sql`:
+
+Find the line:
+```yaml
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/sql/rls.sql
+```
+
+Add **immediately after** the rls step (preserving any indentation):
+```yaml
+      - name: Run chat-function regression suite
+        run: psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/sql/chat.sql
+```
+
+- [ ] **Step 4: Run the tests locally**
+
+Run:
+```bash
+make db-apply
+psql "$(grep -E '^SUPABASE_DB_URL' .env.local | cut -d= -f2-)" -v ON_ERROR_STOP=1 -f tests/sql/chat.sql
+```
+
+Expected: prints `tests/sql/chat.sql passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/sql/chat.sql .github/workflows/db-validate.yml
+git commit -m "test(chat): SQL regression suite for chat_* functions"
+```
+
+---
+
+# Phase 2 — Entity Registry + Specs
+
+Mirrors `src/lib/identifiers/` exactly. The registry is a singleton with collision detection. Each EntitySpec exports the `kind`, an icon, and a `fetchCard(id)` that calls `supabase.rpc('chat_entity_card', {p_kind, p_id})`.
+
+---
+
+### Task 4: EntitySpec types
+
+**Files:**
+- Create: `src/lib/chat-entities/types.ts`
+
+- [ ] **Step 1: Write the types**
+
+```typescript
+// src/lib/chat-entities/types.ts
+//
+// Generic entity-context registry — mirrors src/lib/identifiers/types.ts.
+// One EntitySpec per kind; the runtime serializes a fetched card into a
+// system-prompt block and uses `related` pointers as tool args.
+
+export type EntityKind =
+  | 'observation'
+  | 'species'
+  | 'project'
+  | 'camera_station'
+  | 'observer'
+  | 'self_profile';
+
+export interface EntityCard {
+  kind: EntityKind;
+  id: string;
+  label: string;
+  thumbnail?: string | null;
+  summary_text: string;
+  fields: Record<string, string | number | boolean | null>;
+  suggested_questions: string[];
+  related: {
+    project_id?: string;
+    primary_taxon_id?: string;
+    location_id?: string;
+    observer_id?: string;
+  };
+}
+
+export interface EntitySpec {
+  kind: EntityKind;
+  /** Emoji or short brand icon shown in the chip. */
+  icon: string;
+  /** EN/ES short label for tabs/menus. */
+  label: { en: string; es: string };
+  /**
+   * Fetch the canonical card for the given id. Implementations call
+   * supabase.rpc('chat_entity_card', { p_kind, p_id }) and shape the
+   * response. Throws on network error; returns null when the row is
+   * missing or RLS hides it.
+   */
+  fetchCard(id: string): Promise<EntityCard | null>;
+  /**
+   * Tools this entity kind tends to need. Used to pre-prime the
+   * tool list shown to the model in the system prompt.
+   */
+  suggestedTools: string[];
+}
+
+export interface ChatEntityRegistry {
+  register(spec: EntitySpec): void;
+  get(kind: EntityKind): EntitySpec | undefined;
+  list(): EntitySpec[];
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm run typecheck`
+
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/chat-entities/types.ts
+git commit -m "feat(chat-entities): types for EntityCard + EntitySpec + registry"
+```
+
+---
+
+### Task 5: Registry singleton + tests
+
+**Files:**
+- Create: `src/lib/chat-entities/registry.ts`
+- Create: `src/lib/chat-entities/registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/chat-entities/registry.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { registry } from './registry';
+import type { EntitySpec } from './types';
+
+const fakeSpec = (kind: EntitySpec['kind']): EntitySpec => ({
+  kind,
+  icon: '·',
+  label: { en: 'X', es: 'X' },
+  async fetchCard() { return null; },
+  suggestedTools: [],
+});
+
+beforeEach(() => {
+  (registry as unknown as { _resetForTests: () => void })._resetForTests();
+});
+
+describe('chat-entities registry', () => {
+  it('registers and retrieves a spec', () => {
+    const spec = fakeSpec('observation');
+    registry.register(spec);
+    expect(registry.get('observation')).toBe(spec);
+  });
+
+  it('throws on duplicate kind registration', () => {
+    registry.register(fakeSpec('species'));
+    expect(() => registry.register(fakeSpec('species'))).toThrow(/collision/);
+  });
+
+  it('list returns every registered spec', () => {
+    registry.register(fakeSpec('observation'));
+    registry.register(fakeSpec('species'));
+    expect(registry.list().map(s => s.kind).sort()).toEqual(['observation', 'species']);
+  });
+
+  it('get returns undefined for unregistered kind', () => {
+    expect(registry.get('project')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `npx vitest run src/lib/chat-entities/registry.test.ts`
+
+Expected: FAIL with "Cannot find module './registry'".
+
+- [ ] **Step 3: Implement the registry**
+
+```typescript
+// src/lib/chat-entities/registry.ts
+//
+// Singleton EntitySpec registry. Collision-detected at register-time so
+// double-bootstrap raises loudly. Mirrors src/lib/identifiers/registry.ts.
+
+import type { ChatEntityRegistry, EntityKind, EntitySpec } from './types';
+
+class Registry implements ChatEntityRegistry {
+  private specs = new Map<EntityKind, EntitySpec>();
+
+  register(spec: EntitySpec): void {
+    if (this.specs.has(spec.kind)) {
+      throw new Error(`Chat entity kind collision: ${spec.kind}`);
+    }
+    this.specs.set(spec.kind, spec);
+  }
+
+  get(kind: EntityKind): EntitySpec | undefined {
+    return this.specs.get(kind);
+  }
+
+  list(): EntitySpec[] {
+    return Array.from(this.specs.values());
+  }
+
+  _resetForTests(): void {
+    this.specs.clear();
+  }
+}
+
+export const registry: ChatEntityRegistry = new Registry();
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `npx vitest run src/lib/chat-entities/registry.test.ts`
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat-entities/registry.ts src/lib/chat-entities/registry.test.ts
+git commit -m "feat(chat-entities): singleton registry with collision detection"
+```
+
+---
+
+### Task 6: Observation EntitySpec + test
+
+**Files:**
+- Create: `src/lib/chat-entities/observation.ts`
+- Create: `src/lib/chat-entities/observation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/chat-entities/observation.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const rpcMock = vi.fn();
+vi.mock('../supabase', () => ({
+  getSupabase: () => ({ rpc: rpcMock }),
+}));
+
+import { observationSpec } from './observation';
+
+beforeEach(() => {
+  rpcMock.mockReset();
+});
+
+describe('observation EntitySpec', () => {
+  it('kind is "observation"', () => {
+    expect(observationSpec.kind).toBe('observation');
+  });
+
+  it('fetchCard calls chat_entity_card with kind+id', async () => {
+    rpcMock.mockResolvedValue({
+      data: {
+        kind: 'observation',
+        id: 'abc',
+        label: 'Test',
+        summary_text: 's',
+        fields: {},
+        suggested_questions: [],
+        related: {},
+      },
+      error: null,
+    });
+    const card = await observationSpec.fetchCard('abc');
+    expect(rpcMock).toHaveBeenCalledWith('chat_entity_card', {
+      p_kind: 'observation',
+      p_id: 'abc',
+    });
+    expect(card?.label).toBe('Test');
+  });
+
+  it('returns null when RPC returns null data', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: null });
+    expect(await observationSpec.fetchCard('abc')).toBeNull();
+  });
+
+  it('throws on RPC error', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(observationSpec.fetchCard('abc')).rejects.toThrow(/boom/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `npx vitest run src/lib/chat-entities/observation.test.ts`
+
+Expected: FAIL with "Cannot find module './observation'".
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/lib/chat-entities/observation.ts
+import { getSupabase } from '../supabase';
+import type { EntityCard, EntitySpec } from './types';
+
+export const observationSpec: EntitySpec = {
+  kind: 'observation',
+  icon: '🔍',
+  label: { en: 'Observation', es: 'Observación' },
+  async fetchCard(id) {
+    const { data, error } = await getSupabase().rpc('chat_entity_card', {
+      p_kind: 'observation',
+      p_id: id,
+    });
+    if (error) throw new Error(error.message);
+    return (data as EntityCard) ?? null;
+  },
+  suggestedTools: ['find_observations', 'find_species'],
+};
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `npx vitest run src/lib/chat-entities/observation.test.ts`
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat-entities/observation.ts src/lib/chat-entities/observation.test.ts
+git commit -m "feat(chat-entities): observation EntitySpec"
+```
+
+---
+
+### Task 7: Five remaining EntitySpecs (species, project, camera_station, observer, self_profile)
+
+These are all the same shape as `observation.ts` — only `kind`, `icon`, `label`, and `suggestedTools` differ. Use one task to write all five plus a single shared test pattern.
+
+**Files:**
+- Create: `src/lib/chat-entities/species.ts`
+- Create: `src/lib/chat-entities/project.ts`
+- Create: `src/lib/chat-entities/camera-station.ts`
+- Create: `src/lib/chat-entities/observer.ts`
+- Create: `src/lib/chat-entities/self-profile.ts`
+- Create: `src/lib/chat-entities/specs.test.ts`
+
+- [ ] **Step 1: Write the shared test**
+
+```typescript
+// src/lib/chat-entities/specs.test.ts
+import { describe, it, expect, vi } from 'vitest';
+
+const rpcMock = vi.fn();
+vi.mock('../supabase', () => ({ getSupabase: () => ({ rpc: rpcMock }) }));
+
+import { speciesSpec } from './species';
+import { projectSpec } from './project';
+import { cameraStationSpec } from './camera-station';
+import { observerSpec } from './observer';
+import { selfProfileSpec } from './self-profile';
+
+const cases = [
+  ['species', speciesSpec],
+  ['project', projectSpec],
+  ['camera_station', cameraStationSpec],
+  ['observer', observerSpec],
+  ['self_profile', selfProfileSpec],
+] as const;
+
+describe.each(cases)('%s EntitySpec', (kind, spec) => {
+  it(`kind is "${kind}"`, () => {
+    expect(spec.kind).toBe(kind);
+  });
+
+  it('fetchCard calls chat_entity_card with the right kind', async () => {
+    rpcMock.mockReset();
+    rpcMock.mockResolvedValue({ data: null, error: null });
+    await spec.fetchCard('xxx');
+    expect(rpcMock).toHaveBeenCalledWith('chat_entity_card', {
+      p_kind: kind,
+      p_id: 'xxx',
+    });
+  });
+
+  it('throws on RPC error', async () => {
+    rpcMock.mockReset();
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'rls denied' } });
+    await expect(spec.fetchCard('xxx')).rejects.toThrow(/rls denied/);
+  });
+});
+```
+
+- [ ] **Step 2: Implement each spec**
+
+```typescript
+// src/lib/chat-entities/species.ts
+import { getSupabase } from '../supabase';
+import type { EntityCard, EntitySpec } from './types';
+
+export const speciesSpec: EntitySpec = {
+  kind: 'species',
+  icon: '🌿',
+  label: { en: 'Species', es: 'Especie' },
+  async fetchCard(id) {
+    const { data, error } = await getSupabase().rpc('chat_entity_card', {
+      p_kind: 'species',
+      p_id: id,
+    });
+    if (error) throw new Error(error.message);
+    return (data as EntityCard) ?? null;
+  },
+  suggestedTools: ['find_observations', 'find_species'],
+};
+```
+
+```typescript
+// src/lib/chat-entities/project.ts
+import { getSupabase } from '../supabase';
+import type { EntityCard, EntitySpec } from './types';
+
+export const projectSpec: EntitySpec = {
+  kind: 'project',
+  icon: '🗺️',
+  label: { en: 'Project', es: 'Proyecto' },
+  async fetchCard(id) {
+    const { data, error } = await getSupabase().rpc('chat_entity_card', {
+      p_kind: 'project',
+      p_id: id,
+    });
+    if (error) throw new Error(error.message);
+    return (data as EntityCard) ?? null;
+  },
+  suggestedTools: ['find_observations', 'find_camera_stations'],
+};
+```
+
+```typescript
+// src/lib/chat-entities/camera-station.ts
+import { getSupabase } from '../supabase';
+import type { EntityCard, EntitySpec } from './types';
+
+export const cameraStationSpec: EntitySpec = {
+  kind: 'camera_station',
+  icon: '📷',
+  label: { en: 'Camera station', es: 'Estación' },
+  async fetchCard(id) {
+    const { data, error } = await getSupabase().rpc('chat_entity_card', {
+      p_kind: 'camera_station',
+      p_id: id,
+    });
+    if (error) throw new Error(error.message);
+    return (data as EntityCard) ?? null;
+  },
+  suggestedTools: ['find_observations'],
+};
+```
+
+```typescript
+// src/lib/chat-entities/observer.ts
+import { getSupabase } from '../supabase';
+import type { EntityCard, EntitySpec } from './types';
+
+export const observerSpec: EntitySpec = {
+  kind: 'observer',
+  icon: '👤',
+  label: { en: 'Observer', es: 'Observador' },
+  async fetchCard(id) {
+    const { data, error } = await getSupabase().rpc('chat_entity_card', {
+      p_kind: 'observer',
+      p_id: id,
+    });
+    if (error) throw new Error(error.message);
+    return (data as EntityCard) ?? null;
+  },
+  suggestedTools: ['find_observations', 'find_species'],
+};
+```
+
+```typescript
+// src/lib/chat-entities/self-profile.ts
+import { getSupabase } from '../supabase';
+import type { EntityCard, EntitySpec } from './types';
+
+export const selfProfileSpec: EntitySpec = {
+  kind: 'self_profile',
+  icon: '🪪',
+  label: { en: 'My profile', es: 'Mi perfil' },
+  async fetchCard(id) {
+    const { data, error } = await getSupabase().rpc('chat_entity_card', {
+      p_kind: 'self_profile',
+      p_id: id,
+    });
+    if (error) throw new Error(error.message);
+    return (data as EntityCard) ?? null;
+  },
+  suggestedTools: ['find_observations'],
+};
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npx vitest run src/lib/chat-entities/`
+
+Expected: 4 (registry) + 4 (observation) + 5×3 (specs) = 23 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/chat-entities/{species,project,camera-station,observer,self-profile,specs.test}.ts
+git commit -m "feat(chat-entities): species/project/camera-station/observer/self-profile specs"
+```
+
+---
+
+### Task 8: Bootstrap function
+
+**Files:**
+- Create: `src/lib/chat-entities/index.ts`
+
+- [ ] **Step 1: Write the file**
+
+```typescript
+// src/lib/chat-entities/index.ts
+//
+// Bootstrap: registers every built-in EntitySpec. Call once from ChatView
+// mount (top of script). Idempotent — re-bootstrap is a no-op after the
+// first call (the registry's collision check would throw, so we guard).
+
+import { registry } from './registry';
+import { observationSpec } from './observation';
+import { speciesSpec } from './species';
+import { projectSpec } from './project';
+import { cameraStationSpec } from './camera-station';
+import { observerSpec } from './observer';
+import { selfProfileSpec } from './self-profile';
+
+export { registry } from './registry';
+export type { EntityCard, EntityKind, EntitySpec } from './types';
+
+let bootstrapped = false;
+
+export function bootstrapChatEntities(): void {
+  if (bootstrapped) return;
+  bootstrapped = true;
+  registry.register(observationSpec);
+  registry.register(speciesSpec);
+  registry.register(projectSpec);
+  registry.register(cameraStationSpec);
+  registry.register(observerSpec);
+  registry.register(selfProfileSpec);
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm run typecheck`
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/chat-entities/index.ts
+git commit -m "feat(chat-entities): bootstrap function registers all built-ins"
+```
+
+---
+
+### Task 9: parseAttachQuerystring helper + tests
+
+**Files:**
+- Create: `src/lib/parse-attach-querystring.ts`
+- Create: `src/lib/parse-attach-querystring.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/parse-attach-querystring.test.ts
+import { describe, it, expect } from 'vitest';
+import { parseAttachQuerystring } from './parse-attach-querystring';
+
+describe('parseAttachQuerystring', () => {
+  const KINDS = ['observation', 'species', 'project', 'camera_station', 'observer', 'self_profile'];
+
+  it('returns null for empty input', () => {
+    expect(parseAttachQuerystring(null)).toBeNull();
+    expect(parseAttachQuerystring('')).toBeNull();
+  });
+
+  it('parses kind:id form', () => {
+    expect(parseAttachQuerystring('observation:abc-123')).toEqual({
+      kind: 'observation',
+      id: 'abc-123',
+    });
+  });
+
+  it('rejects unknown kind', () => {
+    expect(parseAttachQuerystring('foo:bar')).toBeNull();
+  });
+
+  it('rejects malformed input (missing colon)', () => {
+    expect(parseAttachQuerystring('observation')).toBeNull();
+  });
+
+  it('rejects empty id segment', () => {
+    expect(parseAttachQuerystring('observation:')).toBeNull();
+  });
+
+  it('accepts every supported kind', () => {
+    for (const k of KINDS) {
+      expect(parseAttachQuerystring(`${k}:x`)?.kind).toBe(k);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `npx vitest run src/lib/parse-attach-querystring.test.ts`
+
+Expected: FAIL with "Cannot find module".
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/lib/parse-attach-querystring.ts
+import type { EntityKind } from './chat-entities/types';
+
+const KINDS: ReadonlySet<EntityKind> = new Set([
+  'observation', 'species', 'project', 'camera_station', 'observer', 'self_profile',
+]);
+
+export function parseAttachQuerystring(value: string | null): { kind: EntityKind; id: string } | null {
+  if (!value) return null;
+  const colon = value.indexOf(':');
+  if (colon <= 0 || colon === value.length - 1) return null;
+  const kind = value.slice(0, colon);
+  const id = value.slice(colon + 1);
+  if (!KINDS.has(kind as EntityKind)) return null;
+  if (!id) return null;
+  return { kind: kind as EntityKind, id };
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `npx vitest run src/lib/parse-attach-querystring.test.ts`
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/parse-attach-querystring.ts src/lib/parse-attach-querystring.test.ts
+git commit -m "feat(chat): parseAttachQuerystring helper for ?attach=kind:id"
+```
+
+---
+
+# Phase 3 — Chat Tools
+
+A typed JSON tool layer. Each tool has `name`, `description` (for the system prompt), `validateArgs(args)` (hand-rolled, no Zod), and `run(args)` (a Supabase RPC call).
+
+---
+
+### Task 10: chat-tools registry + 5 tools + tests
+
+**Files:**
+- Create: `src/lib/chat-tools.ts`
+- Create: `src/lib/chat-tools.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/chat-tools.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const rpcMock = vi.fn();
+vi.mock('./supabase', () => ({ getSupabase: () => ({ rpc: rpcMock }) }));
+
+import { runTool, listTools, toolDefinitions } from './chat-tools';
+
+beforeEach(() => {
+  rpcMock.mockReset();
+});
+
+describe('chat-tools', () => {
+  it('exposes 5 tools', () => {
+    const names = listTools().map(t => t.name).sort();
+    expect(names).toEqual([
+      'find_camera_stations',
+      'find_observations',
+      'find_observers',
+      'find_projects',
+      'find_species',
+    ]);
+  });
+
+  it('toolDefinitions is a JSON-shaped string for the system prompt', () => {
+    const defs = toolDefinitions();
+    expect(typeof defs).toBe('string');
+    expect(defs).toContain('find_observations');
+    expect(defs).toContain('find_species');
+  });
+
+  it('runTool: unknown name returns error', async () => {
+    const r = await runTool({ name: 'unknown', args: {} });
+    expect(r).toEqual({ error: 'unknown_tool' });
+  });
+
+  it('runTool: invalid args returns invalid_args', async () => {
+    // find_observations expects p_filters as an object
+    const r = await runTool({ name: 'find_observations', args: { p_filters: 'not an object' as unknown } });
+    expect(r).toMatchObject({ error: 'invalid_args' });
+  });
+
+  it('runTool: dispatches a valid call and returns ok', async () => {
+    rpcMock.mockResolvedValue({ data: [{ id: 'a' }], error: null });
+    const r = await runTool({ name: 'find_species', args: { p_query: 'magnolia', p_limit: 5 } });
+    expect(rpcMock).toHaveBeenCalledWith('chat_find_species', { p_query: 'magnolia', p_limit: 5 });
+    expect(r).toEqual({ ok: true, data: [{ id: 'a' }] });
+  });
+
+  it('runTool: RPC network error → {error: "network"}', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'fetch failed' } });
+    const r = await runTool({ name: 'find_species', args: { p_query: 'x' } });
+    expect(r).toMatchObject({ error: 'network' });
+  });
+
+  it('runTool: thrown promise → {error: "offline"}', async () => {
+    rpcMock.mockRejectedValue(new Error('Failed to fetch'));
+    const r = await runTool({ name: 'find_species', args: { p_query: 'x' } });
+    expect(r).toMatchObject({ error: 'offline' });
+  });
+
+  it('find_observations validates radius_km is a number', async () => {
+    rpcMock.mockResolvedValue({ data: [], error: null });
+    const ok = await runTool({
+      name: 'find_observations',
+      args: { p_filters: { radius_km: 25 }, p_limit: 10 },
+    });
+    expect(ok).toMatchObject({ ok: true });
+
+    const bad = await runTool({
+      name: 'find_observations',
+      args: { p_filters: { radius_km: 'far' as unknown as number } },
+    });
+    expect(bad).toMatchObject({ error: 'invalid_args' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `npx vitest run src/lib/chat-tools.test.ts`
+
+Expected: FAIL with "Cannot find module './chat-tools'".
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/lib/chat-tools.ts
+//
+// Typed JSON tool layer for chat. Each tool wraps one Supabase RPC and
+// exposes a hand-rolled validator (no Zod dependency). The model emits
+// `{"tool": "<name>", "args": { ... }}`; the runtime parses, validates,
+// dispatches, and feeds the result back to the model as a tool message.
+//
+// Errors returned (never thrown):
+//   { error: 'unknown_tool' }   — name not in the registry
+//   { error: 'invalid_args' }   — failed validateArgs(); detail in `detail`
+//   { error: 'network' }        — supabase returned an error
+//   { error: 'offline' }        — fetch threw (network down)
+
+import { getSupabase } from './supabase';
+
+export type ToolResult =
+  | { ok: true; data: unknown }
+  | { error: 'unknown_tool' }
+  | { error: 'invalid_args'; detail: string }
+  | { error: 'network'; detail: string }
+  | { error: 'offline'; detail: string };
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  /** JSON schema-ish description for the system prompt. */
+  args_schema: Record<string, string>;
+  validateArgs(args: unknown): { ok: true; value: Record<string, unknown> } | { ok: false; reason: string };
+  run(args: Record<string, unknown>): Promise<unknown>;
+}
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+function rpcCall(fn: string, args: Record<string, unknown>): Promise<unknown> {
+  return getSupabase().rpc(fn, args).then((r: { data: unknown; error: { message: string } | null }) => {
+    if (r.error) throw new Error('NETWORK:' + r.error.message);
+    return r.data;
+  });
+}
+
+const findObservations: ToolDef = {
+  name: 'find_observations',
+  description: 'Search observations the signed-in user can see, with optional filters.',
+  args_schema: {
+    'p_filters': 'object — { owner?: "me", primary_taxon_id?: uuid, project_id?: uuid, near_observation_id?: uuid, radius_km?: number, research_grade?: boolean }',
+    'p_limit':   'number — 1..50, default 10',
+  },
+  validateArgs(args) {
+    if (!isObject(args)) return { ok: false, reason: 'args must be an object' };
+    const { p_filters, p_limit } = args;
+    if (p_filters !== undefined && !isObject(p_filters)) return { ok: false, reason: 'p_filters must be an object' };
+    if (p_filters && isObject(p_filters)) {
+      if ('radius_km' in p_filters && typeof p_filters.radius_km !== 'number') {
+        return { ok: false, reason: 'radius_km must be a number' };
+      }
+      if ('research_grade' in p_filters && typeof p_filters.research_grade !== 'boolean') {
+        return { ok: false, reason: 'research_grade must be a boolean' };
+      }
+    }
+    if (p_limit !== undefined && typeof p_limit !== 'number') return { ok: false, reason: 'p_limit must be a number' };
+    return { ok: true, value: { p_filters: p_filters ?? {}, p_limit: (p_limit as number) ?? 10 } };
+  },
+  run(args) {
+    return rpcCall('chat_find_observations', args);
+  },
+};
+
+const findSpecies: ToolDef = {
+  name: 'find_species',
+  description: 'Search the taxonomy by canonical/scientific/common name.',
+  args_schema: { p_query: 'string', p_limit: 'number — 1..50, default 10' },
+  validateArgs(args) {
+    if (!isObject(args)) return { ok: false, reason: 'args must be an object' };
+    if (typeof args.p_query !== 'string' || !args.p_query.trim()) return { ok: false, reason: 'p_query must be a non-empty string' };
+    if (args.p_limit !== undefined && typeof args.p_limit !== 'number') return { ok: false, reason: 'p_limit must be a number' };
+    return { ok: true, value: { p_query: args.p_query, p_limit: (args.p_limit as number) ?? 10 } };
+  },
+  run(args) { return rpcCall('chat_find_species', args); },
+};
+
+const findProjects: ToolDef = {
+  name: 'find_projects',
+  description: 'Search projects by name or slug.',
+  args_schema: { p_query: 'string', p_limit: 'number — 1..50, default 10' },
+  validateArgs(args) {
+    if (!isObject(args)) return { ok: false, reason: 'args must be an object' };
+    if (typeof args.p_query !== 'string' || !args.p_query.trim()) return { ok: false, reason: 'p_query must be a non-empty string' };
+    if (args.p_limit !== undefined && typeof args.p_limit !== 'number') return { ok: false, reason: 'p_limit must be a number' };
+    return { ok: true, value: { p_query: args.p_query, p_limit: (args.p_limit as number) ?? 10 } };
+  },
+  run(args) { return rpcCall('chat_find_projects', args); },
+};
+
+const findCameraStations: ToolDef = {
+  name: 'find_camera_stations',
+  description: 'List camera stations for a given project id.',
+  args_schema: { p_project_id: 'uuid', p_limit: 'number — 1..50, default 20' },
+  validateArgs(args) {
+    if (!isObject(args)) return { ok: false, reason: 'args must be an object' };
+    if (typeof args.p_project_id !== 'string') return { ok: false, reason: 'p_project_id must be a uuid string' };
+    if (args.p_limit !== undefined && typeof args.p_limit !== 'number') return { ok: false, reason: 'p_limit must be a number' };
+    return { ok: true, value: { p_project_id: args.p_project_id, p_limit: (args.p_limit as number) ?? 20 } };
+  },
+  run(args) { return rpcCall('chat_find_camera_stations', args); },
+};
+
+const findObservers: ToolDef = {
+  name: 'find_observers',
+  description: 'Search observers by username or display name (public profiles only).',
+  args_schema: { p_query: 'string', p_limit: 'number — 1..50, default 10' },
+  validateArgs(args) {
+    if (!isObject(args)) return { ok: false, reason: 'args must be an object' };
+    if (typeof args.p_query !== 'string' || !args.p_query.trim()) return { ok: false, reason: 'p_query must be a non-empty string' };
+    if (args.p_limit !== undefined && typeof args.p_limit !== 'number') return { ok: false, reason: 'p_limit must be a number' };
+    return { ok: true, value: { p_query: args.p_query, p_limit: (args.p_limit as number) ?? 10 } };
+  },
+  run(args) { return rpcCall('chat_find_observers', args); },
+};
+
+const REGISTRY: Record<string, ToolDef> = {
+  find_observations:    findObservations,
+  find_species:         findSpecies,
+  find_projects:        findProjects,
+  find_camera_stations: findCameraStations,
+  find_observers:       findObservers,
+};
+
+export function listTools(): ToolDef[] {
+  return Object.values(REGISTRY);
+}
+
+/** Stringified tool catalogue suitable for inclusion in the system prompt. */
+export function toolDefinitions(): string {
+  return JSON.stringify(
+    listTools().map(t => ({ name: t.name, description: t.description, args: t.args_schema })),
+    null,
+    2,
+  );
+}
+
+export async function runTool(call: { name: string; args: unknown }): Promise<ToolResult> {
+  const def = REGISTRY[call.name];
+  if (!def) return { error: 'unknown_tool' };
+  const v = def.validateArgs(call.args);
+  if (!v.ok) return { error: 'invalid_args', detail: v.reason };
+  try {
+    const data = await def.run(v.value);
+    return { ok: true, data };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.startsWith('NETWORK:')) return { error: 'network', detail: msg.slice(8) };
+    return { error: 'offline', detail: msg };
+  }
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `npx vitest run src/lib/chat-tools.test.ts`
+
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat-tools.ts src/lib/chat-tools.test.ts
+git commit -m "feat(chat): chat-tools registry + 5 tools (find_observations, _species, _projects, _camera_stations, _observers)"
+```
+
+---
+
+# Phase 4 — Engine Layer
+
+`local-ai.ts` gains `loadGemmaTextEngine()`. `chat-engine.ts` is new — it wraps both engines, runs the streaming + tool-call loop (1 round cap), and emits telemetry.
+
+---
+
+### Task 11: loadGemmaTextEngine in local-ai.ts
+
+**Files:**
+- Modify: `src/lib/local-ai.ts`
+- Modify: `src/lib/local-ai.test.ts` (add tests for the new loader)
+
+- [ ] **Step 1: Read the existing onnx-vision.ts to understand transformers.js usage**
+
+Run: `grep -n "loadGemma\|gemmaSupported\|getGemmaCacheStatus\|identifyImageWithGemma" src/lib/onnx-vision.ts | head`
+
+Expected: Several references. Read the function bodies of `loadGemma` and the model-id constant.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `src/lib/local-ai.test.ts`:
+
+```typescript
+describe('loadGemmaTextEngine', () => {
+  it('throws when WebGPU is unavailable', async () => {
+    const orig = (globalThis as { navigator?: { gpu?: unknown } }).navigator;
+    (globalThis as { navigator: { gpu?: unknown; deviceMemory?: number } }).navigator = { deviceMemory: 8 };
+    try {
+      const { loadGemmaTextEngine } = await import('./local-ai');
+      await expect(loadGemmaTextEngine(() => {})).rejects.toThrow(/WebGPU/);
+    } finally {
+      (globalThis as { navigator?: unknown }).navigator = orig;
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run test — expect failure (loadGemmaTextEngine not exported)**
+
+Run: `npx vitest run src/lib/local-ai.test.ts -t "loadGemmaTextEngine"`
+
+Expected: FAIL with "loadGemmaTextEngine is not a function" or similar.
+
+- [ ] **Step 4: Implement loadGemmaTextEngine**
+
+Add to `src/lib/local-ai.ts` after `loadTextEngine`:
+
+```typescript
+export const GEMMA_TEXT_MODEL_ID = 'onnx_gemma4_text';
+
+/**
+ * Load Gemma 4 E2B for text-only chat. Reuses the transformers.js + ONNX
+ * runtime path from onnx-vision.ts (same model weights). Cached after first
+ * load like the WebLLM models. Cancellation flag is shared via the
+ * cancelledFlags set so cancelModelDownload() handles it consistently.
+ */
+export async function loadGemmaTextEngine(
+  onProgress: (p: LoadProgress) => void,
+): Promise<{
+  generate: (messages: Array<{ role: string; content: string }>, opts?: { max_tokens?: number; stream?: boolean }) =>
+    AsyncIterable<{ choices: Array<{ delta?: { content?: string }; message?: { content: string } }> }>;
+}> {
+  if (!localAISupported()) throw new Error('WebGPU not available — Gemma 4 unavailable on this browser.');
+  cancelledFlags.delete(GEMMA_TEXT_MODEL_ID);
+  await requestPersistentStorage().catch(() => {});
+
+  const { loadGemma, generateGemmaText } = await import('./onnx-vision');
+  await loadGemma((p) => {
+    if (cancelledFlags.has(GEMMA_TEXT_MODEL_ID)) {
+      throw new Error('Download cancelled');
+    }
+    onProgress({
+      progress: p.progress ?? 0,
+      text: p.text ?? '',
+      timeElapsedMs: p.timeElapsedMs ?? 0,
+    });
+  });
+
+  // Wrap onnx-vision's generator into the OpenAI-style stream interface
+  // chat-engine consumes. Implementation lives in onnx-vision; this is just
+  // the engine handle.
+  return {
+    generate: (messages, opts) => generateGemmaText(messages, opts ?? {}),
+  };
+}
+```
+
+- [ ] **Step 5: Add `generateGemmaText` shim in onnx-vision.ts**
+
+Find the existing `loadGemma` function in `src/lib/onnx-vision.ts`. Add this export immediately below it (or at the bottom of the file):
+
+```typescript
+/**
+ * Text-only generation using the loaded Gemma 4 E2B model. Yields chunks
+ * shaped like `{ choices: [{ delta: { content } }] }` so chat-engine can
+ * consume Gemma and Llama through the same async iterator.
+ */
+export async function* generateGemmaText(
+  messages: Array<{ role: string; content: string }>,
+  opts: { max_tokens?: number; stream?: boolean },
+): AsyncIterable<{ choices: Array<{ delta?: { content?: string }; message?: { content: string } }> }> {
+  // Concatenate messages into a single prompt — Gemma E2B uses a
+  // <|user|>/<|assistant|> chat template handled by transformers.js.
+  const generator = await getGemmaGenerator();
+  const prompt = messages.map(m => `<|${m.role}|>\n${m.content}`).join('\n') + '\n<|assistant|>\n';
+  const max_new_tokens = Math.min(opts.max_tokens ?? 512, 1024);
+  if (opts.stream) {
+    // transformers.js v3 supports a streamer callback; for v1 we collect
+    // and emit one delta. Streaming refinement is a v1.1 polish.
+    const out = await generator(prompt, { max_new_tokens, do_sample: false });
+    const text = (out as Array<{ generated_text: string }>)[0]?.generated_text?.replace(prompt, '') ?? '';
+    yield { choices: [{ delta: { content: text } }] };
+    return;
+  }
+  const out = await generator(prompt, { max_new_tokens, do_sample: false });
+  const text = (out as Array<{ generated_text: string }>)[0]?.generated_text?.replace(prompt, '') ?? '';
+  yield { choices: [{ message: { content: text } }] };
+}
+```
+
+If `getGemmaGenerator` is the internal handle for the loaded text model, use it. If `loadGemma` only exposes the vision pipeline, add a `getGemmaTextGenerator` that loads a text-only pipeline using the same cached weights. Verify by reading the existing `loadGemma` body before writing this — the existing function may already cache the right thing.
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run src/lib/local-ai.test.ts`
+
+Expected: all existing tests pass + the new loadGemmaTextEngine test passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/local-ai.ts src/lib/onnx-vision.ts src/lib/local-ai.test.ts
+git commit -m "feat(local-ai): loadGemmaTextEngine for Gemma 4 E2B text chat"
+```
+
+---
+
+### Task 12: chat-engine.ts streaming + tool-call loop
+
+**Files:**
+- Create: `src/lib/chat-engine.ts`
+- Create: `src/lib/chat-engine.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/chat-engine.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadGemmaMock = vi.fn();
+const loadLlamaMock = vi.fn();
+vi.mock('./local-ai', () => ({
+  loadGemmaTextEngine: () => loadGemmaMock(),
+  loadTextEngine: () => loadLlamaMock(),
+  localAISupported: () => true,
+}));
+
+const runToolMock = vi.fn();
+vi.mock('./chat-tools', () => ({
+  runTool: (...a: unknown[]) => runToolMock(...a),
+  toolDefinitions: () => '[]',
+  listTools: () => [],
+}));
+
+import { streamChat } from './chat-engine';
+
+function fakeStream(chunks: string[]) {
+  return {
+    async *generate() {
+      for (const c of chunks) yield { choices: [{ delta: { content: c } }] };
+    },
+  };
+}
+
+beforeEach(() => {
+  loadGemmaMock.mockReset();
+  loadLlamaMock.mockReset();
+  runToolMock.mockReset();
+});
+
+describe('streamChat', () => {
+  it('streams pure prose from Gemma when no tool call', async () => {
+    loadGemmaMock.mockResolvedValue(fakeStream(['Hello ', 'world.']));
+    const out: string[] = [];
+    for await (const chunk of streamChat({ messages: [{ role: 'user', content: 'hi' }] })) {
+      if (chunk.type === 'text') out.push(chunk.delta);
+    }
+    expect(out.join('')).toBe('Hello world.');
+  });
+
+  it('detects a tool call, dispatches, re-prompts, returns final prose', async () => {
+    // First completion: tool call. Second completion: final prose.
+    let callIdx = 0;
+    loadGemmaMock.mockResolvedValue({
+      async *generate() {
+        if (callIdx++ === 0) {
+          yield { choices: [{ delta: { content: '{"tool":"find_species","args":{"p_query":"magnolia"}}' } }] };
+        } else {
+          yield { choices: [{ delta: { content: 'Found 1 species: Magnolia.' } }] };
+        }
+      },
+    });
+    runToolMock.mockResolvedValue({ ok: true, data: [{ scientific_name: 'Magnolia grandiflora' }] });
+
+    const events: Array<{ type: string; delta?: string; tool?: string }> = [];
+    for await (const chunk of streamChat({ messages: [{ role: 'user', content: 'find magnolia' }] })) {
+      events.push(chunk);
+    }
+    expect(events.find(e => e.type === 'tool_call')?.tool).toBe('find_species');
+    expect(events.filter(e => e.type === 'text').map(e => e.delta).join('')).toContain('Magnolia');
+  });
+
+  it('caps tool calls at 1 round per turn', async () => {
+    let callIdx = 0;
+    loadGemmaMock.mockResolvedValue({
+      async *generate() {
+        // Both completions emit tool calls — only the first should dispatch.
+        const tool = `{"tool":"find_species","args":{"p_query":"x${callIdx++}"}}`;
+        yield { choices: [{ delta: { content: tool } }] };
+      },
+    });
+    runToolMock.mockResolvedValue({ ok: true, data: [] });
+
+    const events: Array<{ type: string }> = [];
+    for await (const chunk of streamChat({ messages: [{ role: 'user', content: 'x' }] })) {
+      events.push(chunk);
+    }
+    const toolEvents = events.filter(e => e.type === 'tool_call');
+    expect(toolEvents).toHaveLength(1);
+  });
+
+  it('falls back to Llama when Gemma load fails', async () => {
+    loadGemmaMock.mockRejectedValue(new Error('webgpu init failed'));
+    loadLlamaMock.mockResolvedValue({
+      chat: { completions: { create: async () => ({
+        async *[Symbol.asyncIterator]() { yield { choices: [{ delta: { content: 'fallback' } }] }; },
+      }) } },
+    });
+
+    const events: Array<{ type: string; delta?: string; engine?: string }> = [];
+    for await (const chunk of streamChat({ messages: [{ role: 'user', content: 'x' }] })) {
+      events.push(chunk);
+    }
+    expect(events.find(e => e.type === 'engine_fallback')?.engine).toBe('llama');
+    expect(events.filter(e => e.type === 'text').map(e => e.delta).join('')).toContain('fallback');
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `npx vitest run src/lib/chat-engine.test.ts`
+
+Expected: FAIL with "Cannot find module './chat-engine'".
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/lib/chat-engine.ts
+//
+// Chat dispatch: Gemma 4 E2B by default, Llama-3.2-1B as fallback.
+// Implements a streaming + 1-round tool-call loop. Emits typed events
+// the UI consumes: text deltas, tool calls, tool results, engine fallbacks.
+//
+// The model is expected to either (a) emit prose, or (b) emit a single
+// JSON object `{"tool": "<name>", "args": { ... }}` with no surrounding
+// prose. We detect (b) by looking for a `{"tool":` substring within the
+// first 64 chars of accumulated output. Anything else is treated as prose.
+
+import { runTool, toolDefinitions } from './chat-tools';
+import { loadGemmaTextEngine, loadTextEngine } from './local-ai';
+
+export type ChatMessage = { role: 'system' | 'user' | 'assistant' | 'tool'; content: string };
+
+export type StreamEvent =
+  | { type: 'text'; delta: string }
+  | { type: 'tool_call'; tool: string; args: unknown }
+  | { type: 'tool_result'; tool: string; result: unknown }
+  | { type: 'engine_fallback'; engine: 'llama'; reason: string }
+  | { type: 'error'; message: string };
+
+export interface StreamChatInput {
+  messages: ChatMessage[];
+  /** Optional override; default tries Gemma then Llama. */
+  prefer?: 'gemma' | 'llama';
+}
+
+const TOOL_RE = /^\s*\{\s*"tool"\s*:/;
+const MAX_TOOL_ROUNDS = 1;
+const SYSTEM_TOOLS_PROMPT = `You may emit a JSON tool call to look up data. Tools available:\n%TOOLS%\nWhen calling a tool, respond with ONLY a JSON object: {"tool": "<name>", "args": { ... }}. Otherwise reply in prose. Use tools sparingly.`;
+
+function withToolPrompt(messages: ChatMessage[]): ChatMessage[] {
+  const sys = SYSTEM_TOOLS_PROMPT.replace('%TOOLS%', toolDefinitions());
+  return [{ role: 'system', content: sys }, ...messages];
+}
+
+async function* streamGemma(messages: ChatMessage[]): AsyncIterable<{ delta?: string; final?: string }> {
+  const eng = await loadGemmaTextEngine(() => {});
+  for await (const chunk of eng.generate(messages, { max_tokens: 512, stream: true })) {
+    const c = chunk.choices?.[0];
+    const delta = c?.delta?.content ?? c?.message?.content ?? '';
+    if (delta) yield { delta };
+  }
+}
+
+async function* streamLlama(messages: ChatMessage[]): AsyncIterable<{ delta?: string }> {
+  const eng = await loadTextEngine(() => {});
+  const stream = await eng.chat.completions.create({
+    messages: messages as Array<{ role: 'system' | 'user' | 'assistant' | 'tool'; content: string }>,
+    max_tokens: 512,
+    stream: true,
+  });
+  for await (const chunk of stream as AsyncIterable<{ choices?: Array<{ delta?: { content?: string } }> }>) {
+    const delta = chunk.choices?.[0]?.delta?.content ?? '';
+    if (delta) yield { delta };
+  }
+}
+
+async function* runOnce(
+  messages: ChatMessage[],
+  prefer: 'gemma' | 'llama' | undefined,
+): AsyncIterable<StreamEvent> {
+  if (prefer === 'llama') {
+    for await (const c of streamLlama(messages)) {
+      if (c.delta) yield { type: 'text', delta: c.delta };
+    }
+    return;
+  }
+  // Gemma path with Llama fallback on load error.
+  try {
+    for await (const c of streamGemma(messages)) {
+      if (c.delta) yield { type: 'text', delta: c.delta };
+    }
+  } catch (e) {
+    yield { type: 'engine_fallback', engine: 'llama', reason: e instanceof Error ? e.message : String(e) };
+    for await (const c of streamLlama(messages)) {
+      if (c.delta) yield { type: 'text', delta: c.delta };
+    }
+  }
+}
+
+/**
+ * Streaming chat with a 1-round tool-call loop. Yields:
+ *   { type: 'text', delta }            — model text deltas
+ *   { type: 'tool_call', tool, args }  — when the model emitted a tool
+ *   { type: 'tool_result', tool, … }   — after tool dispatch
+ *   { type: 'engine_fallback', … }     — when Gemma fell back to Llama
+ *   { type: 'error', message }         — terminal error
+ */
+export async function* streamChat(input: StreamChatInput): AsyncIterable<StreamEvent> {
+  const messages = withToolPrompt(input.messages);
+  let toolRounds = 0;
+
+  while (true) {
+    let accumulated = '';
+    let toolCallText: string | null = null;
+    const buffered: StreamEvent[] = [];
+
+    for await (const ev of runOnce(messages, input.prefer)) {
+      if (ev.type === 'text') {
+        accumulated += ev.delta;
+        // Decide once we have enough chars to recognise a tool call.
+        if (toolCallText === null && accumulated.length >= 16 && !TOOL_RE.test(accumulated)) {
+          // Definitely prose — flush buffered + this delta.
+          for (const b of buffered) yield b;
+          buffered.length = 0;
+          yield ev;
+        } else if (toolCallText === null) {
+          // Still ambiguous — buffer.
+          buffered.push(ev);
+        } else {
+          // Tool call mode — keep accumulating but don't yield text deltas.
+        }
+        if (TOOL_RE.test(accumulated)) toolCallText = accumulated;
+      } else {
+        // Engine fallbacks etc. pass through.
+        for (const b of buffered) yield b;
+        buffered.length = 0;
+        yield ev;
+      }
+    }
+
+    // End of model output. Decide what to do.
+    if (toolCallText && toolRounds < MAX_TOOL_ROUNDS) {
+      // Parse the tool call.
+      let parsed: { tool?: string; args?: unknown } | null = null;
+      try { parsed = JSON.parse(toolCallText.trim()); } catch { /* fallthrough */ }
+      if (!parsed?.tool) {
+        // Not a valid tool call — treat the buffered text as prose.
+        for (const b of buffered) yield b;
+        return;
+      }
+      yield { type: 'tool_call', tool: parsed.tool, args: parsed.args ?? {} };
+      const result = await runTool({ name: parsed.tool, args: parsed.args ?? {} });
+      yield { type: 'tool_result', tool: parsed.tool, result };
+      toolRounds++;
+      // Append the tool result and re-prompt.
+      messages.push({ role: 'assistant', content: toolCallText });
+      messages.push({ role: 'tool', content: JSON.stringify(result) });
+      continue;
+    }
+
+    // No tool call (or cap reached). Flush whatever buffer we still have.
+    for (const b of buffered) yield b;
+    return;
+  }
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `npx vitest run src/lib/chat-engine.test.ts`
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npm run typecheck`
+
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/chat-engine.ts src/lib/chat-engine.test.ts
+git commit -m "feat(chat): chat-engine with Gemma-default + 1-round tool-call loop + Llama fallback"
+```
+
+---
+
+### Task 13: Gemma-text download card in ProfileEditForm
+
+**Files:**
+- Modify: `src/components/ProfileEditForm.astro` (locate the existing Phi/Llama download cards and add a Gemma-text card mirroring their shape)
+
+- [ ] **Step 1: Find the existing card markup**
+
+Run: `grep -n "id=\"vision-download\"\|id=\"text-download\"\|webllm_phi35_vision\|Llama-3.2-1B" src/components/ProfileEditForm.astro | head -20`
+
+Read 30 lines of context around each match. The download cards are typically rendered by `renderPluginCard()` from `src/lib/identifier-card-html.ts`. Check whether ProfileEditForm renders Gemma at all today — if it already renders the Gemma vision card, mirror that shape; the new card has a different model id (`onnx_gemma4_text` vs. `onnx_gemma4_vision`).
+
+- [ ] **Step 2: Add a Gemma-text MODELS entry**
+
+In `src/lib/identifier-card-html.ts` (or wherever the `MODELS` object is defined), add:
+
+```typescript
+const MODELS: Record<ModelKey, { id: string; label: string; sizeLabel: string }> = {
+  vision:     { id: 'Phi-3.5-vision-instruct-q4f16_1-MLC', label: 'Phi-3.5-vision', sizeLabel: '~4 GB' },
+  text:       { id: 'Llama-3.2-1B-Instruct-q4f16_1-MLC',   label: 'Llama-3.2-1B',   sizeLabel: '~880 MB' },
+  gemma_text: { id: 'onnx_gemma4_text',                    label: 'Gemma 4 E2B (text)', sizeLabel: '~500 MB' },
+};
+```
+
+Extend the `ModelKey` type union to include `'gemma_text'`. If the file uses `ModelKey = keyof typeof MODELS`, this is automatic; otherwise update the union.
+
+- [ ] **Step 3: Render the new card**
+
+Find the JSX/HTML rendering loop for download cards in `ProfileEditForm.astro`. Add a new `<li>` mirroring the Phi/Llama cards with these IDs (substitute prefix `gemma-text-`):
+
+```html
+<li class="rounded-lg border border-zinc-200 dark:border-zinc-800 p-3" data-model-card="gemma_text">
+  <div class="flex items-start justify-between gap-3 flex-wrap">
+    <div class="min-w-0 flex-1">
+      <div class="flex items-center gap-2 flex-wrap">
+        <span class="text-base">✨</span>
+        <p class="text-sm font-medium">Gemma 4 E2B (text chat)</p>
+        <span id="gemma-text-status" class="hidden bg-emerald-500/15 text-emerald-700 px-1.5 py-0.5 rounded text-[10px]">Active</span>
+      </div>
+      <p class="text-xs text-zinc-500 mt-0.5">{tr.profile.ai.gemma_text_description}</p>
+      <p class="text-[10px] text-zinc-400 mt-1 font-mono">on-device · 💬 · ~500 MB</p>
+    </div>
+    <div class="flex flex-wrap gap-2 flex-none">
+      <button type="button" id="gemma-text-download" class="rounded-lg border border-emerald-600/60 px-3 py-1.5 text-xs font-medium">{tr.profile.ai.download}</button>
+      <button type="button" id="gemma-text-delete" class="hidden rounded-lg border border-red-300 px-3 py-1.5 text-xs font-medium text-red-700">{tr.profile.ai.delete}</button>
+    </div>
+  </div>
+  <div id="gemma-text-progress" class="hidden mt-2 text-[10px] font-mono text-zinc-500"></div>
+</li>
+```
+
+- [ ] **Step 4: Wire the download button**
+
+Find the existing button-handler script block in `ProfileEditForm.astro`. The Phi/Llama buttons call something like `refreshModel('vision')`/`refreshModel('text')`. Add a parallel call:
+
+```typescript
+document.getElementById('gemma-text-download')?.addEventListener('click', async () => {
+  const { loadGemmaTextEngine } = await import('../lib/local-ai');
+  const progressEl = document.getElementById('gemma-text-progress');
+  progressEl?.classList.remove('hidden');
+  try {
+    await loadGemmaTextEngine((p) => {
+      if (progressEl) progressEl.textContent = `${Math.round(p.progress * 100)}% — ${p.text}`;
+    });
+    document.getElementById('gemma-text-status')?.classList.remove('hidden');
+    document.getElementById('gemma-text-delete')?.classList.remove('hidden');
+  } catch (e) {
+    if (progressEl) progressEl.textContent = e instanceof Error ? e.message : String(e);
+  }
+});
+```
+
+The delete handler should call `clearGemmaCache()` from `src/lib/onnx-vision.ts` (if it exists; if not, this is a v1.1 follow-up — leave the button hidden).
+
+- [ ] **Step 5: Add i18n strings**
+
+In `src/i18n/en.json`, add under `profile.ai`:
+```json
+"gemma_text_description": "Google Gemma 4 E2B for on-device text chat. Stronger reasoner than Llama 1B. ~500 MB one-time download. Runs entirely in your browser."
+```
+
+In `src/i18n/es.json`:
+```json
+"gemma_text_description": "Google Gemma 4 E2B para chat de texto en el dispositivo. Razona mejor que Llama 1B. Descarga única de ~500 MB. Se ejecuta totalmente en tu navegador."
+```
+
+- [ ] **Step 6: Type-check + test**
+
+Run: `npm run typecheck && npm run test`
+
+Expected: 0 type errors; all tests green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/ProfileEditForm.astro src/lib/identifier-card-html.ts src/i18n/en.json src/i18n/es.json
+git commit -m "feat(profile): Gemma 4 (text) download card in AI settings"
+```
+
+---
+
+# Phase 5 — UI Decomposition
+
+ChatView shrinks from 1,441 LOC to a ~400-LOC orchestrator. New sibling components own their own internals. Events flow through CustomEvents on `document`.
+
+---
+
+### Task 14: Extract ChatBubble.astro
+
+**Files:**
+- Create: `src/components/ChatBubble.astro`
+- Modify: `src/components/ChatView.astro` (replace inline `bubbleHtml(...)` with `<ChatBubble />` rendering loop)
+
+- [ ] **Step 1: Read the current bubble code**
+
+Run: `grep -n "function bubbleHtml\|renderCascadeFooter\|renderCompareFooter\|renderAttachmentPreview" src/components/ChatView.astro`
+
+Read 30 lines around each match. Note any DOM IDs the parent script wires up.
+
+- [ ] **Step 2: Create the new component**
+
+```astro
+---
+// src/components/ChatBubble.astro
+//
+// Pure render of one chat bubble. The orchestrator (ChatView) iterates
+// over its conversation array and dispatches one of these per turn.
+//
+// Bubble actions (copy / save-as-observation / re-run) are wired by the
+// parent via event delegation on `[data-chat-bubble]`. This component
+// renders the buttons but never owns the listeners.
+---
+
+<!-- Marker rendered by parent JS that does .innerHTML. The actual markup is
+     produced by the bubble-rendering helpers in `chat-bubble-html.ts` which
+     this component re-exports for the parent's setBubbleStreaming() path. -->
+<template id="chat-bubble-template">
+  <div data-chat-bubble class="max-w-[85%] rounded-2xl px-3 py-2 text-sm"></div>
+</template>
+```
+
+The bubble HTML is currently produced by string-template helpers in `ChatView.astro`. To keep the change small in this task, **do not move the helpers yet** — just extract them into a new file `src/lib/chat-bubble-html.ts`, importable from both `ChatView.astro` and (if needed) `ChatComposer.astro`.
+
+Create `src/lib/chat-bubble-html.ts`:
+
+```typescript
+// Bubble-rendering helpers extracted from ChatView. Pure string templates;
+// no DOM access, no listeners. The parent does .innerHTML and then attaches
+// listeners via querySelectorAll().
+
+import type { CascadeCandidate } from './chat-attachment-helpers';
+
+export type ChatRole = 'user' | 'assistant';
+export interface ChatAttachment { kind: 'photo' | 'audio'; objectUrl: string; mimeType: string; durationSec?: number }
+export interface ChatTurnLite {
+  role: ChatRole;
+  content: string;
+  attachment?: ChatAttachment;
+  pending?: boolean;
+  cascadeResult?: { best: CascadeCandidate | null; attachmentKind: 'photo'|'audio'; attachmentBlobUrl: string; attachmentMime: string };
+  compareResult?: { attachmentKind: 'photo'|'audio'; attachmentBlobUrl: string; attachmentMime: string; entries: Array<{ id: string; name: string; ok: boolean; result?: CascadeCandidate; error?: string }> };
+  entityChip?: { kind: string; label: string; icon: string };
+}
+
+export function escapeHtml(s: string): string {
+  return s.replace(/[<>&'"]/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;',"'":'&#39;','"':'&quot;'}[c]!));
+}
+
+export function bubbleHtml(turn: ChatTurnLite, idx: number, isEs: boolean): string {
+  const isUser = turn.role === 'user';
+  const align  = isUser ? 'ml-auto' : 'mr-auto';
+  const bg     = isUser
+    ? 'bg-emerald-700 text-white'
+    : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 border border-zinc-200 dark:border-zinc-800';
+  const role   = isUser ? (isEs ? 'Tú' : 'You') : 'Rastrum';
+  const att    = turn.attachment ? renderAttachmentPreview(turn.attachment) : '';
+  const chip   = turn.entityChip
+    ? `<div class="inline-flex items-center gap-1 rounded-full border border-emerald-600/30 bg-emerald-50 dark:bg-emerald-900/10 px-2 py-0.5 text-[11px] mb-1">
+         <span>${escapeHtml(turn.entityChip.icon)}</span>
+         <span class="truncate max-w-[180px]">${escapeHtml(turn.entityChip.label)}</span>
+       </div>`
+    : '';
+  const body = turn.pending
+    ? `<span class="inline-flex items-center gap-2 italic"><span class="animate-pulse">…</span>${escapeHtml(turn.content)}</span>`
+    : escapeHtml(turn.content);
+  return `<div data-chat-bubble data-turn-idx="${idx}" class="${align} ${bg} max-w-[85%] rounded-2xl px-3 py-2 text-sm">
+    <div class="text-[10px] uppercase tracking-wider opacity-70 mb-0.5">${role}</div>
+    ${chip}
+    ${att}
+    <div data-bubble-body>${body}</div>
+  </div>`;
+}
+
+function renderAttachmentPreview(att: ChatAttachment): string {
+  if (att.kind === 'photo') {
+    return `<img src="${att.objectUrl}" alt="" class="max-h-48 rounded-md mb-2" />`;
+  }
+  return `<audio controls src="${att.objectUrl}" class="w-full mb-2"></audio>`;
+}
+```
+
+- [ ] **Step 3: Update ChatView.astro to import these helpers**
+
+Replace the inline `bubbleHtml`, `renderAttachmentPreview`, `escapeHtml`, and `ChatTurn` type definitions in `ChatView.astro` with:
+
+```typescript
+import { bubbleHtml, escapeHtml, type ChatTurnLite, type ChatRole, type ChatAttachment } from '../lib/chat-bubble-html';
+```
+
+Adjust references throughout the script. The functions `renderCascadeFooter` and `renderCompareFooter` can stay inline for now (they're large and tightly coupled to local state); a follow-up task can move them.
+
+- [ ] **Step 4: Run unit tests + type-check**
+
+Run: `npm run typecheck && npm run test`
+
+Expected: 0 errors; existing tests pass.
+
+- [ ] **Step 5: Build + smoke**
+
+Run: `npm run build`
+
+Expected: build succeeds. Manually load `/en/chat/` in `npm run dev` — verify the chat bubble layout renders the same as before.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/chat-bubble-html.ts src/components/ChatBubble.astro src/components/ChatView.astro
+git commit -m "refactor(chat): extract bubble HTML helpers from ChatView"
+```
+
+---
+
+### Task 15: Extract ChatComposer.astro
+
+**Files:**
+- Create: `src/components/ChatComposer.astro`
+- Modify: `src/components/ChatView.astro` (replace the composer markup with `<ChatComposer />`; keep the script that wires the form submit)
+
+The composer owns: photo/gallery/audio/voice icons, the textarea, the send button, the attachment chip (photo/audio), the entity chip slot, and the model picker. It dispatches CustomEvents but doesn't own conversation state.
+
+- [ ] **Step 1: Move the composer JSX into the new component**
+
+```astro
+---
+// src/components/ChatComposer.astro
+//
+// Owns the textarea + attachment buttons + model picker + chips.
+// Dispatches: rastrum:chat-attach-photo, rastrum:chat-attach-audio,
+// rastrum:chat-attach-entity, rastrum:chat-detach-entity, rastrum:chat-submit.
+//
+// Lifts no state to globals; the parent listens on document.
+
+import { t } from '../i18n/utils';
+
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const tr = t(lang);
+---
+
+<form id="chat-form" class="hidden fixed bottom-0 left-0 right-0 sm:static border-t border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 sm:border-0 sm:bg-transparent z-30" style="padding-bottom: env(safe-area-inset-bottom);">
+  <div class="max-w-3xl mx-auto px-4 sm:px-0 py-3 sm:py-0 space-y-2">
+    <!-- entity chip -->
+    <div id="chat-entity-chip-slot"></div>
+    <!-- attachment chip (photo/audio) -->
+    <div id="chat-attachment-chip" class="hidden flex items-center gap-2 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 p-2">
+      <div id="chat-attachment-thumb" class="w-12 h-12 rounded-md overflow-hidden bg-zinc-200 dark:bg-zinc-800 flex items-center justify-center text-zinc-500 text-xs flex-shrink-0"></div>
+      <div class="flex-1 min-w-0">
+        <p id="chat-attachment-label" class="text-xs font-medium text-zinc-700 dark:text-zinc-300 truncate"></p>
+        <p id="chat-attachment-meta" class="text-[10px] text-zinc-500 truncate"></p>
+      </div>
+      <button id="chat-attachment-remove" type="button" aria-label={tr.chat.attach_remove} class="w-7 h-7 rounded-full bg-zinc-200 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 text-sm flex items-center justify-center hover:bg-zinc-300 dark:hover:bg-zinc-700 flex-shrink-0">×</button>
+    </div>
+    <!-- model picker (existing markup; keep IDs unchanged) -->
+    <!-- ... copy from ChatView lines ~83–98 verbatim ... -->
+    <!-- buttons + textarea row (existing markup; keep IDs unchanged) -->
+    <!-- ... copy from ChatView lines ~100–186 verbatim ... -->
+  </div>
+</form>
+
+<script>
+  // Listeners for attach buttons → CustomEvent dispatch.
+  const formEl = document.getElementById('chat-form');
+  const attachEntityBtn = document.getElementById('chat-attach-entity-btn');
+  attachEntityBtn?.addEventListener('click', () => {
+    document.dispatchEvent(new CustomEvent('rastrum:chat-open-entity-picker'));
+  });
+
+  formEl?.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const ta = document.getElementById('chat-input') as HTMLTextAreaElement | null;
+    document.dispatchEvent(new CustomEvent('rastrum:chat-submit', {
+      detail: { text: ta?.value ?? '' },
+    }));
+  });
+</script>
+```
+
+For Step 1, **copy the existing composer HTML verbatim from ChatView.astro lines 61–186** into the position marked "copy from ChatView…" above. Add a new "📋 Attach context" button **next to the photo/audio buttons** with `id="chat-attach-entity-btn"`.
+
+- [ ] **Step 2: Update ChatView.astro to use ChatComposer**
+
+In `ChatView.astro`, replace the entire `<form id="chat-form">…</form>` block (lines 61–186) with:
+
+```astro
+<ChatComposer lang={lang} />
+```
+
+Add the import at the top of the frontmatter:
+```astro
+import ChatComposer from './ChatComposer.astro';
+```
+
+Move the composer-form-submit handler from the inline `<script>` so it listens to `rastrum:chat-submit` instead of submitting directly.
+
+- [ ] **Step 3: Type-check + build**
+
+Run: `npm run typecheck && npm run build`
+
+Expected: 0 errors; build succeeds.
+
+- [ ] **Step 4: Manual smoke**
+
+Run `npm run dev`, open `/en/chat/`. Verify: send works, photo attach works, audio attach works, voice button works, model picker works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ChatComposer.astro src/components/ChatView.astro
+git commit -m "refactor(chat): extract ChatComposer + add Attach context button"
+```
+
+---
+
+### Task 16: ChatEntityChip.astro
+
+**Files:**
+- Create: `src/components/ChatEntityChip.astro`
+
+The chip is rendered into `#chat-entity-chip-slot` from ChatView when an entity is attached. Click on the chip opens the entity's canonical page in a new tab.
+
+- [ ] **Step 1: Write the component**
+
+```astro
+---
+// src/components/ChatEntityChip.astro
+//
+// Compact representation of an attached entity inside the composer.
+// Rendered by ChatView via document.getElementById('chat-entity-chip-slot').innerHTML.
+// Standalone <ChatEntityChip /> usage is rare; this is mostly an HTML template
+// that the parent imports via the chat-bubble-html helpers.
+---
+
+<template id="chat-entity-chip-template">
+  <div data-chat-entity-chip class="flex items-center gap-2 rounded-lg border border-emerald-300 dark:border-emerald-700/40 bg-emerald-50 dark:bg-emerald-900/10 p-2 text-sm">
+    <span data-chip-icon class="text-base flex-shrink-0"></span>
+    <a data-chip-link target="_blank" rel="noopener" class="flex-1 min-w-0 truncate font-medium text-emerald-900 dark:text-emerald-100 hover:underline"></a>
+    <button data-chip-detach type="button" aria-label="Remove" class="w-6 h-6 rounded-full bg-emerald-200 dark:bg-emerald-800 text-emerald-900 dark:text-emerald-100 text-xs flex items-center justify-center hover:bg-emerald-300">×</button>
+  </div>
+</template>
+```
+
+Add a render helper in `src/lib/chat-bubble-html.ts`:
+
+```typescript
+import type { EntityKind } from './chat-entities/types';
+
+export function entityChipHtml(opts: { kind: EntityKind; id: string; label: string; icon: string; lang: 'en'|'es' }): string {
+  const url = canonicalEntityUrl(opts.kind, opts.id, opts.lang);
+  return `<div data-chat-entity-chip class="flex items-center gap-2 rounded-lg border border-emerald-300 dark:border-emerald-700/40 bg-emerald-50 dark:bg-emerald-900/10 p-2 text-sm">
+    <span class="text-base flex-shrink-0">${escapeHtml(opts.icon)}</span>
+    <a href="${url}" target="_blank" rel="noopener" class="flex-1 min-w-0 truncate font-medium text-emerald-900 dark:text-emerald-100 hover:underline">${escapeHtml(opts.label)}</a>
+    <button data-chip-detach type="button" aria-label="Remove" class="w-6 h-6 rounded-full bg-emerald-200 dark:bg-emerald-800 text-emerald-900 dark:text-emerald-100 text-xs flex items-center justify-center hover:bg-emerald-300">×</button>
+  </div>`;
+}
+
+function canonicalEntityUrl(kind: EntityKind, id: string, lang: 'en'|'es'): string {
+  switch (kind) {
+    case 'observation':    return `/share/obs/?id=${encodeURIComponent(id)}`;
+    case 'species':        return `/${lang}/${lang === 'es' ? 'especie' : 'species'}/${encodeURIComponent(id)}/`;
+    case 'project':        return `/${lang}/${lang === 'es' ? 'proyectos' : 'projects'}/detail/?slug=${encodeURIComponent(id)}`;
+    case 'observer':       return `/${lang}/${lang === 'es' ? 'perfil' : 'profile'}/u/${encodeURIComponent(id)}/`;
+    case 'self_profile':   return `/${lang}/${lang === 'es' ? 'perfil' : 'profile'}/`;
+    case 'camera_station': return '#';
+    default: return '#';
+  }
+}
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+Run: `npm run typecheck`
+
+Expected: 0 errors.
+
+```bash
+git add src/components/ChatEntityChip.astro src/lib/chat-bubble-html.ts
+git commit -m "feat(chat): ChatEntityChip + entityChipHtml helper"
+```
+
+---
+
+### Task 17: ChatEntityPicker.astro + tests
+
+**Files:**
+- Create: `src/components/ChatEntityPicker.astro`
+- Create: `tests/unit/chat-entity-picker.test.ts`
+
+- [ ] **Step 1: Component**
+
+```astro
+---
+// src/components/ChatEntityPicker.astro
+//
+// Popover triggered from ChatComposer's "📋 Attach context" button.
+// Tabs across the 6 entity kinds. Each tab queries one Supabase RPC
+// (the chat_find_* functions). Selecting a row dispatches
+// rastrum:chat-attach-entity and closes.
+
+import { t } from '../i18n/utils';
+
+interface Props { lang: 'en' | 'es' }
+const { lang } = Astro.props;
+const tr = t(lang);
+---
+
+<div id="chat-entity-picker" class="hidden fixed inset-0 z-50 bg-black/40 flex items-end sm:items-center justify-center" role="dialog" aria-modal="true" aria-label={tr.chat.attach_entity_label}>
+  <div class="bg-white dark:bg-zinc-900 w-full sm:max-w-lg rounded-t-xl sm:rounded-xl shadow-2xl">
+    <header class="flex items-center justify-between p-3 border-b border-zinc-200 dark:border-zinc-800">
+      <h2 class="text-sm font-semibold">{tr.chat.attach_entity_label}</h2>
+      <button id="chat-entity-picker-close" aria-label={tr.chat.close} class="w-8 h-8 rounded-full hover:bg-zinc-100 dark:hover:bg-zinc-800">×</button>
+    </header>
+    <div role="tablist" class="flex overflow-x-auto border-b border-zinc-200 dark:border-zinc-800 text-xs">
+      <button data-pkr-tab="observation"    role="tab" class="chat-pkr-tab">{tr.chat.entities.observation}</button>
+      <button data-pkr-tab="species"        role="tab" class="chat-pkr-tab">{tr.chat.entities.species}</button>
+      <button data-pkr-tab="project"        role="tab" class="chat-pkr-tab">{tr.chat.entities.project}</button>
+      <button data-pkr-tab="camera_station" role="tab" class="chat-pkr-tab">{tr.chat.entities.camera_station}</button>
+      <button data-pkr-tab="observer"       role="tab" class="chat-pkr-tab">{tr.chat.entities.observer}</button>
+      <button data-pkr-tab="self_profile"   role="tab" class="chat-pkr-tab">{tr.chat.entities.self_profile}</button>
+    </div>
+    <div class="p-3">
+      <input id="chat-entity-picker-search" type="search" placeholder={tr.chat.attach_entity_search} class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-950 px-3 py-2 text-sm" />
+    </div>
+    <ul id="chat-entity-picker-list" class="max-h-[60vh] overflow-y-auto px-3 pb-3 space-y-2"></ul>
+  </div>
+</div>
+
+<style>
+  .chat-pkr-tab { @apply px-3 py-2 whitespace-nowrap border-b-2 border-transparent hover:bg-zinc-50 dark:hover:bg-zinc-800/40; }
+  .chat-pkr-tab[aria-selected="true"] { @apply border-emerald-600 text-emerald-700 dark:text-emerald-400; }
+</style>
+
+<script>
+  import { getSupabase } from '../lib/supabase';
+  import { registry, bootstrapChatEntities } from '../lib/chat-entities';
+  import type { EntityKind } from '../lib/chat-entities/types';
+
+  bootstrapChatEntities();
+
+  const dialog = document.getElementById('chat-entity-picker');
+  const list   = document.getElementById('chat-entity-picker-list');
+  const search = document.getElementById('chat-entity-picker-search') as HTMLInputElement | null;
+
+  let activeTab: EntityKind = 'observation';
+  let lastQuery = '';
+
+  function setActiveTab(kind: EntityKind) {
+    activeTab = kind;
+    document.querySelectorAll('.chat-pkr-tab').forEach(b => {
+      const sel = (b as HTMLButtonElement).dataset.pkrTab === kind;
+      (b as HTMLButtonElement).setAttribute('aria-selected', String(sel));
+    });
+    refresh();
+  }
+
+  async function refresh() {
+    if (!list) return;
+    list.innerHTML = '<li class="text-xs text-zinc-500 italic">Loading…</li>';
+    const sb = getSupabase();
+    const q = lastQuery.trim();
+    let rows: Array<{ id: string; label: string }> = [];
+    try {
+      if (activeTab === 'observation') {
+        const { data } = await sb.rpc('chat_find_observations', { p_filters: q ? { /* server-side query is by id only; client filters */ } : { owner: 'me' }, p_limit: 20 });
+        rows = (data ?? []).map((r: { id: string; scientific_name?: string; observed_at?: string }) =>
+          ({ id: r.id, label: `${r.scientific_name ?? '—'} · ${r.observed_at ? new Date(r.observed_at).toLocaleDateString() : ''}` }));
+      } else if (activeTab === 'species') {
+        const { data } = await sb.rpc('chat_find_species', { p_query: q || ' ', p_limit: 20 });
+        rows = (data ?? []).map((r: { id: string; scientific_name: string }) => ({ id: r.id, label: r.scientific_name }));
+      } else if (activeTab === 'project') {
+        const { data } = await sb.rpc('chat_find_projects', { p_query: q || ' ', p_limit: 20 });
+        rows = (data ?? []).map((r: { id: string; slug: string; name?: string }) => ({ id: r.slug, label: r.name ?? r.slug }));
+      } else if (activeTab === 'observer') {
+        const { data } = await sb.rpc('chat_find_observers', { p_query: q || ' ', p_limit: 20 });
+        rows = (data ?? []).map((r: { id: string; display_name?: string; username?: string }) => ({ id: r.id, label: r.display_name ?? r.username ?? r.id }));
+      } else if (activeTab === 'self_profile') {
+        const { data: me } = await sb.auth.getUser();
+        if (me?.user) rows = [{ id: me.user.id, label: 'Me' }];
+      } else if (activeTab === 'camera_station') {
+        list.innerHTML = '<li class="text-xs text-zinc-500 italic">Open a project page first.</li>';
+        return;
+      }
+    } catch (e) {
+      list.innerHTML = `<li class="text-xs text-red-600">${(e as Error).message}</li>`;
+      return;
+    }
+
+    if (rows.length === 0) {
+      list.innerHTML = '<li class="text-xs text-zinc-500 italic">No matches.</li>';
+      return;
+    }
+    list.innerHTML = rows.map(r => {
+      const spec = registry.get(activeTab);
+      return `<li><button type="button" data-row-id="${r.id}" class="w-full text-left rounded-lg border border-zinc-200 dark:border-zinc-800 p-2 hover:bg-zinc-50 dark:hover:bg-zinc-800/40">
+        <span class="mr-2">${spec?.icon ?? ''}</span>${r.label}
+      </button></li>`;
+    }).join('');
+  }
+
+  list?.addEventListener('click', (ev) => {
+    const btn = (ev.target as Element)?.closest('button[data-row-id]') as HTMLButtonElement | null;
+    if (!btn) return;
+    const id = btn.dataset.rowId!;
+    document.dispatchEvent(new CustomEvent('rastrum:chat-attach-entity', {
+      detail: { kind: activeTab, id },
+    }));
+    dialog?.classList.add('hidden');
+  });
+
+  document.addEventListener('rastrum:chat-open-entity-picker', () => {
+    dialog?.classList.remove('hidden');
+    setActiveTab('observation');
+  });
+  document.getElementById('chat-entity-picker-close')?.addEventListener('click', () => dialog?.classList.add('hidden'));
+  document.querySelectorAll('.chat-pkr-tab').forEach(b => b.addEventListener('click', (e) => {
+    setActiveTab((e.currentTarget as HTMLButtonElement).dataset.pkrTab as EntityKind);
+  }));
+  search?.addEventListener('input', () => { lastQuery = search.value; refresh(); });
+</script>
+```
+
+- [ ] **Step 2: Mount in ChatView**
+
+In `src/components/ChatView.astro` add the import + mount:
+
+```astro
+import ChatEntityPicker from './ChatEntityPicker.astro';
+// …
+<ChatEntityPicker lang={lang} />
+```
+
+- [ ] **Step 3: Write the test**
+
+```typescript
+// tests/unit/chat-entity-picker.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const rpcMock = vi.fn();
+vi.mock('../../src/lib/supabase', () => ({ getSupabase: () => ({
+  rpc: rpcMock,
+  auth: { getUser: async () => ({ data: { user: { id: 'me' } } }) },
+}) }));
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  document.body.innerHTML = `
+    <div id="chat-entity-picker" class="hidden">
+      <button class="chat-pkr-tab" data-pkr-tab="species" aria-selected="false"></button>
+      <button class="chat-pkr-tab" data-pkr-tab="observation" aria-selected="true"></button>
+      <input id="chat-entity-picker-search" />
+      <ul id="chat-entity-picker-list"></ul>
+      <button id="chat-entity-picker-close"></button>
+    </div>`;
+});
+
+describe('chat-entity-picker', () => {
+  it('opening dispatches refresh and selects observation tab', async () => {
+    rpcMock.mockResolvedValue({ data: [], error: null });
+    // dynamic import after DOM is ready (component script runs at import-time)
+    await import('../../src/components/ChatEntityPicker.astro?inline').catch(() => {});
+    document.dispatchEvent(new CustomEvent('rastrum:chat-open-entity-picker'));
+    await new Promise(r => setTimeout(r, 0));
+    expect(rpcMock).toHaveBeenCalledWith('chat_find_observations', expect.any(Object));
+  });
+});
+```
+
+If `?inline` import doesn't work in the harness (Astro components are SSR), wire the test to instead import `src/lib/chat-entity-picker-controller.ts` — which means refactoring the script block out of the `.astro` file into a TS file. Decide based on whether vitest can compile `.astro`. If not, do the refactor:
+
+```typescript
+// src/lib/chat-entity-picker-controller.ts
+// Pull the entire <script> block from ChatEntityPicker.astro and export
+// `bindChatEntityPicker(): void`. The component then becomes:
+//   <script>import {bindChatEntityPicker} from '../lib/chat-entity-picker-controller'; bindChatEntityPicker();</script>
+```
+
+- [ ] **Step 4: Run tests + commit**
+
+Run: `npm run typecheck && npm run test`
+
+Expected: 0 errors; new picker test passes.
+
+```bash
+git add src/components/ChatEntityPicker.astro src/components/ChatView.astro tests/unit/chat-entity-picker.test.ts src/lib/chat-entity-picker-controller.ts
+git commit -m "feat(chat): ChatEntityPicker popover with 6 entity tabs"
+```
+
+---
+
+### Task 18: Wire chat-engine into ChatView (replace direct Llama path) + handle ?attach=
+
+**Files:**
+- Modify: `src/components/ChatView.astro`
+
+- [ ] **Step 1: Replace `streamLlamaInterpretation` with `streamChat` for the user→assistant turn**
+
+Find the form submit handler in `ChatView.astro` (the part that calls `engine.chat.completions.create` for user prose). Replace with:
+
+```typescript
+import { streamChat, type ChatMessage } from '../lib/chat-engine';
+import { parseAttachQuerystring } from '../lib/parse-attach-querystring';
+import { bootstrapChatEntities, registry } from '../lib/chat-entities';
+import type { EntityCard, EntityKind } from '../lib/chat-entities/types';
+
+bootstrapChatEntities();
+
+let attachedEntity: EntityCard | null = null;
+
+document.addEventListener('rastrum:chat-attach-entity', async (ev) => {
+  const detail = (ev as CustomEvent<{ kind: EntityKind; id: string }>).detail;
+  const spec = registry.get(detail.kind);
+  if (!spec) return;
+  try {
+    const card = await spec.fetchCard(detail.id);
+    if (!card) return; // silently drop; toast shown separately
+    attachedEntity = card;
+    renderEntityChip(card);
+    seedSuggestion(card);
+    document.dispatchEvent(new CustomEvent('rastrum:onboarding-event', {
+      detail: { type: 'chat.entity.attached', kind: card.kind, source: 'picker' },
+    }));
+  } catch (e) {
+    const errEl = document.getElementById('chat-attach-error');
+    if (errEl) {
+      errEl.textContent = (e instanceof Error ? e.message : String(e));
+      errEl.classList.remove('hidden');
+      setTimeout(() => errEl.classList.add('hidden'), 4000);
+    }
+  }
+});
+
+document.addEventListener('rastrum:chat-detach-entity', () => {
+  attachedEntity = null;
+  const slot = document.getElementById('chat-entity-chip-slot');
+  if (slot) slot.innerHTML = '';
+});
+
+function renderEntityChip(card: EntityCard) {
+  const slot = document.getElementById('chat-entity-chip-slot');
+  if (!slot) return;
+  // entityChipHtml from src/lib/chat-bubble-html.ts:
+  import('../lib/chat-bubble-html').then(({ entityChipHtml }) => {
+    slot.innerHTML = entityChipHtml({
+      kind: card.kind, id: card.id, label: card.label, icon: registry.get(card.kind)?.icon ?? '·', lang: isEs ? 'es' : 'en',
+    });
+    slot.querySelector('[data-chip-detach]')?.addEventListener('click', () => {
+      document.dispatchEvent(new CustomEvent('rastrum:chat-detach-entity'));
+    });
+  });
+}
+
+function seedSuggestion(card: EntityCard) {
+  const ta = document.getElementById('chat-input') as HTMLTextAreaElement | null;
+  if (!ta || ta.value || !card.suggested_questions[0]) return;
+  ta.placeholder = card.suggested_questions[0];
+}
+
+// Handle ?attach=…
+const params = new URLSearchParams(location.search);
+const parsed = parseAttachQuerystring(params.get('attach'));
+if (parsed) {
+  document.dispatchEvent(new CustomEvent('rastrum:chat-attach-entity', { detail: parsed }));
+  // Strip the param so refresh doesn't re-attach.
+  params.delete('attach');
+  history.replaceState(null, '', `${location.pathname}${params.toString() ? '?' + params.toString() : ''}`);
+}
+
+document.addEventListener('rastrum:chat-submit', async (ev) => {
+  const text = (ev as CustomEvent<{ text: string }>).detail.text.trim();
+  if (!text) return;
+
+  const userTurn = { role: 'user' as const, content: text, entityChip: attachedEntity ? { kind: attachedEntity.kind, label: attachedEntity.label, icon: registry.get(attachedEntity.kind)?.icon ?? '·' } : undefined };
+  conversation.push(userTurn);
+  paintConversation();
+
+  // Build the message list.
+  const messages: ChatMessage[] = [];
+  messages.push({ role: 'system', content: CHAT_SYSTEM_PROMPT });
+  if (attachedEntity) {
+    messages.push({ role: 'system', content: `[Context]\n${attachedEntity.summary_text}` });
+  }
+  // Last 6 turns from conversation (excluding the just-pushed user turn so we don't double count it).
+  const history = conversation.slice(-7, -1).map(t => ({
+    role: t.role,
+    content: t.content.slice(0, 600),  // truncate to ~120 tokens
+  }));
+  messages.push(...history);
+  messages.push({ role: 'user', content: text });
+
+  // Placeholder pending bubble for the assistant.
+  const placeholderIdx = conversation.push({ role: 'assistant', content: '', pending: true }) - 1;
+  paintConversation();
+
+  let assembled = '';
+  for await (const event of streamChat({ messages })) {
+    if (event.type === 'text') {
+      assembled += event.delta;
+      conversation[placeholderIdx].content = assembled;
+      conversation[placeholderIdx].pending = false;
+      setBubbleStreaming(placeholderIdx, assembled);
+    } else if (event.type === 'tool_call') {
+      document.dispatchEvent(new CustomEvent('rastrum:onboarding-event', {
+        detail: { type: 'chat.tool.called', tool_name: event.tool, ok: true },
+      }));
+    } else if (event.type === 'tool_result' && (event.result as { error?: string }).error) {
+      document.dispatchEvent(new CustomEvent('rastrum:onboarding-event', {
+        detail: { type: 'chat.tool.failed', tool_name: event.tool, reason: (event.result as { error: string }).error },
+      }));
+    } else if (event.type === 'engine_fallback') {
+      document.dispatchEvent(new CustomEvent('rastrum:onboarding-event', {
+        detail: { type: 'chat.engine.fallback', from: 'gemma', to: event.engine },
+      }));
+    }
+  }
+  conversation[placeholderIdx].pending = false;
+  paintConversation();
+  await persistAssistantTurn(conversation[placeholderIdx]);
+});
+```
+
+Note: leave the existing photo/audio cascade path intact — those paths use the cascade interpretation flow, not the new chat-engine path. The new `streamChat` is for **plain text turns with optional entity context**.
+
+- [ ] **Step 2: Extend `ChatTurnRecord` for entity_attachment + tool_calls**
+
+The spec persists a lightweight `entity_attachment?: { kind, id, label }` and `tool_calls?: Array<{name, args, result}>` on each turn so chip rendering survives reload.
+
+Open `src/lib/db.ts`. Find the `ChatTurnRecord` interface. Extend it:
+
+```typescript
+export interface ChatTurnRecord {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: string;
+  attachments?: Array<{ kind: 'photo' | 'audio'; mimeType: string; durationSec?: number }>;
+  // ↓ new fields (M01 chat improvements)
+  entity_attachment?: { kind: string; id: string; label: string };
+  tool_calls?: Array<{ name: string; args: unknown; result: unknown }>;
+}
+```
+
+In `src/lib/chat-history.ts`, update `appendTurn` to forward the new optional fields when present (`attachments` already does this; mirror the pattern). Run the existing `chat-history.test.ts` and confirm it still passes.
+
+If the Dexie schema needs a version bump for the new optional fields: optional fields don't require a schema change in Dexie v3+, but verify by reading the existing `getDB()` definition. Bump only if you see explicit `Schema` definitions naming columns.
+
+- [ ] **Step 3: Type-check + build + manual smoke**
+
+Run: `npm run typecheck && npm run build`
+
+Expected: 0 errors; build succeeds.
+
+Open `/en/chat/?attach=observation:00000000-0000-0000-0000-000000000004` in dev (replace with a real obs id). Verify the chip appears and a suggested question seeds the placeholder.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ChatView.astro src/lib/db.ts src/lib/chat-history.ts
+git commit -m "feat(chat): wire chat-engine + entity attach handler in ChatView"
+```
+
+---
+
+# Phase 6 — Deep Links
+
+`AskRastrumButton` drops into 5 entity surfaces. Each invocation builds a URL of the form `/{lang}/chat/?attach=<kind>:<id>`.
+
+---
+
+### Task 19: AskRastrumButton.astro + tests
+
+**Files:**
+- Create: `src/components/AskRastrumButton.astro`
+- Create: `tests/unit/ask-rastrum-button.test.ts`
+
+- [ ] **Step 1: Component**
+
+```astro
+---
+// src/components/AskRastrumButton.astro
+//
+// Deep-link button that opens /chat/ with an entity pre-attached.
+
+import { t } from '../i18n/utils';
+import type { EntityKind } from '../lib/chat-entities/types';
+
+interface Props {
+  lang: 'en' | 'es';
+  kind: EntityKind;
+  id: string;
+  /** "primary" → emerald fill; "ghost" → outline. */
+  variant?: 'primary' | 'ghost';
+  /** Shorthand: "icon" hides the label, just shows 💬. */
+  display?: 'full' | 'icon';
+}
+
+const { lang, kind, id, variant = 'ghost', display = 'full' } = Astro.props;
+const tr = t(lang);
+const href = `/${lang}/${lang === 'es' ? 'chat' : 'chat'}/?attach=${encodeURIComponent(kind)}:${encodeURIComponent(id)}`;
+const label = tr.chat.ask_rastrum;
+
+const cls = variant === 'primary'
+  ? 'inline-flex items-center gap-1 min-h-9 rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-1.5 text-xs font-semibold text-white'
+  : 'inline-flex items-center gap-1 min-h-9 rounded-lg border border-emerald-600/60 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/10';
+---
+
+<a href={href} class={cls} aria-label={label} title={label}>
+  <span aria-hidden="true">💬</span>
+  {display === 'full' && <span>{label}</span>}
+</a>
+```
+
+- [ ] **Step 2: Test**
+
+```typescript
+// tests/unit/ask-rastrum-button.test.ts
+import { describe, it, expect } from 'vitest';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import AskRastrumButton from '../../src/components/AskRastrumButton.astro';
+
+describe('AskRastrumButton', () => {
+  it('builds /en/chat/?attach=observation:abc', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(AskRastrumButton, {
+      props: { lang: 'en', kind: 'observation', id: 'abc' },
+    });
+    expect(html).toContain('href="/en/chat/?attach=observation%3Aabc"');
+    expect(html).toContain('Ask Rastrum');
+  });
+
+  it('builds /es/chat/?attach=species:xyz', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(AskRastrumButton, {
+      props: { lang: 'es', kind: 'species', id: 'xyz' },
+    });
+    expect(html).toContain('href="/es/chat/?attach=species%3Axyz"');
+  });
+
+  it('display=icon hides the label', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(AskRastrumButton, {
+      props: { lang: 'en', kind: 'project', id: 'abc', display: 'icon' },
+    });
+    expect(html).not.toContain('Ask Rastrum');
+    expect(html).toContain('💬');
+  });
+});
+```
+
+If `experimental_AstroContainer` isn't available in this Astro version, fall back to a rendering shim test using `astro/runtime` or simply reading the file and checking the URL-builder line. Verify Astro version in `package.json` first.
+
+- [ ] **Step 3: Run tests + commit**
+
+```bash
+npm run typecheck && npm run test
+git add src/components/AskRastrumButton.astro tests/unit/ask-rastrum-button.test.ts
+git commit -m "feat(chat): AskRastrumButton component"
+```
+
+---
+
+### Task 20: Mount AskRastrumButton in ShareObsView, MyObservationsView, SpeciesProfileView, ProjectDetailView, PublicProfileView
+
+**Files:** (one task per surface to keep diffs reviewable)
+
+- [ ] **Step 1: ShareObsView.astro**
+
+Find the actions row (around line 191 — `<div class="flex items-start justify-between gap-2 flex-wrap">`). Add inside the appropriate flex group:
+
+```astro
+<AskRastrumButton lang={lang} kind="observation" id={obs.id} variant="primary" />
+```
+
+Add the import at the top: `import AskRastrumButton from './AskRastrumButton.astro';`
+
+Commit: `feat(chat): Ask Rastrum on observation share page`
+
+- [ ] **Step 2: MyObservationsView.astro**
+
+Find the per-obs action buttons row (around line 311–327). Inject the button after the share button. Use `display="icon"` to keep the row tight.
+
+Commit: `feat(chat): Ask Rastrum on MyObs cards`
+
+- [ ] **Step 3: SpeciesProfileView.astro**
+
+Find the hero section (around line 60). Add the button after the taxonomy chips, with `kind="species"` and the species id. If the species id isn't readily available in the component scope, add a prop for it at the parent level.
+
+Commit: `feat(chat): Ask Rastrum on species profile`
+
+- [ ] **Step 4: ProjectDetailView.astro**
+
+Find the header (around line 44) and add the button next to the "Add station" button.
+
+Commit: `feat(chat): Ask Rastrum on project detail`
+
+- [ ] **Step 5: PublicProfileView.astro**
+
+Find the header (around line 51, near the FollowButton). Add the button in the same flex group.
+
+Commit: `feat(chat): Ask Rastrum on public profile`
+
+- [ ] **Step 6: Run typecheck + build for each commit**
+
+After each surface, run `npm run typecheck && npm run build` and verify the home of each entity surface still renders.
+
+---
+
+# Phase 7 — i18n + Telemetry + E2E + Runbook
+
+---
+
+### Task 21: i18n keys (EN + ES parity)
+
+**Files:**
+- Modify: `src/i18n/en.json`
+- Modify: `src/i18n/es.json`
+
+- [ ] **Step 1: Add keys to en.json**
+
+Add under `chat` (existing):
+```json
+"ask_rastrum": "Ask Rastrum",
+"attach_entity_label": "Attach context",
+"attach_entity_search": "Search…",
+"close": "Close",
+"entities": {
+  "observation": "Observations",
+  "species": "Species",
+  "project": "Projects",
+  "camera_station": "Stations",
+  "observer": "Observers",
+  "self_profile": "Me"
+},
+"tools": {
+  "ran": "Looked at {tool}",
+  "failed": "Couldn't run {tool}",
+  "offline": "Offline — couldn't run {tool}"
+},
+"engine_fallback_banner": "Using lighter model — Gemma unavailable.",
+"context_load_error": "Couldn't load context — try when online."
+```
+
+- [ ] **Step 2: Mirror in es.json**
+
+```json
+"ask_rastrum": "Pregunta a Rastrum",
+"attach_entity_label": "Adjuntar contexto",
+"attach_entity_search": "Buscar…",
+"close": "Cerrar",
+"entities": {
+  "observation": "Observaciones",
+  "species": "Especies",
+  "project": "Proyectos",
+  "camera_station": "Estaciones",
+  "observer": "Observadores",
+  "self_profile": "Yo"
+},
+"tools": {
+  "ran": "Consulté {tool}",
+  "failed": "No pude ejecutar {tool}",
+  "offline": "Sin conexión — no pude ejecutar {tool}"
+},
+"engine_fallback_banner": "Usando un modelo más ligero — Gemma no disponible.",
+"context_load_error": "No se pudo cargar el contexto — inténtalo cuando estés en línea."
+```
+
+- [ ] **Step 3: Verify EN/ES parity**
+
+Run:
+```bash
+node -e 'const en = require("./src/i18n/en.json"), es = require("./src/i18n/es.json"); function keys(o,p=""){return Object.entries(o).flatMap(([k,v])=>typeof v==="object"?keys(v,p+k+"."):[p+k]);} const ek=new Set(keys(en)),sk=new Set(keys(es)); console.log("missing in es:", [...ek].filter(k=>!sk.has(k))); console.log("missing in en:", [...sk].filter(k=>!ek.has(k)));'
+```
+
+Expected: both lists empty.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/i18n/en.json src/i18n/es.json
+git commit -m "i18n(chat): keys for entities, tools, ask_rastrum, attach_entity"
+```
+
+---
+
+### Task 22: E2E specs
+
+**Files:**
+- Create: `tests/e2e/chat-deep-link.spec.ts`
+- Create: `tests/e2e/chat-entity-picker.spec.ts`
+
+- [ ] **Step 1: chat-deep-link.spec.ts**
+
+```typescript
+// tests/e2e/chat-deep-link.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('chat deep-link from observation page pre-attaches the obs', async ({ page }) => {
+  // Stub Supabase for the entity-card RPC.
+  await page.route('**/rest/v1/rpc/chat_entity_card', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        kind: 'observation',
+        id: 'test-obs-id',
+        label: 'Setophaga magnolia · May 8 · CDMX',
+        summary_text: 'Test observation summary.',
+        fields: {},
+        suggested_questions: ['Why is this needs review?'],
+        related: {},
+      }),
+    });
+  });
+
+  await page.goto('/en/chat/?attach=observation:test-obs-id');
+  await expect(page.locator('[data-chat-entity-chip]')).toBeVisible();
+  await expect(page.locator('[data-chat-entity-chip]')).toContainText('Setophaga magnolia');
+  // URL should be cleaned.
+  await expect.poll(() => page.url()).not.toContain('attach=');
+});
+```
+
+- [ ] **Step 2: chat-entity-picker.spec.ts**
+
+```typescript
+// tests/e2e/chat-entity-picker.spec.ts
+import { test, expect } from '@playwright/test';
+
+test('chat entity picker opens, shows tabs, selects a row', async ({ page }) => {
+  await page.route('**/rest/v1/rpc/chat_find_observations', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'obs-1', scientific_name: 'Test Species', observed_at: '2026-05-08T00:00:00Z' },
+      ]),
+    });
+  });
+  await page.route('**/rest/v1/rpc/chat_entity_card', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        kind: 'observation',
+        id: 'obs-1',
+        label: 'Test Species',
+        summary_text: 's',
+        fields: {},
+        suggested_questions: [],
+        related: {},
+      }),
+    });
+  });
+
+  await page.goto('/en/chat/');
+  await page.locator('#chat-attach-entity-btn').click();
+  await expect(page.locator('#chat-entity-picker')).toBeVisible();
+  await page.locator('button[data-row-id="obs-1"]').click();
+  await expect(page.locator('[data-chat-entity-chip]')).toContainText('Test Species');
+});
+```
+
+- [ ] **Step 3: Run E2E locally**
+
+Run: `npm run test:e2e`
+
+Expected: both new specs pass on chromium + mobile-chrome.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/chat-deep-link.spec.ts tests/e2e/chat-entity-picker.spec.ts
+git commit -m "test(e2e): chat deep-link + entity-picker"
+```
+
+---
+
+### Task 23: Runbook + index
+
+**Files:**
+- Create: `docs/runbooks/chat-improvements.md`
+- Modify: `docs/runbooks/00-index.md` (add a row)
+
+- [ ] **Step 1: Write the runbook**
+
+Save as `docs/runbooks/chat-improvements.md`:
+
+```markdown
+# Chat improvements (2026-05-09 release)
+
+Operator notes for the Gemma-text + entity-context chat redesign.
+
+## What shipped
+
+- **Gemma 4 E2B as text-chat backbone** — alongside Llama-3.2-1B.
+  Defaults to Gemma when WebGPU + ≥6 GB device memory; falls back to
+  Llama otherwise.
+- **Entity context** — chat can be deep-linked or in-chat picked from
+  six entity kinds: observation, species, project, camera_station,
+  observer, self_profile.
+- **Five typed tools** — `find_observations`, `find_species`,
+  `find_projects`, `find_camera_stations`, `find_observers`.
+  1-round cap per turn.
+- **Decomposed ChatView** — slimmed from 1,441 LOC to ~400 LOC
+  orchestrator + 4 sibling components.
+
+## Known limits (v1.1 follow-ups)
+
+- Multi-round tool-calling (chains of tool calls) is capped at 1 round.
+- No guided writes — chat surfaces no "apply this fix" buttons.
+- `location` entity kind deferred until the locations-first-class
+  schema lands (`docs/superpowers/specs/2026-05-03-locations-first-class-design.md`).
+
+## Smoke checks
+
+After deploy:
+
+- [ ] `/en/chat/?attach=observation:<known-id>` — chip renders, URL cleaned.
+- [ ] In-chat picker opens, tabs switch, search filters.
+- [ ] Cross-entity follow-up: attach an obs, ask "find similar nearby" — model emits a tool call, results render.
+- [ ] Offline: airplane mode → attached obs Q&A still works; tool call shows offline footer.
+- [ ] Mobile composer with chip + photo attachment both staged at the same time.
+- [ ] Gemma fallback: corrupt the OPFS Gemma cache, reload chat, expect Llama-fallback banner.
+
+## Telemetry events
+
+Listen on `document` for `rastrum:onboarding-event` with these `detail.type` values:
+
+- `chat.entity.attached` `{ kind, source: "deep-link"|"picker" }`
+- `chat.tool.called` `{ tool_name, ok }`
+- `chat.tool.failed` `{ tool_name, reason }`
+- `chat.engine.fallback` `{ from, to }`
+
+Wire to your analytics in `BaseLayout.astro` if needed; the chat does not call any analytics service directly.
+
+## Rotating the schema
+
+The new SQL functions live in `docs/specs/infra/supabase-schema.sql` near the bottom. Re-applying with `make db-apply` is safe (idempotent). The schema-security lint (`infra/lint-schema-security.sql`) enforces the SECURITY INVOKER + REVOKE PUBLIC + search_path invariants on every PR.
+
+## SQL regression
+
+`tests/sql/chat.sql` runs in `db-validate.yml` after every PR that touches the schema. Cases include obscure-coords branching, self-profile RLS gate, find_observations owner filter, and dispatcher fallthrough on unknown kinds.
+```
+
+- [ ] **Step 2: Add to index**
+
+In `docs/runbooks/00-index.md`, add a row in the appropriate section pointing to `chat-improvements.md`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/runbooks/chat-improvements.md docs/runbooks/00-index.md
+git commit -m "docs(runbook): chat improvements operator notes"
+```
+
+---
+
+### Task 24: Final pre-PR sweep
+
+- [ ] **Step 1: Full type-check**
+
+Run: `npm run typecheck`
+
+Expected: 0 errors.
+
+- [ ] **Step 2: Full test run**
+
+Run: `npm run test`
+
+Expected: all tests pass; new tests counted (registry 4, observation 4, specs 15, parse-attach 6, chat-tools 8, chat-engine 4, picker 1, ask-rastrum 3 ≈ 45 new tests).
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+
+Expected: 0 errors. Page count should still be ~209 + parity (EN/ES).
+
+- [ ] **Step 4: E2E**
+
+Run: `npm run test:e2e`
+
+Expected: previous suite + 2 new specs pass.
+
+- [ ] **Step 5: Manual smoke (browser)**
+
+Run: `npm run dev`. In the browser:
+
+- Visit `/en/chat/`. Send a plain message. Verify Gemma loads and replies (or falls back to Llama if WebGPU unavailable; banner shows).
+- Visit `/en/chat/?attach=observation:<known-id>`. Verify chip renders, suggested question seeds the placeholder, send works.
+- Open the in-chat picker, switch tabs, pick an observer. Verify chip swaps.
+- Attach a photo + an entity simultaneously. Verify both render.
+- Type "find similar observations nearby". Verify a tool footer appears in the assistant bubble.
+
+- [ ] **Step 6: Commit (any final fixes)**
+
+```bash
+git add -A
+git commit -m "chore(chat): final fixes from pre-PR sweep" --allow-empty
+```
+
+- [ ] **Step 7: Open PR**
+
+```bash
+gh pr create --base main --head $(git branch --show-current) --title "feat(chat): Gemma 4 text + entity context + decomposition" --body "$(cat <<'EOF'
+## Summary
+
+- Adds **Gemma 4 E2B** as a text-chat backbone (Llama-3.2-1B stays as fallback).
+- Adds a **generic chat-entity registry** with 6 kinds: observation, species, project, camera_station, observer, self_profile.
+- Adds a **typed JSON tool layer** with 5 tools backed by Supabase RPCs (`chat_find_*`); 1-round cap per turn.
+- **Decomposes ChatView.astro** from 1,441 LOC to ~400 LOC orchestrator + 4 sibling components.
+
+Spec: \`docs/superpowers/specs/2026-05-09-chat-improvements-design.md\`
+Runbook: \`docs/runbooks/chat-improvements.md\`
+
+## Test plan
+
+- [ ] CI green: typecheck, vitest, db-validate (incl. tests/sql/chat.sql), e2e.
+- [ ] /en/chat/?attach=observation:<id> pre-attaches and cleans URL.
+- [ ] In-chat picker tabs work for all 6 kinds.
+- [ ] Cross-entity follow-up: tool call rendered as collapsed footer.
+- [ ] Offline degrade: chat works for attached entity Q&A; tool calls fail gracefully.
+- [ ] Gemma fallback: Llama banner appears when Gemma weights are unavailable.
+- [ ] Mobile composer with both photo + entity chip staged renders cleanly.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Plan summary
+
+| Phase | Tasks | Outcome |
+|---|---|---|
+| 1 — SQL | 1, 2, 3 | 6 SECURITY INVOKER RPCs + regression suite |
+| 2 — Registry | 4–9 | Generic EntitySpec + 6 specs + parser |
+| 3 — Tools | 10 | chat-tools dispatcher + 5 tools |
+| 4 — Engine | 11, 12, 13 | Gemma loader + chat-engine + ProfileEdit card |
+| 5 — UI | 14, 15, 16, 17, 18 | ChatBubble/Composer/Chip/Picker; ChatView slim |
+| 6 — Deep links | 19, 20 | AskRastrumButton on 5 surfaces |
+| 7 — i18n+E2E | 21, 22, 23, 24 | i18n keys, E2E, runbook, pre-PR sweep |
+
+24 tasks, ~120 commits planned (each step is one commit-ready unit). Bite-sized — typical task = 4–7 steps.

--- a/docs/superpowers/plans/2026-05-09-home-page-redesign.md
+++ b/docs/superpowers/plans/2026-05-09-home-page-redesign.md
@@ -1,0 +1,2076 @@
+# Home Page Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the conflated `/` route into anon-only marketing + a Fogg-aligned `/home` (es: `/inicio`) signed-in dashboard with a kairos-driven dynamic hero. Fix the production 400 from `country_code` being queried on the wrong table.
+
+**Architecture:** Two-PR rollout. PR 1 is a hotfix that strips `<HomeWidgets/>` from `/`. PR 2 builds `/home` (greeting → dynamic hero → 4 chips → recent strip), adds a live-pulse strip + LATAM-recent peek to `/`, wires auto-redirect, and adds 3 server-cached RPCs. All new strings live in `i18n/{en,es}.json` per the EN/ES parity rule.
+
+**Tech Stack:** Astro · TypeScript strict · Tailwind · Supabase (Postgres + RLS) · Vitest (happy-dom) · Playwright. Spec: `docs/superpowers/specs/2026-05-09-home-page-redesign-design.md`.
+
+---
+
+## Pre-flight
+
+- [ ] **Read the design spec end-to-end:** `docs/superpowers/specs/2026-05-09-home-page-redesign-design.md`
+- [ ] **Read CLAUDE.md** sections on EN/ES parity, schema security invariants, tailwind safelist, and chrome conventions.
+- [ ] **Verify schema baseline** — confirm `notifications`, `user_streaks`, `watchlist_alerts` tables exist:
+
+  ```bash
+  grep -nE "CREATE TABLE.*notifications|CREATE TABLE.*user_streaks|CREATE TABLE.*watchlist_alerts" docs/specs/infra/supabase-schema.sql
+  ```
+
+  Expected: each table is found. If `watchlist_alerts` is absent, see Task 6 fallback.
+
+- [ ] **Run baseline tests** to confirm a green starting point:
+
+  ```bash
+  npm run typecheck
+  npm run test
+  ```
+
+  Expected: zero TypeScript errors, 734+ tests pass.
+
+---
+
+## Task 1: PR 1 hotfix — strip `<HomeWidgets/>` from `/`
+
+**Why first:** the production 400 bleeds users on every home-page load. Ships independently.
+
+**Files:**
+- Modify: `src/pages/en/index.astro`
+- Modify: `src/pages/es/index.astro`
+- Test: `tests/unit/home-no-widgets.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/home-no-widgets.test.ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('home page does not import HomeWidgets', () => {
+  for (const lang of ['en', 'es'] as const) {
+    it(`${lang} index.astro has no HomeWidgets import or usage`, () => {
+      const path = join(process.cwd(), `src/pages/${lang}/index.astro`);
+      const src = readFileSync(path, 'utf8');
+      expect(src).not.toMatch(/HomeWidgets/);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run tests/unit/home-no-widgets.test.ts
+```
+
+Expected: FAIL — both `en` and `es` matches `/HomeWidgets/`.
+
+- [ ] **Step 3: Remove the import + usage from both pages**
+
+In `src/pages/en/index.astro`:
+- Delete line: `import HomeWidgets from '../../components/HomeWidgets.astro';`
+- Delete line: `<HomeWidgets lang={lang} />`
+
+In `src/pages/es/index.astro`: same two deletions (the `lang` value is `'es'` but the lines mirror).
+
+- [ ] **Step 4: Run the test to verify it passes + run full suite**
+
+```bash
+npx vitest run tests/unit/home-no-widgets.test.ts
+npm run typecheck
+npm run build
+```
+
+Expected: test passes; zero TS errors; 209 pages build clean.
+
+- [ ] **Step 5: Commit + open PR 1**
+
+```bash
+git add src/pages/en/index.astro src/pages/es/index.astro tests/unit/home-no-widgets.test.ts
+git commit -m "$(cat <<'EOF'
+fix(home): remove HomeWidgets to stop /rest/v1/observations 400
+
+HomeWidgets queries country_code on observations, but that column lives
+on users. PostgREST returns 400 on every / load. Strip the widget; /home
+will rebuild this with a corrected query in a follow-up.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+gh pr create --base main --title "fix(home): strip HomeWidgets to stop production 400" \
+  --body "Fixes the production 400 from \`country_code\` being queried on the wrong table. Follow-up PR rebuilds the dashboard at \`/home\` per docs/superpowers/specs/2026-05-09-home-page-redesign-design.md."
+```
+
+After this, all subsequent tasks belong to PR 2.
+
+---
+
+## Task 2: SQL — `home_pulse_stats` RPC
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql` (append to end of file, in a new section)
+
+- [ ] **Step 1: Add the RPC**
+
+Append to `docs/specs/infra/supabase-schema.sql`:
+
+```sql
+-- =====================================================================
+-- M33: home page redesign — pulse + counts + falta-dex summary
+-- See docs/superpowers/specs/2026-05-09-home-page-redesign-design.md.
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION public.home_pulse_stats()
+RETURNS TABLE(obs_30d int, species_30d int, active_observers_30d int)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT
+    (SELECT count(*)::int FROM observations
+       WHERE sync_status='synced' AND observed_at > now() - interval '30 days'),
+    (SELECT count(DISTINCT primary_taxon_id)::int FROM observations
+       WHERE sync_status='synced' AND observed_at > now() - interval '30 days'
+         AND primary_taxon_id IS NOT NULL),
+    (SELECT count(DISTINCT observer_id)::int FROM observations
+       WHERE sync_status='synced' AND observed_at > now() - interval '30 days');
+$$;
+GRANT EXECUTE ON FUNCTION public.home_pulse_stats() TO anon, authenticated;
+```
+
+- [ ] **Step 2: Apply locally + verify**
+
+```bash
+make db-apply
+make db-psql
+# inside psql:
+SELECT * FROM public.home_pulse_stats();
+\q
+```
+
+Expected: returns one row with three integer columns.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(home): home_pulse_stats() RPC for marketing pulse strip
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+The pre-merge `db-validate.yml` workflow will replay the schema twice and verify idempotency.
+
+---
+
+## Task 3: SQL — `pending_validation_count` RPC
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql` (append to the same section as Task 2)
+
+- [ ] **Step 1: Add the RPC**
+
+Append to the same M33 section:
+
+```sql
+-- Returns the number of pending community IDs in taxa where the caller
+-- holds the 'expert' role. Capped at 99 (UI shows "99+"). Returns 0 for
+-- non-experts.
+CREATE OR REPLACE FUNCTION public.pending_validation_count()
+RETURNS int
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  n   int;
+BEGIN
+  IF uid IS NULL THEN RETURN 0; END IF;
+  IF NOT has_role(uid, 'expert') THEN RETURN 0; END IF;
+
+  SELECT LEAST(count(*), 99)::int INTO n
+  FROM identifications i
+  JOIN observations    o ON o.id = i.observation_id
+  WHERE i.is_research_grade = false
+    AND i.validated_by IS NULL
+    AND o.observer_id <> uid;
+
+  RETURN COALESCE(n, 0);
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.pending_validation_count() TO authenticated;
+```
+
+- [ ] **Step 2: Apply + verify**
+
+```bash
+make db-apply
+make db-psql
+# inside psql, as a non-authenticated session:
+SELECT public.pending_validation_count();
+-- Expected: 0 (uid is null)
+\q
+```
+
+Expected: returns `0` for an anon caller; non-zero for a real signed-in expert.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(home): pending_validation_count() RPC scoped to expert role
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: SQL — `falta_dex_summary` RPC
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql` (append to the same section)
+
+- [ ] **Step 1: Add the RPC**
+
+```sql
+-- Returns a summary of falta-dex gaps for the caller — count of taxa
+-- not yet observed in user's region_primary, plus the region label
+-- itself. Returns (0, NULL) for users without region_primary set.
+CREATE OR REPLACE FUNCTION public.falta_dex_summary()
+RETURNS TABLE(gap_count int, region text)
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  user_region text;
+BEGIN
+  IF uid IS NULL THEN
+    RETURN QUERY SELECT 0::int, NULL::text; RETURN;
+  END IF;
+
+  SELECT region_primary INTO user_region FROM users WHERE id = uid;
+  IF user_region IS NULL THEN
+    RETURN QUERY SELECT 0::int, NULL::text; RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    LEAST(count(DISTINCT t.id), 999)::int AS gap_count,
+    user_region                          AS region
+  FROM taxa t
+  WHERE t.id IN (
+    SELECT DISTINCT primary_taxon_id FROM observations
+    WHERE state_province = user_region AND primary_taxon_id IS NOT NULL
+  )
+  AND t.id NOT IN (
+    SELECT DISTINCT primary_taxon_id FROM observations
+    WHERE observer_id = uid AND primary_taxon_id IS NOT NULL
+  );
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.falta_dex_summary() TO authenticated;
+```
+
+- [ ] **Step 2: Apply + verify**
+
+```bash
+make db-apply
+make db-psql
+# inside psql:
+SELECT * FROM public.falta_dex_summary();
+\q
+```
+
+Expected: one row, `(0, NULL)` for the apply role; real values for a user with `region_primary` set.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(home): falta_dex_summary() RPC for chips counter
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: i18n + routes scaffolding
+
+**Files:**
+- Modify: `src/i18n/utils.ts`
+- Modify: `src/i18n/en.json`
+- Modify: `src/i18n/es.json`
+
+- [ ] **Step 1: Add the route entry**
+
+In `src/i18n/utils.ts`, find the `routes` object (around line 25) and add:
+
+```ts
+home: { en: '/home', es: '/inicio' },
+```
+
+Place it alphabetically with the other route entries.
+
+- [ ] **Step 2: Add EN strings**
+
+In `src/i18n/en.json`, add a top-level `"home_dashboard"` block (the existing `"home"` block is for marketing — keep it):
+
+```json
+"home_dashboard": {
+  "greeting": {
+    "madrugada": "Hello, {name}",
+    "morning": "Good morning, {name}",
+    "afternoon": "Good afternoon, {name}",
+    "evening": "Good evening, {name}",
+    "anonymous_madrugada": "Hello",
+    "anonymous_morning": "Good morning",
+    "anonymous_afternoon": "Good afternoon",
+    "anonymous_evening": "Good evening"
+  },
+  "streak": { "label_one": "day streak", "label_other": "day streak", "aria": "{count} day streak" },
+  "hero": {
+    "streak_at_risk": {
+      "eyebrow": "Keep your streak alive",
+      "title": "Your {streakDays}-day streak ends at midnight",
+      "subtitle": "You haven't logged today. One observation by midnight keeps it.",
+      "cta": "Observe now"
+    },
+    "watchlist_hit": {
+      "eyebrow": "Watchlist match nearby",
+      "title": "{taxonName} seen {km} km away",
+      "subtitle": "Spotted by another observer in the last 24h. Worth a trip?",
+      "cta": "Open on map"
+    },
+    "pending_ids": {
+      "eyebrow": "Your expertise is needed",
+      "title": "{count} community IDs need a second opinion",
+      "subtitle": "You're an expert in {taxonGroup} — your verdict counts.",
+      "cta": "Open queue"
+    },
+    "observe_default": {
+      "eyebrow": "Right now, in your area",
+      "title": "Observe now",
+      "title_morning": "Morning is peak activity",
+      "subtitle": "Tap to log what you see.",
+      "subtitle_morning": "Birds and insects are most active. Tap to log what you see.",
+      "cta": "Open camera"
+    }
+  },
+  "chips": {
+    "inbox": "Inbox",
+    "validate": "Validate",
+    "falta_dex": "Falta-dex",
+    "watchlist": "Watchlist",
+    "count_suffix": "",
+    "count_overflow": "99+"
+  },
+  "recent": {
+    "title_local": "Recent in {country}",
+    "title_global": "Recent observations",
+    "view_all": "View all",
+    "loading": "Loading…",
+    "empty": "No recent observations.",
+    "unknown_species": "Unknown species"
+  }
+}
+```
+
+In the existing `"home"` block (marketing) add a new `"pulse"` and `"recent_latam"` sub-block:
+
+```json
+"pulse": {
+  "label": "{obs} observations · {species} species · {observers} active observers · last 30 days",
+  "label_short": "{obs} observations · {species} species"
+},
+"recent_latam": {
+  "title": "Recent in Latin America",
+  "loading": "Loading…",
+  "anon_observer": "an observer in {country}"
+}
+```
+
+- [ ] **Step 3: Mirror in ES**
+
+In `src/i18n/es.json`, add the same `"home_dashboard"` block with Spanish copy (keys identical to EN):
+
+```json
+"home_dashboard": {
+  "greeting": {
+    "madrugada": "Hola, {name}",
+    "morning": "Buenos días, {name}",
+    "afternoon": "Buenas tardes, {name}",
+    "evening": "Buenas noches, {name}",
+    "anonymous_madrugada": "Hola",
+    "anonymous_morning": "Buenos días",
+    "anonymous_afternoon": "Buenas tardes",
+    "anonymous_evening": "Buenas noches"
+  },
+  "streak": { "label_one": "día de racha", "label_other": "días de racha", "aria": "Racha de {count} días" },
+  "hero": {
+    "streak_at_risk": {
+      "eyebrow": "Mantén tu racha",
+      "title": "Tu racha de {streakDays} días termina a medianoche",
+      "subtitle": "No has registrado hoy. Una observación antes de medianoche la conserva.",
+      "cta": "Observar ahora"
+    },
+    "watchlist_hit": {
+      "eyebrow": "Coincidencia en tu lista cercana",
+      "title": "{taxonName} visto a {km} km",
+      "subtitle": "Avistado por otra persona en las últimas 24h. ¿Vale la pena ir?",
+      "cta": "Ver en el mapa"
+    },
+    "pending_ids": {
+      "eyebrow": "Necesitan tu experiencia",
+      "title": "{count} IDs de la comunidad esperan tu opinión",
+      "subtitle": "Eres experta/o en {taxonGroup} — tu veredicto cuenta.",
+      "cta": "Abrir cola"
+    },
+    "observe_default": {
+      "eyebrow": "Ahora, en tu zona",
+      "title": "Observar ahora",
+      "title_morning": "La mañana es la hora de máxima actividad",
+      "subtitle": "Toca para registrar lo que veas.",
+      "subtitle_morning": "Las aves e insectos están más activos. Toca para registrar.",
+      "cta": "Abrir cámara"
+    }
+  },
+  "chips": {
+    "inbox": "Bandeja",
+    "validate": "Validar",
+    "falta_dex": "Falta-dex",
+    "watchlist": "Lista",
+    "count_suffix": "",
+    "count_overflow": "99+"
+  },
+  "recent": {
+    "title_local": "Recientes en {country}",
+    "title_global": "Observaciones recientes",
+    "view_all": "Ver todo",
+    "loading": "Cargando…",
+    "empty": "Sin observaciones recientes.",
+    "unknown_species": "Especie desconocida"
+  }
+}
+```
+
+And in the existing `"home"` block:
+
+```json
+"pulse": {
+  "label": "{obs} observaciones · {species} especies · {observers} observadores activos · últimos 30 días",
+  "label_short": "{obs} observaciones · {species} especies"
+},
+"recent_latam": {
+  "title": "Recientes en Latinoamérica",
+  "loading": "Cargando…",
+  "anon_observer": "una persona observando en {country}"
+}
+```
+
+- [ ] **Step 4: Run i18n parity test + typecheck**
+
+```bash
+npx vitest run tests/unit/i18n-parity.test.ts
+npm run typecheck
+```
+
+Expected: parity test passes (EN/ES key sets identical); zero TS errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/i18n/utils.ts src/i18n/en.json src/i18n/es.json
+git commit -m "feat(home): add /home + /inicio routes and i18n scaffolding
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Hero state resolver — pure logic, TDD
+
+**Files:**
+- Create: `src/lib/home-hero.ts`
+- Create: `tests/unit/home-hero.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/unit/home-hero.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolveHeroState, type HeroInputs } from '../../src/lib/home-hero';
+
+const baseInputs: HeroInputs = {
+  streak: null,
+  watchlistHit: null,
+  pendingIdsCount: 0,
+  expertTaxonGroup: null,
+  now: new Date('2026-05-09T20:00:00Z'),  // 20:00 UTC
+  userTimezone: 'UTC',
+};
+
+describe('resolveHeroState', () => {
+  it('falls through to observe_default when no signals', () => {
+    expect(resolveHeroState(baseInputs).kind).toBe('observe_default');
+  });
+
+  it('observe_default flags morningPeak between 5–9 local', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      now: new Date('2026-05-09T07:00:00Z'),
+    });
+    expect(r).toEqual({ kind: 'observe_default', morningPeak: true });
+  });
+
+  it('observe_default morningPeak=false outside 5–9', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      now: new Date('2026-05-09T12:00:00Z'),
+    });
+    expect(r).toEqual({ kind: 'observe_default', morningPeak: false });
+  });
+
+  it('streak_at_risk: only after 18:00 local', () => {
+    const before = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 5, lastObsLocalDay: '2026-05-08' },
+      now: new Date('2026-05-09T15:00:00Z'),  // 15:00 UTC = before 18:00
+    });
+    expect(before.kind).toBe('observe_default');
+
+    const after = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 5, lastObsLocalDay: '2026-05-08' },
+      now: new Date('2026-05-09T19:00:00Z'),  // 19:00 UTC
+    });
+    expect(after.kind).toBe('streak_at_risk');
+    if (after.kind === 'streak_at_risk') expect(after.currentDays).toBe(5);
+  });
+
+  it('streak_at_risk: skipped if user observed today', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 5, lastObsLocalDay: '2026-05-09' },
+      now: new Date('2026-05-09T20:00:00Z'),
+    });
+    expect(r.kind).toBe('observe_default');
+  });
+
+  it('streak_at_risk: skipped if currentDays is 0', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 0, lastObsLocalDay: null },
+      now: new Date('2026-05-09T20:00:00Z'),
+    });
+    expect(r.kind).toBe('observe_default');
+  });
+
+  it('watchlist_hit beats observe_default but loses to streak_at_risk', () => {
+    const watchOnly = resolveHeroState({
+      ...baseInputs,
+      watchlistHit: { taxonName: 'Quetzal', distanceKm: 4, obsId: 'abc', observedAt: '2026-05-09T18:00:00Z' },
+    });
+    expect(watchOnly.kind).toBe('watchlist_hit');
+
+    const both = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 12, lastObsLocalDay: '2026-05-08' },
+      watchlistHit: { taxonName: 'Quetzal', distanceKm: 4, obsId: 'abc', observedAt: '2026-05-09T18:00:00Z' },
+      now: new Date('2026-05-09T19:30:00Z'),
+    });
+    expect(both.kind).toBe('streak_at_risk');
+  });
+
+  it('pending_ids: requires count >= 3 AND expertTaxonGroup', () => {
+    const noGroup = resolveHeroState({ ...baseInputs, pendingIdsCount: 7 });
+    expect(noGroup.kind).toBe('observe_default');
+
+    const withGroup = resolveHeroState({
+      ...baseInputs,
+      pendingIdsCount: 7,
+      expertTaxonGroup: 'Aves',
+    });
+    expect(withGroup.kind).toBe('pending_ids');
+    if (withGroup.kind === 'pending_ids') {
+      expect(withGroup.count).toBe(7);
+      expect(withGroup.taxonGroup).toBe('Aves');
+    }
+
+    const tooFew = resolveHeroState({
+      ...baseInputs,
+      pendingIdsCount: 2,
+      expertTaxonGroup: 'Aves',
+    });
+    expect(tooFew.kind).toBe('observe_default');
+  });
+
+  it('cascade ordering: streak > watchlist > pending > default', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 12, lastObsLocalDay: '2026-05-08' },
+      watchlistHit: { taxonName: 'Quetzal', distanceKm: 4, obsId: 'abc', observedAt: '2026-05-09T18:00:00Z' },
+      pendingIdsCount: 7,
+      expertTaxonGroup: 'Aves',
+      now: new Date('2026-05-09T20:00:00Z'),
+    });
+    expect(r.kind).toBe('streak_at_risk');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/unit/home-hero.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../../src/lib/home-hero'`.
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `src/lib/home-hero.ts`:
+
+```ts
+export type HeroState =
+  | { kind: 'streak_at_risk'; currentDays: number; hoursLeftLocal: number }
+  | { kind: 'watchlist_hit'; taxonName: string; distanceKm: number; obsId: string; observedAt: string }
+  | { kind: 'pending_ids'; count: number; taxonGroup: string; queueUrl: string }
+  | { kind: 'observe_default'; morningPeak: boolean };
+
+export interface HeroInputs {
+  streak: { currentDays: number; lastObsLocalDay: string | null } | null;
+  watchlistHit: { taxonName: string; distanceKm: number; obsId: string; observedAt: string } | null;
+  pendingIdsCount: number;
+  expertTaxonGroup: string | null;
+  now: Date;
+  userTimezone: string;
+}
+
+function localParts(d: Date, tz: string): { hour: number; isoDay: string } {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit',
+    });
+    const parts = Object.fromEntries(fmt.formatToParts(d).map(p => [p.type, p.value]));
+    return {
+      hour: Number(parts.hour ?? '0'),
+      isoDay: `${parts.year}-${parts.month}-${parts.day}`,
+    };
+  } catch {
+    return { hour: d.getUTCHours(), isoDay: d.toISOString().slice(0, 10) };
+  }
+}
+
+export function resolveHeroState(inputs: HeroInputs): HeroState {
+  const { hour, isoDay } = localParts(inputs.now, inputs.userTimezone);
+
+  if (
+    inputs.streak &&
+    inputs.streak.currentDays >= 1 &&
+    inputs.streak.lastObsLocalDay !== isoDay &&
+    hour >= 18
+  ) {
+    return {
+      kind: 'streak_at_risk',
+      currentDays: inputs.streak.currentDays,
+      hoursLeftLocal: 24 - hour,
+    };
+  }
+
+  if (inputs.watchlistHit) {
+    return { kind: 'watchlist_hit', ...inputs.watchlistHit };
+  }
+
+  if (inputs.pendingIdsCount >= 3 && inputs.expertTaxonGroup) {
+    return {
+      kind: 'pending_ids',
+      count: inputs.pendingIdsCount,
+      taxonGroup: inputs.expertTaxonGroup,
+      queueUrl: '/en/console/validate/',
+    };
+  }
+
+  return { kind: 'observe_default', morningPeak: hour >= 5 && hour <= 9 };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run tests/unit/home-hero.test.ts
+npm run typecheck
+```
+
+Expected: 9/9 pass; zero TS errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/home-hero.ts tests/unit/home-hero.test.ts
+git commit -m "feat(home): hero state resolver with 4-priority cascade
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Data loaders — TDD
+
+**Files:**
+- Create: `src/lib/home-loaders.ts`
+- Create: `tests/unit/home-loaders.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/unit/home-loaders.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import {
+  loadInboxCount, loadValidateCount, loadFaltaDexCount, loadWatchlistHit,
+  loadStreak, loadRecent, loadHeroInputs,
+} from '../../src/lib/home-loaders';
+
+function makeClient(handlers: Record<string, () => unknown>) {
+  return {
+    from: (table: string) => {
+      const h = handlers[`from:${table}`];
+      if (!h) throw new Error(`unmocked from('${table}')`);
+      return h();
+    },
+    rpc: (name: string) => {
+      const h = handlers[`rpc:${name}`];
+      if (!h) throw new Error(`unmocked rpc('${name}')`);
+      return h();
+    },
+  };
+}
+
+describe('home-loaders', () => {
+  it('loadInboxCount returns count or 0 on error', async () => {
+    const ok = makeClient({
+      'from:notifications': () => ({
+        select: () => ({ eq: () => ({ is: () => Promise.resolve({ count: 3, error: null }) }) }),
+      }),
+    });
+    expect(await loadInboxCount(ok as never, 'u1')).toBe(3);
+
+    const errored = makeClient({
+      'from:notifications': () => ({
+        select: () => ({ eq: () => ({ is: () => Promise.resolve({ count: null, error: { message: 'x' } }) }) }),
+      }),
+    });
+    expect(await loadInboxCount(errored as never, 'u1')).toBe(0);
+  });
+
+  it('loadValidateCount uses the RPC', async () => {
+    const c = makeClient({
+      'rpc:pending_validation_count': () => Promise.resolve({ data: 7, error: null }),
+    });
+    expect(await loadValidateCount(c as never)).toBe(7);
+  });
+
+  it('loadStreak returns null on error', async () => {
+    const c = makeClient({
+      'from:user_streaks': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: { message: 'x' } }) }) }),
+      }),
+    });
+    expect(await loadStreak(c as never, 'u1')).toBeNull();
+  });
+
+  it('loadHeroInputs runs all loaders in parallel and tolerates partial failure', async () => {
+    const c = makeClient({
+      'from:user_streaks': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({
+          data: { current_days: 5, last_qualifying_day: '2026-05-08' }, error: null,
+        }) }) }),
+      }),
+      'from:watchlist_alerts': () => ({
+        select: () => ({ eq: () => ({ is: () => ({ order: () => ({ limit: () => Promise.resolve({
+          data: [], error: null,
+        }) }) }) }) }),
+      }),
+      'rpc:pending_validation_count': () => Promise.resolve({ data: 0, error: null }),
+      'from:users': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({
+          data: { timezone: 'America/Mexico_City', expert_taxon_group: null }, error: null,
+        }) }) }),
+      }),
+    });
+    const inputs = await loadHeroInputs(c as never, 'u1', new Date('2026-05-09T20:00:00Z'));
+    expect(inputs.streak).toEqual({ currentDays: 5, lastObsLocalDay: '2026-05-08' });
+    expect(inputs.pendingIdsCount).toBe(0);
+    expect(inputs.userTimezone).toBe('America/Mexico_City');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/unit/home-loaders.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the loaders**
+
+Create `src/lib/home-loaders.ts`:
+
+```ts
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { HeroInputs } from './home-hero';
+
+type Client = SupabaseClient;
+
+export async function loadInboxCount(c: Client, userId: string): Promise<number> {
+  try {
+    const { count, error } = await c.from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .is('read_at', null);
+    if (error) return 0;
+    return count ?? 0;
+  } catch { return 0; }
+}
+
+export async function loadValidateCount(c: Client): Promise<number> {
+  try {
+    const { data, error } = await c.rpc('pending_validation_count');
+    if (error) return 0;
+    return typeof data === 'number' ? data : 0;
+  } catch { return 0; }
+}
+
+export async function loadFaltaDexCount(c: Client): Promise<{ count: number; region: string | null }> {
+  try {
+    const { data, error } = await c.rpc('falta_dex_summary');
+    if (error || !data || !Array.isArray(data) || data.length === 0) return { count: 0, region: null };
+    const row = data[0] as { gap_count?: number; region?: string | null };
+    return { count: row.gap_count ?? 0, region: row.region ?? null };
+  } catch { return { count: 0, region: null }; }
+}
+
+export interface WatchlistHit {
+  taxonName: string;
+  distanceKm: number;
+  obsId: string;
+  observedAt: string;
+}
+
+export async function loadWatchlistHit(c: Client, userId: string): Promise<WatchlistHit | null> {
+  try {
+    const { data, error } = await c.from('watchlist_alerts')
+      .select('observation_id, taxon_name, distance_km, observed_at')
+      .eq('user_id', userId)
+      .is('acknowledged_at', null)
+      .order('observed_at', { ascending: false })
+      .limit(1);
+    if (error || !data || data.length === 0) return null;
+    const r = data[0] as { observation_id: string; taxon_name: string; distance_km: number | null; observed_at: string };
+    return {
+      taxonName: r.taxon_name,
+      distanceKm: r.distance_km ?? 0,
+      obsId: r.observation_id,
+      observedAt: r.observed_at,
+    };
+  } catch { return null; }
+}
+
+export interface StreakSnap { currentDays: number; lastObsLocalDay: string | null; }
+
+export async function loadStreak(c: Client, userId: string): Promise<StreakSnap | null> {
+  try {
+    const { data, error } = await c.from('user_streaks')
+      .select('current_days, last_qualifying_day')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (error || !data) return null;
+    const row = data as { current_days: number; last_qualifying_day: string | null };
+    return { currentDays: row.current_days, lastObsLocalDay: row.last_qualifying_day };
+  } catch { return null; }
+}
+
+export async function loadHeroInputs(c: Client, userId: string, now: Date): Promise<HeroInputs> {
+  const [streak, watchlistHit, pendingIdsCount, profile] = await Promise.all([
+    loadStreak(c, userId),
+    loadWatchlistHit(c, userId),
+    loadValidateCount(c),
+    (async () => {
+      try {
+        const { data } = await c.from('users')
+          .select('timezone, expert_taxon_group')
+          .eq('id', userId)
+          .maybeSingle();
+        return data as { timezone: string | null; expert_taxon_group: string | null } | null;
+      } catch { return null; }
+    })(),
+  ]);
+  return {
+    streak,
+    watchlistHit,
+    pendingIdsCount,
+    expertTaxonGroup: profile?.expert_taxon_group ?? null,
+    now,
+    userTimezone: profile?.timezone ?? 'UTC',
+  };
+}
+
+export interface RecentObs {
+  id: string; observedAt: string; stateProvince: string | null;
+  scientificName: string | null; commonName: string | null;
+  photoUrl: string | null;
+}
+
+export async function loadRecent(
+  c: Client,
+  lang: 'en' | 'es',
+  country: string | null,
+): Promise<{ rows: RecentObs[]; usedLocalScope: boolean }> {
+  const select = `
+    id, observed_at, state_province,
+    observer:users!observer_id(country_code),
+    identifications(scientific_name, is_primary, is_research_grade, confidence,
+                    taxa(common_name_es, common_name_en)),
+    media_files(url, is_primary, media_type)
+  `;
+  let usedLocalScope = false;
+  let rows: RecentObs[] = [];
+  if (country) {
+    try {
+      const { data } = await c.from('observations').select(select)
+        .eq('sync_status', 'synced')
+        .eq('observer.country_code', country)
+        .order('observed_at', { ascending: false }).limit(3);
+      if (data && data.length === 3) {
+        usedLocalScope = true;
+        rows = (data as unknown as RawObs[]).map(toRecent(lang));
+      }
+    } catch { /* fall through */ }
+  }
+  if (rows.length < 3) {
+    try {
+      const { data } = await c.from('observations').select(select)
+        .eq('sync_status', 'synced')
+        .order('observed_at', { ascending: false }).limit(3);
+      rows = (data as unknown as RawObs[] ?? []).map(toRecent(lang));
+      usedLocalScope = false;
+    } catch { rows = []; }
+  }
+  return { rows, usedLocalScope };
+}
+
+interface RawObs {
+  id: string; observed_at: string; state_province: string | null;
+  identifications: Array<{ scientific_name: string | null; is_primary: boolean | null; confidence: number | null; taxa: { common_name_en: string | null; common_name_es: string | null } | null }> | null;
+  media_files: Array<{ url: string | null; is_primary: boolean | null; media_type: string | null }> | null;
+}
+
+function toRecent(lang: 'en' | 'es') {
+  return (r: RawObs): RecentObs => {
+    const idents = r.identifications ?? [];
+    const primary = idents.find(i => i.is_primary) ?? [...idents].sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))[0];
+    const photoMedia = (r.media_files ?? []).filter(m => !m.media_type || m.media_type === 'photo');
+    const photo = photoMedia.find(m => m.is_primary)?.url ?? photoMedia.find(m => !!m.url)?.url ?? null;
+    return {
+      id: r.id,
+      observedAt: r.observed_at,
+      stateProvince: r.state_province,
+      scientificName: primary?.scientific_name ?? null,
+      commonName: lang === 'es'
+        ? (primary?.taxa?.common_name_es ?? primary?.taxa?.common_name_en ?? null)
+        : (primary?.taxa?.common_name_en ?? primary?.taxa?.common_name_es ?? null),
+      photoUrl: photo,
+    };
+  };
+}
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+npx vitest run tests/unit/home-loaders.test.ts
+npm run typecheck
+```
+
+Expected: 4/4 tests pass; zero TS errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/home-loaders.ts tests/unit/home-loaders.test.ts
+git commit -m "feat(home): data loaders for /home — error-tolerant + parallel
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: HomeGreeting + HomeHero components
+
+**Files:**
+- Create: `src/components/home/HomeGreeting.astro`
+- Create: `src/components/home/HomeHero.astro`
+- Modify: `tailwind.config.mjs` (safelist)
+
+- [ ] **Step 1: Add Tailwind safelist entries**
+
+In `tailwind.config.mjs`, find the `safelist` array and append:
+
+```js
+// Home hero — kind-driven rail/bg classes resolved at runtime.
+'border-red-400', 'bg-red-50/60', 'text-red-700',
+'border-blue-400', 'bg-blue-50/60', 'text-blue-700',
+'border-purple-400', 'bg-purple-50/60', 'text-purple-700',
+'border-emerald-400', 'bg-emerald-50/60', 'text-emerald-700',
+// dark mode equivalents
+'dark:border-red-700/60', 'dark:bg-red-950/40', 'dark:text-red-300',
+'dark:border-blue-700/60', 'dark:bg-blue-950/40', 'dark:text-blue-300',
+'dark:border-purple-700/60', 'dark:bg-purple-950/40', 'dark:text-purple-300',
+'dark:border-emerald-700/60', 'dark:bg-emerald-950/40', 'dark:text-emerald-300',
+```
+
+- [ ] **Step 2: Write `HomeGreeting.astro`**
+
+```astro
+---
+import { t } from '../../i18n/utils';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+---
+
+<section
+  class="hg-root flex items-center justify-between flex-wrap gap-3"
+  data-lang={lang}
+  data-greeting-madrugada={tr.home_dashboard.greeting.madrugada}
+  data-greeting-morning={tr.home_dashboard.greeting.morning}
+  data-greeting-afternoon={tr.home_dashboard.greeting.afternoon}
+  data-greeting-evening={tr.home_dashboard.greeting.evening}
+  data-streak-label={tr.home_dashboard.streak.label_other}
+  data-streak-aria={tr.home_dashboard.streak.aria}
+>
+  <p class="hg-text text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100" role="status" aria-live="polite">…</p>
+  <span class="hg-streak hidden inline-flex items-center gap-1.5 rounded-full border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-950/40 px-3 py-1.5 text-sm font-semibold text-amber-900 dark:text-amber-200" role="status">
+    <span aria-hidden="true">🔥</span>
+    <span class="hg-streak-text tabular-nums">0</span>
+  </span>
+</section>
+
+<script>
+  import { getSupabase } from '../../lib/supabase';
+  import { loadStreak } from '../../lib/home-loaders';
+  import { buildGreeting } from '../../lib/home-greeting';
+
+  type Lang = 'en' | 'es';
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hg-root');
+    if (!root) return;
+    const lang = (root.dataset.lang as Lang) ?? 'en';
+    let c; try { c = getSupabase(); } catch { return; }
+    const { data: { user } } = await c.auth.getUser();
+    if (!user) return;
+
+    const { data: profile } = await c.from('users')
+      .select('display_name, username').eq('id', user.id).maybeSingle();
+    const name = (profile as { display_name: string | null; username: string | null } | null)?.display_name
+              ?? (profile as { username: string | null } | null)?.username ?? null;
+
+    const text = buildGreeting(new Date().getHours(), lang, name);
+    const el = root.querySelector<HTMLElement>('.hg-text');
+    if (el) el.textContent = text;
+
+    const streak = await loadStreak(c, user.id);
+    if (streak && streak.currentDays > 0) {
+      const pill = root.querySelector<HTMLElement>('.hg-streak');
+      const txt = root.querySelector<HTMLElement>('.hg-streak-text');
+      if (pill && txt) {
+        const tpl = root.dataset.streakLabel ?? '';
+        txt.textContent = `${streak.currentDays} ${tpl}`;
+        const aria = (root.dataset.streakAria ?? '').replace('{count}', String(streak.currentDays));
+        pill.setAttribute('aria-label', aria);
+        pill.classList.remove('hidden');
+      }
+    }
+  }
+
+  init().catch(() => {});
+</script>
+```
+
+- [ ] **Step 3: Write `HomeHero.astro`**
+
+```astro
+---
+import { t } from '../../i18n/utils';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+const h = tr.home_dashboard.hero;
+---
+
+<section
+  class="hh-root rounded-2xl border-2 p-5 sm:p-6 mb-4 hidden"
+  data-lang={lang}
+  data-streak-eyebrow={h.streak_at_risk.eyebrow}
+  data-streak-title={h.streak_at_risk.title}
+  data-streak-subtitle={h.streak_at_risk.subtitle}
+  data-streak-cta={h.streak_at_risk.cta}
+  data-watch-eyebrow={h.watchlist_hit.eyebrow}
+  data-watch-title={h.watchlist_hit.title}
+  data-watch-subtitle={h.watchlist_hit.subtitle}
+  data-watch-cta={h.watchlist_hit.cta}
+  data-pending-eyebrow={h.pending_ids.eyebrow}
+  data-pending-title={h.pending_ids.title}
+  data-pending-subtitle={h.pending_ids.subtitle}
+  data-pending-cta={h.pending_ids.cta}
+  data-default-eyebrow={h.observe_default.eyebrow}
+  data-default-title={h.observe_default.title}
+  data-default-title-morning={h.observe_default.title_morning}
+  data-default-subtitle={h.observe_default.subtitle}
+  data-default-subtitle-morning={h.observe_default.subtitle_morning}
+  data-default-cta={h.observe_default.cta}
+>
+  <div class="hh-eyebrow text-xs uppercase tracking-wider font-bold mb-1.5"></div>
+  <div class="hh-title text-xl sm:text-2xl font-bold leading-tight"></div>
+  <div class="hh-subtitle text-sm mt-1.5 opacity-90"></div>
+  <a class="hh-cta inline-block mt-4 px-5 py-2.5 rounded-lg font-semibold transition-colors" href="#"></a>
+</section>
+
+<script>
+  import { getSupabase } from '../../lib/supabase';
+  import { loadHeroInputs } from '../../lib/home-loaders';
+  import { resolveHeroState } from '../../lib/home-hero';
+
+  type Lang = 'en' | 'es';
+
+  const KIND_CLASSES: Record<string, string[]> = {
+    streak_at_risk: ['border-red-400', 'bg-red-50/60', 'text-red-700', 'dark:border-red-700/60', 'dark:bg-red-950/40', 'dark:text-red-300'],
+    watchlist_hit: ['border-blue-400', 'bg-blue-50/60', 'text-blue-700', 'dark:border-blue-700/60', 'dark:bg-blue-950/40', 'dark:text-blue-300'],
+    pending_ids: ['border-purple-400', 'bg-purple-50/60', 'text-purple-700', 'dark:border-purple-700/60', 'dark:bg-purple-950/40', 'dark:text-purple-300'],
+    observe_default: ['border-emerald-400', 'bg-emerald-50/60', 'text-emerald-700', 'dark:border-emerald-700/60', 'dark:bg-emerald-950/40', 'dark:text-emerald-300'],
+  };
+  const CTA_BG: Record<string, string> = {
+    streak_at_risk: 'bg-red-600 hover:bg-red-700 text-white',
+    watchlist_hit: 'bg-blue-600 hover:bg-blue-700 text-white',
+    pending_ids: 'bg-purple-600 hover:bg-purple-700 text-white',
+    observe_default: 'bg-emerald-700 hover:bg-emerald-800 text-white',
+  };
+
+  function fill(s: string, vars: Record<string, string | number>): string {
+    return s.replace(/\{(\w+)\}/g, (_, k) => String(vars[k] ?? ''));
+  }
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hh-root');
+    if (!root) return;
+    const lang = (root.dataset.lang as Lang) ?? 'en';
+    let c; try { c = getSupabase(); } catch { return; }
+    const { data: { user } } = await c.auth.getUser();
+    if (!user) return;
+
+    const inputs = await loadHeroInputs(c as never, user.id, new Date());
+    const state = resolveHeroState(inputs);
+
+    const cls = KIND_CLASSES[state.kind] ?? [];
+    cls.forEach(k => root.classList.add(k));
+
+    const eyebrow = root.querySelector<HTMLElement>('.hh-eyebrow')!;
+    const title = root.querySelector<HTMLElement>('.hh-title')!;
+    const subtitle = root.querySelector<HTMLElement>('.hh-subtitle')!;
+    const cta = root.querySelector<HTMLAnchorElement>('.hh-cta')!;
+    cta.className = `hh-cta inline-block mt-4 px-5 py-2.5 rounded-lg font-semibold transition-colors ${CTA_BG[state.kind]}`;
+
+    const observeUrl = lang === 'es' ? '/es/observar/' : '/en/observe/';
+
+    if (state.kind === 'streak_at_risk') {
+      eyebrow.textContent = root.dataset.streakEyebrow ?? '';
+      title.textContent = fill(root.dataset.streakTitle ?? '', { streakDays: state.currentDays });
+      subtitle.textContent = root.dataset.streakSubtitle ?? '';
+      cta.textContent = root.dataset.streakCta ?? '';
+      cta.href = observeUrl;
+    } else if (state.kind === 'watchlist_hit') {
+      eyebrow.textContent = root.dataset.watchEyebrow ?? '';
+      title.textContent = fill(root.dataset.watchTitle ?? '', { taxonName: state.taxonName, km: Math.round(state.distanceKm) });
+      subtitle.textContent = root.dataset.watchSubtitle ?? '';
+      cta.textContent = root.dataset.watchCta ?? '';
+      cta.href = `/share/obs/?id=${encodeURIComponent(state.obsId)}`;
+    } else if (state.kind === 'pending_ids') {
+      eyebrow.textContent = root.dataset.pendingEyebrow ?? '';
+      title.textContent = fill(root.dataset.pendingTitle ?? '', { count: state.count });
+      subtitle.textContent = fill(root.dataset.pendingSubtitle ?? '', { taxonGroup: state.taxonGroup });
+      cta.textContent = root.dataset.pendingCta ?? '';
+      cta.href = state.queueUrl;
+    } else {
+      eyebrow.textContent = root.dataset.defaultEyebrow ?? '';
+      title.textContent = state.morningPeak ? (root.dataset.defaultTitleMorning ?? '') : (root.dataset.defaultTitle ?? '');
+      subtitle.textContent = state.morningPeak ? (root.dataset.defaultSubtitleMorning ?? '') : (root.dataset.defaultSubtitle ?? '');
+      cta.textContent = root.dataset.defaultCta ?? '';
+      cta.href = observeUrl;
+    }
+
+    root.classList.remove('hidden');
+    window.dispatchEvent(new CustomEvent('rastrum:home-hero-resolved', {
+      detail: { kind: state.kind },
+    }));
+  }
+
+  init().catch(() => {});
+</script>
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+npm run typecheck
+npm run build
+```
+
+Expected: zero errors; build emits 209+ pages.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/home/HomeGreeting.astro src/components/home/HomeHero.astro tailwind.config.mjs
+git commit -m "feat(home): HomeGreeting + HomeHero components
+
+Hero is data-driven by resolveHeroState; rail and CTA classes are kind-
+indexed and safelisted in tailwind.config.mjs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: HomeChips + HomeRecent components
+
+**Files:**
+- Create: `src/components/home/HomeChips.astro`
+- Create: `src/components/home/HomeRecent.astro`
+- Test: `tests/unit/home-recent-fallback.test.ts`
+
+- [ ] **Step 1: Write `HomeChips.astro`**
+
+```astro
+---
+import { t } from '../../i18n/utils';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+const c = tr.home_dashboard.chips;
+const inboxHref = lang === 'es' ? '/es/bandeja/' : '/en/inbox/';
+const validateHref = lang === 'es' ? '/es/consola/validar/' : '/en/console/validate/';
+const faltaDexHref = lang === 'es' ? '/es/perfil/falta-dex/' : '/en/profile/falta-dex/';
+const watchlistHref = lang === 'es' ? '/es/explorar/lista/' : '/en/explore/watchlist/';
+---
+
+<nav class="hc-root grid grid-cols-2 sm:grid-cols-4 gap-2 mb-6" data-lang={lang} aria-label="Home actions">
+  <a class="hc-tile" href={inboxHref} data-key="inbox"><span class="hc-icon" aria-hidden="true">📬</span><span class="hc-label">{c.inbox}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
+  <a class="hc-tile" href={validateHref} data-key="validate"><span class="hc-icon" aria-hidden="true">🔍</span><span class="hc-label">{c.validate}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
+  <a class="hc-tile" href={faltaDexHref} data-key="falta_dex"><span class="hc-icon" aria-hidden="true">📊</span><span class="hc-label">{c.falta_dex}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
+  <a class="hc-tile" href={watchlistHref} data-key="watchlist"><span class="hc-icon" aria-hidden="true">👀</span><span class="hc-label">{c.watchlist}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
+</nav>
+
+<style>
+  .hc-tile { display:flex; align-items:center; gap:.5rem; padding:.6rem .75rem; border:1px solid rgb(228 228 231); border-radius:.75rem; font-size:.875rem; transition:border-color .15s; }
+  .hc-tile:hover { border-color:rgb(110 231 183); }
+  :global(.dark) .hc-tile { border-color:rgb(63 63 70); }
+  .hc-count { margin-left:auto; min-width:1.5em; text-align:right; font-weight:600; opacity:.8; }
+</style>
+
+<script>
+  import { getSupabase } from '../../lib/supabase';
+  import { loadInboxCount, loadValidateCount, loadFaltaDexCount } from '../../lib/home-loaders';
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hc-root');
+    if (!root) return;
+    let c; try { c = getSupabase(); } catch { return; }
+    const { data: { user } } = await c.auth.getUser();
+    if (!user) return;
+
+    const [inbox, validate, falta] = await Promise.all([
+      loadInboxCount(c, user.id),
+      loadValidateCount(c),
+      loadFaltaDexCount(c),
+    ]);
+
+    const setCount = (key: string, n: number) => {
+      const el = root.querySelector<HTMLElement>(`[data-key="${key}"] .hc-count`);
+      if (!el) return;
+      if (n <= 0) { el.textContent = ''; return; }
+      el.textContent = n >= 99 ? '99+' : String(n);
+    };
+    setCount('inbox', inbox);
+    setCount('validate', validate);
+    setCount('falta_dex', falta.count);
+    // watchlist count: read same source as the hero's watchlistHit — for v1, we omit the count
+    // (the hero promotes it when relevant; the chip is just navigation).
+  }
+
+  init().catch(() => {});
+</script>
+```
+
+- [ ] **Step 2: Write fallback test for HomeRecent**
+
+```ts
+// tests/unit/home-recent-fallback.test.ts
+import { describe, it, expect } from 'vitest';
+import { loadRecent } from '../../src/lib/home-loaders';
+
+function chain(result: { data: unknown[]; error: null }) {
+  const builder: Record<string, unknown> = {};
+  const fn = () => builder;
+  builder.eq = fn; builder.order = fn; builder.limit = () => Promise.resolve(result);
+  return builder;
+}
+
+function makeClient(localRows: unknown[], globalRows: unknown[]) {
+  let call = 0;
+  return {
+    from: () => ({
+      select: () => {
+        call += 1;
+        return chain({ data: call === 1 ? localRows : globalRows, error: null });
+      },
+    }),
+  } as never;
+}
+
+describe('loadRecent fallback', () => {
+  it('uses local scope when local returns 3 rows', async () => {
+    const c = makeClient(
+      [{ id: '1', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+       { id: '2', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+       { id: '3', observed_at: 'x', state_province: null, identifications: null, media_files: [] }],
+      [],
+    );
+    const r = await loadRecent(c, 'en', 'MX');
+    expect(r.usedLocalScope).toBe(true);
+    expect(r.rows).toHaveLength(3);
+  });
+
+  it('falls back to global when local returns < 3 rows', async () => {
+    const c = makeClient(
+      [{ id: '1', observed_at: 'x', state_province: null, identifications: null, media_files: [] }],
+      [{ id: 'g1', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+       { id: 'g2', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+       { id: 'g3', observed_at: 'x', state_province: null, identifications: null, media_files: [] }],
+    );
+    const r = await loadRecent(c, 'en', 'MX');
+    expect(r.usedLocalScope).toBe(false);
+    expect(r.rows.map(x => x.id)).toEqual(['g1', 'g2', 'g3']);
+  });
+
+  it('skips local query when country is null', async () => {
+    const c = makeClient(
+      [],
+      [{ id: 'g1', observed_at: 'x', state_province: null, identifications: null, media_files: [] }],
+    );
+    const r = await loadRecent(c, 'en', null);
+    expect(r.usedLocalScope).toBe(false);
+    expect(r.rows.map(x => x.id)).toEqual(['g1']);
+  });
+});
+```
+
+- [ ] **Step 3: Write `HomeRecent.astro`**
+
+```astro
+---
+import { t } from '../../i18n/utils';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+const r = tr.home_dashboard.recent;
+const viewAllHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/recent/';
+---
+
+<section class="hr-root mb-8" data-lang={lang}
+  data-title-local={r.title_local} data-title-global={r.title_global}
+  data-loading={r.loading} data-empty={r.empty} data-unknown-species={r.unknown_species}>
+  <div class="flex items-baseline justify-between gap-3 mb-3">
+    <h2 class="hr-title text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">{r.title_global}</h2>
+    <a href={viewAllHref} class="text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline">{r.view_all}</a>
+  </div>
+  <p class="hr-loading text-sm text-zinc-500 dark:text-zinc-400">{r.loading}</p>
+  <p class="hr-empty hidden text-sm text-zinc-500 dark:text-zinc-400">{r.empty}</p>
+  <ul class="hr-list grid grid-cols-1 sm:grid-cols-3 gap-3"></ul>
+</section>
+
+<script>
+  import { getSupabase } from '../../lib/supabase';
+  import { loadRecent } from '../../lib/home-loaders';
+  import { formatTimeAgo } from '../../lib/social';
+
+  type Lang = 'en' | 'es';
+
+  function escape(s: string): string {
+    const map: Record<string, string> = { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' };
+    return s.replace(/[&<>"']/g, c => map[c]);
+  }
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hr-root');
+    if (!root) return;
+    const lang = (root.dataset.lang as Lang) ?? 'en';
+    const list = root.querySelector<HTMLUListElement>('.hr-list');
+    const loading = root.querySelector<HTMLElement>('.hr-loading');
+    const empty = root.querySelector<HTMLElement>('.hr-empty');
+    if (!list) return;
+
+    let c; try { c = getSupabase(); } catch { loading?.classList.add('hidden'); return; }
+    const { data: { user } } = await c.auth.getUser();
+    let country: string | null = null;
+    if (user) {
+      const { data } = await c.from('users').select('country_code').eq('id', user.id).maybeSingle();
+      country = (data as { country_code: string | null } | null)?.country_code ?? null;
+    }
+
+    const { rows, usedLocalScope } = await loadRecent(c as never, lang, country);
+    loading?.classList.add('hidden');
+    if (rows.length === 0) { empty?.classList.remove('hidden'); return; }
+
+    if (usedLocalScope && country) {
+      const titleEl = root.querySelector<HTMLElement>('.hr-title');
+      if (titleEl) titleEl.textContent = (root.dataset.titleLocal ?? '').replace('{country}', country);
+    }
+
+    const unknown = root.dataset.unknownSpecies ?? 'Unknown species';
+    list.innerHTML = rows.map(r => {
+      const sci = r.scientificName ?? unknown;
+      const common = r.commonName ?? '';
+      const ago = formatTimeAgo(r.observedAt, lang);
+      const photo = r.photoUrl
+        ? `<img src="${escape(r.photoUrl)}" alt="${escape(sci)}" loading="lazy" class="w-full h-full object-cover" />`
+        : '';
+      return `<li><a href="/share/obs/?id=${encodeURIComponent(r.id)}" class="block overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors">
+        <div class="aspect-square w-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">${photo}</div>
+        <div class="p-2.5">
+          <p class="text-xs italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escape(sci)}</p>
+          ${common ? `<p class="text-xs text-zinc-600 dark:text-zinc-300 truncate">${escape(common)}</p>` : ''}
+          <p class="text-[11px] text-zinc-500 dark:text-zinc-400 mt-1">${escape(ago)}</p>
+        </div>
+      </a></li>`;
+    }).join('');
+  }
+
+  init().catch(() => {});
+</script>
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+npx vitest run tests/unit/home-recent-fallback.test.ts
+npm run typecheck
+npm run build
+```
+
+Expected: 3/3 fallback tests pass; zero TS errors; build clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/home/HomeChips.astro src/components/home/HomeRecent.astro tests/unit/home-recent-fallback.test.ts
+git commit -m "feat(home): HomeChips + HomeRecent with local→global fallback
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: HomeView shared body + `/home` and `/inicio` page shells
+
+**Files:**
+- Create: `src/components/HomeView.astro`
+- Create: `src/pages/en/home/index.astro`
+- Create: `src/pages/es/inicio/index.astro`
+
+- [ ] **Step 1: Write the shared body**
+
+```astro
+---
+// src/components/HomeView.astro
+import HomeGreeting from './home/HomeGreeting.astro';
+import HomeHero from './home/HomeHero.astro';
+import HomeChips from './home/HomeChips.astro';
+import HomeRecent from './home/HomeRecent.astro';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+---
+
+<div class="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 space-y-2">
+  <HomeGreeting lang={lang} />
+  <HomeHero lang={lang} />
+  <HomeChips lang={lang} />
+  <HomeRecent lang={lang} />
+</div>
+```
+
+- [ ] **Step 2: Write `/en/home/index.astro`**
+
+```astro
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import HomeView from '../../../components/HomeView.astro';
+import { t } from '../../../i18n/utils';
+const lang = 'en';
+const tr = t(lang);
+---
+<BaseLayout title={`${tr.site.title} — Home`} description={tr.site.description} lang={lang}>
+  <HomeView lang={lang} />
+</BaseLayout>
+```
+
+- [ ] **Step 3: Write `/es/inicio/index.astro`**
+
+```astro
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import HomeView from '../../../components/HomeView.astro';
+import { t } from '../../../i18n/utils';
+const lang = 'es';
+const tr = t(lang);
+---
+<BaseLayout title={`${tr.site.title} — Inicio`} description={tr.site.description} lang={lang}>
+  <HomeView lang={lang} />
+</BaseLayout>
+```
+
+- [ ] **Step 4: Verify build emits both pages**
+
+```bash
+npm run build
+ls dist/en/home/index.html dist/es/inicio/index.html
+```
+
+Expected: both files exist.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/HomeView.astro src/pages/en/home src/pages/es/inicio
+git commit -m "feat(home): /en/home/ and /es/inicio/ page shells
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Auto-redirect from `/` to `/home` for signed-in users
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro`
+- Test: `tests/unit/home-redirect.test.ts`
+
+- [ ] **Step 1: Find the supabase storage key**
+
+```bash
+grep -n "storageKey\|sb-.*-auth-token" src/lib/supabase.ts
+```
+
+Note the project ref (the substring between `sb-` and `-auth-token` in the storage key — used in the inline script below).
+
+- [ ] **Step 2: Write the redirect test**
+
+```ts
+// tests/unit/home-redirect.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+function shouldRedirect(path: string, hasToken: boolean): string | null {
+  const isLocaleRoot = path === '/en/' || path === '/es/' || path === '/en' || path === '/es';
+  if (!isLocaleRoot || !hasToken) return null;
+  return path.startsWith('/es') ? '/es/inicio/' : '/en/home/';
+}
+
+describe('home redirect logic', () => {
+  it('anon stays on /en/', () => expect(shouldRedirect('/en/', false)).toBeNull());
+  it('signed-in /en/ → /en/home/', () => expect(shouldRedirect('/en/', true)).toBe('/en/home/'));
+  it('signed-in /es/ → /es/inicio/', () => expect(shouldRedirect('/es/', true)).toBe('/es/inicio/'));
+  it('non-locale-root unaffected', () => {
+    expect(shouldRedirect('/en/observe/', true)).toBeNull();
+    expect(shouldRedirect('/en/docs/', true)).toBeNull();
+  });
+  it('handles trailing-slash variants', () => {
+    expect(shouldRedirect('/en', true)).toBe('/en/home/');
+    expect(shouldRedirect('/es', true)).toBe('/es/inicio/');
+  });
+});
+```
+
+- [ ] **Step 3: Run the test (it should pass — pure logic with the function inlined)**
+
+```bash
+npx vitest run tests/unit/home-redirect.test.ts
+```
+
+Expected: 5/5 pass.
+
+- [ ] **Step 4: Add the inline first-paint script to `BaseLayout.astro`**
+
+In `BaseLayout.astro`, immediately after the existing theme resolver `<script is:inline>` block in `<head>`, add:
+
+```astro
+<script is:inline>
+  (function () {
+    try {
+      var path = location.pathname;
+      var isRoot = path === '/en/' || path === '/es/' || path === '/en' || path === '/es';
+      if (!isRoot) return;
+      // The supabase-js storage key is sb-<project-ref>-auth-token; pick the
+      // first localStorage key that matches that shape so we don't have to
+      // hardcode the project ref.
+      for (var i = 0; i < localStorage.length; i++) {
+        var k = localStorage.key(i);
+        if (k && /^sb-.+-auth-token$/.test(k)) {
+          var raw = localStorage.getItem(k);
+          if (!raw) continue;
+          var parsed = JSON.parse(raw);
+          if (parsed && parsed.access_token) {
+            location.replace(path.indexOf('/es') === 0 ? '/es/inicio/' : '/en/home/');
+            return;
+          }
+        }
+      }
+    } catch (e) { /* anon — let marketing render */ }
+  })();
+</script>
+```
+
+- [ ] **Step 5: Verify + commit**
+
+```bash
+npm run typecheck
+npm run build
+npx vitest run tests/unit/home-redirect.test.ts
+git add src/layouts/BaseLayout.astro tests/unit/home-redirect.test.ts
+git commit -m "feat(home): auto-redirect signed-in users from / to /home
+
+Inline first-paint script reads the supabase auth token from localStorage
+synchronously and replaces the URL before any pixels paint. Anon users
+fall through to marketing render.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Auth callback post-redirect + Header logo target
+
+**Files:**
+- Modify: `src/pages/auth/callback.astro`
+- Modify: `src/components/Header.astro`
+
+- [ ] **Step 1: Modify the auth callback**
+
+In `src/pages/auth/callback.astro`, find where `redirect_to` is resolved and substitute `/home` when the resolved value is the locale root. Show enough surrounding context that you can locate the spot:
+
+```ts
+// Look for code like:
+const target = redirectTo || `/${lang}/`;
+// Replace with:
+const localeRoot = `/${lang}/`;
+let target = redirectTo || localeRoot;
+if (target === localeRoot || target === `/${lang}`) {
+  target = lang === 'es' ? '/es/inicio/' : '/en/home/';
+}
+```
+
+- [ ] **Step 2: Update Header.astro logo target**
+
+In `src/components/Header.astro`, the logo link likely currently uses `/${lang}/`. Change the rendered href to `/${lang}/` for anon (default render — anon-safe), and add a client-side script that flips it to `/en/home/` or `/es/inicio/` when a session is detected:
+
+Add to the existing client `<script>` block (or create one if absent):
+
+```ts
+import { getSupabase } from '../lib/supabase';
+
+(async () => {
+  try {
+    const c = getSupabase();
+    const { data: { user } } = await c.auth.getUser();
+    if (!user) return;
+    const logo = document.querySelector<HTMLAnchorElement>('a[data-rastrum-logo]');
+    if (!logo) return;
+    const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
+    logo.href = lang === 'es' ? '/es/inicio/' : '/en/home/';
+  } catch { /* anon */ }
+})();
+```
+
+Add `data-rastrum-logo` to the logo anchor element if it doesn't already have it.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+npm run typecheck
+npm run build
+```
+
+Expected: zero errors.
+
+- [ ] **Step 4: Smoke test in dev**
+
+```bash
+make dev &
+sleep 3
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:4321/en/home/
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:4321/es/inicio/
+kill %1
+```
+
+Expected: both return 200.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/auth/callback.astro src/components/Header.astro
+git commit -m "feat(home): callback deposits at /home; logo points to /home for signed-in
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Marketing pulse + LATAM-recent strips
+
+**Files:**
+- Create: `src/components/HomePulse.astro`
+- Create: `src/components/HomeRecentLatam.astro`
+- Create: `tests/unit/home-pulse-honest.test.ts`
+- Modify: `src/pages/en/index.astro`
+- Modify: `src/pages/es/index.astro`
+
+- [ ] **Step 1: Write honest-norms test**
+
+```ts
+// tests/unit/home-pulse-honest.test.ts
+import { describe, it, expect } from 'vitest';
+
+const PULSE_MIN_THRESHOLD = 1000;
+
+function shouldShowPulse(obs30d: number): boolean {
+  return obs30d >= PULSE_MIN_THRESHOLD;
+}
+
+describe('home pulse honest-norms', () => {
+  it('hides when obs_30d < 1000', () => {
+    expect(shouldShowPulse(0)).toBe(false);
+    expect(shouldShowPulse(500)).toBe(false);
+    expect(shouldShowPulse(999)).toBe(false);
+  });
+  it('shows when obs_30d >= 1000', () => {
+    expect(shouldShowPulse(1000)).toBe(true);
+    expect(shouldShowPulse(50000)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test (passes — pure logic)**
+
+```bash
+npx vitest run tests/unit/home-pulse-honest.test.ts
+```
+
+Expected: 2/2 pass.
+
+- [ ] **Step 3: Write `HomePulse.astro`**
+
+```astro
+---
+import { t } from '../i18n/utils';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+---
+
+<section class="hp-root hidden mt-6 mb-2" data-lang={lang} data-template={tr.home.pulse.label}>
+  <div class="hp-text rounded-lg border border-emerald-500/40 bg-emerald-50 dark:bg-emerald-950/30 px-4 py-3 text-center text-sm text-zinc-700 dark:text-zinc-200" role="status"></div>
+</section>
+
+<script>
+  import { getSupabase } from '../lib/supabase';
+
+  const PULSE_MIN_THRESHOLD = 1000;
+
+  function fmt(n: number, lang: string): string {
+    return new Intl.NumberFormat(lang).format(n);
+  }
+  function fill(s: string, vars: Record<string, string>): string {
+    return s.replace(/\{(\w+)\}/g, (_, k) => vars[k] ?? '');
+  }
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hp-root');
+    if (!root) return;
+    const lang = root.dataset.lang ?? 'en';
+    let c; try { c = getSupabase(); } catch { return; }
+    const { data, error } = await c.rpc('home_pulse_stats');
+    if (error || !data || !Array.isArray(data) || data.length === 0) return;
+    const row = data[0] as { obs_30d: number; species_30d: number; active_observers_30d: number };
+    if (row.obs_30d < PULSE_MIN_THRESHOLD) return;
+
+    const text = fill(root.dataset.template ?? '', {
+      obs: fmt(row.obs_30d, lang),
+      species: fmt(row.species_30d, lang),
+      observers: fmt(row.active_observers_30d, lang),
+    });
+    const el = root.querySelector<HTMLElement>('.hp-text');
+    if (el) el.textContent = text;
+    root.classList.remove('hidden');
+  }
+
+  init().catch(() => {});
+</script>
+```
+
+- [ ] **Step 4: Write `HomeRecentLatam.astro`**
+
+```astro
+---
+import { t } from '../i18n/utils';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+---
+
+<section class="hrl-root hidden mb-8" data-lang={lang} data-title={tr.home.recent_latam.title} data-anon={tr.home.recent_latam.anon_observer}>
+  <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300 mb-3">{tr.home.recent_latam.title}</h2>
+  <ul class="hrl-list grid grid-cols-1 sm:grid-cols-3 gap-3"></ul>
+</section>
+
+<script>
+  import { getSupabase } from '../lib/supabase';
+  import { formatTimeAgo } from '../lib/social';
+
+  const LATAM = ['MX','CO','BR','AR','CL','PE','EC','CR','PA','GT','BO','VE','UY','PY','HN','SV','NI','DO','CU'];
+
+  function escape(s: string): string {
+    const map: Record<string, string> = { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' };
+    return s.replace(/[&<>"']/g, c => map[c]);
+  }
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hrl-root');
+    if (!root) return;
+    const lang = (root.dataset.lang as 'en' | 'es') ?? 'en';
+    let c; try { c = getSupabase(); } catch { return; }
+    const select = `id, observed_at,
+      observer:users!observer_id(country_code),
+      identifications(scientific_name, is_primary, taxa(common_name_es, common_name_en)),
+      media_files(url, is_primary, media_type)`;
+    const { data, error } = await c.from('observations').select(select)
+      .eq('sync_status', 'synced').neq('obscure_level', 'full')
+      .in('observer.country_code', LATAM)
+      .order('observed_at', { ascending: false }).limit(3);
+    if (error || !data || data.length === 0) return;
+
+    const list = root.querySelector<HTMLUListElement>('.hrl-list');
+    if (!list) return;
+    const anonTpl = root.dataset.anon ?? '';
+    list.innerHTML = (data as unknown as Array<{
+      id: string; observed_at: string;
+      observer: { country_code: string | null } | null;
+      identifications: Array<{ scientific_name: string | null; is_primary: boolean | null; taxa: { common_name_en: string | null; common_name_es: string | null } | null }> | null;
+      media_files: Array<{ url: string | null; is_primary: boolean | null; media_type: string | null }> | null;
+    }>).map(r => {
+      const idents = r.identifications ?? [];
+      const primary = idents.find(i => i.is_primary) ?? idents[0];
+      const sci = primary?.scientific_name ?? '';
+      const common = lang === 'es' ? (primary?.taxa?.common_name_es ?? '') : (primary?.taxa?.common_name_en ?? '');
+      const photoMedia = (r.media_files ?? []).filter(m => !m.media_type || m.media_type === 'photo');
+      const photo = photoMedia.find(m => m.is_primary)?.url ?? photoMedia.find(m => !!m.url)?.url ?? '';
+      const country = r.observer?.country_code ?? '';
+      const credit = anonTpl.replace('{country}', country);
+      return `<li><div class="block overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50">
+        <div class="aspect-square w-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">${photo ? `<img src="${escape(photo)}" alt="${escape(sci)}" loading="lazy" class="w-full h-full object-cover" />` : ''}</div>
+        <div class="p-2.5">
+          ${sci ? `<p class="text-xs italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escape(sci)}</p>` : ''}
+          ${common ? `<p class="text-xs text-zinc-600 dark:text-zinc-300 truncate">${escape(common)}</p>` : ''}
+          <p class="text-[11px] text-zinc-500 dark:text-zinc-400 mt-1">${escape(credit)} · ${escape(formatTimeAgo(r.observed_at, lang))}</p>
+        </div>
+      </div></li>`;
+    }).join('');
+    root.classList.remove('hidden');
+  }
+
+  init().catch(() => {});
+</script>
+```
+
+- [ ] **Step 5: Wire into `/` pages**
+
+In `src/pages/en/index.astro`, immediately after the closing `</section>` of the Hero block, insert:
+
+```astro
+import HomePulse from '../../components/HomePulse.astro';
+import HomeRecentLatam from '../../components/HomeRecentLatam.astro';
+```
+
+(in the frontmatter), and in the body after the hero `</section>`:
+
+```astro
+<HomePulse lang={lang} />
+<HomeRecentLatam lang={lang} />
+```
+
+Mirror in `src/pages/es/index.astro`.
+
+- [ ] **Step 6: Verify + commit**
+
+```bash
+npm run typecheck
+npm run build
+git add src/components/HomePulse.astro src/components/HomeRecentLatam.astro tests/unit/home-pulse-honest.test.ts src/pages/en/index.astro src/pages/es/index.astro
+git commit -m "feat(home): marketing pulse + LATAM-recent strips on /
+
+Pulse hides below honest-norms threshold (obs_30d < 1000); LATAM-recent
+strip is anonymized and respects obs_public_read.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: E2E test for the redesigned home
+
+**Files:**
+- Create: `tests/e2e/home.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+// tests/e2e/home.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('home page redesign', () => {
+  test('anon visitor sees marketing on /en/', async ({ page }) => {
+    const failed: string[] = [];
+    page.on('response', r => { if (r.status() >= 400) failed.push(`${r.status()} ${r.url()}`); });
+
+    await page.goto('/en/');
+    await expect(page.locator('h1')).toBeVisible();
+
+    // Specifically assert no observations 400 — the regression we're fixing.
+    const obs400 = failed.filter(s => s.includes('/rest/v1/observations') && s.startsWith('4'));
+    expect(obs400, obs400.join('\n')).toEqual([]);
+  });
+
+  test('/en/home/ renders without auth (will be empty but not error)', async ({ page }) => {
+    await page.goto('/en/home/');
+    // Page renders even for anon; greeting and hero stay hidden until auth resolves.
+    await expect(page.locator('.hg-root, .hh-root, .hc-root, .hr-root').first()).toBeAttached();
+  });
+
+  test('/es/inicio/ exists and is reachable', async ({ page }) => {
+    const res = await page.goto('/es/inicio/');
+    expect(res?.status()).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run E2E**
+
+```bash
+npm run build
+npm run test:e2e -- tests/e2e/home.spec.ts
+```
+
+Expected: 3/3 pass on chromium.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/home.spec.ts
+git commit -m "test(home): e2e — anon /, /en/home/, /es/inicio/ smoke
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Final pre-PR sweep
+
+- [ ] **Step 1: Run the full pre-PR checklist**
+
+```bash
+npm run typecheck
+npm run test
+npm run build
+git status -s
+```
+
+Expected: zero TS errors; all tests pass (current 734 + new ones); 211 pages built (209 + `/en/home/`, `/es/inicio/`); only the staged commits remain.
+
+- [ ] **Step 2: Smoke check the visual companion's locked-decisions screen one last time**
+
+Open `http://localhost:60440` (or the visual companion URL from this brainstorm) — confirm the spec matches the locked decisions screen. If the server has been stopped, skip.
+
+- [ ] **Step 3: Verify the bug is gone**
+
+Manually: build, serve dist, hit `/en/` in a fresh tab — DevTools network panel should show **no** `/rest/v1/observations?...country_code` request. Sign in (real Supabase session) — expect redirect to `/en/home/` and the dashboard to render.
+
+- [ ] **Step 4: Open PR 2**
+
+```bash
+gh pr create --base main --title "feat(home): /home dashboard + marketing pulse + Fogg-aligned dynamic hero" \
+  --body "$(cat <<'EOF'
+## Summary
+- Splits / (anon marketing) and /home (signed-in dashboard, es: /inicio).
+- /home: greeting + 🔥 streak → dynamic hero (4-priority cascade) → 4 chips → recent strip.
+- /: keeps Hero/How/Why; adds live pulse + LATAM-recent (gated by honest-norms threshold).
+- Auto-redirect on /; auth callback deposits at /home; logo points to /home for signed-in users.
+- 3 new RPCs (home_pulse_stats, pending_validation_count, falta_dex_summary).
+- Fogg-aligned: single target behavior per visit, kairos triggers, tailoring; honest copy (no FOMO).
+
+Spec: docs/superpowers/specs/2026-05-09-home-page-redesign-design.md
+
+## Test plan
+- [x] npm run typecheck passes
+- [x] npm run test passes (734+ unit tests)
+- [x] npm run build succeeds (211 pages)
+- [x] tests/unit/home-{hero,loaders,recent-fallback,pulse-honest,redirect,no-widgets}.test.ts pass
+- [x] tests/e2e/home.spec.ts passes on chromium
+- [ ] Manual: /en/ as anon shows pulse + LATAM-recent above the fold
+- [ ] Manual: /en/ as signed-in redirects to /en/home/
+- [ ] Manual: hero kind matches user state (default for new accounts)
+- [ ] Manual: chips show real counts; clicking each navigates correctly
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (run before declaring the plan finished)
+
+**Spec coverage** — every section in the spec has at least one task:
+
+| Spec § | Covered by |
+|---|---|
+| 1 Locked decisions | preamble |
+| 2 Routes & i18n | Tasks 5, 10, 11, 12 |
+| 3 /home components & data | Tasks 6, 7, 8, 9, 10 |
+| 4 Dynamic hero cascade | Tasks 6, 8 |
+| 5 / marketing changes | Tasks 1 (strip), 13 (add) |
+| 6 Migration plan | Tasks 1 (PR 1), 2–14 (PR 2) |
+| 7 Testing | Tasks 6, 7, 9, 11, 13, 14 |
+| 8 i18n | Task 5 |
+| 9 Out of scope | not implemented (correct) |
+| 10 Known risks | covered in Tasks 9 (fallback), 11 (race), 13 (threshold) |
+
+**Placeholder scan** — all step bodies show real code or exact commands; no "TBD" or "implement later".
+
+**Type consistency** — `HeroState`, `HeroInputs`, `RecentObs`, `WatchlistHit`, `StreakSnap` are all defined once (Tasks 6 & 7) and consumed identically downstream. The supabase storage key probe in Task 11 is regex-based to avoid hardcoding a project ref that could drift.
+
+---
+
+*Plan complete. Spec: `docs/superpowers/specs/2026-05-09-home-page-redesign-design.md`. Implementation handoff: see "Execution Handoff" section below the plan when reading in conversation context.*

--- a/docs/superpowers/specs/2026-05-09-chat-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-09-chat-improvements-design.md
@@ -17,7 +17,7 @@ Three gaps the user has surfaced:
 The brainstorm settled five upstream questions:
 
 - **Entry points** — both deep-link from entity surfaces AND in-chat picker.
-- **Entity scope** — observations, species, projects, camera stations, observers, locations, self-profile (one `EntitySpec` interface, six built-ins, generic registry).
+- **Entity scope** — observations, species, projects, camera stations, observers, self-profile (one `EntitySpec` interface, six built-ins, generic registry). `location` is deferred to v1.1 because the `public.locations` table from the 2026-05-03 locations-first-class spec is not yet implemented.
 - **Behaviors** — Q&A, cross-entity follow-ups, drafting, Rastrum-guru help. **Read-only.**
 - **Writes deferred** — guided actions ("apply this fix") become a separate v1.1 spec. Privileged writes need their own action contract, confirmation flow, RLS verification, and audit log.
 - **Architecture** — entity card on attach + typed JSON tool calls for follow-ups (not eager system-prompt stuffing, not local RAG).
@@ -94,7 +94,7 @@ Writes are explicitly out of scope. Multi-round tool calling is explicitly out o
 
 - **`src/lib/chat-entities/types.ts`** — `EntityKind`, `EntityCard`, `EntitySpec` interfaces.
 - **`src/lib/chat-entities/registry.ts`** — singleton registry with collision detection (mirrors `identifiers/registry.ts`).
-- **`src/lib/chat-entities/{observation,species,project,camera-station,observer,location,self-profile}.ts`** — one file per built-in. Each exports an `EntitySpec` that knows how to fetch its card and which tools are most useful for its kind.
+- **`src/lib/chat-entities/{observation,species,project,camera-station,observer,self-profile}.ts`** — one file per built-in. Each exports an `EntitySpec` that knows how to fetch its card and which tools are most useful for its kind.
 - **`src/lib/chat-entities/index.ts`** — `bootstrapChatEntities()` — single call from ChatView mount.
 - **`src/lib/chat-tools.ts`** — tool registry + dispatcher. `runTool({name, args})` returns `{ok, data} | {error}`. Each tool has a hand-rolled `validateArgs(args)` and a `run(args)`. Five tools at v1: `find_observations`, `find_species`, `find_projects`, `find_camera_stations`, `find_observers`. (Karma and self-profile data ride inside the `self_profile` entity card; no separate tool needed.)
 - **`src/lib/chat-engine.ts`** — model dispatch. `getActiveEngine(): 'gemma'|'llama'`, `streamChat(messages, tools)`. Wraps `loadGemmaTextEngine()` + `loadTextEngine()`. Owns the tool-call loop (parse JSON, dispatch tool, append result, re-prompt — 1 round cap).
@@ -185,7 +185,7 @@ Stable contract — every entity kind serializes to the same shape:
 ```ts
 interface EntityCard {
   kind: 'observation' | 'species' | 'project' | 'camera_station'
-       | 'observer' | 'location' | 'self_profile';
+       | 'observer' | 'self_profile';
   id: string;                  // uuid for db rows; slug for species/projects
   label: string;               // 1-line display ("Setophaga magnolia · May 8 · CDMX")
   thumbnail?: string;          // optional 64×64 R2 URL
@@ -225,7 +225,7 @@ interface EntityCard {
 
 ## Privacy invariants (load-bearing)
 
-1. **Observation cards respect `obscure_level`.** `chat_obs_card` reads from `obs_public_read` (which already enforces this), not raw `observations`. For sensitive species, precise coords are returned only when the requester is the observer; everyone else receives the obscured centroid. Implemented as `CASE WHEN auth.uid() = observer_user_id THEN <precise> ELSE <obscured> END` in the RPC.
+1. **Observation cards respect `obscure_level`.** `chat_obs_card` queries `public.observations` (the existing `obs_public_read` RLS policy already gates row-level visibility). The function returns `location` only when the requester is the observer; everyone else receives `location_obscured`. Implemented as `CASE WHEN auth.uid() = observer_user_id THEN location ELSE location_obscured END` in the RPC.
 2. **Observer cards are public-fields only.** `chat_observer_card` joins `community_observers` (the public view) — no email, no centroid, no private profile fields. Self-profile is a separate `kind = self_profile` that pulls private fields gated by `auth.uid() = id`.
 3. **Tool args are validated, not interpolated.** Chat tools never construct SQL — they pass typed args to RPCs. Prevents prompt-injection-as-SQL-injection from a hostile entity card.
 4. **Chat content stays on-device.** Already true. Adding entity attachments doesn't change that — the entity *card* travels through Supabase, but the conversation transcript still lives only in Dexie.
@@ -278,9 +278,9 @@ Piggybacks the existing onboarding-event bus pattern — no new analytics dep:
 - `tests/unit/chat-composer.test.ts` — chip render/remove; suggested-question seeding; "📋" button toggles picker; existing photo/audio paths still work.
 - `tests/unit/ask-rastrum-button.test.ts` — builds correct deep-link URL per locale + entity kind.
 
-### SQL pgTAP (`infra/sql-tests/chat.sql`)
+### SQL regression (`tests/sql/chat.sql`)
 
-Wired into the existing `db-validate.yml` Postgres-17 service container.
+Plain SQL `DO $$ … $$` assertion blocks (mirrors the existing `tests/sql/rls.sql` and `tests/sql/social-rls.sql`). Wired into `db-validate.yml`'s Postgres-17 service container.
 
 - `chat_entity_card('observation', X)` returns coarsened coords for non-owner of an obscured species.
 - `chat_entity_card('self_profile', uid)` rejects when `auth.uid() != uid`.
@@ -318,6 +318,7 @@ Tool-call flows are NOT in E2E — they need a deterministic model output and wo
 - **Guided actions / writes.** Chat surfacing "Apply this fix" buttons that perform privileged writes. Needs its own typed action contract, confirmation step, RLS verification, audit log, undo semantics.
 - **Multi-round tool calling.** Model emits tool call → result → *another* tool call in the same user turn. The 1-round cap is a deliberate v1 floor.
 - **Local RAG over Dexie.** Embedding model + vector index for fully-offline entity Q&A. YAGNI for v1; the on-device card already covers offline Q&A about the *attached* entity.
+- **`location` entity kind.** Deferred until the locations-first-class spec (`docs/superpowers/specs/2026-05-03-locations-first-class-design.md`) lands the `public.locations` table.
 - **Chat history sync.** Conversations remain device-local — no cross-device sync, no Supabase persistence.
 - **Voice output.** Speech recognition (input) is already wired; speech synthesis (output) is not in scope.
 

--- a/docs/superpowers/specs/2026-05-09-chat-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-09-chat-improvements-design.md
@@ -1,0 +1,335 @@
+# Chat improvements — design
+
+> Date: 2026-05-09
+> Scope: `/{en,es}/chat/` — entity-context Q&A, Gemma 4 text backbone, ChatView decomposition
+> Status: design approved; ready for implementation plan
+
+## Context
+
+The chat surface today (`src/components/ChatView.astro`, 1,441 LOC) is an on-device biodiversity assistant. It runs Llama-3.2-1B for text generation and Phi-3.5-vision / Gemma 4 E2B / EfficientNet / PlantNet / Claude Haiku for photo identification. Conversation history lives only in this device's IndexedDB (`chatTurns` Dexie store).
+
+Three gaps the user has surfaced:
+
+1. **Gemma 4 is wired as an identifier plugin but not as a text-chat backbone.** Gemma 4 E2B is a multimodal VLM and a stronger reasoner than the 1B-param Llama. The chat picker already exposes Gemma for vision; text chat still goes through Llama exclusively.
+2. **There is no path to "chat about" an existing entity.** The chat can produce a "Save as observation" CTA after a photo cascade, but it cannot *receive* an existing observation, species, project, camera station, observer, location, or self-profile as conversational context.
+3. **`ChatView.astro` is the largest single component in the repo.** Composer, picker, bubble rendering, cascade interpretation, audio recorder, voice input, and i18n bag all live in one file. Adding entity context on top would push it past 2,000 LOC.
+
+The brainstorm settled five upstream questions:
+
+- **Entry points** — both deep-link from entity surfaces AND in-chat picker.
+- **Entity scope** — observations, species, projects, camera stations, observers, locations, self-profile (one `EntitySpec` interface, six built-ins, generic registry).
+- **Behaviors** — Q&A, cross-entity follow-ups, drafting, Rastrum-guru help. **Read-only.**
+- **Writes deferred** — guided actions ("apply this fix") become a separate v1.1 spec. Privileged writes need their own action contract, confirmation flow, RLS verification, and audit log.
+- **Architecture** — entity card on attach + typed JSON tool calls for follow-ups (not eager system-prompt stuffing, not local RAG).
+
+## Decision
+
+Ship a single coordinated change that does four things together because none of them stand alone usefully:
+
+1. Add **Gemma 4 E2B as a text-chat backbone** (Llama stays as fallback).
+2. Add a **generic `EntitySpec` registry** with six built-in kinds and a stable `EntityCard` contract.
+3. Add a **typed JSON tool layer** (`chat-tools.ts`) with six tools backed by Supabase RPCs.
+4. **Decompose `ChatView.astro`** into orchestrator + four sibling components.
+
+Writes are explicitly out of scope. Multi-round tool calling is explicitly out of scope (1-round cap in v1).
+
+## Architecture
+
+```
+                          ┌─────────────────────────────────────────────┐
+   User entity surfaces ──▶  Deep-link "Ask Rastrum" buttons             │
+   (obs, species, etc.)   │  Pre-attach an entity ref in chat URL/state  │
+                          └─────────────────────────────────────────────┘
+                                       │
+                                       ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  ChatView.astro (slimmed) + new ChatComposer.astro              │
+   │  + ChatEntityPicker.astro + ChatEntityChip.astro                │
+   └─────────────────────────────────────────────────────────────────┘
+                  │                         │
+                  ▼                         ▼
+   ┌─────────────────────────┐   ┌─────────────────────────────────┐
+   │ src/lib/chat-engine.ts  │   │ src/lib/chat-entities/          │
+   │ (model dispatch:        │   │   registry.ts  (entity types)   │
+   │  Gemma text default,    │   │   types.ts     (EntitySpec)     │
+   │  Llama fallback)        │   │   *.ts         (per-entity)     │
+   └─────────────────────────┘   └─────────────────────────────────┘
+                  │                         │
+                  ▼                         ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  src/lib/chat-tools.ts  — typed JSON tool dispatcher            │
+   │  Tools: find_observations, find_species, find_projects,         │
+   │         find_camera_stations, find_observers                    │
+   └─────────────────────────────────────────────────────────────────┘
+                  │
+                  ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  Supabase RPCs (existing views + thin SECURITY INVOKER funcs)   │
+   │    chat_entity_card(kind, id) → JSONB                           │
+   │    chat_find_observations(filters) → SETOF compact rows         │
+   │    chat_find_species(query) → SETOF compact rows                │
+   │    …                                                             │
+   └─────────────────────────────────────────────────────────────────┘
+```
+
+### Five load-bearing decisions
+
+1. **One `EntitySpec` interface; six built-ins.** Mirrors the existing `Identifier` plugin pattern at `src/lib/identifiers/`. Each entity type registers `{ kind, label, fetchCard, suggestedTools }`. Adding a 7th type = one file + `register()` call.
+2. **Tools are typed JSON, not free-text.** Model returns `{"tool":"find_observations","args":{…}}`. Runtime validates against a hand-rolled validator (no new Zod dependency — Rastrum doesn't use Zod elsewhere). Bad calls return `{error}` to the model so it can self-correct.
+3. **Gemma 4 text becomes the default chat backbone.** New `loadGemmaTextEngine()` in `local-ai.ts` reuses the transformers.js path the vision plugin already uses. Llama stays as fallback for low-RAM devices and as the streaming engine for the cascade-interpretation path (which already works there and is tightly coupled to Llama's prompt shape).
+4. **Chat-tools run client-side over Supabase, not as Edge Functions.** Each tool is a thin `supabase.rpc(...)` call. RLS is the security boundary — chat queries as the signed-in user. No new Edge-Function surface to deploy.
+5. **`ChatView.astro` decomposes into orchestrator + 4 siblings.** 1,441 LOC → ~400 LOC orchestrator + `ChatComposer` + `ChatEntityPicker` + `ChatEntityChip` + `ChatBubble`. Each independently testable.
+
+## Components
+
+### New components (Astro)
+
+- **`src/components/ChatComposer.astro`** (~250 LOC). Owns icons + textarea + send + attachment chip + model picker. Dispatches `chat:attach-photo`, `chat:attach-audio`, `chat:attach-entity`, `chat:submit`. One reason to change.
+- **`src/components/ChatEntityPicker.astro`** (~180 LOC). Popover triggered from composer's "📋 Attach context" button. Tabs: Observations / Species / Projects / Stations / Observers / Locations. Each tab queries one Supabase RPC for the user's recent rows. Search input filters within the active tab. Selecting a row dispatches `chat:attach-entity` and closes.
+- **`src/components/ChatEntityChip.astro`** (~80 LOC). Compact representation of an attached entity inside the composer and inside historical bubbles. Shows kind icon + label + remove "×". Click opens the entity's canonical page in a new tab.
+- **`src/components/ChatBubble.astro`** (~150 LOC). Bubble rendering + cascade footer + compare footer + bubble actions. Pure render, no fetches.
+- **`src/components/AskRastrumButton.astro`** (~30 LOC). Deep-link button. Drops into `ShareObsView`, `MyObsItem`, `SpeciesProfileView`, `ProjectDetailView`, `CameraStationItem`, `PublicProfileView`, `LocationDetailView`. Builds `/{lang}/chat/?attach={kind}:{id}`.
+
+### New libs (TypeScript)
+
+- **`src/lib/chat-entities/types.ts`** — `EntityKind`, `EntityCard`, `EntitySpec` interfaces.
+- **`src/lib/chat-entities/registry.ts`** — singleton registry with collision detection (mirrors `identifiers/registry.ts`).
+- **`src/lib/chat-entities/{observation,species,project,camera-station,observer,location,self-profile}.ts`** — one file per built-in. Each exports an `EntitySpec` that knows how to fetch its card and which tools are most useful for its kind.
+- **`src/lib/chat-entities/index.ts`** — `bootstrapChatEntities()` — single call from ChatView mount.
+- **`src/lib/chat-tools.ts`** — tool registry + dispatcher. `runTool({name, args})` returns `{ok, data} | {error}`. Each tool has a hand-rolled `validateArgs(args)` and a `run(args)`. Five tools at v1: `find_observations`, `find_species`, `find_projects`, `find_camera_stations`, `find_observers`. (Karma and self-profile data ride inside the `self_profile` entity card; no separate tool needed.)
+- **`src/lib/chat-engine.ts`** — model dispatch. `getActiveEngine(): 'gemma'|'llama'`, `streamChat(messages, tools)`. Wraps `loadGemmaTextEngine()` + `loadTextEngine()`. Owns the tool-call loop (parse JSON, dispatch tool, append result, re-prompt — 1 round cap).
+- **`src/lib/local-ai.ts`** — extended with `loadGemmaTextEngine(onProgress)`. Reuses transformers.js path from the existing vision plugin.
+
+### Schema additions
+
+In `infra/supabase-schema.sql`, six SECURITY INVOKER functions:
+
+- `chat_entity_card(p_kind text, p_id text) → jsonb` — dispatcher to per-kind card builders based on `p_kind`.
+- `chat_find_observations(p_filters jsonb, p_limit int) → setof jsonb`
+- `chat_find_species(p_query text, p_limit int) → setof jsonb`
+- `chat_find_projects(p_query text, p_limit int) → setof jsonb`
+- `chat_find_camera_stations(p_project_id uuid, p_limit int) → setof jsonb`
+- `chat_find_observers(p_query text, p_limit int) → setof jsonb`
+
+All grant EXECUTE to `authenticated`. Anon gets nothing — chat-with-context is signed-in only. Each function pins `search_path = public, extensions, pg_temp` per the schema-security invariant the lint guard already enforces.
+
+### Modified components
+
+- **`src/components/ChatView.astro`** — slims from 1,441 → ~400 LOC. Becomes pure orchestrator: mounts new components, holds `conversation: ChatTurn[]`, wires events, persists to Dexie. Cascade-interpretation streaming + audio/photo paths move into `ChatBubble` and `chat-engine` respectively.
+- **`src/components/ProfileEditForm.astro`** — adds a "Gemma 4 (text chat)" download card mirroring the existing Phi/Llama cards. Reuses the model-cache UI pattern.
+- **`src/i18n/en.json` + `es.json`** — new keys under `chat.entities.*`, `chat.tools.*`, `chat.attach_entity_*`. EN/ES parity required.
+
+### What stays put
+
+- `src/lib/chat-history.ts`, `chat-attachment-helpers.ts`, `chat-hint.ts` — unchanged.
+- The existing identifier cascade (`identify-runners.ts`, etc.) — unchanged. Chat tools query *for* observations, they don't replace identification.
+
+## Data flow
+
+### Flow A — Deep-link entry
+
+```
+1.  User clicks "💬 Ask Rastrum" on /share/obs/?id=X
+2.  Browser navigates to /en/chat/?attach=observation:X
+3.  ChatView mount reads `?attach=`, validates kind ∈ EntityKind
+4.  fetchEntityCard('observation', X)  →  supabase.rpc('chat_entity_card', {p_kind, p_id})
+5.  RPC returns { kind, id, label, summary_text, fields, suggested_questions }
+6.  ChatView dispatches chat:attach-entity → ChatComposer renders chip
+7.  ChatComposer also seeds the input with one suggested_question (greyed placeholder)
+8.  User edits or accepts → submits → chat-engine streams reply
+```
+
+The querystring is consumed once; ChatView replaces it with `history.replaceState` so a refresh doesn't re-attach.
+
+### Flow B — In-chat picker entry
+
+```
+1.  User clicks "📋 Attach context" in composer
+2.  ChatEntityPicker opens, default tab = Observations
+3.  Picker calls supabase.rpc('chat_find_observations', {p_filters: {owner: 'me'}, p_limit: 20})
+4.  User picks a row → picker dispatches chat:attach-entity, closes
+5.  Same fetchEntityCard path as Flow A from step 4
+```
+
+### Flow C — Conversation turn with tools
+
+```
+1.  User submits text (with attached entity card)
+2.  chat-engine builds messages:
+       system: CHAT_SYSTEM_PROMPT + tool definitions JSON-schema
+       system: [Context] <entity card serialized as plain text>
+       (history of prior turns, each ≤120 tokens)
+       user:   <text>
+3.  chat-engine.streamChat() begins streaming from Gemma (or Llama fallback)
+4.  Model emits either prose OR a tool call:
+       {"tool":"find_observations","args":{"species":"Setophaga magnolia","near":"obs:X","radius_km":50}}
+5.  If a tool call is detected (lookahead match on `{"tool":`), runtime stops streaming,
+    validates args, dispatches via runTool() → supabase.rpc(...)
+6.  Tool result appended as a `tool` role message; model is re-prompted (single round-trip)
+7.  Final prose streams into the bubble; tool_calls are persisted on the turn
+    (rendered as a collapsed "🔧 Looked at 3 observations" footer)
+```
+
+**Tool-call loop is capped at 1 round per user turn in v1.** Multi-round (model emits tool call → result → another tool call) is a v1.1 follow-up. Stops the model from spiralling.
+
+### Flow D — Offline degrade
+
+- `fetchEntityCard` fails → composer shows "Couldn't load context — try when online" and the chip is removed. User can still chat without context.
+- Tool dispatch fails (network) → tool returns `{error: "offline"}` — model says "I can't look that up right now" and answers from the entity card it already has.
+- The chat itself stays alive offline because Gemma/Llama run on-device; only the entity layer needs network.
+
+### Entity-card schema
+
+Stable contract — every entity kind serializes to the same shape:
+
+```ts
+interface EntityCard {
+  kind: 'observation' | 'species' | 'project' | 'camera_station'
+       | 'observer' | 'location' | 'self_profile';
+  id: string;                  // uuid for db rows; slug for species/projects
+  label: string;               // 1-line display ("Setophaga magnolia · May 8 · CDMX")
+  thumbnail?: string;          // optional 64×64 R2 URL
+  summary_text: string;        // ≤500 chars, plain prose; what the model "reads"
+  fields: Record<string,        // key/value for structured rendering in the chip popover
+    string | number | boolean | null>;
+  suggested_questions: string[]; // 2–3 EN/ES strings keyed off the entity kind + locale
+  related: {                   // typed pointers the model can use as tool args
+    project_id?: string;
+    primary_taxon_id?: string;
+    location_id?: string;
+    observer_id?: string;
+  };
+}
+```
+
+### Conversation persistence
+
+- `ChatTurnRecord` (Dexie store, already exists) gets two optional new fields: `entity_attachment?: { kind, id, label }` and `tool_calls?: Array<{name, args, result}>`.
+- The full entity card is **not** persisted on every turn — only the lightweight `entity_attachment`. On rehydrate, ChatView re-fetches the card if needed.
+- Existing `CHAT_HISTORY_LIMIT = 50` stays.
+
+## Error handling
+
+| Failure mode | Behavior | Surfacing |
+|---|---|---|
+| `?attach=…` with unknown `kind` or non-uuid `id` | Silently drop the param, render plain chat | No error UI |
+| `chat_entity_card` RPC returns 404 (entity gone, RLS hides it) | Toast "Couldn't find that {kind}", chip not added | Toast (existing `notify()` helper) |
+| `chat_entity_card` RPC throws (network/server) | Show "Try again when online", composer unblocked, no chip | Inline composer error (existing `chat-attach-error` element) |
+| Picker tab fetch fails | Empty list + "Couldn't load — try again" with retry button | In-tab inline message |
+| Model emits tool call with invalid JSON | Treat as prose, append hidden system note, re-prompt **once**, then give up | Silent recovery |
+| Tool args fail validator | Append `{"error":"invalid_args","detail":…}` as tool result; model gets one more chance | Footer shows "🔧 (failed) find_observations" |
+| Tool RPC throws | `{"error":"network"}` fed back; model recovers in prose | Footer shows "🔧 (offline) find_observations" |
+| Model exceeds 1-round tool-call cap | Drop subsequent tool calls, force prose | No user-visible error |
+| Gemma engine fails to load | Auto-fallback to Llama, log a warn-once to console | Banner: "Using lighter model — Gemma unavailable" |
+| Both engines fail | Disable composer, show consent gate again | Existing path |
+
+## Privacy invariants (load-bearing)
+
+1. **Observation cards respect `obscure_level`.** `chat_obs_card` reads from `obs_public_read` (which already enforces this), not raw `observations`. For sensitive species, precise coords are returned only when the requester is the observer; everyone else receives the obscured centroid. Implemented as `CASE WHEN auth.uid() = observer_user_id THEN <precise> ELSE <obscured> END` in the RPC.
+2. **Observer cards are public-fields only.** `chat_observer_card` joins `community_observers` (the public view) — no email, no centroid, no private profile fields. Self-profile is a separate `kind = self_profile` that pulls private fields gated by `auth.uid() = id`.
+3. **Tool args are validated, not interpolated.** Chat tools never construct SQL — they pass typed args to RPCs. Prevents prompt-injection-as-SQL-injection from a hostile entity card.
+4. **Chat content stays on-device.** Already true. Adding entity attachments doesn't change that — the entity *card* travels through Supabase, but the conversation transcript still lives only in Dexie.
+5. **`function_errors` audit on RPCs.** Every chat-tool RPC writes through the existing `function_errors` sink on exception — same pattern admin EFs use. Lets us see misuse without logging conversation content.
+
+## Performance budgets
+
+- **Entity-card fetch** ≤200 ms p95 (single-row RPC over warm Supabase).
+- **Picker first-paint** ≤150 ms (skeleton if slower).
+- **Gemma 4 E2B text load** one-time ~500 MB download via existing transformers.js cache; subsequent loads <2 s.
+- **Per-turn token budget**:
+  - System + tools schema: ≤600 tokens
+  - Entity card serialised: ≤500 tokens
+  - History: last 6 turns, each truncated to 120 tokens → ≤720
+  - User text: free
+  - Reserve 1024 for output → fits comfortably in Gemma 4's 8k context with headroom
+- **`ChatView.astro` size** target ≤500 LOC after decomposition.
+
+## Telemetry (no PII)
+
+Piggybacks the existing onboarding-event bus pattern — no new analytics dep:
+
+- `chat.entity.attached` `{ kind, source: 'deep-link'|'picker' }`
+- `chat.tool.called` `{ tool_name, ok }`
+- `chat.tool.failed` `{ tool_name, reason: 'validation'|'network'|'rls' }`
+- `chat.engine.fallback` `{ from: 'gemma', to: 'llama' }`
+
+## Testing
+
+### Unit (Vitest)
+
+- `src/lib/chat-entities/registry.test.ts` — collision detection, register/lookup, bootstrap idempotency. Mirrors `identifiers/registry.test.ts`.
+- `src/lib/chat-entities/observation.test.ts` — entity-card serializer with mocked RPC: obscure_level coarsening, owner-vs-non-owner branch, missing media handling.
+- `src/lib/chat-entities/{species,project,camera-station,observer,location,self-profile}.test.ts` — one happy-path + one RLS-denied test each.
+- `src/lib/chat-tools.test.ts` — args validator (good/bad inputs per tool), dispatcher round-trip with mocked Supabase, `{error: 'offline'}` propagation.
+- `src/lib/chat-engine.test.ts` — mocked Gemma stream emitting:
+  1. Pure prose → bubble assembled correctly
+  2. Single tool call → dispatch → re-prompt → final prose
+  3. Tool call with invalid JSON → fallback to prose
+  4. Tool call with bad args → error result fed back, model recovers
+  5. Two tool calls in one turn → second is dropped (1-round cap)
+  6. Gemma load fails → Llama fallback engaged, warning emitted
+- `src/lib/local-ai.test.ts` — extend with `loadGemmaTextEngine` (mocked at the transformers.js boundary, same pattern as `local-ai.test.ts`).
+- `src/lib/chat-history.test.ts` — extend for the new optional fields.
+- `src/lib/chat-attachment-helpers.test.ts` — keep existing tests; add tests for `parseAttachQuerystring` (querystring → `{kind, id}` validator).
+
+### Component tests (happy-dom via Vitest)
+
+- `tests/unit/chat-entity-picker.test.ts` — tab switch fires the right RPC; selection dispatches `chat:attach-entity`; empty state renders.
+- `tests/unit/chat-composer.test.ts` — chip render/remove; suggested-question seeding; "📋" button toggles picker; existing photo/audio paths still work.
+- `tests/unit/ask-rastrum-button.test.ts` — builds correct deep-link URL per locale + entity kind.
+
+### SQL pgTAP (`infra/sql-tests/chat.sql`)
+
+Wired into the existing `db-validate.yml` Postgres-17 service container.
+
+- `chat_entity_card('observation', X)` returns coarsened coords for non-owner of an obscured species.
+- `chat_entity_card('self_profile', uid)` rejects when `auth.uid() != uid`.
+- `chat_find_observations` respects RLS — anon gets nothing.
+- `chat_find_observers` returns from `community_observers` (no centroid).
+- All six new functions have explicit `REVOKE EXECUTE … FROM PUBLIC` + `GRANT TO authenticated`.
+- Idempotency: drop+create the functions twice in the test, second pass must succeed.
+
+### E2E (Playwright)
+
+Two specs added to the intentionally minimal suite. Both run on chromium + mobile-chrome.
+
+- `tests/e2e/chat-deep-link.spec.ts` — sign-in via test fixture, navigate to a seeded `/share/obs/?id=…`, click "Ask Rastrum", assert chip is present in composer with the expected label, assert URL was rewritten (no `?attach=` after).
+- `tests/e2e/chat-entity-picker.spec.ts` — open chat directly, click "📋", switch to Species tab, type, pick a row, assert chip appears.
+
+Tool-call flows are NOT in E2E — they need a deterministic model output and would be flaky; those are unit-tested with mocks.
+
+### Manual smoke checklist (in the runbook)
+
+- Deep-link from each entity surface (obs / species / project / station / observer / location / self profile).
+- Picker tab switching, search, EN+ES copy.
+- Cross-entity follow-up: attach an obs, ask "find similar observations nearby", assert the model emits a tool call and the result renders.
+- Offline: airplane mode → obs already attached → Q&A still works; "find similar nearby" → graceful failure.
+- Mobile composer with chip + attachment chip both staged.
+- Gemma fallback: corrupt the OPFS Gemma cache, reload chat, observe the Llama-fallback banner.
+
+### Regression guards
+
+- `scripts/check-define-vars-imports.sh` already runs in CI.
+- The schema-security lint (`infra/lint-schema-security.sql`) already runs in `db-validate.yml` — automatically covers the new RPCs' `search_path` + `REVOKE PUBLIC` requirements.
+- No new CI workflows needed.
+
+## Out of scope (v1.1 follow-ups)
+
+- **Guided actions / writes.** Chat surfacing "Apply this fix" buttons that perform privileged writes. Needs its own typed action contract, confirmation step, RLS verification, audit log, undo semantics.
+- **Multi-round tool calling.** Model emits tool call → result → *another* tool call in the same user turn. The 1-round cap is a deliberate v1 floor.
+- **Local RAG over Dexie.** Embedding model + vector index for fully-offline entity Q&A. YAGNI for v1; the on-device card already covers offline Q&A about the *attached* entity.
+- **Chat history sync.** Conversations remain device-local — no cross-device sync, no Supabase persistence.
+- **Voice output.** Speech recognition (input) is already wired; speech synthesis (output) is not in scope.
+
+## Open questions
+
+None remaining at design close. All architectural forks resolved during brainstorm.
+
+## References
+
+- `src/components/ChatView.astro` — current 1,441-LOC monolith.
+- `src/lib/local-ai.ts` — text + vision engine loaders.
+- `src/lib/identifiers/` — pattern the entity registry mirrors.
+- `docs/specs/modules/11-in-browser-ai.md` — the in-browser AI module spec.
+- `docs/specs/modules/13-identifier-registry.md` — pattern for plugin registries.
+- `infra/lint-schema-security.sql` — schema-security invariants the new RPCs must satisfy.

--- a/docs/superpowers/specs/2026-05-09-home-page-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-09-home-page-redesign-design.md
@@ -1,0 +1,350 @@
+# Home page redesign — `/home` (signed-in) + `/` (marketing)
+
+**Status:** design · 2026-05-09
+**Owner:** Artemio
+**Triggers:**
+- Production bug: `/` issues a `GET /rest/v1/observations?select=…,country_code,…` that 400s because `country_code` lives on `users`, not `observations` (PR #704/#844 regression).
+- Strategic: a single `/` route is trying to serve two audiences (anonymous evaluators and signed-in observers) and doing both jobs poorly.
+
+**Outcome:** split the route, fix the 400, build a Fogg-aligned dashboard for signed-in users, and add light social-proof to marketing for anon visitors.
+
+---
+
+## 1. Locked decisions (recap)
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | **Split routes** — `/` stays anon-only marketing; `/home` is the signed-in dashboard | Each page does one job; avoids the "every visitor downloads dashboard logic" tax |
+| 2 | **Auto-redirect** — signed-in users hitting `/` bounce to `/home` via first-paint script | Fogg one-target-per-audience principle; transparent if read is synchronous |
+| 3 | **Post-sign-in callback deposits at `/home`** — when the original return target is the locale root | Continuity from sign-in completion |
+| 4 | **`/home` flavor: dynamic-hero hybrid** — single CTA whose label/target resolves at load time from a 4-priority cascade | Fogg's *single target behavior* + *kairos* + *tailoring* in one surface |
+| 5 | **Marketing `/` scope: minimal + live pulse** — strip `HomeWidgets`, add live counter strip + 3-card LATAM-recent peek | High-leverage middle option; respects v1.1.5 honest-norms invariant |
+
+---
+
+## 2. Routes & i18n
+
+| EN | ES | Audience | Behavior |
+|---|---|---|---|
+| `/en/` | `/es/` | anon | marketing renders |
+| `/en/` | `/es/` | signed-in | first-paint script redirects to `/en/home/` or `/es/inicio/` |
+| `/en/home/` | `/es/inicio/` | signed-in | dashboard renders |
+| `/en/home/` | `/es/inicio/` | anon | redirect to sign-in (`/en/sign-in?redirect_to=/en/home/`) |
+
+`/inicio` follows the existing translated-slug convention in `src/i18n/utils.ts` (cf. `/observe` → `/observar`, `/explore` → `/explorar`). Add `routes.home = { en: '/home', es: '/inicio' }`.
+
+**Auto-redirect implementation** (in `BaseLayout.astro` first-paint script — same pattern as the theme resolver):
+```js
+const path = location.pathname;
+const isLocaleRoot = path === '/en/' || path === '/es/' || path === '/en' || path === '/es';
+if (isLocaleRoot) {
+  try {
+    const raw = localStorage.getItem('sb-<project-ref>-auth-token');
+    if (raw && JSON.parse(raw)?.access_token) {
+      const target = path.startsWith('/es') ? '/es/inicio/' : '/en/home/';
+      location.replace(target);
+    }
+  } catch { /* anon — let marketing render */ }
+}
+```
+Synchronous read avoids a flash of marketing. Errors silently fall through to the marketing render.
+
+**Header logo target** (`Header.astro`): `/en/` for anon, `/en/home/` for signed-in. Locale-aware. Resolution happens client-side after auth state is known; default render is the locale root (anon-safe), client script swaps the `href` if a session exists.
+
+**Post-sign-in callback** (`src/pages/auth/callback.astro`): if the resolved `redirect_to` is the locale root, substitute the home route. Other targets (e.g. magic link from `/observe`) are preserved.
+
+---
+
+## 3. `/home` — components & data
+
+### File layout
+
+```
+src/pages/en/home/index.astro       — page shell (lang='en')
+src/pages/es/inicio/index.astro     — page shell (lang='es')
+src/components/HomeView.astro       — shared body (per the EN/ES parity rule)
+src/components/home/
+  ├── HomeGreeting.astro            — "Buenos días, X" + 🔥 streak pill
+  ├── HomeHero.astro                — dynamic hero (§4)
+  ├── HomeChips.astro               — Inbox / Validate / Falta-dex / Watchlist
+  └── HomeRecent.astro              — 3-card recent-nearby strip
+src/lib/home-loaders.ts             — async data loaders (one per chip)
+src/lib/home-hero.ts                — pure hero-state resolver (§4)
+```
+
+The four child components are pure renderers; data fetching lives in `src/lib/home-loaders.ts` and is invoked from `HomeView.astro`'s `<script>` block via `Promise.all` for parallelism.
+
+### Data contracts
+
+| Component | Source | Query / RPC | Auth |
+|---|---|---|---|
+| Greeting + streak | `users`, `user_streaks` | self-row, `current_days` | RLS self-read |
+| Hero state | composed (§4) | `loadHeroState(userId, lang, now)` | RLS self-read |
+| Inbox count | `notifications` | `select count(*) where user_id = auth.uid() and read_at is null` | RLS self-read |
+| Validate count | RPC `pending_validation_count()` | sum across user's expert taxa, capped at 99+ | SECURITY INVOKER, scoped via `has_role('expert')` |
+| Falta-dex count | RPC `falta_dex_summary()` | returns `{ gap_count, region }` | self only |
+| Watchlist | `watchlist_alerts` | unread alert count + most-recent obs | RLS self-read |
+| Recent nearby | `observations` join `users!observer_id(country_code)` | embedded-resource filter (below) | `obs_public_read` |
+
+### Recent-nearby query (also fixes the 400)
+
+```ts
+const country = profile?.country_code ?? null;
+
+let query = supabase.from('observations').select(`
+  id, observed_at, state_province,
+  observer:users!observer_id(country_code),
+  identifications(scientific_name, is_primary, is_research_grade, confidence,
+                  taxa(common_name_es, common_name_en)),
+  media_files(url, is_primary, media_type)
+`)
+.eq('sync_status', 'synced')
+.order('observed_at', { ascending: false })
+.limit(3);
+
+if (country) query = query.eq('observer.country_code', country);
+```
+
+Fallback chain:
+1. If `country` present and result `.length === 3` → render local (title: "Recent in MX").
+2. If `country` present and result `.length < 3` → refetch global (title: "Recent observations").
+3. If `country` null → fetch global directly.
+
+PostgREST embedded-resource filtering (`.eq('observer.country_code', country)`) is supported since v10; verified working against the project's PostgREST version.
+
+### States
+
+- **Loading**: each chip + the recent strip render skeleton on first paint, real data on resolve.
+- **Empty**: chips with `count === 0` collapse to a muted "no items" state but stay visible (so the layout doesn't reflow). Recent strip hides entirely if zero results after fallback.
+- **Error**: each query is independently swallowed — a chip that errors silently hides; hero defaults to `observe_default`. The page never blocks render on a failed query.
+
+### Mobile reflow
+
+| Breakpoint | Greeting | Hero | Chips | Recent |
+|---|---|---|---|---|
+| `< sm` (< 640px) | streak wraps below | full width | horizontal scroll row | 1 col |
+| `sm`–`lg` | inline | full width | 2×2 grid | 3 col |
+| `≥ lg` | inline | full width | 4×1 row | 3 col |
+
+### Performance budget
+
+- 4 chip queries + 1 hero compose + 1 recent query = 6 round-trips, parallelized → expected ≈ one P95 RTT (~250ms on 4G).
+- Skeleton paint < 100ms (no JS for skeleton).
+- Total bundle delta from new components: < 5 KB gzipped (mostly i18n strings).
+
+---
+
+## 4. Dynamic hero · priority cascade
+
+### Resolver (`src/lib/home-hero.ts`)
+
+Pure function; no I/O of its own — accepts pre-loaded inputs and returns a `HeroState` discriminated union.
+
+```ts
+type HeroState =
+  | { kind: 'streak_at_risk', currentDays: number, hoursLeftLocal: number }
+  | { kind: 'watchlist_hit', taxonName: string, distanceKm: number, obsId: string, observedAt: string }
+  | { kind: 'pending_ids', count: number, taxonGroup: string, queueUrl: string }
+  | { kind: 'observe_default', morningPeak: boolean };
+
+interface HeroInputs {
+  streak: { currentDays: number; lastObsLocalDay: string | null } | null;
+  watchlistHit: { taxonName: string; distanceKm: number; obsId: string; observedAt: string } | null;
+  pendingIdsCount: number;
+  expertTaxonGroup: string | null;
+  now: Date;
+  userTimezone: string;
+}
+
+export function resolveHeroState(inputs: HeroInputs, lang: 'en' | 'es'): HeroState;
+```
+
+### Cascade (first match wins)
+
+1. **`streak_at_risk`** —
+   - `streak.currentDays >= 1` AND
+   - `streak.lastObsLocalDay !== today (in user's timezone, fall back to UTC)` AND
+   - local hour `≥ 18`
+   - **Why the 18:00 gate:** loss-framing only triggers in the evening so it doesn't shout at users who haven't had time yet. Threshold `≥ 1` ensures we never invent a streak.
+
+2. **`watchlist_hit`** —
+   - any `watchlist_alerts` row in the last 24h AND
+   - observation within 50 km of `users.centroid_geog` AND
+   - `acknowledged_at IS NULL`
+   - Pick closest if multiple. Skipped silently if `centroid_geog` is null (M28 opt-in).
+
+3. **`pending_ids`** —
+   - `pending_validation_count() ≥ 3` for taxa where the user `has_role('expert')`.
+   - Threshold `≥ 3` keeps the trigger meaningful (1–2 is too noisy).
+
+4. **`observe_default`** —
+   - Always falls through. `morningPeak = true` if local hour 5–9 (changes copy: "It's peak bird activity" / "es la hora de máxima actividad").
+
+### Fallback chain
+
+If any input loader errors, that rule is skipped and the cascade continues. If all error, `observe_default` always renders. The hero never blanks.
+
+### Copy
+
+`src/i18n/{en,es}.json` → `home.hero.<kind>.{title, subtitle, cta}`. Subtitles take template params: `{count}`, `{km}`, `{hoursLeft}`, `{streakDays}`, `{taxonName}`.
+
+**Honest-framing rules** (per v1.1.5 persuasive-tech invariants):
+- "Streak at risk" must read factually: "You haven't logged today. One observation by midnight keeps your N-day streak." Not "Hurry!" / "Don't lose it!"
+- No fabricated counts. If a value is uncertain, the whole rule skips rather than rounding up.
+- No countdown timers (engagement-bait pattern).
+
+### Visual
+
+Each kind has a distinct rail color (already-locked v1.1.5 accent-rail pattern):
+- `streak_at_risk`: red rail + amber accent
+- `watchlist_hit`: blue rail
+- `pending_ids`: purple rail
+- `observe_default`: emerald (brand)
+
+All four use one component shell (`HomeHero.astro`) with a `kind`-driven Tailwind class set. Classes are **safelisted in `tailwind.config.mjs`** (matches the existing `railClass()` pattern in `Header.astro` — required because the class names are computed dynamically).
+
+### Analytics
+
+Emits `rastrum:home-hero-resolved` DOM event with `{ kind, fallback_path: string[] }`. No-op stub by default — operators attach a listener in `BaseLayout.astro` if they want to count cascade firings.
+
+---
+
+## 5. `/` marketing changes
+
+### Removed
+
+- `<HomeWidgets />` from `src/pages/{en,es}/index.astro`.
+- `src/components/HomeWidgets.astro` itself stays in the tree for one release, then gets deleted in a follow-up cleanup PR. The dashboard's greeting + streak + recent code is a partial fork — patterns translate, but the file is not 1:1 reusable.
+
+### Added · live pulse strip (`src/components/HomePulse.astro`)
+
+```
+📍 12,847 observations · 1,392 species · 184 active observers · last 30 days
+```
+
+- Backed by RPC `home_pulse_stats()` returning `{ obs_30d, species_30d, active_observers_30d }`.
+- **Honest-norms gate**: hide the entire strip if `obs_30d < 1000`. (Threshold lives in `src/lib/honest-norms.ts` next to `MIN_N_THRESHOLD`.) Below the threshold the marketing page just doesn't have this section — same v1.1.5 rule as peer-norms.
+- Edge Function caches the result for 5 minutes (`Cache-Control: max-age=300`) — no per-pageview DB load.
+- Copy in `i18n/{en,es}.json` → `home.pulse.*`.
+
+### Added · recent in LATAM (`src/components/HomeRecentLatam.astro`)
+
+- 3 cards, same shape as the dashboard's recent strip, but anonymized: hides observer name (shows e.g. "an observer in MX"), uses `obs_public_read`-respecting query (sensitive species already coarsened by RLS).
+- Query:
+  ```sql
+  observations
+  WHERE sync_status = 'synced'
+    AND obscure_level != 'full'
+    AND observer.country_code IN ('MX','CO','BR','AR','CL','PE','EC','CR','PA',
+                                  'GT','BO','VE','UY','PY','HN','SV','NI','DO','CU')
+  ORDER BY observed_at DESC LIMIT 3
+  ```
+  via embedded `users!observer_id(country_code)`.
+- Falls back to global if < 3 LATAM results. Strip hides entirely if 0 results overall.
+
+### Page render order (anon visitor, top → bottom)
+
+1. SeasonalAccent + Hero + 3 CTAs (current, unchanged)
+2. **HomePulse** — live counters strip (new)
+3. **HomeRecentLatam** — 3 cards (new)
+4. How It Works (current, unchanged)
+5. Why Rastrum (current, unchanged)
+
+The pulse + recent strips are the only above-the-fold additions; below-the-fold content is unchanged.
+
+---
+
+## 6. Migration plan
+
+### PR 1 · Hotfix `/` 400 (ships first, same day)
+
+- Strip `<HomeWidgets />` from `src/pages/{en,es}/index.astro`.
+- One unit test asserting `index.astro` doesn't import `HomeWidgets`.
+- Closes the production 400.
+- ~10 LOC change. No SQL, no i18n, no new components.
+
+### PR 2 · `/home` + marketing pulse (ships after, ~1 week)
+
+- All new components, routes, RPCs, i18n.
+- Auto-redirect logic in `BaseLayout.astro`.
+- New SQL: 3 RPCs — `home_pulse_stats`, `pending_validation_count`, `falta_dex_summary`. Verified absent in current schema (2026-05-09).
+- Header logo target update (`Header.astro`).
+- E2E test: `/en/` → cookie-fixture sign-in → expect redirect to `/en/home/`; assert hero, chips, recent rendered.
+
+### SQL additions (`docs/specs/infra/supabase-schema.sql`, idempotent)
+
+```sql
+CREATE OR REPLACE FUNCTION public.home_pulse_stats()
+RETURNS TABLE(obs_30d int, species_30d int, active_observers_30d int)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT
+    (SELECT count(*)::int FROM observations
+       WHERE sync_status='synced' AND observed_at > now() - interval '30 days'),
+    (SELECT count(DISTINCT primary_taxon_id)::int FROM observations
+       WHERE sync_status='synced' AND observed_at > now() - interval '30 days'
+       AND primary_taxon_id IS NOT NULL),
+    (SELECT count(DISTINCT observer_id)::int FROM observations
+       WHERE sync_status='synced' AND observed_at > now() - interval '30 days');
+$$;
+GRANT EXECUTE ON FUNCTION public.home_pulse_stats() TO anon, authenticated;
+```
+
+Same `SET search_path` invariant as every other `pl*` function (per CLAUDE.md schema security rules). `pending_validation_count()` and `falta_dex_summary()` follow the same template, scoped per-user by `auth.uid()`.
+
+---
+
+## 7. Testing
+
+### Unit (vitest)
+
+- `home-hero.test.ts` — table-driven tests for the cascade with fixtures for each kind + every fallback path (10–15 cases).
+- `home-loaders.test.ts` — each chip loader returns the expected shape; errors are swallowed (no throws).
+- `home-pulse-honest.test.ts` — pulse strip hides when `obs_30d < 1000`.
+- `home-redirect.test.ts` — anon stays on `/`; signed-in stub triggers redirect to `/home`.
+- `home-recent-fallback.test.ts` — local query with < 3 results triggers global fallback; query string never contains `country_code` as an observation column.
+
+### E2E (Playwright, `tests/e2e/home.spec.ts`)
+
+One spec covering:
+- Anon hits `/en/` → marketing page renders, no console errors, no 4xx requests.
+- Signed-in (cookie fixture) hits `/en/` → redirected to `/en/home/`; greeting visible; at least one chip renders.
+- Mobile viewport: chips horizontal scroll renders correctly.
+- `/es/` → `/es/inicio/` redirect parity.
+
+---
+
+## 8. i18n
+
+- Every new string in `en.json` AND `es.json`.
+- Existing parity test (`tests/unit/i18n-parity.test.ts`) catches drift.
+- New keys: `home.pulse.*`, `home.recent_latam.*`, `home.hero.streak_at_risk.*`, `home.hero.watchlist_hit.*`, `home.hero.pending_ids.*`, `home.hero.observe_default.*`, `home.greeting.*`, `home.chips.*`, `home.recent.*`.
+
+---
+
+## 9. Out of scope (explicitly v1.1)
+
+- Personalized "for you" feed below the fold (separate design).
+- Push notifications for hero triggers.
+- A/B test of dynamic hero vs static (not enough traffic for honest stats yet).
+- Dashboard widgets for projects / camera stations (project-specific, not `/home`-relevant).
+- Replacing the current `HomeWidgets.astro` file (kept until PR 2 is merged + verified, then deleted in a follow-up).
+- Personalized counter for the marketing live-pulse (e.g., "12,847 observations *near you*") — would require client-side IP geolocation, not in scope.
+- Trust signals strip on marketing (open-source, no tracking, privacy) — separate marketing-page redesign work.
+
+---
+
+## 10. Known risks
+
+| Risk | Mitigation |
+|---|---|
+| Auto-redirect race — synchronous localStorage read may miss a session that's still being persisted | First-paint script runs *before* `getSupabase()` initializes; if read returns null we fall through to marketing. Worst case: signed-in user briefly sees marketing then gets redirected on a real auth event. Mark the body `data-pending-auth` so consumers don't render greeting prematurely. |
+| Hero cascade thrashing — input loader latencies vary; the cascade may "promote" a lower-priority state mid-paint | Resolver runs once after `Promise.all` of all inputs settles. No re-resolution unless the page is reloaded. |
+| `home_pulse_stats()` becomes expensive at scale | Cached at the Edge Function layer for 5 minutes; the underlying query plan uses partial indexes already shipped (`idx_observations_sync_status_observed_at`). Re-evaluate if `obs_30d > 10M`. |
+| `country_code` filter via embedded-resource breaks on PostgREST upgrade | Pin behavior in an integration test that asserts the URL serializer matches expected form. |
+| The "streak at risk" trigger feels manipulative to some users | Profile preference `disable_kairos_nudges` (boolean) — when true, the hero always renders `observe_default`. v1.1 follow-up if user feedback warrants. Not shipped in v1. |
+
+---
+
+*Design saved as `docs/superpowers/specs/2026-05-09-home-page-redesign-design.md`. Implementation plan to be drafted next via the writing-plans skill, after user review.*

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,7 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import SeasonalAccent from '../../components/SeasonalAccent.astro';
-import HomeWidgets from '../../components/HomeWidgets.astro';
 import { t, getLocalizedPath, getDocPath, routes } from '../../i18n/utils';
 
 const lang = 'en';
@@ -9,8 +8,6 @@ const tr = t(lang);
 ---
 
 <BaseLayout title={`${tr.site.title} — ${tr.home.hero_title}`} description={tr.site.description} lang={lang}>
-  <HomeWidgets lang={lang} />
-
   <!-- Hero -->
   <section class="text-center py-16 sm:py-24 space-y-6">
     <SeasonalAccent class="mb-2 flex justify-center" />

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,7 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import SeasonalAccent from '../../components/SeasonalAccent.astro';
-import HomeWidgets from '../../components/HomeWidgets.astro';
 import { t, getLocalizedPath, getDocPath, routes } from '../../i18n/utils';
 
 const lang = 'es';
@@ -9,8 +8,6 @@ const tr = t(lang);
 ---
 
 <BaseLayout title={`${tr.site.title} — ${tr.home.hero_title}`} description={tr.site.description} lang={lang}>
-  <HomeWidgets lang={lang} />
-
   <!-- Hero -->
   <section class="text-center py-16 sm:py-24 space-y-6">
     <SeasonalAccent class="mb-2 flex justify-center" />

--- a/tests/unit/home-no-widgets.test.ts
+++ b/tests/unit/home-no-widgets.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('home page does not import HomeWidgets', () => {
+  for (const lang of ['en', 'es'] as const) {
+    it(`${lang} index.astro has no HomeWidgets import or usage`, () => {
+      const path = join(process.cwd(), `src/pages/${lang}/index.astro`);
+      const src = readFileSync(path, 'utf8');
+      expect(src).not.toMatch(/HomeWidgets/);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`HomeWidgets` issues `GET /rest/v1/observations?select=…,country_code,…` on every load of `/`. `country_code` lives on `users`, not `observations` — PostgREST returns 400, the widget renders empty, and the failed request shows up in DevTools every page view (regression from PR #704/#844).

This PR strips `HomeWidgets` from `/en/` and `/es/`. The dashboard is being rebuilt at `/home` (and `/inicio`) per the spec/plan linked below — that's the follow-up PR. This one is the hotfix to close the 400 today.

- Spec: `docs/superpowers/specs/2026-05-09-home-page-redesign-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-home-page-redesign.md` (Task 1)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 1492/1492 pass (2 new tests in `home-no-widgets.test.ts`)
- [x] `npm run build` — 241 pages
- [ ] Manual: open `/en/` post-deploy, DevTools network panel shows no `/rest/v1/observations?...country_code` request