### PR TITLE
fix(home): add taxa.rarity_tier column — fixes daily_challenge_for_user 400 (#852)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -7150,10 +7150,12 @@ ALTER TABLE public.taxa ADD COLUMN IF NOT EXISTS nom059_status text;
 -- hero_observation_id: the observation that provides the hero photo
 -- hero_updated_at: when the hero was last recomputed
 -- slug: URL-safe species identifier (lower, spaces→dashes)
+-- rarity_tier: 1=common, 2=uncommon, 3=rare, 4=very rare (used by daily challenge)
 ALTER TABLE public.taxa ADD COLUMN IF NOT EXISTS hero_media_id uuid REFERENCES public.media_files(id) ON DELETE SET NULL;
 ALTER TABLE public.taxa ADD COLUMN IF NOT EXISTS hero_observation_id uuid REFERENCES public.observations(id) ON DELETE SET NULL;
 ALTER TABLE public.taxa ADD COLUMN IF NOT EXISTS hero_updated_at timestamptz;
 ALTER TABLE public.taxa ADD COLUMN IF NOT EXISTS slug text;
+ALTER TABLE public.taxa ADD COLUMN IF NOT EXISTS rarity_tier int CHECK (rarity_tier BETWEEN 1 AND 4);
 
 -- Back-fill slugs for existing taxa (idempotent)
 UPDATE public.taxa
@@ -10795,8 +10797,7 @@ BEGIN
       ELSE COALESCE(t.common_name_es, t.scientific_name) || ' — especie regional'
     END AS why
   FROM public.taxa t
-  WHERE t.rarity_tier IS NOT NULL
-    AND t.rarity_tier <= 3
+  WHERE (t.rarity_tier IS NULL OR t.rarity_tier <= 3)  -- NULL = unclassified, treat as common
     AND (
       v_country_code IS NULL
       OR EXISTS (

--- a/tests/unit/daily-challenge.test.ts
+++ b/tests/unit/daily-challenge.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for daily_challenge_for_user client helper.
+ *
+ * Bug: RPC returned 400 because taxa.rarity_tier column didn't exist.
+ * Fix: Added ADD COLUMN IF NOT EXISTS rarity_tier int to taxa in schema.
+ *      Updated WHERE clause to treat NULL rarity_tier as common.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Reset module cache between tests so the in-memory day-cache doesn't leak.
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('fetchDailyChallenge', () => {
+  async function setup(mockReturn: { data: unknown; error: unknown }) {
+    const mockRpc = vi.fn().mockResolvedValue(mockReturn);
+    vi.doMock('../../src/lib/supabase', () => ({
+      getSupabase: () => ({ rpc: mockRpc }),
+    }));
+    const { fetchDailyChallenge } = await import('../../src/lib/daily-challenge');
+    return { fetchDailyChallenge, mockRpc };
+  }
+
+  const FAKE_USER = '00000000-0000-0000-0000-000000000001';
+
+  const SAMPLE = {
+    taxon_id: 'taxon-1',
+    scientific_name: 'Quercus rugosa',
+    common_name_en: 'Netleaf Oak',
+    common_name_es: 'Encino',
+    kingdom: 'Plantae',
+    rarity_tier: 2,
+    thumbnail_url: 'https://example.com/img.jpg',
+    why: 'Encino — planta local',
+  };
+
+  it('returns challenge when RPC succeeds', async () => {
+    const { fetchDailyChallenge, mockRpc } = await setup({ data: [SAMPLE], error: null });
+    const result = await fetchDailyChallenge(FAKE_USER);
+    expect(result).not.toBeNull();
+    expect(result?.scientific_name).toBe('Quercus rugosa');
+    expect(result?.rarity_tier).toBe(2);
+    expect(mockRpc).toHaveBeenCalledWith('daily_challenge_for_user', { p_user_id: FAKE_USER });
+  });
+
+  it('returns null when RPC returns empty array (no taxa match)', async () => {
+    const { fetchDailyChallenge } = await setup({ data: [], error: null });
+    expect(await fetchDailyChallenge(FAKE_USER)).toBeNull();
+  });
+
+  it('returns null when RPC returns null data', async () => {
+    const { fetchDailyChallenge } = await setup({ data: null, error: null });
+    expect(await fetchDailyChallenge(FAKE_USER)).toBeNull();
+  });
+
+  it('returns null (no throw) when RPC errors — widget hides gracefully', async () => {
+    const { fetchDailyChallenge } = await setup({
+      data: null,
+      error: new Error('column rarity_tier does not exist'),
+    });
+    const result = await fetchDailyChallenge(FAKE_USER);
+    expect(result).toBeNull();
+  });
+
+  it('handles null rarity_tier (unclassified taxa — treated as common by schema)', async () => {
+    const { fetchDailyChallenge } = await setup({
+      data: [{ ...SAMPLE, rarity_tier: null }],
+      error: null,
+    });
+    const result = await fetchDailyChallenge(FAKE_USER);
+    expect(result).not.toBeNull();
+    expect(result?.rarity_tier).toBeNull();
+  });
+
+  it('memoizes within the same UTC day', async () => {
+    const { fetchDailyChallenge, mockRpc } = await setup({ data: [SAMPLE], error: null });
+    await fetchDailyChallenge(FAKE_USER);
+    await fetchDailyChallenge(FAKE_USER);
+    // Cache should prevent second RPC call
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Root cause

`daily_challenge_for_user()` returned 400 because `taxa.rarity_tier` didn't exist in the schema. The RPC was written assuming the column existed but it was never added via `ALTER TABLE`.

## Fix

1. **Schema:** `ALTER TABLE taxa ADD COLUMN IF NOT EXISTS rarity_tier int CHECK (rarity_tier BETWEEN 1 AND 4)`

2. **Function:** Updated `WHERE` clause to handle `NULL rarity_tier` (unclassified taxa treated as common, so the widget always returns candidates before rarity data is backfilled):
   ```sql
   -- before: WHERE t.rarity_tier IS NOT NULL AND t.rarity_tier <= 3
   WHERE (t.rarity_tier IS NULL OR t.rarity_tier <= 3)
   ```

3. **Tests:** 6 unit tests covering happy path, empty/null results, RPC error (graceful null), null rarity_tier, and memoization.

## Reported by

Artemio (+5215560476808) via bug report 2026-05-09T20:30:57Z