### PR TITLE
feat(schema): observation defaults memory + is_first_in_sector() [#942 PR1/7]

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11100,3 +11100,61 @@ BEGIN
 END;
 $$;
 GRANT EXECUTE ON FUNCTION public.falta_dex_summary() TO authenticated;
+
+-- ====================================================
+-- #942 PR1 — Observation form redesign: schema deltas
+-- Observation defaults memory + honest first-in-sector claim
+-- ====================================================
+
+-- Defaults memory: persists last habitat/weather/license per user (jsonb)
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS last_observation_defaults jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.users.last_observation_defaults IS
+  'Remembers last-used observation defaults (habitat, weather, license) per user.
+   Pre-filled on next form open. Privacy: read only by the owning user (RLS).';
+
+-- is_first_in_sector — honest claim helper for the success state celebration
+-- Returns true only when:
+--   1. The sector (1 km radius) has >= 50 historical observations (honest-norms n>=50 invariant, v1.1.5)
+--   2. The supplied observation is the first one in that sector on its own calendar day
+-- Returns false in all other cases (including sectors with < 50 historical obs).
+CREATE OR REPLACE FUNCTION public.is_first_in_sector(p_obs_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH this_obs AS (
+    SELECT location, observed_at
+    FROM public.observations
+    WHERE id = p_obs_id
+      AND location IS NOT NULL
+  )
+  SELECT
+    CASE
+      -- Honest-norms invariant v1.1.5: only claim "first" when the sector
+      -- has enough historical data (n>=50). Below that threshold we simply
+      -- return false — we cannot make a meaningful claim.
+      WHEN (
+        SELECT count(*)
+        FROM public.observations o, this_obs t
+        WHERE o.location IS NOT NULL
+          AND ST_DWithin(o.location::geography, t.location::geography, 1000)
+          AND o.id != p_obs_id
+      ) < 50 THEN false
+      -- Sector has enough history: check if this obs is truly the first today.
+      ELSE NOT EXISTS (
+        SELECT 1
+        FROM public.observations o, this_obs t
+        WHERE o.location IS NOT NULL
+          AND ST_DWithin(o.location::geography, t.location::geography, 1000)
+          AND date_trunc('day', o.observed_at AT TIME ZONE 'UTC')
+            = date_trunc('day', t.observed_at AT TIME ZONE 'UTC')
+          AND o.id != p_obs_id
+      )
+    END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.is_first_in_sector(uuid) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.is_first_in_sector(uuid) TO authenticated;

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11125,35 +11125,39 @@ LANGUAGE sql STABLE
 SECURITY DEFINER
 SET search_path = public, extensions, pg_temp
 AS $$
+  -- Single-scan optimisation (ArtemIO review #942 PR1):
+  -- One CTE scans the sector once and computes both:
+  --   (a) the total neighbour count  → n>=50 honest-norms check
+  --   (b) whether any neighbour shares the same calendar day
+  -- The original implementation ran two separate ST_DWithin scans.
   WITH this_obs AS (
     SELECT location, observed_at
     FROM public.observations
     WHERE id = p_obs_id
       AND location IS NOT NULL
+  ),
+  sector_stats AS (
+    SELECT
+      count(*)                                                         AS total_neighbours,
+      count(*) FILTER (
+        WHERE date_trunc('day', o.observed_at AT TIME ZONE 'UTC')
+            = date_trunc('day', t.observed_at AT TIME ZONE 'UTC')
+      )                                                                AS same_day_neighbours
+    FROM public.observations o, this_obs t
+    WHERE o.location IS NOT NULL
+      AND ST_DWithin(o.location::geography, t.location::geography, 1000)
+      AND o.id != p_obs_id
   )
   SELECT
     CASE
       -- Honest-norms invariant v1.1.5: only claim "first" when the sector
       -- has enough historical data (n>=50). Below that threshold we simply
       -- return false — we cannot make a meaningful claim.
-      WHEN (
-        SELECT count(*)
-        FROM public.observations o, this_obs t
-        WHERE o.location IS NOT NULL
-          AND ST_DWithin(o.location::geography, t.location::geography, 1000)
-          AND o.id != p_obs_id
-      ) < 50 THEN false
-      -- Sector has enough history: check if this obs is truly the first today.
-      ELSE NOT EXISTS (
-        SELECT 1
-        FROM public.observations o, this_obs t
-        WHERE o.location IS NOT NULL
-          AND ST_DWithin(o.location::geography, t.location::geography, 1000)
-          AND date_trunc('day', o.observed_at AT TIME ZONE 'UTC')
-            = date_trunc('day', t.observed_at AT TIME ZONE 'UTC')
-          AND o.id != p_obs_id
-      )
-    END;
+      WHEN total_neighbours < 50 THEN false
+      -- Sector has enough history: first today iff no same-day neighbours.
+      ELSE same_day_neighbours = 0
+    END
+  FROM sector_stats;
 $$;
 
 REVOKE EXECUTE ON FUNCTION public.is_first_in_sector(uuid) FROM PUBLIC;


### PR DESCRIPTION
## Summary

Part 1 of 7 for issue #942 (Observation form redesign — Fogg-aligned ability + celebration).

Low-risk schema-only PR. No UI changes.

## Changes

### `users.last_observation_defaults` (jsonb)
Remembers last-used habitat/weather/license per user for defaults memory.
Pre-filled on next form open (implemented in PR3).
- `NOT NULL DEFAULT '{}'` — safe, no migration needed for existing rows
- Privacy: read only by owning user (existing RLS on `users` table)
- `jsonb_strip_nulls` used on write to prevent accumulating nulls

### `is_first_in_sector(p_obs_id uuid)` → boolean
Honest claim helper for the success state celebration.
Returns `true` **only when**:
1. The 1 km sector has ≥ 50 historical observations (honest-norms n≥50 invariant, v1.1.5)
2. The supplied observation is the first in that sector on its calendar day

Returns `false` in all other cases. No fabricated urgency.
`SECURITY DEFINER` + `REVOKE FROM PUBLIC` + `GRANT TO authenticated` (standard pattern).

### `observation_count` — no delta needed
Column already exists at schema.sql:44, populated by community-discovery cron. ✅

## Rollback
```sql
ALTER TABLE public.users DROP COLUMN IF EXISTS last_observation_defaults;
DROP FUNCTION IF EXISTS public.is_first_in_sector(uuid);
```

## Part of
- [ ] PR1 (this) — Schema deltas
- [ ] PR2 — suggest_nearby_species wild filter + photo_url null
- [ ] PR3 — observation-defaults.ts lib + form pre-fill
- [ ] PR4 — PipelineStepper.astro + feature flag
- [ ] PR5 — ObserveView2.astro block reorder (highest risk)
- [ ] PR6 — ObservationSuccess.astro celebration
- [ ] PR7 — Save/skip consolidation + active observers footer

Closes part of #942