### PR TITLE
fix: suggest_nearby_species 404 + gotrue lock contention (#710 #android)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10820,3 +10820,96 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.daily_challenge_for_user(uuid) FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION public.daily_challenge_for_user(uuid) TO authenticated;
+
+-- ============================================================
+-- #710 — suggest_nearby_species RPC
+-- Returns up to 10 species the viewer could find nearby that
+-- they haven't observed yet, ranked by nearby platform activity.
+--
+-- Month wrapping fix (#881): uses = ANY(ARRAY[prev,cur,next]) with
+-- modular arithmetic instead of BETWEEN p_month±1 which broke at
+-- January (BETWEEN 0 AND 2) and December (BETWEEN 11 AND 13).
+--
+-- Supporting index for the correlated photo_url subquery:
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_media_files_obs_primary
+  ON public.media_files(observation_id, is_primary)
+  WHERE is_primary = true;
+
+CREATE OR REPLACE FUNCTION public.suggest_nearby_species(
+  p_user_id   uuid,
+  p_lat       double precision,
+  p_lng       double precision,
+  p_month     integer,
+  p_radius_km integer DEFAULT 50,
+  p_limit     integer DEFAULT 10
+)
+RETURNS TABLE (
+  taxon_id        uuid,
+  scientific_name text,
+  common_name_es  text,
+  common_name_en  text,
+  kingdom         text,
+  class           text,
+  nearby_count    bigint,
+  photo_url       text
+)
+LANGUAGE sql STABLE
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH user_observed AS (
+    SELECT DISTINCT i.taxon_id
+    FROM public.observations o
+    JOIN public.identifications i ON i.observation_id = o.id AND i.is_primary
+    WHERE o.observer_id = p_user_id
+      AND i.taxon_id IS NOT NULL
+  ),
+  nearby AS (
+    SELECT
+      i.taxon_id,
+      count(*) AS nearby_count
+    FROM public.observations o
+    JOIN public.identifications i ON i.observation_id = o.id AND i.is_primary
+    WHERE o.sync_status = 'synced'
+      AND o.location IS NOT NULL
+      AND ST_DWithin(
+            o.location::geography,
+            ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
+            p_radius_km * 1000
+          )
+      AND EXTRACT(MONTH FROM o.observed_at) = ANY(
+            ARRAY[
+              ((p_month - 2 + 12) % 12) + 1,
+              p_month,
+              (p_month % 12) + 1
+            ]
+          )
+      AND i.taxon_id IS NOT NULL
+      AND i.taxon_id NOT IN (SELECT taxon_id FROM user_observed)
+    GROUP BY i.taxon_id
+    ORDER BY nearby_count DESC
+    LIMIT p_limit * 3
+  )
+  SELECT
+    t.id          AS taxon_id,
+    t.scientific_name,
+    t.common_name_es,
+    t.common_name_en,
+    t.kingdom,
+    t.class,
+    n.nearby_count,
+    (SELECT mf.url FROM public.media_files mf
+       JOIN public.observations mo ON mo.id = mf.observation_id
+       JOIN public.identifications mi ON mi.observation_id = mo.id
+         AND mi.taxon_id = t.id AND mi.is_primary
+       WHERE mf.is_primary AND mo.sync_status = 'synced'
+       LIMIT 1) AS photo_url
+  FROM nearby n
+  JOIN public.taxa t ON t.id = n.taxon_id
+  ORDER BY n.nearby_count DESC
+  LIMIT p_limit;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.suggest_nearby_species(uuid, double precision, double precision, integer, integer, integer) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.suggest_nearby_species(uuid, double precision, double precision, integer, integer, integer) TO authenticated;

--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -112,7 +112,7 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getSupabase, getCachedUser } from '../lib/supabase';
   import { buildGreeting } from '../lib/home-greeting';
   import { formatTimeAgo } from '../lib/social';
   import { fetchSuggestions, type SpeciesSuggestion } from '../lib/suggestions';
@@ -382,7 +382,7 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
       return;
     }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       // Signed-out: render anonymous "Recent observations" only — but skip
       // the personalized hero entirely. Hide the greeting wrapper and show

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -26,6 +26,40 @@ if (!url || !anonKey) {
 let client: SupabaseClient | null = null;
 
 /**
+ * In-memory session cache to reduce concurrent navigator.locks contention.
+ * Multiple components mounting simultaneously each call auth.getUser() which
+ * competes for the gotrue navigator.lock — on Android Chrome with 15+ components
+ * this causes "Lock not released within 5000ms" warnings and AbortErrors.
+ *
+ * This cache holds the last resolved user for the duration of the page load.
+ * It is intentionally short-lived (cleared on visibility change) so stale
+ * sign-out state never persists across tab switches.
+ */
+let _userCache: { user: import('@supabase/supabase-js').User | null; resolvedAt: number } | null = null;
+const USER_CACHE_TTL_MS = 30_000; // 30s — enough to cover a full page hydration burst
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') _userCache = null;
+  });
+}
+
+/**
+ * Returns the current user with a short-lived in-memory cache.
+ * Use this instead of `getSupabase().auth.getUser()` in components that
+ * mount concurrently to avoid navigator.lock contention in gotrue.
+ */
+export async function getCachedUser() {
+  const now = Date.now();
+  if (_userCache && (now - _userCache.resolvedAt) < USER_CACHE_TTL_MS) {
+    return _userCache.user;
+  }
+  const { data: { user } } = await getSupabase().auth.getUser();
+  _userCache = { user, resolvedAt: now };
+  return user;
+}
+
+/**
  * Returns the singleton Supabase client. Only call from client-side code
  * (hydrated islands or <script> blocks) — Astro SSG pages themselves never
  * need this at build time.


### PR DESCRIPTION
Three bugs from Artemio's bug reports on 2026-05-09.

## 1. suggest_nearby_species 404

The function was written by the #876 subagent but got stripped during the rebase-heavy merge (worktree rebasing resolved the conflict by keeping the comment block without the function body).

Restored complete `SECURITY DEFINER` function with:
- Month-boundary fix from #881: `= ANY(ARRAY[prev,cur,next])` (not `BETWEEN ±1` which breaks at Jan/Dec)
- `idx_media_files_obs_primary` index for the correlated photo_url subquery

## 2. gotrue lock contention

7 concurrent "Lock not released within 5000ms" warnings + "Lock broken with steal option" AbortErrors on `/perfil/`. 

Root cause: 15+ components all call `auth.getUser()` on mount, competing for gotrue's navigator.lock.

Fix: `getCachedUser()` in `supabase.ts` — 30s in-memory cache, cleared on `visibilitychange: hidden`. `HomeWidgets` (first to hydrate, most sub-queries) migrated immediately. Other components can migrate incrementally.

## 3. order=observed 400

SW stale — no code fix. User closes all tabs to force SW update.