### PR TITLE
feat(auth): migrate components to getCachedUser() — reduce gotrue lock contention (#933)

### DIFF
--- a/src/components/AdminExpertsView.astro
+++ b/src/components/AdminExpertsView.astro
@@ -98,7 +98,7 @@ const profilePath = getLocalizedPath(lang, routes.profile[lang] + '/');
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   type AppRow = {
     id: string;
@@ -185,7 +185,7 @@ const profilePath = getLocalizedPath(lang, routes.profile[lang] + '/');
       return;
     }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       hide('admin-loading');
       show('admin-not-auth');

--- a/src/components/AppealView.astro
+++ b/src/components/AppealView.astro
@@ -112,7 +112,7 @@ const profilePath = getLocalizedPath(lang, routes.profile[lang] + '/');
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getActiveBanForUser } from '../lib/check-ban-status';
 
   const root = document.querySelector<HTMLElement>('.rastrum-appeal');
@@ -143,7 +143,7 @@ const profilePath = getLocalizedPath(lang, routes.profile[lang] + '/');
       return;
     }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       document.getElementById('appeal-not-signed-in')?.classList.remove('hidden');
       return;

--- a/src/components/BanBanner.astro
+++ b/src/components/BanBanner.astro
@@ -41,7 +41,7 @@ const appealPath = getLocalizedPath(
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getActiveBanForUser } from '../lib/check-ban-status';
 
   async function paintBanBanner() {
@@ -51,7 +51,7 @@ const appealPath = getLocalizedPath(
     let supabase;
     try { supabase = getSupabase(); } catch { return; }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return;
 
     const ban = await getActiveBanForUser(user.id).catch(() => null);

--- a/src/components/BellIcon.astro
+++ b/src/components/BellIcon.astro
@@ -38,7 +38,7 @@ const ariaLabel = lang === 'es' ? 'Bandeja' : 'Inbox';
 </a>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   const POLL_MS = 60_000;
 
@@ -56,8 +56,7 @@ const ariaLabel = lang === 'es' ? 'Bandeja' : 'Inbox';
       // round-trip) — we only need to know "is there a logged-in user"
       // for showing the bell. JWT validation happens on the actual
       // notification-count query against RLS.
-      const { data: { session } } = await supabase.auth.getSession();
-      const user = session?.user ?? null;
+      const user = await getCachedUser();
       if (!user) {
         if (wrapper) wrapper.classList.add('hidden');
         return;

--- a/src/components/BlockedUsersList.astro
+++ b/src/components/BlockedUsersList.astro
@@ -38,7 +38,7 @@ const block = (tr as unknown as {
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { unblockUser } from '../lib/social';
 
   type Row = {
@@ -63,7 +63,7 @@ const block = (tr as unknown as {
       return;
     }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       loading.classList.add('hidden');
       empty.classList.remove('hidden');

--- a/src/components/ChatEntityPicker.astro
+++ b/src/components/ChatEntityPicker.astro
@@ -55,7 +55,7 @@ const labels = {
 </style>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { bootstrapChatEntities, registry } from '../lib/chat-entities';
   import type { EntityKind } from '../lib/chat-entities/types';
   import { escapeHtml } from '../lib/chat-bubble-html';
@@ -104,8 +104,8 @@ const labels = {
         const { data } = await sb.rpc('chat_find_observers', { p_query: q || ' ', p_limit: 20 });
         rows = (data ?? []).map((r: { id: string; display_name?: string; username?: string }) => ({ id: r.id, label: r.display_name ?? r.username ?? r.id }));
       } else if (activeTab === 'self_profile') {
-        const me = await sb.auth.getUser();
-        if (me.data?.user) rows = [{ id: me.data.user.id, label: isEs ? 'Yo' : 'Me' }];
+        const me = await getCachedUser();
+        if (me) rows = [{ id: me.id, label: isEs ? 'Yo' : 'Me' }];
       } else if (activeTab === 'camera_station') {
         list.innerHTML = `<li class="text-xs text-zinc-500 italic">${STATION}</li>`;
         return;

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -119,7 +119,7 @@ const sgReportLabel = sgTree.socialgraph.report.button;
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { buildCommentTree, formatTimeAgo, sanitizeCommentBody, type CommentRow, type CommentNode } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
   import { tierForKarma } from '../lib/karma-frame';
@@ -257,7 +257,7 @@ const sgReportLabel = sgTree.socialgraph.report.button;
       return;
     }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     const currentUserId: string | null = user?.id ?? null;
 
     if (currentUserId) composer?.classList.remove('hidden');

--- a/src/components/CommunityMapView.astro
+++ b/src/components/CommunityMapView.astro
@@ -127,7 +127,7 @@ const stringsJson = JSON.stringify({
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.0/dist/maplibre-gl.css" />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { loadIsoCountries } from '../lib/community';
 
   interface Strings {
@@ -221,7 +221,7 @@ const stringsJson = JSON.stringify({
 
     // Check auth status
     try {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       isAuthenticated = !!user;
     } catch {
       isAuthenticated = false;

--- a/src/components/CommunityView.astro
+++ b/src/components/CommunityView.astro
@@ -219,7 +219,7 @@ const stringsJson = JSON.stringify({
 <script>
   import { parseFilters, serializeFilters, loadGps, saveGps, clearGps, type CommunityFilters, type CommunityGps } from '../lib/community-url';
   import { loadCommunity, loadCommunityNearbyAt, viewerHasCentroid, loadViewerCommunityMeta, loadIsoCountries, COMMUNITY_PAGE_SIZE, type CommunityObserver } from '../lib/community';
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { tierForKarma } from '../lib/karma-frame';
 
   interface Strings {
@@ -503,7 +503,7 @@ const stringsJson = JSON.stringify({
       // enforced server-side via the centroid view's grant; this UI
       // layer is purely UX.
       try {
-        const { data: { user } } = await getSupabase().auth.getUser();
+        const user = await getCachedUser();
         if (!user) { showEmpty(STRINGS.emptyNearbyAnon); return; }
         // Only require centroid when no GPS overlay is set.
         if (!gpsCoords) {

--- a/src/components/ConsoleApiQuotasView.astro
+++ b/src/components/ConsoleApiQuotasView.astro
@@ -43,7 +43,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
 
   type ApiUsageRow = {
@@ -100,9 +100,9 @@ const tr = t(lang);
   let allRows: ApiUsageRow[] = [];
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('api-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('api-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) { show('api-not-auth'); return; }
     show('api-shell');
     await loadRows();

--- a/src/components/ConsoleAuditLogView.astro
+++ b/src/components/ConsoleAuditLogView.astro
@@ -93,7 +93,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { readFilterState, writeFilterState } from '../lib/console-filter-state';
 
   type Row = {
@@ -125,7 +125,7 @@ const tr = t(lang);
 
   async function load() {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) { hide('audit-loading'); show('audit-not-auth'); return; }
 
     show('audit-filters');

--- a/src/components/ConsoleBioblitzView.astro
+++ b/src/components/ConsoleBioblitzView.astro
@@ -113,7 +113,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
 
   type EventRow = {
@@ -157,9 +157,9 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('bioblitz-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('bioblitz-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) { show('bioblitz-not-auth'); return; }
     show('bioblitz-shell');
     await loadEvents();

--- a/src/components/ConsoleCronRunsView.astro
+++ b/src/components/ConsoleCronRunsView.astro
@@ -43,7 +43,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
 
   type CronRunRow = {
@@ -87,9 +87,9 @@ const tr = t(lang);
   const loadFailedLabel = document.querySelector<HTMLElement>('section[data-load-failed-label]')?.dataset.loadFailedLabel ?? 'Could not load cron runs.';
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('cron-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('cron-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) { show('cron-not-auth'); return; }
     show('cron-shell');
     await loadRows();

--- a/src/components/ConsoleExpertExpertiseView.astro
+++ b/src/components/ConsoleExpertExpertiseView.astro
@@ -67,7 +67,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { readFilterState, writeFilterState, applyFilterStateToForm } from '../lib/console-filter-state';
 
@@ -160,9 +160,9 @@ const tr = t(lang);
   }
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('exp-skill-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('exp-skill-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('expert') && !myRoles.has('admin')) {
       show('exp-skill-not-auth');
       return;
@@ -172,7 +172,7 @@ const tr = t(lang);
     const { data, error } = await supabase
       .from('user_expertise')
       .select('taxon_id, score, verified_at, updated_at, taxa(scientific_name, kingdom)')
-      .eq('user_id', session.user.id)
+      .eq('user_id', user.id)
       .order('score', { ascending: false });
 
     hide('exp-skill-loading');

--- a/src/components/ConsoleExpertOverridesView.astro
+++ b/src/components/ConsoleExpertOverridesView.astro
@@ -66,7 +66,7 @@ const isEs = lang === 'es';
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { escapeHtml } from '../lib/escape';
 
@@ -190,9 +190,9 @@ const isEs = lang === 'es';
 
   (async () => {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('exp-overrides-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('exp-overrides-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('expert') && !myRoles.has('admin')) {
       show('exp-overrides-not-auth');
       return;

--- a/src/components/ConsoleExpertOverviewView.astro
+++ b/src/components/ConsoleExpertOverviewView.astro
@@ -64,7 +64,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
 
   function show(id: string) { document.getElementById(id)?.classList.remove('hidden'); }
@@ -76,15 +76,15 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('exp-overview-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('exp-overview-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('expert') && !myRoles.has('admin')) {
       show('exp-overview-not-auth');
       return;
     }
     show('exp-overview-shell');
-    await loadKpis(session.user.id);
+    await loadKpis(user.id);
   }
 
   async function loadKpis(userId: string) {

--- a/src/components/ConsoleExpertTaxonNotesView.astro
+++ b/src/components/ConsoleExpertTaxonNotesView.astro
@@ -66,7 +66,7 @@ const isEs = lang === 'es';
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { escapeHtml } from '../lib/escape';
 
@@ -187,9 +187,9 @@ const isEs = lang === 'es';
 
   (async () => {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('taxon-notes-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('taxon-notes-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('expert') && !myRoles.has('admin')) {
       show('taxon-notes-not-auth');
       return;

--- a/src/components/ConsoleExpertValidationView.astro
+++ b/src/components/ConsoleExpertValidationView.astro
@@ -70,7 +70,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { readFilterState, writeFilterState } from '../lib/console-filter-state';
 
@@ -99,9 +99,9 @@ const tr = t(lang);
   let myTaxaOnly = true;
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('exp-val-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('exp-val-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('expert') && !myRoles.has('admin')) {
       show('exp-val-not-auth');
       return;
@@ -111,7 +111,7 @@ const tr = t(lang);
     if (saved['scope'] === 'all') myTaxaOnly = false;
 
     // Fetch expert_taxa
-    const { data: userData } = await supabase.from('users').select('expert_taxa').eq('id', session.user.id).single();
+    const { data: userData } = await supabase.from('users').select('expert_taxa').eq('id', user.id).single();
     expertTaxa = userData?.expert_taxa ?? [];
 
     // Fetch queue

--- a/src/components/ConsoleFlagsView.astro
+++ b/src/components/ConsoleFlagsView.astro
@@ -57,7 +57,7 @@ const isEs = lang === 'es';
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { escapeHtml } from '../lib/escape';
 
@@ -182,9 +182,9 @@ const isEs = lang === 'es';
 
   (async () => {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('flags-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('flags-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) { show('flags-not-auth'); return; }
     shell?.classList.remove('hidden');
     const params = new URLSearchParams(window.location.search);

--- a/src/components/ConsoleFollowsView.astro
+++ b/src/components/ConsoleFollowsView.astro
@@ -70,7 +70,7 @@ const labels = {
 <div id="fol-config" class="hidden" data-lang={lang} data-drill-follower={labels.drillProfileFollower} data-drill-followee={labels.drillProfileFollowee}></div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import {
     EntityBrowser,
@@ -197,13 +197,13 @@ const labels = {
 
   async function init(): Promise<void> {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
+    const user = await getCachedUser();
+    if (!user) {
       document.getElementById('fol-skeleton')?.classList.add('hidden');
       document.getElementById('fol-not-auth')?.classList.remove('hidden');
       return;
     }
-    const myRoles = await getUserRoles(session.user.id);
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) {
       document.getElementById('fol-skeleton')?.classList.add('hidden');
       document.getElementById('fol-not-auth')?.classList.remove('hidden');

--- a/src/components/ConsoleIdentificationsView.astro
+++ b/src/components/ConsoleIdentificationsView.astro
@@ -73,7 +73,7 @@ const labels = {
 <div id="ids-config" class="hidden" data-lang={lang} data-drill-obs={labels.drillObs}></div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import {
     EntityBrowser,
@@ -241,13 +241,13 @@ const labels = {
 
   async function init(): Promise<void> {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
+    const user = await getCachedUser();
+    if (!user) {
       document.getElementById('ids-skeleton')?.classList.add('hidden');
       document.getElementById('ids-not-auth')?.classList.remove('hidden');
       return;
     }
-    const myRoles = await getUserRoles(session.user.id);
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) {
       document.getElementById('ids-skeleton')?.classList.add('hidden');
       document.getElementById('ids-not-auth')?.classList.remove('hidden');

--- a/src/components/ConsoleKarmaView.astro
+++ b/src/components/ConsoleKarmaView.astro
@@ -67,7 +67,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
 
   type KarmaConfigRow = {
@@ -107,9 +107,9 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('karma-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('karma-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) { show('karma-not-auth'); return; }
     show('karma-shell');
     await Promise.all([loadKarmaConfig(), loadRarityMultipliers(), loadRecentEvents()]);

--- a/src/components/ConsoleLayout.astro
+++ b/src/components/ConsoleLayout.astro
@@ -327,7 +327,7 @@ const knownPills: Set<UserRole> | null = allRoles ?? null;
 
     <script>
       import { installConsoleKeybindings } from '../lib/console-keybindings';
-      import { getSupabase } from '../lib/supabase';
+      import { getCachedUser, getSupabase } from '../lib/supabase';
       import { getUserRoles } from '../lib/user-roles';
       import { rolePillsFor } from '../lib/console-tabs';
       import type { UserRole } from '../lib/types';
@@ -364,7 +364,7 @@ const knownPills: Set<UserRole> | null = allRoles ?? null;
         if (!shell) return;
 
         const supabase = getSupabase();
-        const { data: { user } } = await supabase.auth.getUser();
+        const user = await getCachedUser();
         if (!user) return;
 
         const usernameEl = shell.querySelector('[data-console-username]') as HTMLElement | null;

--- a/src/components/ConsoleMediaView.astro
+++ b/src/components/ConsoleMediaView.astro
@@ -67,7 +67,7 @@ const labels = {
 <div id="med-config" class="hidden" data-lang={lang} data-r2={labels.drillR2Url}></div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import {
     EntityBrowser,
@@ -186,13 +186,13 @@ const labels = {
 
   async function init(): Promise<void> {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
+    const user = await getCachedUser();
+    if (!user) {
       document.getElementById('med-skeleton')?.classList.add('hidden');
       document.getElementById('med-not-auth')?.classList.remove('hidden');
       return;
     }
-    const myRoles = await getUserRoles(session.user.id);
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) {
       document.getElementById('med-skeleton')?.classList.add('hidden');
       document.getElementById('med-not-auth')?.classList.remove('hidden');

--- a/src/components/ConsoleModDisputesView.astro
+++ b/src/components/ConsoleModDisputesView.astro
@@ -65,7 +65,7 @@ const isEs = lang === 'es';
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { escapeHtml } from '../lib/escape';
 
@@ -194,9 +194,9 @@ const isEs = lang === 'es';
 
   (async () => {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('disputes-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('disputes-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('moderator') && !myRoles.has('admin')) {
       show('disputes-not-auth');
       return;

--- a/src/components/ConsoleModOverviewView.astro
+++ b/src/components/ConsoleModOverviewView.astro
@@ -56,7 +56,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
 
   function show(id: string) { document.getElementById(id)?.classList.remove('hidden'); }
@@ -64,9 +64,9 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('mod-overview-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('mod-overview-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('moderator') && !myRoles.has('admin')) {
       show('mod-overview-not-auth');
       return;

--- a/src/components/ConsoleNotificationsView.astro
+++ b/src/components/ConsoleNotificationsView.astro
@@ -61,7 +61,7 @@ const labels = {
 <div id="ntf-config" class="hidden" data-lang={lang}></div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import {
     EntityBrowser,
@@ -190,13 +190,13 @@ const labels = {
 
   async function init(): Promise<void> {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
+    const user = await getCachedUser();
+    if (!user) {
       document.getElementById('ntf-skeleton')?.classList.add('hidden');
       document.getElementById('ntf-not-auth')?.classList.remove('hidden');
       return;
     }
-    const myRoles = await getUserRoles(session.user.id);
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) {
       document.getElementById('ntf-skeleton')?.classList.add('hidden');
       document.getElementById('ntf-not-auth')?.classList.remove('hidden');

--- a/src/components/ConsoleOverviewView.astro
+++ b/src/components/ConsoleOverviewView.astro
@@ -91,7 +91,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
 
   function show(id: string) { document.getElementById(id)?.classList.remove('hidden'); }
@@ -140,9 +140,9 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('admin-overview-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('admin-overview-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) {
       show('admin-overview-not-auth');
       return;

--- a/src/components/ConsoleProjectsView.astro
+++ b/src/components/ConsoleProjectsView.astro
@@ -68,7 +68,7 @@ const labels = {
 <div id="prj-config" class="hidden" data-lang={lang} data-drill-view={labels.drillView} data-drill-obs={labels.drillObs}></div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import {
     EntityBrowser,
@@ -235,13 +235,13 @@ const labels = {
 
   async function init(): Promise<void> {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
+    const user = await getCachedUser();
+    if (!user) {
       document.getElementById('prj-skeleton')?.classList.add('hidden');
       document.getElementById('prj-not-auth')?.classList.remove('hidden');
       return;
     }
-    const myRoles = await getUserRoles(session.user.id);
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) {
       document.getElementById('prj-skeleton')?.classList.add('hidden');
       document.getElementById('prj-not-auth')?.classList.remove('hidden');

--- a/src/components/ConsoleSyncFailuresView.astro
+++ b/src/components/ConsoleSyncFailuresView.astro
@@ -51,7 +51,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { readFilterState, writeFilterState, applyFilterStateToForm } from '../lib/console-filter-state';
 
@@ -84,9 +84,9 @@ const tr = t(lang);
   let allRows: SyncFailureRow[] = [];
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) { show('sync-not-auth'); return; }
-    const myRoles = await getUserRoles(session.user.id);
+    const user = await getCachedUser();
+    if (!user) { show('sync-not-auth'); return; }
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) { show('sync-not-auth'); return; }
     show('sync-shell');
     applyFilterStateToForm(readFilterState(), {

--- a/src/components/ConsoleTaxonChangesView.astro
+++ b/src/components/ConsoleTaxonChangesView.astro
@@ -61,7 +61,7 @@ const labels = {
 <div id="txc-config" class="hidden" data-lang={lang} data-act-conservation={labels.actConservation}></div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import {
     EntityBrowser,
@@ -197,13 +197,13 @@ const labels = {
 
   async function init(): Promise<void> {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
+    const user = await getCachedUser();
+    if (!user) {
       document.getElementById('txc-skeleton')?.classList.add('hidden');
       document.getElementById('txc-not-auth')?.classList.remove('hidden');
       return;
     }
-    const myRoles = await getUserRoles(session.user.id);
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) {
       document.getElementById('txc-skeleton')?.classList.add('hidden');
       document.getElementById('txc-not-auth')?.classList.remove('hidden');

--- a/src/components/ConsoleWatchlistsView.astro
+++ b/src/components/ConsoleWatchlistsView.astro
@@ -56,7 +56,7 @@ const labels = {
 <div id="wl-config" class="hidden" data-lang={lang} data-yes={labels.yes} data-no={labels.no}></div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import {
     EntityBrowser,
@@ -165,13 +165,13 @@ const labels = {
 
   async function init(): Promise<void> {
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
+    const user = await getCachedUser();
+    if (!user) {
       document.getElementById('wl-skeleton')?.classList.add('hidden');
       document.getElementById('wl-not-auth')?.classList.remove('hidden');
       return;
     }
-    const myRoles = await getUserRoles(session.user.id);
+    const myRoles = await getUserRoles(user.id);
     if (!myRoles.has('admin')) {
       document.getElementById('wl-skeleton')?.classList.add('hidden');
       document.getElementById('wl-not-auth')?.classList.remove('hidden');

--- a/src/components/ExpertApplyView.astro
+++ b/src/components/ExpertApplyView.astro
@@ -167,7 +167,7 @@ const roadmapPath = getLocalizedPath(lang, '/docs/roadmap/');
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   type ProfileRow = { is_expert: boolean | null };
 
@@ -186,7 +186,7 @@ const roadmapPath = getLocalizedPath(lang, '/docs/roadmap/');
       return;
     }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       show('expert-signin');
       return;

--- a/src/components/ExpertiseCoverageGrid.astro
+++ b/src/components/ExpertiseCoverageGrid.astro
@@ -36,7 +36,7 @@ const emptyMsg = lang === 'es'
 
 <script>
   import { getExpertiseCoverage, legendTitle, tierColors } from '../lib/expertise-legends';
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   async function init() {
     const grid = document.getElementById('expertise-coverage-grid');
@@ -47,8 +47,8 @@ const emptyMsg = lang === 'es'
     const emptyMsg = grid.dataset.empty ?? '';
 
     if (!userId) {
-      const { data } = await getSupabase().auth.getUser();
-      userId = data.user?.id ?? '';
+      const _authUser = await getCachedUser();
+      userId = _authUser?.id ?? '';
     }
     if (!userId) { grid.innerHTML = `<p class="col-span-full text-xs text-zinc-400">${emptyMsg}</p>`; return; }
 

--- a/src/components/ExpertiseLegendBadge.astro
+++ b/src/components/ExpertiseLegendBadge.astro
@@ -33,7 +33,7 @@ const { lang, userId = '', class: extraClass = '' } = Astro.props;
 
 <script>
   import { getTopLegend, legendTitle, tierColors, tierLabel } from '../lib/expertise-legends';
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   async function init() {
     const el = document.getElementById('expertise-legend-badge');
@@ -44,8 +44,8 @@ const { lang, userId = '', class: extraClass = '' } = Astro.props;
 
     // If no userId provided, use current auth user
     if (!userId) {
-      const { data } = await getSupabase().auth.getUser();
-      userId = data.user?.id ?? '';
+      const _authUser = await getCachedUser();
+      userId = _authUser?.id ?? '';
     }
     if (!userId) return;
 

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -183,7 +183,7 @@ const timeline = (page as unknown as { timeline: Record<string, string> }).timel
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { formatTimeAgo } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
   import {
@@ -581,9 +581,9 @@ const timeline = (page as unknown as { timeline: Record<string, string> }).timel
     let viewerAuthed = false;
     let viewerId: string | null = null;
     try {
-      const { data } = await supabase.auth.getUser();
-      viewerAuthed = !!data.user;
-      viewerId = data.user?.id ?? null;
+      const _viewer = await getCachedUser();
+      viewerAuthed = !!_viewer;
+      viewerId = _viewer?.id ?? null;
     } catch { viewerAuthed = false; viewerId = null; }
 
     async function fetchPage(): Promise<Row[]> {

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -194,7 +194,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
 
 <script>
   import maplibregl from 'maplibre-gl';
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { renderSpeciesCard, type CardLabels } from '../lib/species-card-html';
   import { parseChips, parseSort, buildSpeciesUrl, type ChipsState, type SortMode } from '../lib/species-filters';
   import { deriveGenus, colorForName, buildTaxonomicTree, taxonomicDepth, type TaxonNode } from '../lib/species-display';
@@ -414,7 +414,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     let inDexSet = new Set<string>();
     {
       try {
-        const { data: { user } } = await supabase.auth.getUser();
+        const user = await getCachedUser();
         if (user) {
           const { data: dex } = await supabase
             .from('profile_pokedex')

--- a/src/components/ExploreWatchlistView.astro
+++ b/src/components/ExploreWatchlistView.astro
@@ -45,7 +45,7 @@ const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   const anonCta = document.getElementById('ew-anon-cta');
   const signedInBlock = document.getElementById('ew-signed-in');
@@ -58,7 +58,7 @@ const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
       anonCta?.classList.remove('hidden');
       return;
     }
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (user) {
       signedInBlock?.classList.remove('hidden');
     } else {

--- a/src/components/ExportView.astro
+++ b/src/components/ExportView.astro
@@ -82,7 +82,7 @@ const tr = t(lang);
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { toDwCRecord, toCSV, toCsvSnib, toCsvConanp, downloadCSV, type DwCInput } from '../lib/darwin-core';
   import type { UserProfile } from '../lib/types';
 
@@ -97,7 +97,7 @@ const tr = t(lang);
 
   async function refreshCount() {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) { if (countEl) countEl.textContent = '0'; btn && (btn.disabled = true); return; }
     const { count } = await supabase
       .from('observations')
@@ -119,7 +119,7 @@ const tr = t(lang);
 
     try {
       const supabase = getSupabase();
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) throw new Error('Not signed in');
 
       const { data: profile } = await supabase

--- a/src/components/FollowButton.astro
+++ b/src/components/FollowButton.astro
@@ -52,7 +52,7 @@ const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { followUser, unfollowUser } from '../lib/social';
 
   type FollowEl = HTMLElement & { __wired?: boolean };
@@ -114,7 +114,7 @@ const signInPath = getLocalizedPath(lang, routes.signIn[lang] + '/');
     let supabase;
     try { supabase = getSupabase(); } catch { return; }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
 
     if (!user) {
       paint(btn, 'signin', root);

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -319,7 +319,7 @@ const docColumns = [
 
 <!-- Auth status: keeps the existing avatar-swap behavior -->
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { signOut, SUPABASE_AUTH_STORAGE_KEY, HEADER_AVATAR_CACHE_KEY, HEADER_AVATAR_NAME_KEY } from '../lib/auth';
   import { getUserRoles } from '../lib/user-roles';
   import type { UserProfile } from '../lib/types';
@@ -414,9 +414,9 @@ const docColumns = [
 
   (async () => {
     try {
-      const { data: { session } } = await getSupabase().auth.getSession();
-      await paint(!!session, session?.user as Parameters<typeof paint>[1]);
-      if (session?.user) await maybeShowConsolePill(session.user.id);
+      const user = await getCachedUser();
+      await paint(!!user, user as Parameters<typeof paint>[1]);
+      if (user) await maybeShowConsolePill(user.id);
       getSupabase().auth.onAuthStateChange(async (_evt, s) => {
         paint(!!s, s?.user as Parameters<typeof paint>[1]);
         if (s?.user) await maybeShowConsolePill(s.user.id);

--- a/src/components/ImpactView.astro
+++ b/src/components/ImpactView.astro
@@ -169,7 +169,7 @@ const cards = [
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { formatTransectKm, formatCount, isUserImpact } from '../lib/impact';
 
   const root = document.querySelector<HTMLElement>('.rastrum-impact');
@@ -265,7 +265,7 @@ const cards = [
       return;
     }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       hide(loading);
       show(anonCta);

--- a/src/components/InboxView.astro
+++ b/src/components/InboxView.astro
@@ -114,7 +114,7 @@ const subtitleCopy = lang === 'es'
 </BaseLayout>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   type Lang = 'en' | 'es';
 
@@ -344,7 +344,7 @@ const subtitleCopy = lang === 'es'
       showSignIn();
       return;
     }
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       showSignIn();
       return;
@@ -431,7 +431,7 @@ const subtitleCopy = lang === 'es'
       markAll.disabled = true;
       try {
         const sb = getSupabase();
-        const { data: { user: me } } = await sb.auth.getUser();
+        const me = await getCachedUser();
         if (!me) return;
         await sb
           .from('notifications')

--- a/src/components/KarmaLeaderboardView.astro
+++ b/src/components/KarmaLeaderboardView.astro
@@ -264,7 +264,7 @@ const stringsJson = JSON.stringify({
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { tierForKarma } from '../lib/karma-frame';
   import {
     viewFromSearch,
@@ -447,8 +447,8 @@ const stringsJson = JSON.stringify({
       const supabase = getSupabase();
       // Get user's own country first for pre-selection
       let userCountry = '';
-      const { data: sessionData } = await supabase.auth.getSession();
-      const userId = sessionData?.session?.user?.id;
+      const _karmaUser = await getCachedUser();
+      const userId = _karmaUser?.id;
       if (userId) {
         const { data: userData } = await supabase
           .from('community_observers')
@@ -798,8 +798,8 @@ const stringsJson = JSON.stringify({
   async function getCurrentUserId(): Promise<string | null> {
     try {
       const supabase = getSupabase();
-      const { data } = await supabase.auth.getSession();
-      return data.session?.user?.id ?? null;
+      const _user = await getCachedUser();
+      return _user?.id ?? null;
     } catch {
       return null;
     }

--- a/src/components/MobileBottomBar.astro
+++ b/src/components/MobileBottomBar.astro
@@ -181,9 +181,9 @@ const discoverActive  = isActiveSection(currentPath, 'community',     lang);
 
 <!--
   First-paint cache. Header.astro writes `rastrum.headerAvatar` to localStorage
-  every time it resolves a session; we read it synchronously here so the
+  every time it resolves a user; we read it synchronously here so the
   authed variant (with FAB) shows on first paint instead of flashing the
-  4-tab anon layout while Supabase resolves the session asynchronously.
+  4-tab anon layout while Supabase resolves the user asynchronously.
 -->
 <script is:inline>
   (function () {
@@ -205,7 +205,7 @@ const discoverActive  = isActiveSection(currentPath, 'community',     lang);
   another tab, etc.) so the bar stays in sync.
 -->
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   const authed = document.getElementById('mbb-authed');
   const anon   = document.getElementById('mbb-anon');
@@ -218,8 +218,8 @@ const discoverActive  = isActiveSection(currentPath, 'community',     lang);
 
   (async () => {
     try {
-      const { data: { session } } = await getSupabase().auth.getSession();
-      paint(!!session);
+      const user = await getCachedUser();
+      paint(!!user);
       getSupabase().auth.onAuthStateChange((_e, s) => paint(!!s));
     } catch { /* env not set; leave anon visible */ }
   })();

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -194,7 +194,7 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
 </aside>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { signOut, SUPABASE_AUTH_STORAGE_KEY, HEADER_AVATAR_CACHE_KEY, HEADER_AVATAR_NAME_KEY } from '../lib/auth';
   import { getUserRoles } from '../lib/user-roles';
 
@@ -241,9 +241,9 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
   }
   (async () => {
     try {
-      const { data: { session } } = await getSupabase().auth.getSession();
-      paintAuth(!!session);
-      if (session?.user) await maybeShowConsoleLink(session.user.id);
+      const user = await getCachedUser();
+      paintAuth(!!user);
+      if (user) await maybeShowConsoleLink(user.id);
       getSupabase().auth.onAuthStateChange(async (_e, s) => {
         paintAuth(!!s);
         if (s?.user) await maybeShowConsoleLink(s.user.id);

--- a/src/components/MyObservationsView.astro
+++ b/src/components/MyObservationsView.astro
@@ -226,7 +226,7 @@ const tabs = [
 <FirstObservationCelebration lang={lang} />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { isSyncFilter, type SyncFilter } from '../lib/social';
   import { buildBugReportUrl } from '../lib/bug-report';
   import { parseImpactFilter, type ImpactFilter } from '../lib/impact-filter';
@@ -850,8 +850,8 @@ const tabs = [
     // Guard: check session first. getSession() reads from localStorage and
     // is synchronous-ish — it won't hang on a stale token the way getUser()
     // can when the refresh token is invalid and GoTrue retries internally.
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
+    const _session_user = await getCachedUser();
+    if (!_session_user) {
       showExpiredSessionUI();
       return;
     }

--- a/src/components/NotificationPrefsView.astro
+++ b/src/components/NotificationPrefsView.astro
@@ -194,7 +194,7 @@ const EMAIL_TOGGLES = [
 </div>
 
 <script>
-import { getSupabase } from '../lib/supabase';
+import { getCachedUser, getSupabase } from '../lib/supabase';
 
 type NotifPrefs = {
   push?: Record<string, boolean>;
@@ -252,7 +252,7 @@ function prefSet(channel: string, trigger: string, value: boolean) {
 
 async function savePrefs() {
   const sb = getSupabase();
-  const { data: { user } } = await sb.auth.getUser();
+  const user = await getCachedUser();
   if (!user) return;
 
   const { error } = await sb
@@ -281,7 +281,7 @@ async function init() {
   }
 
   const sb = getSupabase();
-  const { data: { user } } = await sb.auth.getUser();
+  const user = await getCachedUser();
   if (!user) return;
 
   // Load current prefs

--- a/src/components/OnboardingTour.astro
+++ b/src/components/OnboardingTour.astro
@@ -181,7 +181,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
 />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   type StepDef = { title: string; body: string; target: string | null; kind?: 'privacy_preset' };
 
@@ -357,7 +357,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     let sb;
     try { sb = getSupabase(); } catch { return; }
     try {
-      const { data: { user } } = await sb.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       await sb.from('users').update({ profile_privacy: PRESET_DEFS[preset] }).eq('id', user.id);
     } catch { /* env not configured / column missing — fail closed */ }
@@ -587,7 +587,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     if (seen()) return;
     let sb;
     try { sb = getSupabase(); } catch { return; }
-    const { data: { user } } = await sb.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return;
     // Cross-device dedupe: if this user already configured privacy on another
     // browser/session, the server holds profile_privacy. Treat that as proof

--- a/src/components/PokedexView.astro
+++ b/src/components/PokedexView.astro
@@ -129,7 +129,7 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
 </style>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { escAttr } from '../lib/karma';
   import { renderSpeciesCard, type CardLabels } from '../lib/species-card-html';
   import {
@@ -678,7 +678,7 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
       emptyEl?.classList.remove('hidden');
       return;
     }
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       loading?.classList.add('hidden');
       emptyEl?.classList.remove('hidden');
@@ -705,7 +705,7 @@ const exploreHref       = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'exp
       errorEl?.classList.remove('hidden');
       return;
     }
-    const { data: { user: viewer } } = await supabase.auth.getUser();
+    const viewer = await getCachedUser();
     const { data: profile, error: lookupErr } = await supabase
       .from('users')
       .select('id, username')

--- a/src/components/PoolDonateView.astro
+++ b/src/components/PoolDonateView.astro
@@ -131,10 +131,10 @@ const cancelLabel = lang === 'es' ? 'Cancelar' : 'Cancel';
     const noCredsMsg   = root.dataset.noCredsMsg ?? '';
 
     // Dynamic imports to keep the page lightweight for anonymous visitors
-    const { getSupabase } = await import('../lib/supabase');
-    const { data: { session } } = await getSupabase().auth.getSession();
+    const { getSupabase, getCachedUser } = await import('../lib/supabase');
+    const user = await getCachedUser();
 
-    if (!session) {
+    if (!user) {
       signInEl?.classList.remove('hidden');
       return;
     }

--- a/src/components/PrivacyIntroBanner.astro
+++ b/src/components/PrivacyIntroBanner.astro
@@ -36,7 +36,7 @@ const settingsHref = lang === 'es' ? '/es/perfil/ajustes/privacy/' : '/en/profil
 </aside>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { PRIVACY_PRESETS } from '../lib/profile-widgets';
 
   async function init() {
@@ -44,7 +44,7 @@ const settingsHref = lang === 'es' ? '/es/perfil/ajustes/privacy/' : '/en/profil
     if (!banner) return;
     let supabase;
     try { supabase = getSupabase(); } catch { return; }
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return;
     const { data } = await supabase
       .from('users')

--- a/src/components/PrivacyMatrix.astro
+++ b/src/components/PrivacyMatrix.astro
@@ -200,7 +200,7 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
 />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { SUPABASE_AUTH_STORAGE_KEY } from '../lib/auth';
   import {
     applyPreset,
@@ -222,7 +222,7 @@ const levels: Array<{ key: 'public' | 'signed_in' | 'private'; label: string }> 
 
   async function init(rootEl: HTMLElement) {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       window.location.replace(rootEl.dataset.lang === 'es' ? '/es/ingresar/' : '/en/sign-in/');
       return;

--- a/src/components/ProfileBasicForm.astro
+++ b/src/components/ProfileBasicForm.astro
@@ -155,7 +155,7 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { shouldShowInferredCountryBadge, buildCommunityDiscoveryPayload } from '../lib/profile-edit';
   import type { UserProfile } from '../lib/types';
 
@@ -217,7 +217,7 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
   async function load() {
     if (!form) return;
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       window.location.replace(`${window.location.pathname.startsWith('/es/') ? '/es/ingresar/' : '/en/sign-in/'}`);
       return;
@@ -291,7 +291,7 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
     };
 
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return;
 
     const { error } = await supabase.from('users').update(payload).eq('id', user.id);
@@ -416,7 +416,7 @@ const privacyTr = (tr as unknown as { privacy: { manage_in_tab_note: string } })
       setSppWarn(reasonMap[r.reason ?? 'unknown'] ?? r.message ?? '');
     } else {
       const supabase = getSupabase();
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (user) {
         await supabase.from('users').update({ streak_digest_opt_in: turningOn }).eq('id', user.id);
       }

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -338,7 +338,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
 />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { shouldShowInferredCountryBadge, buildCommunityDiscoveryPayload } from '../lib/profile-edit';
   import type { UserProfile } from '../lib/types';
 
@@ -402,7 +402,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
   async function load() {
     if (!form) return;
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       window.location.replace(`${window.location.pathname.startsWith('/es/') ? '/es/ingresar/' : '/en/sign-in/'}`);
       return;
@@ -484,7 +484,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
     };
 
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return;
 
     const { error } = await supabase.from('users').update(payload).eq('id', user.id);

--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -268,7 +268,7 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { escAttr } from '../lib/karma';
   import { tierForKarma } from '../lib/karma-frame';
   import type { UserProfile } from '../lib/types';
@@ -301,7 +301,7 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
 
   async function run() {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
 
     if (!user) {
       signedOut?.classList.remove('hidden');
@@ -551,7 +551,7 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
     if (!totalEl || !listEl) return;
 
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return;
 
     const [{ data: u }, { data: events }, { data: expertise }] = await Promise.all([

--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -541,7 +541,7 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
 </script>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getSupabase, getCachedUser } from '../lib/supabase';
   import { formatDelta, escAttr } from '../lib/karma';
 
   (async function hydrateKarma() {

--- a/src/components/ProjectDetailView.astro
+++ b/src/components/ProjectDetailView.astro
@@ -181,10 +181,10 @@ const proj = (tr as unknown as { projects: Record<string, string> }).projects;
   // ── M31: camera stations ─────────────────────────────────────────
   async function initStations(projectId: string, ownerUserId: string) {
     const { listProjectStations, createStation, trapNights, isValidStationKey, listStationPeriods, createPeriod, closePeriod } = await import('../lib/camera-stations');
-    const { getSupabase } = await import('../lib/supabase');
+    const { getSupabase, getCachedUser } = await import('../lib/supabase');
     const sb = getSupabase();
-    const { data: { session } } = await sb.auth.getSession();
-    const isOwner = session?.user?.id === ownerUserId;
+    const user = await getCachedUser();
+    const isOwner = user?.id === ownerUserId;
 
     const addBtn   = document.getElementById('stations-add-btn');
     const ownerWarn = document.getElementById('stations-owner-only');
@@ -195,7 +195,7 @@ const proj = (tr as unknown as { projects: Record<string, string> }).projects;
     const errBox   = document.getElementById('stations-form-error');
 
     if (isOwner) addBtn?.classList.remove('hidden');
-    else if (session?.user) ownerWarn?.classList.remove('hidden');
+    else if (user) ownerWarn?.classList.remove('hidden');
 
     addBtn?.addEventListener('click', () => form?.classList.remove('hidden'));
     cancelBtn?.addEventListener('click', () => {

--- a/src/components/ProjectNewView.astro
+++ b/src/components/ProjectNewView.astro
@@ -104,7 +104,7 @@ const projectsBase = routes.projects[lang];
 <script>
   import { upsertProject, validatePolygonGeoJSON, isValidSlug } from '../lib/projects';
   import { validateKMLOrKMZ } from '../lib/kml-parser';
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
   const root = document.querySelector('[data-projects-base]') as HTMLElement | null;
@@ -122,8 +122,8 @@ const projectsBase = routes.projects[lang];
 
     (async () => {
       const sb = getSupabase();
-      const { data: { session } } = await sb.auth.getSession();
-      if (!session?.user) {
+      const user = await getCachedUser();
+      if (!user) {
         signInWarn?.classList.remove('hidden');
         return;
       }

--- a/src/components/ProjectsListView.astro
+++ b/src/components/ProjectsListView.astro
@@ -50,7 +50,7 @@ const projectsBase = routes.projects[lang];
 
 <script>
   import { listProjects } from '../lib/projects';
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { escapeHtml } from '../lib/escape';
 
   const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
@@ -65,8 +65,8 @@ const projectsBase = routes.projects[lang];
 
     async function load() {
       const sb = getSupabase();
-      const { data: { session } } = await sb.auth.getSession();
-      if (session?.user) {
+      const user = await getCachedUser();
+      if (user) {
         cta?.classList.remove('hidden');
       }
       let rows;
@@ -76,20 +76,20 @@ const projectsBase = routes.projects[lang];
         console.warn('[rastrum] projects list failed', err);
         rows = [];
       }
-      const mineRows = session?.user
-        ? rows.filter((r) => r.owner_user_id === session.user.id)
+      const mineRows = user
+        ? rows.filter((r) => r.owner_user_id === user.id)
         : [];
-      const otherRows = session?.user
-        ? rows.filter((r) => r.owner_user_id !== session.user.id && r.visibility === 'public')
+      const otherRows = user
+        ? rows.filter((r) => r.owner_user_id !== user.id && r.visibility === 'public')
         : rows.filter((r) => r.visibility === 'public');
 
-      if (mineRows.length === 0 && session?.user) {
+      if (mineRows.length === 0 && user) {
         mineEmpty?.classList.remove('hidden');
       }
       if (otherRows.length === 0) {
         pubEmpty?.classList.remove('hidden');
       }
-      if (!session?.user) {
+      if (!user) {
         // Hide the "my projects" section entirely when not signed in.
         document.querySelector('[data-section="my"]')?.classList.add('hidden');
       }

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -235,7 +235,7 @@ const sponsoringI18n = {
 <script type="application/json" id="public-profile-i18n" set:html={JSON.stringify(sponsoringI18n)}></script>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { wireOverflowMenu } from '../lib/overflow-menu';
   import { openConfirmDialog } from '../lib/confirm-dialog';
   import { tierForKarma } from '../lib/karma-frame';
@@ -302,7 +302,7 @@ const sponsoringI18n = {
       return;
     }
 
-    const { data: { user: viewer } } = await supabase.auth.getUser();
+    const viewer = await getCachedUser();
 
     const { data: profile } = await supabase
       .from('users')

--- a/src/components/ReactionStrip.astro
+++ b/src/components/ReactionStrip.astro
@@ -93,7 +93,7 @@ const sizeClasses = size === 'md'
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { react } from '../lib/social';
 
   type ReactTarget = 'observation' | 'photo' | 'identification';
@@ -149,7 +149,7 @@ const sizeClasses = size === 'md'
     }
 
     // My reactions
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     const mine = new Set<string>();
     if (user) {
       const { data: myRows } = await supabase

--- a/src/components/SignInForm.astro
+++ b/src/components/SignInForm.astro
@@ -97,13 +97,13 @@ const tr = t(lang);
     verifyPasskey,
     passkeySupported,
   } from '../lib/auth';
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   // If the user already has a valid session, skip the form entirely.
   (async () => {
     try {
-      const { data: { session } } = await getSupabase().auth.getSession();
-      if (session?.user) {
+      const user = await getCachedUser();
+      if (user) {
         const isEsPath = window.location.pathname.startsWith('/es/');
         window.location.replace(isEsPath ? '/es/' : '/en/');
       }

--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -1165,8 +1165,9 @@ const langJson = JSON.stringify(lang);
     try { bens = await listSponsorships('sponsor'); } catch { /* silent */ }
     tbody.innerHTML = '';
 
-    const supabase = (await import('../lib/supabase')).getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { getSupabase, getCachedUser } = await import('../lib/supabase');
+    const supabase = getSupabase();
+    const user = await getCachedUser();
     const myId = user?.id;
 
     const ids = Array.from(new Set(bens.map(b => b.beneficiary_id)));
@@ -1263,8 +1264,9 @@ const langJson = JSON.stringify(lang);
   });
 
   async function refreshAnalytics(days = 30) {
-    const supabase = (await import('../lib/supabase')).getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const { getSupabase, getCachedUser } = await import('../lib/supabase');
+    const supabase = getSupabase();
+    const user = await getCachedUser();
     if (!user) return;
 
     const sinceIso   = new Date(Date.now() - days * 24 * 60 * 60_000).toISOString();

--- a/src/components/SponsorshipBanner.astro
+++ b/src/components/SponsorshipBanner.astro
@@ -9,7 +9,7 @@ const tr = t(lang);
 
 <script>
   import { listSponsorships, getUsage } from '../lib/sponsorships';
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   interface CachedUsage { pctUsed: number; cap: number; usedThisMonth: number; sponsorshipId: string; }
   const CACHE_KEY = 'rastrum.sponsorshipBanner';
@@ -19,10 +19,8 @@ const tr = t(lang);
     const banner = document.getElementById('sponsorship-banner') as HTMLElement | null;
     if (!banner) return;
 
-    let supabaseSession;
-    try { supabaseSession = (await getSupabase().auth.getSession()).data.session; }
-    catch { return; }
-    if (!supabaseSession) return;
+    const supabaseUser = await getCachedUser().catch(() => null);
+    if (!supabaseUser) return;
 
     let usage: CachedUsage | null = null;
     const cached = sessionStorage.getItem(CACHE_KEY);

--- a/src/components/StreakCard.astro
+++ b/src/components/StreakCard.astro
@@ -79,7 +79,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { summarizeStreak, formatStreakDays, type StreakRow, type StreakState } from '../lib/social';
   import { normalizeMatrix } from '../lib/privacy-presets';
 
@@ -145,7 +145,7 @@ const tr = t(lang);
       return;
     }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       // Not signed in — ProfileView handles signed-out state; hide the card.
       root.classList.add('hidden');

--- a/src/components/StreakRemindersSection.astro
+++ b/src/components/StreakRemindersSection.astro
@@ -113,7 +113,7 @@ const psp = (tr as unknown as { profile_streak_push: { section_title: string; se
         setSppWarn(reasonMap[r.reason ?? 'unknown'] ?? r.message ?? '');
       } else {
         const supabase = supabaseLib.getSupabase();
-        const { data: { user } } = await supabase.auth.getUser();
+        const user = await supabaseLib.getCachedUser();
         if (user) {
           await supabase.from('users').update({ streak_digest_opt_in: turningOn }).eq('id', user.id);
         }

--- a/src/components/SuggestIdModal.astro
+++ b/src/components/SuggestIdModal.astro
@@ -104,7 +104,7 @@ const v = (tr as unknown as { validation: Record<string, string> }).validation;
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { microcopyForVote, type Bucket } from '../lib/karma';
 
   const modal = document.getElementById('suggest-id-modal') as HTMLElement | null;
@@ -288,7 +288,7 @@ const v = (tr as unknown as { validation: Record<string, string> }).validation;
 
       try {
         const supabase = getSupabase();
-        const { data: { user } } = await supabase.auth.getUser();
+        const user = await getCachedUser();
         if (!user) throw new Error('not_signed_in');
 
         // Resolve taxon_id by name (required — see spec; the consensus

--- a/src/components/SurprisesPrefsSection.astro
+++ b/src/components/SurprisesPrefsSection.astro
@@ -73,15 +73,15 @@ const docHref = lang === 'es' ? getDocPath('es', 'surprises') : getDocPath('en',
       errorEl.classList.remove('hidden');
     }
 
-    const { getSupabase } = await import('../lib/supabase.ts');
+    const { getSupabase, getCachedUser } = await import('../lib/supabase.ts');
     const supabase = getSupabase();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user?.id) {
+    const user = await getCachedUser();
+    if (!user?.id) {
       cb.disabled = true;
       setStatus(false);
       return;
     }
-    const userId = session.user.id;
+    const userId = user.id;
 
     // Read current pref
     try {

--- a/src/components/ValidationDashboardView.astro
+++ b/src/components/ValidationDashboardView.astro
@@ -57,13 +57,13 @@ const queuePath = getLocalizedPath(lang, routes.exploreValidate[lang] + '/');
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
 
   const root = document.querySelector<HTMLElement>('.rastrum-validation-dashboard');
   if (root) {
     (async () => {
       const supabase = getSupabase();
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) {
         document.getElementById('vd-signin')?.classList.remove('hidden');
         return;

--- a/src/components/ValidationQueueView.astro
+++ b/src/components/ValidationQueueView.astro
@@ -72,7 +72,7 @@ const sharePathBase = '/share/obs/';
 <SuggestIdModal lang={lang} />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import type { ValidationQueueRow } from '../lib/types';
 
   const root = document.querySelector<HTMLElement>('.rastrum-validation-queue');
@@ -177,7 +177,7 @@ const sharePathBase = '/share/obs/';
       try {
         const supabase = getSupabase();
         // Auth state (decides whether to show signin prompt + Sugerir CTAs).
-        const { data: { user } } = await supabase.auth.getUser();
+        const user = await getCachedUser();
         userId = user?.id ?? null;
         if (!userId) document.getElementById('vq-signin')?.classList.remove('hidden');
 

--- a/src/components/WatchlistView.astro
+++ b/src/components/WatchlistView.astro
@@ -48,7 +48,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase } from '../lib/supabase';
   import { formatTimeAgo } from '../lib/social';
 
   type ActivityRow = {
@@ -112,7 +112,7 @@ const tr = t(lang);
     let supabase;
     try { supabase = getSupabase(); } catch { hideSkeleton(); return; }
 
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) { hideSkeleton(); return; }
 
     const since = new Date();

--- a/src/components/profile/ProfileActivityTimeline.astro
+++ b/src/components/profile/ProfileActivityTimeline.astro
@@ -50,7 +50,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
   import { groupActivityByWeek, type ActivityRow } from '../../lib/profile-widgets';
   import { escAttr } from '../../lib/karma';
 
@@ -78,7 +78,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
     try { supabase = getSupabase(); } catch { return; }
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       userId = user.id;
     }

--- a/src/components/profile/ProfileBadgesGrid.astro
+++ b/src/components/profile/ProfileBadgesGrid.astro
@@ -37,7 +37,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
   import { escAttr } from '../../lib/karma';
 
   async function hydrate(el: HTMLElement) {
@@ -49,7 +49,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
     try { supabase = getSupabase(); } catch { return; }
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       userId = user.id;
     }

--- a/src/components/profile/ProfileCalendarHeatmap.astro
+++ b/src/components/profile/ProfileCalendarHeatmap.astro
@@ -50,7 +50,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
   import { buildCalendarGrid, type CalendarBucket } from '../../lib/profile-widgets';
 
   const widgets = document.querySelectorAll<HTMLElement>('[data-widget="calendar-heatmap"]');
@@ -78,7 +78,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
     try { supabase = getSupabase(); } catch { return; }
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       userId = user.id;
     }

--- a/src/components/profile/ProfileKarmaSection.astro
+++ b/src/components/profile/ProfileKarmaSection.astro
@@ -115,7 +115,7 @@ const stringsJson = JSON.stringify({
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
   import { escAttr, formatDelta } from '../../lib/karma';
   import { distanceToNextMilestone } from '../../lib/karma-milestones';
 
@@ -166,7 +166,7 @@ const stringsJson = JSON.stringify({
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
       if (deferred) return;
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       userId = user.id;
     }

--- a/src/components/profile/ProfileObservationMap.astro
+++ b/src/components/profile/ProfileObservationMap.astro
@@ -45,14 +45,14 @@ const mapPath = lang === 'es' ? '/es/explorar/mapa/' : '/en/explore/map/';
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
 
   async function hydrate(el: HTMLElement) {
     let supabase;
     try { supabase = getSupabase(); } catch { return; }
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       userId = user.id;
     }

--- a/src/components/profile/ProfilePercentileCards.astro
+++ b/src/components/profile/ProfilePercentileCards.astro
@@ -91,7 +91,7 @@ const aria                = tp.aria_bar            ?? (lang === 'es' ? 'Barra de
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
   import {
     buildCards,
     hasSufficientCohort,
@@ -124,7 +124,7 @@ const aria                = tp.aria_bar            ?? (lang === 'es' ? 'Barra de
     const lang = root.dataset.lang ?? 'en';
     let supabase;
     try { supabase = getSupabase(); } catch { setVisible(root, 'insufficient'); return; }
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       root.classList.add('hidden');
       return;

--- a/src/components/profile/ProfileStreakRing.astro
+++ b/src/components/profile/ProfileStreakRing.astro
@@ -53,14 +53,14 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
 
   async function hydrate(el: HTMLElement) {
     let supabase;
     try { supabase = getSupabase(); } catch { return; }
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       userId = user.id;
     }

--- a/src/components/profile/ProfileTaxonomicDonut.astro
+++ b/src/components/profile/ProfileTaxonomicDonut.astro
@@ -40,7 +40,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
   import { arcPath, donutFromCounts } from '../../lib/profile-widgets';
 
   const PALETTE: Record<string, string> = {
@@ -64,7 +64,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
     try { supabase = getSupabase(); } catch { return; }
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       userId = user.id;
     }

--- a/src/components/profile/ProfileTopSpeciesGrid.astro
+++ b/src/components/profile/ProfileTopSpeciesGrid.astro
@@ -37,7 +37,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedUser, getSupabase } from '../../lib/supabase';
   import { capTopSpecies, type TopSpeciesRow } from '../../lib/profile-widgets';
   import { escAttr } from '../../lib/karma';
 
@@ -50,7 +50,7 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
     try { supabase = getSupabase(); } catch { return; }
     let userId = el.dataset.targetUserId ?? null;
     if (!userId) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       userId = user.id;
     }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -44,12 +44,24 @@ if (typeof document !== 'undefined') {
   });
 }
 
+// Invalidate cache on sign-out so components reflect signed-out state immediately.
+// We attach this lazily (first getCachedUser() call) to avoid circular initialization.
+let _authListenerAttached = false;
+function ensureAuthListener() {
+  if (_authListenerAttached) return;
+  _authListenerAttached = true;
+  getSupabase().auth.onAuthStateChange((event) => {
+    if (event === 'SIGNED_OUT') _userCache = null;
+  });
+}
+
 /**
  * Returns the current user with a short-lived in-memory cache.
  * Use this instead of `getSupabase().auth.getUser()` in components that
  * mount concurrently to avoid navigator.lock contention in gotrue.
  */
 export async function getCachedUser() {
+  ensureAuthListener();
   const now = Date.now();
   if (_userCache && (now - _userCache.resolvedAt) < USER_CACHE_TTL_MS) {
     return _userCache.user;


### PR DESCRIPTION
Migrates all component auth.getUser() calls to getCachedUser() + adds SIGNED_OUT invalidation. Fixes gotrue lock contention on Android Chrome. Closes #933