### PR TITLE
fix(profile): graceful fallback for broken thumbnail images

### DIFF
--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -519,7 +519,7 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
         return `
           <a href="${escAttr(href)}" class="block rounded-lg border border-zinc-200 dark:border-zinc-800 overflow-hidden hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors aspect-square bg-zinc-100 dark:bg-zinc-800">
             ${photo
-              ? `<img src="${escAttr(photo)}" alt="${escAttr(sci ?? '')}" loading="lazy" class="w-full h-full object-cover" />`
+              ? `<img src="${escAttr(photo)}" alt="${escAttr(sci ?? '')}" loading="lazy" class="w-full h-full object-cover" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'" /><div class="w-full h-full items-center justify-center text-zinc-400" style="display:none"><svg aria-hidden="true" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909"/></svg></div>`
               : `<div class="w-full h-full flex items-center justify-center text-zinc-400"><svg aria-hidden="true" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909"/></svg></div>`
             }
           </a>`;


### PR DESCRIPTION
## Problem

Profile page Recent Activity grid showed browser broken-image icons for 3/4 thumbnails. The observations have rows in `media_files` with URLs but the files don't exist in storage (orphaned references from test observations or failed uploads).

## Fix

Added `onerror` handler on the thumbnail `<img>`: hides the broken image and shows the existing placeholder SVG instead. Same visual result as an observation with no photo — clean empty tile with the landscape icon.

## Root cause note

The underlying data issue (orphaned media_files rows) should be cleaned up in a separate maintenance task. This fix makes the UI resilient regardless of data state.