### PR TITLE
fix(observe): guard undefined File.type — Android Chrome crash (#eugenio-report)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -472,13 +472,13 @@ let hintTimer: ReturnType<typeof setTimeout> | null = null;
 
 document.addEventListener('rastrum:files-dropped', (e: Event) => {
   const ev = e as CustomEvent<{ files: File[] }>;
-  const files = ev.detail.files;
+  const files = (ev.detail.files ?? []).filter(Boolean);
   if (!files.length || !fileHint) return;
 
   // Determine dominant file type
-  const hasAudio  = files.some(f => f.type.startsWith('audio/'));
-  const hasVideo  = files.some(f => f.type.startsWith('video/'));
-  const hasPhoto  = files.some(f => f.type.startsWith('image/'));
+  const hasAudio  = files.some(f => f?.type?.startsWith('audio/'));
+  const hasVideo  = files.some(f => f?.type?.startsWith('video/'));
+  const hasPhoto  = files.some(f => f?.type?.startsWith('image/'));
 
   let hint = '';
   if (hasAudio && hasPhoto) {

--- a/src/lib/make-drop-target.ts
+++ b/src/lib/make-drop-target.ts
@@ -37,7 +37,7 @@ export function makeDropTarget(
     if (!list) return [];
     const files = Array.from(list);
     if (!accept?.length) return files;
-    return files.filter(f => accept.some(prefix => f.type.startsWith(prefix)));
+    return files.filter(f => f && accept.some(prefix => f.type?.startsWith(prefix)));
   }
 
   function showOverlay() {


### PR DESCRIPTION
Reported by Eugenio (Oaxaca, Android 10, Chrome 147) via bug report.

**Error:** `Cannot read properties of undefined (reading 'type')`

Android Chrome 147's DataTransfer can include `undefined`/`null` entries in the files array under certain conditions (multi-file selection from gallery on some OEM Android builds).

**Fix:**
- `ObserveView2.astro`: `(ev.detail.files ?? []).filter(Boolean)` + optional chaining `f?.type?.startsWith()`
- `make-drop-target.ts`: guard `f &&` before `f.type.startsWith()`

Also includes the pipeline escape hatch (15s timeout → 'Saltar identificación y continuar') triggered by the gotrue lock timeout observed in same session:
`Lock "lock:rastrum-auth-v1" was not released within 5000ms`