### PR TITLE
fix(home): wire HomeWidgets into home pages + fix E2E greeting tests

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -472,13 +472,13 @@ let hintTimer: ReturnType<typeof setTimeout> | null = null;
 
 document.addEventListener('rastrum:files-dropped', (e: Event) => {
   const ev = e as CustomEvent<{ files: File[] }>;
-  const files = ev.detail.files;
+  const files = (ev.detail.files ?? []).filter(Boolean);
   if (!files.length || !fileHint) return;
 
   // Determine dominant file type
-  const hasAudio  = files.some(f => f.type.startsWith('audio/'));
-  const hasVideo  = files.some(f => f.type.startsWith('video/'));
-  const hasPhoto  = files.some(f => f.type.startsWith('image/'));
+  const hasAudio  = files.some(f => f?.type?.startsWith('audio/'));
+  const hasVideo  = files.some(f => f?.type?.startsWith('video/'));
+  const hasPhoto  = files.some(f => f?.type?.startsWith('image/'));
 
   let hint = '';
   if (hasAudio && hasPhoto) {

--- a/src/lib/make-drop-target.ts
+++ b/src/lib/make-drop-target.ts
@@ -37,7 +37,7 @@ export function makeDropTarget(
     if (!list) return [];
     const files = Array.from(list);
     if (!accept?.length) return files;
-    return files.filter(f => accept.some(prefix => f.type.startsWith(prefix)));
+    return files.filter(f => f && accept.some(prefix => f.type?.startsWith(prefix)));
   }
 
   function showOverlay() {

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import SeasonalAccent from '../../components/SeasonalAccent.astro';
+import HomeWidgets from '../../components/HomeWidgets.astro';
 import { t, getLocalizedPath, getDocPath, routes } from '../../i18n/utils';
 
 const lang = 'en';
@@ -8,6 +9,9 @@ const tr = t(lang);
 ---
 
 <BaseLayout title={`${tr.site.title} — ${tr.home.hero_title}`} description={tr.site.description} lang={lang}>
+  <!-- Personalized home widgets (#704) — signed-in users see greeting +
+       streak + nearby-recent. Signed-out visitors see the marketing hero. -->
+  <HomeWidgets lang={lang} />
   <!-- Hero -->
   <section class="text-center py-16 sm:py-24 space-y-6">
     <SeasonalAccent class="mb-2 flex justify-center" />

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import SeasonalAccent from '../../components/SeasonalAccent.astro';
+import HomeWidgets from '../../components/HomeWidgets.astro';
 import { t, getLocalizedPath, getDocPath, routes } from '../../i18n/utils';
 
 const lang = 'es';
@@ -8,6 +9,9 @@ const tr = t(lang);
 ---
 
 <BaseLayout title={`${tr.site.title} — ${tr.home.hero_title}`} description={tr.site.description} lang={lang}>
+  <!-- Widgets personalizados (#704) — usuarios autenticados ven saludo +
+       racha + recientes cercanos. Visitantes ven el hero de marketing. -->
+  <HomeWidgets lang={lang} />
   <!-- Hero -->
   <section class="text-center py-16 sm:py-24 space-y-6">
     <SeasonalAccent class="mb-2 flex justify-center" />

--- a/tests/e2e/home-greeting.spec.ts
+++ b/tests/e2e/home-greeting.spec.ts
@@ -3,10 +3,9 @@
  * embedded in the widget root data-attributes (server-rendered, no auth needed)
  * AND that the DOM element reflects the phrase when the widget initializes.
  *
- * Two-layer strategy:
- *  1. data-label check: always passes in CI (static HTML, no auth required).
- *  2. DOM text check: attempted with a soft timeout; skipped if element is
- *     hidden (signed-out path hides the greeting wrapper).
+ * HomeWidgets is included in /en/ and /es/ home pages (#704).
+ * The .home-widgets root is always in the DOM; the greeting wrapper is hidden
+ * for signed-out visitors but the data-label-* attributes are always present.
  */
 import { test, expect } from '@playwright/test';
 
@@ -14,7 +13,7 @@ type BucketCase = {
   hour: number;
   locale: 'en' | 'es';
   path: string;
-  labelAttr: string;          // data-label-greeting-<bucket> on the widget root
+  labelAttr: string;
   expected: string;
 };
 
@@ -31,7 +30,6 @@ const CASES: BucketCase[] = [
 
 for (const { hour, locale, path, labelAttr, expected } of CASES) {
   test(`greeting label at ${hour}:00 (${locale}): "${expected}"`, async ({ page }) => {
-    // Mock Date before page scripts run so pickGreeting() uses the right bucket.
     const isoTs = `2026-05-09T${String(hour).padStart(2, '0')}:30:00.000Z`;
     await page.addInitScript((ts: string) => {
       const fixed = new Date(ts).valueOf();
@@ -53,19 +51,18 @@ for (const { hour, locale, path, labelAttr, expected } of CASES) {
 
     await page.goto(path, { waitUntil: 'domcontentloaded' });
 
-    // Layer 1: data-label attribute is server-rendered — always present, no auth.
+    // Layer 1: data-label attribute — server-rendered, always present, no auth.
     const root = page.locator('.home-widgets').first();
-    await expect(root).toBeAttached({ timeout: 5_000 });
+    await expect(root).toBeAttached({ timeout: 7_000 });
     const labelValue = await root.getAttribute(labelAttr);
     expect(labelValue).toBe(expected);
 
-    // Layer 2: if the greeting element is visible (signed-in path or future
-    // anon greeting), also verify the rendered text.
+    // Layer 2: rendered text — only if the greeting element is visible
+    // (requires auth session; skipped in CI signed-out path).
     const greetingEl = page.locator('[data-testid="home-greeting"]').first();
     const isVisible = await greetingEl.isVisible().catch(() => false);
     if (isVisible) {
       await expect(greetingEl).toContainText(expected, { timeout: 3_000 });
     }
-    // If not visible (signed-out in CI), layer 1 is sufficient coverage.
   });
 }


### PR DESCRIPTION
## Two bugs in one

### 1. HomeWidgets never wired into home pages

`HomeWidgets.astro` was created in the v1.1 sprint (#704) but never imported into `src/pages/en/index.astro` or `src/pages/es/index.astro`. Users visiting the home page saw the marketing hero with no personalized greeting, streak, daily challenge, or suggestions.

**Fix:** Added `import HomeWidgets` + `<HomeWidgets lang={lang} />` to both home pages, rendered above the hero section.

### 2. E2E home-greeting tests failing

Tests failed because `await expect(root).toBeAttached()` timed out — the `.home-widgets` element didn't exist in the DOM since HomeWidgets wasn't on the page.

Now that HomeWidgets is on the home pages, the `.home-widgets` root is always server-rendered with `data-label-greeting-*` attributes. Updated test to use 7s timeout to account for CI preview startup time.