### PR TITLE
feat(home): integrate dynamic hero + chips + recent into HomeWidgets

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10989,7 +10989,6 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.recompute_taxa_rarity() FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION public.recompute_taxa_rarity() TO service_role;
-=======
 -- =====================================================================
 -- M33: home page redesign — pulse + counts + falta-dex summary
 -- See docs/superpowers/specs/2026-05-09-home-page-redesign-design.md.

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10917,7 +10917,7 @@ $$;
 REVOKE EXECUTE ON FUNCTION public.suggest_nearby_species(uuid, double precision, double precision, integer, integer, integer) FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION public.suggest_nearby_species(uuid, double precision, double precision, integer, integer, integer) TO authenticated;
 
--- ============================================================
+-- ====================================================
 -- #934 — taxa.rarity_tier backfill + nightly recompute
 -- Tier 1 = common    (≥50 synced observations on platform)
 -- Tier 2 = uncommon  (10–49 observations)
@@ -10989,3 +10989,115 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.recompute_taxa_rarity() FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION public.recompute_taxa_rarity() TO service_role;
+=======
+-- =====================================================================
+-- M33: home page redesign — pulse + counts + falta-dex summary
+-- See docs/superpowers/specs/2026-05-09-home-page-redesign-design.md.
+-- =====================================================================
+
+-- Marketing live-pulse counts (last 30 days). Cached at the EF layer.
+CREATE OR REPLACE FUNCTION public.home_pulse_stats()
+RETURNS TABLE(obs_30d int, species_30d int, active_observers_30d int)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT
+    (SELECT count(*)::int FROM observations
+       WHERE sync_status='synced' AND observed_at >= now() - interval '30 days'),
+    (SELECT count(DISTINCT primary_taxon_id)::int FROM observations
+       WHERE sync_status='synced' AND observed_at >= now() - interval '30 days'
+         AND primary_taxon_id IS NOT NULL),
+    (SELECT count(DISTINCT observer_id)::int FROM observations
+       WHERE sync_status='synced' AND observed_at >= now() - interval '30 days');
+$$;
+GRANT EXECUTE ON FUNCTION public.home_pulse_stats() TO anon, authenticated;
+
+-- Partial index — accelerates pending_validation_count's WHERE clause.
+CREATE INDEX IF NOT EXISTS idx_id_pending
+  ON public.identifications (observation_id)
+  WHERE is_research_grade = false AND validated_by IS NULL;
+
+-- Returns the number of pending community IDs scoped to the caller's
+-- expert kingdoms (users.expert_taxa). Capped at 99 (UI shows "99+").
+-- Returns 0 for non-experts. Falls back to all taxa when expert_taxa is
+-- NULL or empty so newly-onboarded experts still see the queue.
+CREATE OR REPLACE FUNCTION public.pending_validation_count()
+RETURNS int
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  n   int;
+BEGIN
+  IF uid IS NULL THEN RETURN 0; END IF;
+  IF NOT has_role(uid, 'expert') THEN RETURN 0; END IF;
+
+  SELECT LEAST(count(*), 99)::int INTO n
+  FROM identifications i
+  JOIN observations    o ON o.id = i.observation_id
+  JOIN taxa            t ON t.id = i.taxon_id
+  JOIN users           u ON u.id = uid
+  WHERE i.is_research_grade = false
+    AND i.validated_by IS NULL
+    AND o.observer_id <> uid
+    AND (u.expert_taxa IS NULL
+         OR cardinality(u.expert_taxa) = 0
+         OR t.kingdom = ANY(u.expert_taxa));
+
+  RETURN COALESCE(n, 0);
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.pending_validation_count() TO authenticated;
+
+-- Composite indexes — accelerate falta_dex_summary's two regional/owner
+-- subqueries. Idempotent.
+CREATE INDEX IF NOT EXISTS idx_obs_state_taxon
+  ON public.observations (state_province, primary_taxon_id)
+  WHERE primary_taxon_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_obs_observer_taxon
+  ON public.observations (observer_id, primary_taxon_id)
+  WHERE primary_taxon_id IS NOT NULL;
+
+-- Returns a summary of falta-dex gaps for the caller — count of taxa
+-- observed in user's region_primary but NOT yet observed by the caller,
+-- capped at 999. Returns (0, NULL) for users without region_primary set.
+-- Both subqueries btrim(state_province) to match the leaderboard
+-- convention; the user's-own subquery filters sync_status='synced' so
+-- pending drafts don't silently exclude taxa from the gap count.
+CREATE OR REPLACE FUNCTION public.falta_dex_summary()
+RETURNS TABLE(gap_count int, region text)
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  user_region text;
+BEGIN
+  IF uid IS NULL THEN
+    RETURN QUERY SELECT 0::int, NULL::text; RETURN;
+  END IF;
+
+  SELECT btrim(region_primary) INTO user_region FROM users WHERE id = uid;
+  IF user_region IS NULL OR length(user_region) = 0 THEN
+    RETURN QUERY SELECT 0::int, NULL::text; RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    LEAST(count(DISTINCT t.id), 999)::int AS gap_count,
+    user_region                          AS region
+  FROM taxa t
+  WHERE t.id IN (
+    SELECT DISTINCT primary_taxon_id FROM observations
+    WHERE btrim(state_province) = user_region AND primary_taxon_id IS NOT NULL
+  )
+  AND t.id NOT IN (
+    SELECT DISTINCT primary_taxon_id FROM observations
+    WHERE observer_id = uid
+      AND primary_taxon_id IS NOT NULL
+      AND sync_status = 'synced'
+  );
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.falta_dex_summary() TO authenticated;

--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -1,5 +1,8 @@
 ---
 import { t } from '../i18n/utils';
+import HomeHero from './home/HomeHero.astro';
+import HomeChips from './home/HomeChips.astro';
+import HomeRecent from './home/HomeRecent.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -9,9 +12,7 @@ const { lang } = Astro.props;
 const tr = t(lang);
 const widgets = tr.home.widgets;
 const suggestions = widgets.suggestions;
-const greeting = tr.home.greeting;
 
-const recentHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/recent/';
 const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
 const leaderboardHref = lang === 'es' ? '/es/comunidad/tabla-de-lideres/' : '/en/community/leaderboard/';
 const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
@@ -28,14 +29,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
   data-label-streak-one={widgets.streak_label_one}
   data-label-streak-aria={widgets.streak_aria}
   data-label-streak-aria-one={widgets.streak_aria_one}
-  data-label-nearby-title-global={widgets.nearby_title_global}
-  data-label-nearby-title-local={widgets.nearby_title_local}
-  data-label-nearby-empty={widgets.nearby_empty}
-  data-label-nearby-view-all={widgets.nearby_view_all}
-  data-label-nearby-loading={widgets.nearby_loading}
-  data-label-nearby-anon={widgets.nearby_anonymous}
-  data-label-nearby-unknown-species={widgets.nearby_unknown_species}
-  data-recent-href={recentHref}
   data-observe-href={observeHref}
   data-label-challenge-title={widgets.challenge.title}
   data-label-challenge-cta={widgets.challenge.cta_observe}
@@ -66,7 +59,10 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     </span>
   </div>
 
-  <!-- #710 Suggestions widget (signed-in users with location only) -->
+  <HomeHero lang={lang} />
+  <HomeChips lang={lang} />
+
+  <!-- #710 Daily Challenge -->
   <div class="home-widgets-challenge hidden">
     <!-- populated by script -->
   </div>
@@ -94,97 +90,21 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     <p class="hw-suggestions-loading text-sm text-zinc-500 dark:text-zinc-400">{suggestions.loading}</p>
     <p class="hw-suggestions-empty hidden text-sm text-zinc-500 dark:text-zinc-400">{suggestions.empty}</p>
     <ul class="hw-suggestions-list grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-3"></ul>
-
   </div>
 
-  <div class="home-widgets-nearby">
-    <div class="flex items-baseline justify-between gap-3 mb-3">
-      <h2 class="hw-nearby-title text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">{widgets.nearby_title_local}</h2>
-      <a
-        href={recentHref}
-        class="text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline"
-      >{widgets.nearby_view_all}</a>
-    </div>
-    <p class="hw-nearby-loading text-sm text-zinc-500 dark:text-zinc-400">{widgets.nearby_loading}</p>
-    <p class="hw-nearby-empty hidden text-sm text-zinc-500 dark:text-zinc-400">{widgets.nearby_empty}</p>
-    <ul class="hw-nearby-list grid grid-cols-1 sm:grid-cols-3 gap-3"></ul>
-  </div>
+  <HomeRecent lang={lang} />
 </section>
 
 <script>
   import { getSupabase, getCachedUser } from '../lib/supabase';
   import { buildGreeting } from '../lib/home-greeting';
-  import { formatTimeAgo } from '../lib/social';
+  import { loadStreak } from '../lib/home-loaders';
   import { fetchSuggestions, type SpeciesSuggestion } from '../lib/suggestions';
-  import { fetchDailyChallenge } from '../lib/daily-challenge';
-  import { fetchWeather, WMO_BUCKETS } from '../lib/home-weather';
-  type WeatherKind = 'sunny' | 'rainy' | 'cloudy' | 'snow' | 'foggy' | 'windy';
-
 
   type Lang = 'en' | 'es';
 
-  type Ident = {
-    scientific_name: string | null;
-    is_primary: boolean | null;
-    is_research_grade: boolean | null;
-    confidence: number | null;
-    taxa: { common_name_es: string | null; common_name_en: string | null } | null;
-  };
-
-  type Media = { url: string | null; is_primary: boolean | null; media_type: string | null };
-
-  type Row = {
-    id: string;
-    observed_at: string;
-    state_province: string | null;
-    country_code: string | null;
-    identifications: Ident[] | Ident | null;
-    media_files: Media[];
-  };
-
   function escapeText(s: string): string {
     return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' } as Record<string, string>)[c]);
-  }
-
-  function pickIdent(r: Row): Ident | null {
-    if (!r.identifications) return null;
-    if (Array.isArray(r.identifications)) {
-      if (r.identifications.length === 0) return null;
-      const primary = r.identifications.find(i => i?.is_primary);
-      if (primary) return primary;
-      return [...r.identifications].sort((a, b) => (b?.confidence ?? 0) - (a?.confidence ?? 0))[0] ?? null;
-    }
-    return r.identifications;
-  }
-
-  function rowMarkup(r: Row, lang: Lang, unknownLabel: string): string {
-    const ident = pickIdent(r);
-    const sci = ident?.scientific_name ?? unknownLabel;
-    const common = lang === 'es'
-      ? (ident?.taxa?.common_name_es ?? ident?.taxa?.common_name_en ?? '')
-      : (ident?.taxa?.common_name_en ?? ident?.taxa?.common_name_es ?? '');
-    const photoMedia = (r.media_files ?? []).filter(m => !m?.media_type || m.media_type === 'photo');
-    const photo = photoMedia.find(m => m?.is_primary)?.url ?? photoMedia.find(m => !!m?.url)?.url ?? '';
-    const ago = formatTimeAgo(r.observed_at, lang);
-    const commonHtml = common ? `<p class="text-xs text-zinc-600 dark:text-zinc-300 truncate">${escapeText(common)}</p>` : '';
-
-    return `<li>
-      <a
-        href="/share/obs/?id=${encodeURIComponent(r.id)}"
-        class="block overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors"
-      >
-        <div class="aspect-square w-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
-          ${photo
-            ? `<img src="${escapeText(photo)}" alt="${escapeText(sci)}" loading="lazy" class="w-full h-full object-cover" />`
-            : ''}
-        </div>
-        <div class="p-2.5">
-          <p class="text-xs italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escapeText(sci)}</p>
-          ${commonHtml}
-          <p class="text-[11px] text-zinc-500 dark:text-zinc-400 mt-1">${escapeText(ago)}</p>
-        </div>
-      </a>
-    </li>`;
   }
 
   function streakLabel(n: number, root: HTMLElement): string {
@@ -304,7 +224,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     const subtitleEl = sugRoot.querySelector<HTMLElement>('.hw-suggestions-subtitle');
     if (!listEl) return;
 
-    // Update subtitle month name
     if (subtitleEl) {
       const tpl = sugRoot.dataset.labelSubtitle ?? '';
       subtitleEl.textContent = tpl.replace('{{month}}', monthName(lang));
@@ -314,26 +233,23 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     emptyEl?.classList.add('hidden');
     listEl.innerHTML = '';
 
-    // Request geolocation
     let lat: number, lng: number;
     try {
       const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
         navigator.geolocation.getCurrentPosition(resolve, reject, {
           timeout: 8000,
-          maximumAge: 5 * 60 * 1000, // 5 min cache
+          maximumAge: 5 * 60 * 1000,
         });
       });
       lat = pos.coords.latitude;
       lng = pos.coords.longitude;
     } catch {
-      // Permission denied or unavailable — keep widget hidden
       loadingEl?.classList.add('hidden');
       return;
     }
 
     try {
-      // seed param forces a different result set on refresh (use limit oversample trick)
-      const limit = 10 + (seed % 5); // vary limit slightly to get different rows
+      const limit = 10 + (seed % 5);
       const all = await fetchSuggestions(userId, lat, lng, { limit });
       const dismissed = getDismissed();
       const filtered = all.filter(s => !dismissed.has(s.taxon_id)).slice(0, 5);
@@ -348,7 +264,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
       listEl.innerHTML = filtered.map(s => suggestionCard(s, lang, sugRoot)).join('');
       sugRoot.classList.remove('hidden');
 
-      // Wire up dismiss buttons
       listEl.querySelectorAll<HTMLButtonElement>('button[data-dismiss]').forEach(btn => {
         btn.addEventListener('click', () => {
           const taxonId = btn.dataset.dismiss ?? '';
@@ -368,102 +283,14 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     }
   }
 
-  // ─────────────────────────────────────────────────────────────────────────
+  // ── Leaderboard / Next badge / Daily challenge ───────────────────────────
 
-  async function init() {
-    const root = document.querySelector<HTMLElement>('.home-widgets');
-    if (!root) return;
-    const lang = (root.dataset.lang === 'es' ? 'es' : 'en') as Lang;
-
-    let supabase;
-    try {
-      supabase = getSupabase();
-    } catch {
-      return;
-    }
-
-    const user = await getCachedUser();
-    if (!user) {
-      // Signed-out: render anonymous "Recent observations" only — but skip
-      // the personalized hero entirely. Hide the greeting wrapper and show
-      // the global feed.
-      root.classList.remove('hidden');
-      const greeting = root.querySelector<HTMLElement>('.home-widgets-greeting');
-      greeting?.classList.add('hidden');
-      const titleEl = root.querySelector<HTMLElement>('.hw-nearby-title');
-      if (titleEl) titleEl.textContent = root.dataset.labelNearbyTitleGlobal ?? titleEl.textContent;
-      await paintNearby(root, lang, null, null);
-      return;
-    }
-
-    const { data: profile } = await supabase
-      .from('users')
-      .select('display_name, username, country_code, region_primary')
-      .eq('id', user.id)
-      .maybeSingle<{ display_name: string | null; username: string | null; country_code: string | null; region_primary: string | null }>();
-
-    const displayName = profile?.display_name ?? profile?.username ?? null;
-    const country = profile?.country_code ?? null;
-
-    root.classList.remove('hidden');
-    const greetingEl = root.querySelector<HTMLElement>('.hw-greeting-text');
-    if (greetingEl) {
-      greetingEl.textContent = pickGreeting(new Date().getHours(), lang, displayName, root);
-    }
-
-    // Streak badge — read user_streaks (RLS allows self-read regardless of opt-in).
-    try {
-      const { data: streak } = await supabase
-        .from('user_streaks')
-        .select('current_days')
-        .eq('user_id', user.id)
-        .maybeSingle<{ current_days: number }>();
-      const n = streak?.current_days ?? 0;
-      if (n > 0) {
-        const pill = root.querySelector<HTMLElement>('.hw-streak');
-        const text = root.querySelector<HTMLElement>('.hw-streak-text');
-        if (pill && text) {
-          text.textContent = streakLabel(n, root);
-          pill.setAttribute('aria-label', streakAriaLabel(n, root));
-          pill.classList.remove('hidden');
-        }
-      }
-    } catch { /* streaks are optional; ignore */ }
-
-    const titleEl = root.querySelector<HTMLElement>('.hw-nearby-title');
-    if (titleEl) {
-      titleEl.textContent = country
-        ? (root.dataset.labelNearbyTitleLocal ?? titleEl.textContent)
-        : (root.dataset.labelNearbyTitleGlobal ?? titleEl.textContent);
-    }
-
-    await paintLeaderboard(root, lang, user.id);
-    await paintNextBadge(root, lang, user.id);
-    await paintChallenge(root, lang, user.id);
-    await paintNearby(root, lang, country, profile?.region_primary ?? null);
-
-    // Fire suggestions widget (no await — it runs in parallel via geolocation)
-    let suggestionSeed = 0;
-    paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional widget */});
-
-    // Wire up the Refresh button
-    const sugRoot = root.querySelector<HTMLElement>('.home-widgets-suggestions');
-    sugRoot?.querySelector<HTMLButtonElement>('.hw-suggestions-refresh')?.addEventListener('click', () => {
-      suggestionSeed = (suggestionSeed + 1) % 100;
-      // Clear dismissed on refresh
-      try { sessionStorage.removeItem(DISMISSED_KEY); } catch { /* ignore */ }
-      paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional */});
-    });
-  }
-
-  async function paintLeaderboard(root: HTMLElement, lang: Lang, _userId: string): Promise<void> {
+  async function paintLeaderboard(root: HTMLElement, _lang: Lang, _userId: string): Promise<void> {
     const container = root.querySelector<HTMLElement>('.home-widgets-leaderboard');
     if (!container) return;
 
     let supabase;
-    try {
-      supabase = getSupabase();
-    } catch { return; }
+    try { supabase = getSupabase(); } catch { return; }
 
     type LeaderRow = {
       user_id: string;
@@ -474,7 +301,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     };
 
     try {
-      // Query top 3 from 30d MV — sorted server-side
       const { data, error } = await supabase
         .from('karma_leaderboard_30d')
         .select('user_id, username, display_name, avatar_url, karma_30d')
@@ -526,9 +352,7 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     if (!container) return;
 
     let supabase;
-    try {
-      supabase = getSupabase();
-    } catch { return; }
+    try { supabase = getSupabase(); } catch { return; }
 
     type BadgeRow = {
       key: string;
@@ -542,7 +366,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     type UserBadgeRow = { badge_key: string; awarded_at: string | null };
 
     try {
-      // Get all badges and which ones the user has earned
       const [{ data: allBadges }, { data: userBadges }] = await Promise.all([
         supabase.from('badges').select('key, name_en, name_es, description_en, description_es, tier').limit(100),
         supabase.from('user_badges').select('badge_key, awarded_at').eq('user_id', userId),
@@ -551,7 +374,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
       if (!allBadges) return;
       const earnedKeys = new Set((userBadges ?? []).map((ub: UserBadgeRow) => ub.badge_key));
 
-      // Find first unearned badge (ordered by tier: bronze → silver → gold → platinum)
       const tierOrder: Record<string, number> = { bronze: 0, silver: 1, gold: 2, platinum: 3 };
       const unearned = (allBadges as BadgeRow[])
         .filter(b => !earnedKeys.has(b.key))
@@ -618,13 +440,10 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
 
   async function paintChallenge(root: HTMLElement, lang: Lang, userId: string): Promise<void> {
     const container = root.querySelector<HTMLElement>('.home-widgets-challenge');
-
     if (!container) return;
 
     let supabase;
-    try {
-      supabase = getSupabase();
-    } catch { return; }
+    try { supabase = getSupabase(); } catch { return; }
 
     type ChallengeRow = {
       taxon_id: string;
@@ -662,7 +481,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
       const observeBase = root.dataset.observeHref ?? (lang === 'es' ? '/es/observar/' : '/en/observe/');
       const ctaHref = `${observeBase}?taxon_id=${encodeURIComponent(ch.taxon_id)}`;
 
-      // Check if already observed today
       const todayStart = new Date();
       todayStart.setUTCHours(0, 0, 0, 0);
 
@@ -673,8 +491,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
         .eq('sync_status', 'synced')
         .gte('observed_at', todayStart.toISOString());
 
-      // Simplified completed check — if they have any observation today we show completed
-      // (full taxon join would require identifications query)
       const completed = (count ?? 0) > 0;
 
       const thumbHtml = ch.thumbnail_url
@@ -698,82 +514,72 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
               ${commonName ? `<p class="text-xs text-zinc-600 dark:text-zinc-300 truncate mb-1">${escapeText(commonName)}</p>` : ''}
               ${ch.why ? `<p class="text-[11px] text-zinc-500 dark:text-zinc-400 mb-2"><span class="font-medium">${escapeText(whyLabel)}:</span> ${escapeText(ch.why)}</p>` : ''}
               ${ctaHtml}
-
             </div>
           </div>
         </div>`;
       container.classList.remove('hidden');
     } catch { /* challenge is optional */ }
-
   }
 
+  // ─────────────────────────────────────────────────────────────────────────
 
-  async function paintNearby(root: HTMLElement, lang: Lang, country: string | null, _region: string | null): Promise<void> {
-    const listEl = root.querySelector<HTMLUListElement>('.hw-nearby-list');
-    const loadingEl = root.querySelector<HTMLElement>('.hw-nearby-loading');
-    const emptyEl = root.querySelector<HTMLElement>('.hw-nearby-empty');
-    const unknownLabel = root.dataset.labelNearbyUnknownSpecies ?? 'Unknown species';
-    if (!listEl) return;
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.home-widgets');
+    if (!root) return;
+    const lang = (root.dataset.lang === 'es' ? 'es' : 'en') as Lang;
 
     let supabase;
-    try {
-      supabase = getSupabase();
-    } catch {
-      loadingEl?.classList.add('hidden');
+    try { supabase = getSupabase(); } catch { return; }
+
+    const user = await getCachedUser();
+    if (!user) {
+      // Signed-out: keep the widget hidden. The marketing hero / how / why
+      // sections handle the anon experience. HomeRecent will silently no-op
+      // its own auth check — no dangling spinners.
       return;
     }
 
-    try {
-      let query = supabase
-        .from('observations')
-        .select(`
-          id, observed_at, state_province, country_code,
-          identifications(scientific_name, is_primary, is_research_grade, confidence, taxa(common_name_es, common_name_en)),
-          media_files(url, is_primary, media_type)
-        `)
-        .eq('sync_status', 'synced')
-        .order('observed_at', { ascending: false })
-        .limit(3);
-      if (country) query = query.eq('country_code', country);
-      const { data, error } = await query;
-      if (error) throw error;
-      const rows = ((data ?? []) as unknown) as Row[];
+    const { data: profile } = await supabase
+      .from('users')
+      .select('display_name, username')
+      .eq('id', user.id)
+      .maybeSingle<{ display_name: string | null; username: string | null }>();
 
-      // Country-scoped fetch may yield zero rows in low-density regions —
-      // fall back to global so the widget never goes empty for signed-in
-      // users with a known country.
-      const finalRows = rows.length > 0 || !country
-        ? rows
-        : await (async () => {
-            const { data: g } = await supabase
-              .from('observations')
-              .select(`
-                id, observed_at, state_province, country_code,
-                identifications(scientific_name, is_primary, is_research_grade, confidence, taxa(common_name_es, common_name_en)),
-                media_files(url, is_primary, media_type)
-              `)
-              .eq('sync_status', 'synced')
-              .order('observed_at', { ascending: false })
-              .limit(3);
-            // Title flips back to global when we fell back.
-            const titleEl = root.querySelector<HTMLElement>('.hw-nearby-title');
-            if (titleEl) titleEl.textContent = root.dataset.labelNearbyTitleGlobal ?? titleEl.textContent;
-            return ((g ?? []) as unknown) as Row[];
-          })();
+    const displayName = profile?.display_name ?? profile?.username ?? null;
 
-      loadingEl?.classList.add('hidden');
-      if (finalRows.length === 0) {
-        emptyEl?.classList.remove('hidden');
-        return;
-      }
-      listEl.innerHTML = finalRows.map(r => rowMarkup(r, lang, unknownLabel)).join('');
-    } catch {
-      loadingEl?.classList.add('hidden');
-      emptyEl?.classList.remove('hidden');
+    root.classList.remove('hidden');
+    const greetingEl = root.querySelector<HTMLElement>('.hw-greeting-text');
+    if (greetingEl) {
+      greetingEl.textContent = pickGreeting(new Date().getHours(), lang, displayName, root);
     }
+
+    const streak = await loadStreak(supabase, user.id);
+    const n = streak?.currentDays ?? 0;
+    if (n > 0) {
+      const pill = root.querySelector<HTMLElement>('.hw-streak');
+      const text = root.querySelector<HTMLElement>('.hw-streak-text');
+      if (pill && text) {
+        text.textContent = streakLabel(n, root);
+        pill.setAttribute('aria-label', streakAriaLabel(n, root));
+        pill.classList.remove('hidden');
+      }
+    }
+
+    await paintLeaderboard(root, lang, user.id);
+    await paintNextBadge(root, lang, user.id);
+    await paintChallenge(root, lang, user.id);
+
+    // Suggestions runs in parallel via geolocation; doesn't block.
+    let suggestionSeed = 0;
+    paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional */});
+
+    const sugRoot = root.querySelector<HTMLElement>('.home-widgets-suggestions');
+    sugRoot?.querySelector<HTMLButtonElement>('.hw-suggestions-refresh')?.addEventListener('click', () => {
+      suggestionSeed = (suggestionSeed + 1) % 100;
+      try { sessionStorage.removeItem(DISMISSED_KEY); } catch { /* ignore */ }
+      paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional */});
+    });
   }
 
-  init().catch(() => {
-    document.querySelector<HTMLElement>('.home-widgets .hw-nearby-loading')?.classList.add('hidden');
-  });
+  init().catch(() => {});
 </script>

--- a/src/components/home/HomeChips.astro
+++ b/src/components/home/HomeChips.astro
@@ -1,0 +1,59 @@
+---
+import { t } from '../../i18n/utils';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+const c = tr.home.widgets.chips;
+const inboxHref = lang === 'es' ? '/es/bandeja/' : '/en/inbox/';
+const validateHref = lang === 'es' ? '/es/consola/validacion/' : '/en/console/validation/';
+const faltaDexHref = lang === 'es' ? '/es/perfil/dex/' : '/en/profile/dex/';
+const watchlistHref = lang === 'es' ? '/es/explorar/seguimiento/' : '/en/explore/watchlist/';
+---
+
+<nav class="hc-root grid grid-cols-2 sm:grid-cols-4 gap-2 mb-6" data-lang={lang} aria-label="Home actions">
+  <a class="hc-tile" href={inboxHref} data-key="inbox"><span class="hc-icon" aria-hidden="true">📬</span><span class="hc-label">{c.inbox}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
+  <a class="hc-tile" href={validateHref} data-key="validate"><span class="hc-icon" aria-hidden="true">🔍</span><span class="hc-label">{c.validate}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
+  <a class="hc-tile" href={faltaDexHref} data-key="falta_dex"><span class="hc-icon" aria-hidden="true">📊</span><span class="hc-label">{c.falta_dex}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
+  <a class="hc-tile" href={watchlistHref} data-key="watchlist"><span class="hc-icon" aria-hidden="true">👀</span><span class="hc-label">{c.watchlist}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
+</nav>
+
+<style>
+  .hc-tile { display:flex; align-items:center; gap:.5rem; padding:.6rem .75rem; border:1px solid rgb(228 228 231); border-radius:.75rem; font-size:.875rem; transition:border-color .15s; }
+  .hc-tile:hover { border-color:rgb(110 231 183); }
+  :global(.dark) .hc-tile { border-color:rgb(63 63 70); }
+  .hc-count { margin-left:auto; min-width:1.5em; text-align:right; font-weight:600; opacity:.8; }
+</style>
+
+<script>
+  import { getSupabase, getCachedUser } from '../../lib/supabase';
+  import { loadInboxCount, loadValidateCount, loadFaltaDexCount } from '../../lib/home-loaders';
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hc-root');
+    if (!root) return;
+    const user = await getCachedUser();
+    if (!user) return;
+    let c; try { c = getSupabase(); } catch { return; }
+
+    const [inbox, validate, falta] = await Promise.all([
+      loadInboxCount(c, user.id),
+      loadValidateCount(c),
+      loadFaltaDexCount(c),
+    ]);
+
+    const setCount = (key: string, n: number) => {
+      const el = root.querySelector<HTMLElement>(`[data-key="${key}"] .hc-count`);
+      if (!el) return;
+      if (n <= 0) { el.textContent = ''; return; }
+      el.textContent = n >= 99 ? '99+' : String(n);
+    };
+    setCount('inbox', inbox);
+    setCount('validate', validate);
+    setCount('falta_dex', falta.count);
+    // watchlist count omitted in v1 — promotion of watchlist hits happens
+    // through the hero (when the loader is wired up in v1.1). The chip
+    // remains as a navigation affordance.
+  }
+
+  init().catch(() => {});
+</script>

--- a/src/components/home/HomeHero.astro
+++ b/src/components/home/HomeHero.astro
@@ -1,0 +1,117 @@
+---
+import { t } from '../../i18n/utils';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+const h = tr.home.widgets.hero;
+---
+
+<section
+  class="hh-root rounded-2xl border-2 p-5 sm:p-6 mb-4 hidden"
+  data-lang={lang}
+  data-streak-eyebrow={h.streak_at_risk.eyebrow}
+  data-streak-title={h.streak_at_risk.title}
+  data-streak-subtitle={h.streak_at_risk.subtitle}
+  data-streak-cta={h.streak_at_risk.cta}
+  data-watch-eyebrow={h.watchlist_hit.eyebrow}
+  data-watch-title={h.watchlist_hit.title}
+  data-watch-subtitle={h.watchlist_hit.subtitle}
+  data-watch-cta={h.watchlist_hit.cta}
+  data-pending-eyebrow={h.pending_ids.eyebrow}
+  data-pending-title={h.pending_ids.title}
+  data-pending-subtitle={h.pending_ids.subtitle}
+  data-pending-cta={h.pending_ids.cta}
+  data-default-eyebrow={h.observe_default.eyebrow}
+  data-default-title={h.observe_default.title}
+  data-default-title-morning={h.observe_default.title_morning}
+  data-default-subtitle={h.observe_default.subtitle}
+  data-default-subtitle-morning={h.observe_default.subtitle_morning}
+  data-default-cta={h.observe_default.cta}
+>
+  <div class="hh-eyebrow text-xs uppercase tracking-wider font-bold mb-1.5"></div>
+  <div class="hh-title text-xl sm:text-2xl font-bold leading-tight"></div>
+  <div class="hh-subtitle text-sm mt-1.5 opacity-90"></div>
+  <a class="hh-cta inline-block mt-4 px-5 py-2.5 rounded-lg font-semibold transition-colors" href="#"></a>
+</section>
+
+<script>
+  import { getSupabase, getCachedUser } from '../../lib/supabase';
+  import { loadHeroInputs } from '../../lib/home-loaders';
+  import { resolveHeroState } from '../../lib/home-hero';
+
+  type Lang = 'en' | 'es';
+
+  const KIND_CLASSES: Record<string, string[]> = {
+    streak_at_risk: ['border-red-400', 'bg-red-50/60', 'text-red-700', 'dark:border-red-700/60', 'dark:bg-red-950/40', 'dark:text-red-300'],
+    watchlist_hit: ['border-blue-400', 'bg-blue-50/60', 'text-blue-700', 'dark:border-blue-700/60', 'dark:bg-blue-950/40', 'dark:text-blue-300'],
+    pending_ids: ['border-purple-400', 'bg-purple-50/60', 'text-purple-700', 'dark:border-purple-700/60', 'dark:bg-purple-950/40', 'dark:text-purple-300'],
+    observe_default: ['border-emerald-400', 'bg-emerald-50/60', 'text-emerald-700', 'dark:border-emerald-700/60', 'dark:bg-emerald-950/40', 'dark:text-emerald-300'],
+  };
+  const CTA_BG: Record<string, string> = {
+    streak_at_risk: 'bg-red-600 hover:bg-red-700 text-white',
+    watchlist_hit: 'bg-blue-600 hover:bg-blue-700 text-white',
+    pending_ids: 'bg-purple-600 hover:bg-purple-700 text-white',
+    observe_default: 'bg-emerald-700 hover:bg-emerald-800 text-white',
+  };
+
+  function fill(s: string, vars: Record<string, string | number>): string {
+    return s.replace(/\{(\w+)\}/g, (_, k) => String(vars[k] ?? ''));
+  }
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hh-root');
+    if (!root) return;
+    const lang = (root.dataset.lang as Lang) ?? 'en';
+    const user = await getCachedUser();
+    if (!user) return;
+    let c; try { c = getSupabase(); } catch { return; }
+
+    const inputs = await loadHeroInputs(c as never, user.id, new Date());
+    const state = resolveHeroState(inputs);
+
+    const cls = KIND_CLASSES[state.kind] ?? [];
+    cls.forEach(k => root.classList.add(k));
+
+    const eyebrow = root.querySelector<HTMLElement>('.hh-eyebrow')!;
+    const title = root.querySelector<HTMLElement>('.hh-title')!;
+    const subtitle = root.querySelector<HTMLElement>('.hh-subtitle')!;
+    const cta = root.querySelector<HTMLAnchorElement>('.hh-cta')!;
+    cta.className = `hh-cta inline-block mt-4 px-5 py-2.5 rounded-lg font-semibold transition-colors ${CTA_BG[state.kind]}`;
+
+    const observeUrl = lang === 'es' ? '/es/observar/' : '/en/observe/';
+    const validateUrl = lang === 'es' ? '/es/consola/validacion/' : '/en/console/validation/';
+
+    if (state.kind === 'streak_at_risk') {
+      eyebrow.textContent = root.dataset.streakEyebrow ?? '';
+      title.textContent = fill(root.dataset.streakTitle ?? '', { streakDays: state.currentDays });
+      subtitle.textContent = root.dataset.streakSubtitle ?? '';
+      cta.textContent = root.dataset.streakCta ?? '';
+      cta.href = observeUrl;
+    } else if (state.kind === 'watchlist_hit') {
+      eyebrow.textContent = root.dataset.watchEyebrow ?? '';
+      title.textContent = fill(root.dataset.watchTitle ?? '', { taxonName: state.taxonName, km: Math.round(state.distanceKm) });
+      subtitle.textContent = root.dataset.watchSubtitle ?? '';
+      cta.textContent = root.dataset.watchCta ?? '';
+      cta.href = `/share/obs/?id=${encodeURIComponent(state.obsId)}`;
+    } else if (state.kind === 'pending_ids') {
+      eyebrow.textContent = root.dataset.pendingEyebrow ?? '';
+      title.textContent = fill(root.dataset.pendingTitle ?? '', { count: state.count });
+      subtitle.textContent = fill(root.dataset.pendingSubtitle ?? '', { taxonGroup: state.taxonGroup });
+      cta.textContent = root.dataset.pendingCta ?? '';
+      cta.href = validateUrl;
+    } else {
+      eyebrow.textContent = root.dataset.defaultEyebrow ?? '';
+      title.textContent = state.morningPeak ? (root.dataset.defaultTitleMorning ?? '') : (root.dataset.defaultTitle ?? '');
+      subtitle.textContent = state.morningPeak ? (root.dataset.defaultSubtitleMorning ?? '') : (root.dataset.defaultSubtitle ?? '');
+      cta.textContent = root.dataset.defaultCta ?? '';
+      cta.href = observeUrl;
+    }
+
+    root.classList.remove('hidden');
+    window.dispatchEvent(new CustomEvent('rastrum:home-hero-resolved', {
+      detail: { kind: state.kind },
+    }));
+  }
+
+  init().catch(() => {});
+</script>

--- a/src/components/home/HomeRecent.astro
+++ b/src/components/home/HomeRecent.astro
@@ -1,0 +1,82 @@
+---
+import { t } from '../../i18n/utils';
+import WhyAmISeeingThis from '../WhyAmISeeingThis.astro';
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+const w = tr.home.widgets;
+const viewAllHref = lang === 'es' ? '/es/explorar/recientes/' : '/en/explore/recent/';
+---
+
+<section class="hr-root mb-8" data-lang={lang}
+  data-title-local={w.nearby_title_local} data-title-global={w.nearby_title_global}
+  data-loading={w.nearby_loading} data-empty={w.nearby_empty} data-unknown-species={w.nearby_unknown_species}>
+  <div class="flex items-baseline justify-between gap-3 mb-2">
+    <h2 class="hr-title text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">{w.nearby_title_global}</h2>
+    <a href={viewAllHref} class="text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline">{w.nearby_view_all}</a>
+  </div>
+  <div class="mb-3"><WhyAmISeeingThis algorithm="home_recent_nearby" lang={lang} /></div>
+  <p class="hr-loading text-sm text-zinc-500 dark:text-zinc-400">{w.nearby_loading}</p>
+  <p class="hr-empty hidden text-sm text-zinc-500 dark:text-zinc-400">{w.nearby_empty}</p>
+  <ul class="hr-list grid grid-cols-1 sm:grid-cols-3 gap-3"></ul>
+</section>
+
+<script>
+  import { getSupabase, getCachedUser } from '../../lib/supabase';
+  import { loadRecent } from '../../lib/home-loaders';
+  import { formatTimeAgo } from '../../lib/social';
+
+  type Lang = 'en' | 'es';
+
+  function escape(s: string): string {
+    const map: Record<string, string> = { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' };
+    return s.replace(/[&<>"']/g, ch => map[ch]);
+  }
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('.hr-root');
+    if (!root) return;
+    const lang = (root.dataset.lang as Lang) ?? 'en';
+    const list = root.querySelector<HTMLUListElement>('.hr-list');
+    const loading = root.querySelector<HTMLElement>('.hr-loading');
+    const empty = root.querySelector<HTMLElement>('.hr-empty');
+    if (!list) return;
+
+    let c; try { c = getSupabase(); } catch { loading?.classList.add('hidden'); return; }
+    const user = await getCachedUser();
+    let country: string | null = null;
+    if (user) {
+      const { data } = await c.from('users').select('country_code').eq('id', user.id).maybeSingle();
+      country = (data as { country_code: string | null } | null)?.country_code ?? null;
+    }
+
+    const { rows, usedLocalScope } = await loadRecent(c as never, lang, country);
+    loading?.classList.add('hidden');
+    if (rows.length === 0) { empty?.classList.remove('hidden'); return; }
+
+    if (usedLocalScope && country) {
+      const titleEl = root.querySelector<HTMLElement>('.hr-title');
+      if (titleEl) titleEl.textContent = (root.dataset.titleLocal ?? '').replace('{country}', country);
+    }
+
+    const unknown = root.dataset.unknownSpecies ?? 'Unknown species';
+    list.innerHTML = rows.map(r => {
+      const sci = r.scientificName ?? unknown;
+      const common = r.commonName ?? '';
+      const ago = formatTimeAgo(r.observedAt, lang);
+      const photo = r.photoUrl
+        ? `<img src="${escape(r.photoUrl)}" alt="${escape(sci)}" loading="lazy" class="w-full h-full object-cover" />`
+        : '';
+      return `<li><a href="/share/obs/?id=${encodeURIComponent(r.id)}" class="block overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors">
+        <div class="aspect-square w-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">${photo}</div>
+        <div class="p-2.5">
+          <p class="text-xs italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escape(sci)}</p>
+          ${common ? `<p class="text-xs text-zinc-600 dark:text-zinc-300 truncate">${escape(common)}</p>` : ''}
+          <p class="text-[11px] text-zinc-500 dark:text-zinc-400 mt-1">${escape(ago)}</p>
+        </div>
+      </a></li>`;
+    }).join('');
+  }
+
+  init().catch(() => {});
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -178,6 +178,41 @@
         "rarity_common": "Common",
         "rarity_uncommon": "Uncommon",
         "rarity_rare": "Rare"
+      },
+      "hero": {
+        "streak_at_risk": {
+          "eyebrow": "Keep your streak alive",
+          "title": "Your {streakDays}-day streak ends at midnight",
+          "subtitle": "You haven't logged today. One observation by midnight keeps it.",
+          "cta": "Observe now"
+        },
+        "watchlist_hit": {
+          "eyebrow": "Watchlist match nearby",
+          "title": "{taxonName} seen {km} km away",
+          "subtitle": "Spotted by another observer in the last 24h. Worth a trip?",
+          "cta": "Open on map"
+        },
+        "pending_ids": {
+          "eyebrow": "Your expertise is needed",
+          "title": "{count} community IDs need a second opinion",
+          "subtitle": "You're an expert in {taxonGroup} — your verdict counts.",
+          "cta": "Open queue"
+        },
+        "observe_default": {
+          "eyebrow": "Right now, in your area",
+          "title": "Observe now",
+          "title_morning": "Morning is peak activity",
+          "subtitle": "Tap to log what you see.",
+          "subtitle_morning": "Birds and insects are most active. Tap to log what you see.",
+          "cta": "Open camera"
+        }
+      },
+      "chips": {
+        "inbox": "Inbox",
+        "validate": "Validate",
+        "falta_dex": "Falta-dex",
+        "watchlist": "Watchlist",
+        "count_overflow": "99+"
       }
     }
   },

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -178,6 +178,41 @@
         "rarity_common": "Común",
         "rarity_uncommon": "Poco común",
         "rarity_rare": "Rara"
+      },
+      "hero": {
+        "streak_at_risk": {
+          "eyebrow": "Mantén tu racha",
+          "title": "Tu racha de {streakDays} días termina a medianoche",
+          "subtitle": "No has registrado hoy. Una observación antes de medianoche la conserva.",
+          "cta": "Observar ahora"
+        },
+        "watchlist_hit": {
+          "eyebrow": "Coincidencia en tu lista cercana",
+          "title": "{taxonName} visto a {km} km",
+          "subtitle": "Avistado por otra persona en las últimas 24h. ¿Vale la pena ir?",
+          "cta": "Ver en el mapa"
+        },
+        "pending_ids": {
+          "eyebrow": "Necesitan tu experiencia",
+          "title": "{count} IDs de la comunidad esperan tu opinión",
+          "subtitle": "Eres experta/o en {taxonGroup} — tu veredicto cuenta.",
+          "cta": "Abrir cola"
+        },
+        "observe_default": {
+          "eyebrow": "Ahora, en tu zona",
+          "title": "Observar ahora",
+          "title_morning": "La mañana es la hora de máxima actividad",
+          "subtitle": "Toca para registrar lo que veas.",
+          "subtitle_morning": "Las aves e insectos están más activos. Toca para registrar.",
+          "cta": "Abrir cámara"
+        }
+      },
+      "chips": {
+        "inbox": "Bandeja",
+        "validate": "Validar",
+        "falta_dex": "Falta-dex",
+        "watchlist": "Lista",
+        "count_overflow": "99+"
       }
     }
   },

--- a/src/lib/algorithms.ts
+++ b/src/lib/algorithms.ts
@@ -17,7 +17,8 @@ export type AlgorithmId =
   | 'falta_dex_missing'
   | 'contextual_species_chips'
   | 'profile_percentile_cards'
-  | 'active_observers_today';
+  | 'active_observers_today'
+  | 'home_recent_nearby';
 
 export interface AlgorithmCopy {
   /** Inputs the ranker consumes — one bullet per input. */
@@ -285,6 +286,42 @@ export const ALGORITHMS: Record<AlgorithmId, AlgorithmEntry> = {
         ],
         window: 'Hoy (UTC) — reinicia a las 00:00 UTC cada día',
         settings_label: 'Editar perfil (país)',
+      },
+    },
+    settings_path: {
+      en: routes.profileEdit.en,
+      es: routes.profileEdit.es,
+    },
+  },
+  home_recent_nearby: {
+    headline: {
+      en: 'Why am I seeing these observations?',
+      es: '¿Por qué veo estas observaciones?',
+    },
+    summary: {
+      en: 'Most recent observations from observers in your country, with a global fallback if there are fewer than 3.',
+      es: 'Observaciones más recientes de personas en tu país, con respaldo global si hay menos de 3.',
+    },
+    copy: {
+      en: {
+        inputs: [
+          'Sync timestamp (most recent first)',
+          'Country code from your profile (used to scope to nearby observers)',
+          'Public visibility (private observations are excluded)',
+          'No engagement signals — order does not depend on likes, IDs, or follows',
+        ],
+        window: 'Top 3 most recent synced public observations',
+        settings_label: 'Profile country & privacy settings',
+      },
+      es: {
+        inputs: [
+          'Marca de tiempo de sincronización (más recientes primero)',
+          'Código de país de tu perfil (se usa para limitar a personas cercanas)',
+          'Visibilidad pública (las observaciones privadas se excluyen)',
+          'Sin señales de engagement — el orden no depende de likes, IDs ni seguidores',
+        ],
+        window: 'Las 3 observaciones públicas sincronizadas más recientes',
+        settings_label: 'País del perfil y privacidad',
       },
     },
     settings_path: {

--- a/src/lib/home-hero.ts
+++ b/src/lib/home-hero.ts
@@ -1,0 +1,63 @@
+export type HeroState =
+  | { kind: 'streak_at_risk'; currentDays: number; hoursLeftLocal: number }
+  | { kind: 'watchlist_hit'; taxonName: string; distanceKm: number; obsId: string; observedAt: string }
+  | { kind: 'pending_ids'; count: number; taxonGroup: string }
+  | { kind: 'observe_default'; morningPeak: boolean };
+
+export interface HeroInputs {
+  streak: { currentDays: number; lastObsLocalDay: string | null } | null;
+  watchlistHit: { taxonName: string; distanceKm: number; obsId: string; observedAt: string } | null;
+  pendingIdsCount: number;
+  expertTaxonGroup: string | null;
+  now: Date;
+  userTimezone: string;
+}
+
+function localParts(d: Date, tz: string): { hour: number; minute: number; isoDay: string } {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit',
+    });
+    const parts = Object.fromEntries(fmt.formatToParts(d).map(p => [p.type, p.value]));
+    return {
+      hour: Number(parts.hour ?? '0'),
+      minute: Number(parts.minute ?? '0'),
+      isoDay: `${parts.year}-${parts.month}-${parts.day}`,
+    };
+  } catch {
+    return { hour: d.getUTCHours(), minute: d.getUTCMinutes(), isoDay: d.toISOString().slice(0, 10) };
+  }
+}
+
+export function resolveHeroState(inputs: HeroInputs): HeroState {
+  const { hour, minute, isoDay } = localParts(inputs.now, inputs.userTimezone);
+
+  if (
+    inputs.streak &&
+    inputs.streak.currentDays >= 1 &&
+    inputs.streak.lastObsLocalDay !== isoDay &&
+    hour >= 18
+  ) {
+    return {
+      kind: 'streak_at_risk',
+      currentDays: inputs.streak.currentDays,
+      hoursLeftLocal: Math.round(((24 - hour) - minute / 60) * 10) / 10,
+    };
+  }
+
+  if (inputs.watchlistHit) {
+    return { kind: 'watchlist_hit', ...inputs.watchlistHit };
+  }
+
+  if (inputs.pendingIdsCount >= 3 && inputs.expertTaxonGroup) {
+    return {
+      kind: 'pending_ids',
+      count: inputs.pendingIdsCount,
+      taxonGroup: inputs.expertTaxonGroup,
+    };
+  }
+
+  return { kind: 'observe_default', morningPeak: hour >= 5 && hour <= 9 };
+}

--- a/src/lib/home-loaders.ts
+++ b/src/lib/home-loaders.ts
@@ -1,0 +1,161 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { HeroInputs } from './home-hero';
+
+type Client = SupabaseClient;
+
+export async function loadInboxCount(c: Client, userId: string): Promise<number> {
+  try {
+    const { count, error } = await c.from('notifications')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .is('read_at', null);
+    if (error) return 0;
+    return count ?? 0;
+  } catch { return 0; }
+}
+
+export async function loadValidateCount(c: Client): Promise<number> {
+  try {
+    const { data, error } = await c.rpc('pending_validation_count');
+    if (error) return 0;
+    return typeof data === 'number' ? data : 0;
+  } catch { return 0; }
+}
+
+export async function loadFaltaDexCount(c: Client): Promise<{ count: number; region: string | null }> {
+  try {
+    const { data, error } = await c.rpc('falta_dex_summary');
+    if (error || !data || !Array.isArray(data) || data.length === 0) return { count: 0, region: null };
+    const row = data[0] as { gap_count?: number; region?: string | null };
+    return { count: row.gap_count ?? 0, region: row.region ?? null };
+  } catch { return { count: 0, region: null }; }
+}
+
+export interface WatchlistHit {
+  taxonName: string;
+  distanceKm: number;
+  obsId: string;
+  observedAt: string;
+}
+
+// v1 deferred — no `watchlist_alerts` table or matcher RPC yet. Returning
+// null lets the hero cascade fall through to the next priority. Revisit in
+// v1.1 once a watchlist-match RPC ships.
+export async function loadWatchlistHit(_c: Client, _userId: string): Promise<WatchlistHit | null> {
+  return null;
+}
+
+export interface StreakSnap { currentDays: number; lastObsLocalDay: string | null; }
+
+export async function loadStreak(c: Client, userId: string): Promise<StreakSnap | null> {
+  try {
+    const { data, error } = await c.from('user_streaks')
+      .select('current_days, last_qualifying_day')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (error || !data) return null;
+    const row = data as { current_days: number; last_qualifying_day: string | null };
+    return { currentDays: row.current_days, lastObsLocalDay: row.last_qualifying_day };
+  } catch { return null; }
+}
+
+export async function loadHeroInputs(c: Client, userId: string, now: Date): Promise<HeroInputs> {
+  const [streak, watchlistHit, pendingIdsCount, profile] = await Promise.all([
+    loadStreak(c, userId),
+    loadWatchlistHit(c, userId),
+    loadValidateCount(c),
+    (async () => {
+      try {
+        const { data } = await c.from('users')
+          .select('timezone, expert_taxa')
+          .eq('id', userId)
+          .maybeSingle();
+        return data as { timezone: string | null; expert_taxa: string[] | null } | null;
+      } catch { return null; }
+    })(),
+  ]);
+  return {
+    streak,
+    watchlistHit,
+    pendingIdsCount,
+    expertTaxonGroup: profile?.expert_taxa?.[0] ?? null,
+    now,
+    userTimezone: profile?.timezone ?? 'UTC',
+  };
+}
+
+export interface RecentObs {
+  id: string; observedAt: string; stateProvince: string | null;
+  scientificName: string | null; commonName: string | null;
+  photoUrl: string | null;
+}
+
+export async function loadRecent(
+  c: Client,
+  lang: 'en' | 'es',
+  country: string | null,
+): Promise<{ rows: RecentObs[]; usedLocalScope: boolean }> {
+  // !inner turns the implicit LEFT JOIN into INNER JOIN, which means the
+  // .eq('observer.country_code', country) actually filters parent rows.
+  // Without !inner, PostgREST silently no-ops the embedded-resource filter.
+  const select = `
+    id, observed_at, state_province,
+    observer:users!observer_id!inner(country_code),
+    identifications(scientific_name, is_primary, confidence,
+                    taxa(common_name_es, common_name_en)),
+    media_files(url, is_primary, media_type)
+  `;
+  let usedLocalScope = false;
+  let rows: RecentObs[] = [];
+  if (country) {
+    try {
+      const { data } = await c.from('observations').select(select)
+        .eq('sync_status', 'synced')
+        .eq('observer.country_code', country)
+        .order('observed_at', { ascending: false }).limit(3);
+      // Strict 3-row threshold: if local has < 3 we fall back to global so
+      // the strip stays visually balanced (3 cards) rather than mixing 1-2
+      // local with global filler.
+      if (data && data.length === 3) {
+        usedLocalScope = true;
+        rows = (data as unknown as RawObs[]).map(toRecent(lang));
+      }
+    } catch { /* fall through */ }
+  }
+  if (rows.length < 3) {
+    try {
+      const { data } = await c.from('observations').select(select)
+        .eq('sync_status', 'synced')
+        .order('observed_at', { ascending: false }).limit(3);
+      rows = (data as unknown as RawObs[] ?? []).map(toRecent(lang));
+      usedLocalScope = false;
+    } catch { rows = []; }
+  }
+  return { rows, usedLocalScope };
+}
+
+interface RawObs {
+  id: string; observed_at: string; state_province: string | null;
+  observer: { country_code: string | null } | null;
+  identifications: Array<{ scientific_name: string | null; is_primary: boolean | null; confidence: number | null; taxa: { common_name_en: string | null; common_name_es: string | null } | null }> | null;
+  media_files: Array<{ url: string | null; is_primary: boolean | null; media_type: string | null }> | null;
+}
+
+function toRecent(lang: 'en' | 'es') {
+  return (r: RawObs): RecentObs => {
+    const idents = r.identifications ?? [];
+    const primary = idents.find(i => i.is_primary) ?? [...idents].sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))[0];
+    const photoMedia = (r.media_files ?? []).filter(m => !m.media_type || m.media_type === 'photo');
+    const photo = photoMedia.find(m => m.is_primary)?.url ?? photoMedia.find(m => !!m.url)?.url ?? null;
+    return {
+      id: r.id,
+      observedAt: r.observed_at,
+      stateProvince: r.state_province,
+      scientificName: primary?.scientific_name ?? null,
+      commonName: lang === 'es'
+        ? (primary?.taxa?.common_name_es ?? primary?.taxa?.common_name_en ?? null)
+        : (primary?.taxa?.common_name_en ?? primary?.taxa?.common_name_es ?? null),
+      photoUrl: photo,
+    };
+  };
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -25,6 +25,20 @@ export default {
     'shadow-[0_0_16px_rgba(217,70,239,0.7)]',
     'motion-safe:animate-pulse',
     'motion-safe:animate-rastrum-legend-spin',
+    // Home hero — kind-driven rail/bg/text classes resolved at runtime.
+    'border-red-400', 'bg-red-50/60', 'text-red-700',
+    'border-blue-400', 'bg-blue-50/60', 'text-blue-700',
+    'border-purple-400', 'bg-purple-50/60', 'text-purple-700',
+    'border-emerald-400', 'bg-emerald-50/60', 'text-emerald-700',
+    'dark:border-red-700/60', 'dark:bg-red-950/40', 'dark:text-red-300',
+    'dark:border-blue-700/60', 'dark:bg-blue-950/40', 'dark:text-blue-300',
+    'dark:border-purple-700/60', 'dark:bg-purple-950/40', 'dark:text-purple-300',
+    'dark:border-emerald-700/60', 'dark:bg-emerald-950/40', 'dark:text-emerald-300',
+    'bg-red-600', 'hover:bg-red-700',
+    'bg-blue-600', 'hover:bg-blue-700',
+    'bg-purple-600', 'hover:bg-purple-700',
+    'bg-emerald-700', 'hover:bg-emerald-800',
+    'text-white',
   ],
   theme: {
     extend: {

--- a/tests/unit/home-hero.test.ts
+++ b/tests/unit/home-hero.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { resolveHeroState, type HeroInputs } from '../../src/lib/home-hero';
+
+const baseInputs: HeroInputs = {
+  streak: null,
+  watchlistHit: null,
+  pendingIdsCount: 0,
+  expertTaxonGroup: null,
+  now: new Date('2026-05-09T20:00:00Z'),
+  userTimezone: 'UTC',
+};
+
+describe('resolveHeroState', () => {
+  it('falls through to observe_default when no signals', () => {
+    expect(resolveHeroState(baseInputs).kind).toBe('observe_default');
+  });
+
+  it('observe_default flags morningPeak between 5–9 local', () => {
+    const r = resolveHeroState({ ...baseInputs, now: new Date('2026-05-09T07:00:00Z') });
+    expect(r).toEqual({ kind: 'observe_default', morningPeak: true });
+  });
+
+  it('observe_default morningPeak=false outside 5–9', () => {
+    const r = resolveHeroState({ ...baseInputs, now: new Date('2026-05-09T12:00:00Z') });
+    expect(r).toEqual({ kind: 'observe_default', morningPeak: false });
+  });
+
+  it('streak_at_risk: only after 18:00 local', () => {
+    const before = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 5, lastObsLocalDay: '2026-05-08' },
+      now: new Date('2026-05-09T15:00:00Z'),
+    });
+    expect(before.kind).toBe('observe_default');
+
+    const after = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 5, lastObsLocalDay: '2026-05-08' },
+      now: new Date('2026-05-09T19:00:00Z'),
+    });
+    expect(after.kind).toBe('streak_at_risk');
+    if (after.kind === 'streak_at_risk') {
+      expect(after.currentDays).toBe(5);
+      expect(after.hoursLeftLocal).toBe(5);
+    }
+  });
+
+  it('streak_at_risk: skipped if user observed today', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 5, lastObsLocalDay: '2026-05-09' },
+      now: new Date('2026-05-09T20:00:00Z'),
+    });
+    expect(r.kind).toBe('observe_default');
+  });
+
+  it('streak_at_risk: skipped if currentDays is 0', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 0, lastObsLocalDay: null },
+      now: new Date('2026-05-09T20:00:00Z'),
+    });
+    expect(r.kind).toBe('observe_default');
+  });
+
+  it('streak_at_risk: triggers at currentDays === 1 (threshold)', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 1, lastObsLocalDay: '2026-05-08' },
+      now: new Date('2026-05-09T19:00:00Z'),
+    });
+    expect(r.kind).toBe('streak_at_risk');
+    if (r.kind === 'streak_at_risk') expect(r.currentDays).toBe(1);
+  });
+
+  it('watchlist_hit beats observe_default but loses to streak_at_risk', () => {
+    const watchOnly = resolveHeroState({
+      ...baseInputs,
+      watchlistHit: { taxonName: 'Quetzal', distanceKm: 4, obsId: 'abc', observedAt: '2026-05-09T18:00:00Z' },
+    });
+    expect(watchOnly.kind).toBe('watchlist_hit');
+
+    const both = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 12, lastObsLocalDay: '2026-05-08' },
+      watchlistHit: { taxonName: 'Quetzal', distanceKm: 4, obsId: 'abc', observedAt: '2026-05-09T18:00:00Z' },
+      now: new Date('2026-05-09T19:30:00Z'),
+    });
+    expect(both.kind).toBe('streak_at_risk');
+  });
+
+  it('pending_ids: requires count >= 3 AND expertTaxonGroup', () => {
+    const noGroup = resolveHeroState({ ...baseInputs, pendingIdsCount: 7 });
+    expect(noGroup.kind).toBe('observe_default');
+
+    const withGroup = resolveHeroState({
+      ...baseInputs,
+      pendingIdsCount: 7,
+      expertTaxonGroup: 'Aves',
+    });
+    expect(withGroup.kind).toBe('pending_ids');
+    if (withGroup.kind === 'pending_ids') {
+      expect(withGroup.count).toBe(7);
+      expect(withGroup.taxonGroup).toBe('Aves');
+    }
+
+    const tooFew = resolveHeroState({
+      ...baseInputs,
+      pendingIdsCount: 2,
+      expertTaxonGroup: 'Aves',
+    });
+    expect(tooFew.kind).toBe('observe_default');
+  });
+
+  it('cascade ordering: streak > watchlist > pending > default', () => {
+    const r = resolveHeroState({
+      ...baseInputs,
+      streak: { currentDays: 12, lastObsLocalDay: '2026-05-08' },
+      watchlistHit: { taxonName: 'Quetzal', distanceKm: 4, obsId: 'abc', observedAt: '2026-05-09T18:00:00Z' },
+      pendingIdsCount: 7,
+      expertTaxonGroup: 'Aves',
+      now: new Date('2026-05-09T20:00:00Z'),
+    });
+    expect(r.kind).toBe('streak_at_risk');
+  });
+});

--- a/tests/unit/home-loaders.test.ts
+++ b/tests/unit/home-loaders.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+  loadInboxCount, loadValidateCount, loadFaltaDexCount, loadWatchlistHit,
+  loadStreak, loadHeroInputs,
+} from '../../src/lib/home-loaders';
+
+function makeClient(handlers: Record<string, () => unknown>) {
+  return {
+    from: (table: string) => {
+      const h = handlers[`from:${table}`];
+      if (!h) throw new Error(`unmocked from('${table}')`);
+      return h();
+    },
+    rpc: (name: string) => {
+      const h = handlers[`rpc:${name}`];
+      if (!h) throw new Error(`unmocked rpc('${name}')`);
+      return h();
+    },
+  };
+}
+
+describe('home-loaders', () => {
+  it('loadInboxCount returns count or 0 on error', async () => {
+    const ok = makeClient({
+      'from:notifications': () => ({
+        select: () => ({ eq: () => ({ is: () => Promise.resolve({ count: 3, error: null }) }) }),
+      }),
+    });
+    expect(await loadInboxCount(ok as never, 'u1')).toBe(3);
+
+    const errored = makeClient({
+      'from:notifications': () => ({
+        select: () => ({ eq: () => ({ is: () => Promise.resolve({ count: null, error: { message: 'x' } }) }) }),
+      }),
+    });
+    expect(await loadInboxCount(errored as never, 'u1')).toBe(0);
+  });
+
+  it('loadValidateCount uses the RPC', async () => {
+    const c = makeClient({
+      'rpc:pending_validation_count': () => Promise.resolve({ data: 7, error: null }),
+    });
+    expect(await loadValidateCount(c as never)).toBe(7);
+  });
+
+  it('loadValidateCount returns 0 on RPC error or non-number', async () => {
+    const errored = makeClient({
+      'rpc:pending_validation_count': () => Promise.resolve({ data: null, error: { message: 'x' } }),
+    });
+    expect(await loadValidateCount(errored as never)).toBe(0);
+
+    const garbled = makeClient({
+      'rpc:pending_validation_count': () => Promise.resolve({ data: 'not-a-number', error: null }),
+    });
+    expect(await loadValidateCount(garbled as never)).toBe(0);
+  });
+
+  it('loadFaltaDexCount uses the RPC and returns shape', async () => {
+    const c = makeClient({
+      'rpc:falta_dex_summary': () => Promise.resolve({
+        data: [{ gap_count: 12, region: 'Jalisco' }],
+        error: null,
+      }),
+    });
+    expect(await loadFaltaDexCount(c as never)).toEqual({ count: 12, region: 'Jalisco' });
+  });
+
+  it('loadStreak returns null on error', async () => {
+    const c = makeClient({
+      'from:user_streaks': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: { message: 'x' } }) }) }),
+      }),
+    });
+    expect(await loadStreak(c as never, 'u1')).toBeNull();
+  });
+
+  it('loadStreak parses good data', async () => {
+    const c = makeClient({
+      'from:user_streaks': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({
+          data: { current_days: 5, last_qualifying_day: '2026-05-08' }, error: null,
+        }) }) }),
+      }),
+    });
+    expect(await loadStreak(c as never, 'u1')).toEqual({ currentDays: 5, lastObsLocalDay: '2026-05-08' });
+  });
+
+  it('loadWatchlistHit returns null in v1 (deferred)', async () => {
+    const c = makeClient({});
+    expect(await loadWatchlistHit(c as never, 'u1')).toBeNull();
+  });
+
+  it('loadHeroInputs runs all loaders in parallel and tolerates partial failure', async () => {
+    const c = makeClient({
+      'from:user_streaks': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({
+          data: { current_days: 5, last_qualifying_day: '2026-05-08' }, error: null,
+        }) }) }),
+      }),
+      'rpc:pending_validation_count': () => Promise.resolve({ data: 0, error: null }),
+      'from:users': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({
+          data: { timezone: 'America/Mexico_City', expert_taxa: ['Aves'] }, error: null,
+        }) }) }),
+      }),
+    });
+    const inputs = await loadHeroInputs(c as never, 'u1', new Date('2026-05-09T20:00:00Z'));
+    expect(inputs.streak).toEqual({ currentDays: 5, lastObsLocalDay: '2026-05-08' });
+    expect(inputs.pendingIdsCount).toBe(0);
+    expect(inputs.userTimezone).toBe('America/Mexico_City');
+    expect(inputs.expertTaxonGroup).toBe('Aves');
+    expect(inputs.watchlistHit).toBeNull();
+  });
+
+  it('loadHeroInputs handles missing user profile gracefully', async () => {
+    const c = makeClient({
+      'from:user_streaks': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }),
+      }),
+      'rpc:pending_validation_count': () => Promise.resolve({ data: null, error: { message: 'x' } }),
+      'from:users': () => ({
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }),
+      }),
+    });
+    const inputs = await loadHeroInputs(c as never, 'u1', new Date('2026-05-09T20:00:00Z'));
+    expect(inputs.streak).toBeNull();
+    expect(inputs.pendingIdsCount).toBe(0);
+    expect(inputs.userTimezone).toBe('UTC');
+    expect(inputs.expertTaxonGroup).toBeNull();
+    expect(inputs.watchlistHit).toBeNull();
+  });
+});

--- a/tests/unit/home-recent-fallback.test.ts
+++ b/tests/unit/home-recent-fallback.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { loadRecent } from '../../src/lib/home-loaders';
+
+function chain(result: { data: unknown[]; error: null }) {
+  const builder: Record<string, unknown> = {};
+  const fn = () => builder;
+  builder.eq = fn; builder.order = fn; builder.limit = () => Promise.resolve(result);
+  return builder;
+}
+
+function makeClient(localRows: unknown[], globalRows: unknown[]) {
+  let call = 0;
+  return {
+    from: () => ({
+      select: () => {
+        call += 1;
+        return chain({ data: call === 1 ? localRows : globalRows, error: null });
+      },
+    }),
+  } as never;
+}
+
+describe('loadRecent fallback', () => {
+  it('uses local scope when local returns 3 rows', async () => {
+    const c = makeClient(
+      [{ id: '1', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+       { id: '2', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+       { id: '3', observed_at: 'x', state_province: null, identifications: null, media_files: [] }],
+      [],
+    );
+    const r = await loadRecent(c, 'en', 'MX');
+    expect(r.usedLocalScope).toBe(true);
+    expect(r.rows).toHaveLength(3);
+  });
+
+  it('falls back to global when local returns < 3 rows', async () => {
+    const c = makeClient(
+      [{ id: '1', observed_at: 'x', state_province: null, identifications: null, media_files: [] }],
+      [{ id: 'g1', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+       { id: 'g2', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+       { id: 'g3', observed_at: 'x', state_province: null, identifications: null, media_files: [] }],
+    );
+    const r = await loadRecent(c, 'en', 'MX');
+    expect(r.usedLocalScope).toBe(false);
+    expect(r.rows.map(x => x.id)).toEqual(['g1', 'g2', 'g3']);
+  });
+
+  it('skips local query when country is null', async () => {
+    // Country=null means only the global query fires; the mock's first
+    // call must therefore return global rows.
+    const single = {
+      from: () => ({
+        select: () => chain({ data: [
+          { id: 'g1', observed_at: 'x', state_province: null, identifications: null, media_files: [] },
+        ], error: null }),
+      }),
+    } as never;
+    const r = await loadRecent(single, 'en', null);
+    expect(r.usedLocalScope).toBe(false);
+    expect(r.rows.map(x => x.id)).toEqual(['g1']);
+  });
+});


### PR DESCRIPTION
## Summary

Single-route integration. Replaces the broken `country_code`-on-`observations` query (still firing in prod despite #925) with a server-side `!inner` filter, and adds the Fogg-aligned dynamic hero + 4-chip launchpad above the existing widgets. Same route (`/`), no auto-redirect, no `/home` shell — just better content under the existing greeting strip.

### What's new on `/` (signed-in users)

```
/  (one route, status quo for routing)
├── greeting + 🔥 streak       (unchanged)
├── HomeHero                  ← NEW: kairos-driven dynamic CTA
├── HomeChips                 ← NEW: 2×2 launchpad (Inbox · Validate · Falta-dex · Watchlist)
├── Daily Challenge           (preserved)
├── Suggestions               (preserved)
└── HomeRecent                ← REPLACES the broken nearby query (uses observer:users!observer_id!inner FK filter + algorithm-disclosure pill)
```

### Hero state machine (4-priority cascade, first match wins)

1. **`streak_at_risk`** — currentDays ≥ 1 AND no obs today AND local hour ≥ 18 (loss-framing only fires in evening)
2. **`watchlist_hit`** — v1 stub returns null; cascade falls through (real matcher RPC = v1.1)
3. **`pending_ids`** — only fires for experts with ≥3 unvalidated IDs in their kingdoms
4. **`observe_default`** — always falls through; copy flips on morning peak (5–9 local)

### Schema (M33)

3 new RPCs in `docs/specs/infra/supabase-schema.sql`, all `SECURITY INVOKER`, all with pinned `search_path`:
- `home_pulse_stats()` — total/species/observers (last 30d), granted to anon + authenticated (currently unused — landed for parity with future marketing strip; see follow-ups)
- `pending_validation_count()` — scoped to caller's `expert_taxa` array, capped at 99
- `falta_dex_summary()` — caller's region gap count, btrim'd `state_province` match, capped at 999

3 supporting partial indexes: `idx_id_pending`, `idx_obs_state_taxon`, `idx_obs_observer_taxon`.

### Algorithm-disclosure (CLAUDE.md "no black box")

`home_recent_nearby` registered in `algorithms.ts`; `<WhyAmISeeingThis>` pill rendered on `HomeRecent`. Inputs, window, and settings link all surfaced.

### `getCachedUser()` migration

All new components use `getCachedUser()` (per #933 convention) instead of `auth.getUser()`.

## What this PR does NOT do

- **No `/home` route**, no auto-redirect, no Header logo swap. The single-route choice from #925 stays.
- **No marketing pulse strip on `/`** — anon users keep the existing Hero/How/Why content unchanged.
- **No watchlist matcher** — `loadWatchlistHit` is a v1 stub. Hero gracefully falls through.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` — 1738/1739 pass (one unrelated pre-existing failure in `posthog-events` cohortWeek, fails on main too)
- [x] `npm run build` clean
- [x] 22 new unit tests across `home-hero`, `home-loaders`, `home-recent-fallback`
- [ ] Manual: signed-in user on `/` sees greeting → hero (defaults to `observe_default`) → chips → daily challenge → suggestions → recent strip
- [ ] Manual: dev tools shows no `/rest/v1/observations?...country_code=...` 400 (the bug `loadRecent` actually fixes)
- [ ] Manual: clicking Inbox / Validate / Falta-dex / Watchlist chips routes correctly

## Spec & plan history

- Original brainstorm: `docs/superpowers/specs/2026-05-09-home-page-redesign-design.md` (split-route plan)
- Implementation plan: `docs/superpowers/plans/2026-05-09-home-page-redesign.md` (15 tasks for split-route)
- This PR pivoted to single-route integration after #925 chose option Ⓐ. Spec and plan retained as project history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)