### PR TITLE
fix(i18n): add missing notifications.prefs keys (#870 follow-up)

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1759,6 +1759,29 @@
       "permission_blocked": "Browser notifications are blocked. Enable them in your browser site settings, then try again.",
       "unsupported": "This browser doesn't support web push (try Chrome on Android or Safari 16.4+ on iOS).",
       "vapid_missing": "Push isn't configured yet — the operator must publish a VAPID key first."
+    },
+    "prefs": {
+      "push_section": "Push notifications",
+      "email_section": "Email notifications",
+      "quiet_hours_section": "Quiet hours",
+      "quiet_hours_hint": "No push notifications will be delivered during these hours",
+      "quiet_start": "Start",
+      "quiet_end": "End",
+      "timezone_label": "Your timezone",
+      "save_error": "Could not save your preferences. Please try again.",
+      "saved": "Preferences saved.",
+      "push_after_rain": "After-rain alert",
+      "push_migration_window": "Migration window alert",
+      "push_lunar_event": "Lunar event alert",
+      "push_streak_reminder": "Streak reminder",
+      "push_kairos_golden_hour": "Golden-hour prompt (kairos)",
+      "push_badge_unlock": "Badge unlocked",
+      "push_comment_on_my_obs": "Comment on my observation",
+      "push_new_follower": "New follower",
+      "push_id_accepted_on_my_obs": "ID accepted on my observation",
+      "email_weekly_digest": "Weekly digest",
+      "email_badge_unlock": "Badge unlocked",
+      "email_new_follower": "New follower"
     }
   },
   "surprises": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1759,6 +1759,29 @@
       "permission_blocked": "Las notificaciones del navegador están bloqueadas. Actívalas en la configuración del sitio y vuelve a intentar.",
       "unsupported": "Este navegador no soporta web push (prueba Chrome en Android o Safari 16.4+ en iOS).",
       "vapid_missing": "El push aún no está configurado — el operador debe publicar primero una llave VAPID."
+    },
+    "prefs": {
+      "push_section": "Notificaciones push",
+      "email_section": "Notificaciones por correo",
+      "quiet_hours_section": "Horas de silencio",
+      "quiet_hours_hint": "No se enviarán push durante estas horas",
+      "quiet_start": "Inicio",
+      "quiet_end": "Fin",
+      "timezone_label": "Tu zona horaria",
+      "save_error": "No se pudo guardar. Intenta de nuevo.",
+      "saved": "Preferencias guardadas.",
+      "push_after_rain": "Alerta post-lluvia",
+      "push_migration_window": "Alerta de ventana de migración",
+      "push_lunar_event": "Alerta de evento lunar",
+      "push_streak_reminder": "Recordatorio de racha",
+      "push_kairos_golden_hour": "Prompt de hora dorada (kairos)",
+      "push_badge_unlock": "Insignia desbloqueada",
+      "push_comment_on_my_obs": "Comentario en mi observación",
+      "push_new_follower": "Nuevo seguidor",
+      "push_id_accepted_on_my_obs": "ID aceptado en mi observación",
+      "email_weekly_digest": "Resumen semanal",
+      "email_badge_unlock": "Insignia desbloqueada",
+      "email_new_follower": "Nuevo seguidor"
     }
   },
   "surprises": {


### PR DESCRIPTION
notifications.prefs.* keys were lost in the squash merge of #900. This caused all PRs after #900 to fail verify due to: `Cannot read properties of undefined (reading 'push_after_rain')`