### PR TITLE
fix(profile): observations.user_id → observer_id + bump v2026.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rastrum",
   "type": "module",
-  "version": "2026.5.4",
+  "version": "2026.5.5",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -474,7 +474,7 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
     const { data: obsRows } = await supabase
       .from('observations')
       .select('id, sync_status, obscure_level, observed_at')
-      .eq('user_id', user.id)
+      .eq('observer_id', user.id)
       .eq('sync_status', 'synced')
       .order('observed_at', { ascending: false })
       .limit(4);

--- a/src/lib/taxon-autocomplete.ts
+++ b/src/lib/taxon-autocomplete.ts
@@ -168,7 +168,7 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
     ? supabase
         .from('observations')
         .select('primary_scientific_name')
-        .eq('user_id', user.id)
+        .eq('observer_id', user.id)
         .ilike('primary_scientific_name', `${q}%`)
         .limit(MAX_RESULTS)
     : null;


### PR DESCRIPTION
## Root cause (real this time)

The 400 was NOT a stale SW — it was a genuine bug. `observations` table uses `observer_id` as the FK to users, not `user_id`. Two files were filtering with the wrong column name:

- `ProfileView.astro`: `.eq('user_id', user.id)` on the recent-thumbnails query → 400
- `taxon-autocomplete.ts`: `.eq('user_id', user.id)` on the history autocomplete → 400

PostgREST returns 400 when you filter on a column that doesn't exist.

## Version bump

Bumped `package.json` to `2026.5.5`. The SW uses `VERSION = '__BUILD_VERSION__'` injected at build time — bumping the package version changes the build artifact hashes, which forces the SW to update automatically on all devices without manual cache clearing.