### PR TITLE
feat(schema): suggest_nearby_species wild-only filter + no stranger thumbnails [#942 PR2/7]

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10877,6 +10877,8 @@ AS $$
     WHERE o.sync_status = 'synced'
       AND o.location IS NOT NULL
       AND o.establishment_means = 'wild'  -- #942: exclude cultivated/captive/domestic species
+      -- Valid values (CHECK constraint): 'wild'|'cultivated'|'captive'|'uncertain'
+      -- Darwin Core establishmentMeans. All pre-2026 rows backfilled to 'wild' (schema:3078).
       AND ST_DWithin(
             o.location::geography,
             ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10876,6 +10876,7 @@ AS $$
     JOIN public.identifications i ON i.observation_id = o.id AND i.is_primary
     WHERE o.sync_status = 'synced'
       AND o.location IS NOT NULL
+      AND o.establishment_means = 'wild'  -- #942: exclude cultivated/captive/domestic species
       AND ST_DWithin(
             o.location::geography,
             ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
@@ -10902,12 +10903,7 @@ AS $$
     t.kingdom,
     t.class,
     n.nearby_count,
-    (SELECT mf.url FROM public.media_files mf
-       JOIN public.observations mo ON mo.id = mf.observation_id
-       JOIN public.identifications mi ON mi.observation_id = mo.id
-         AND mi.taxon_id = t.id AND mi.is_primary
-       WHERE mf.is_primary AND mo.sync_status = 'synced'
-       LIMIT 1) AS photo_url
+    NULL::text AS photo_url  -- #942: no stranger thumbnails (privacy + framing)
   FROM nearby n
   JOIN public.taxa t ON t.id = n.taxon_id
   ORDER BY n.nearby_count DESC

--- a/src/lib/algorithms.ts
+++ b/src/lib/algorithms.ts
@@ -187,30 +187,32 @@ export const ALGORITHMS: Record<AlgorithmId, AlgorithmEntry> = {
       es: '¿Por qué veo estas especies probables?',
     },
     summary: {
-      en: 'A density estimate from public observations near the location and month of the photo you are about to log.',
-      es: 'Una estimación de densidad a partir de observaciones públicas cercanas a la ubicación y al mes de la foto que vas a registrar.',
+      en: 'A density estimate from wild public observations near the location and month of the photo you are about to log. Filters to wild-only (excludes cultivated plants and captive/domestic animals).',
+      es: 'Una estimación de densidad a partir de observaciones públicas silvestres cercanas a la ubicación y al mes de la foto que vas a registrar. Filtra a observaciones silvestres únicamente (excluye plantas cultivadas y animales domésticos/cautivos).',
     },
     copy: {
       en: {
         inputs: [
           'Approximate location (geohash-5 cell, ≈ ±2.4 km) of the photo or your device',
           'Current calendar month (seasonality)',
-          'Count of public community observations matching that cell + month, descending',
+          'Count of wild public community observations matching that cell + month, descending',
           'Distance to the closest matching observation (tiebreaker)',
           'No model, no curated baseline — these are real community sightings only',
+          'Filtered to establishment_means = wild — excludes cultivated plants and captive/domestic animals',
         ],
-        window: 'Public observations within the same geohash-5 cell, in the current month, all years',
+        window: 'Wild public observations within the same geohash-5 cell, in the current month, all years',
         settings_label: 'Edit profile (location & defaults)',
       },
       es: {
         inputs: [
           'Ubicación aproximada (celda geohash-5, ≈ ±2.4 km) de la foto o tu dispositivo',
           'Mes calendario actual (estacionalidad)',
-          'Conteo de observaciones públicas de la comunidad en esa celda + mes, descendente',
+          'Conteo de observaciones públicas silvestres de la comunidad en esa celda + mes, descendente',
           'Distancia a la observación coincidente más cercana (desempate)',
           'Sin modelo, sin baseline curado — solo son observaciones reales de la comunidad',
+          'Filtrado a establishment_means = wild — excluye plantas cultivadas y animales domésticos/cautivos',
         ],
-        window: 'Observaciones públicas dentro de la misma celda geohash-5, en el mes actual, todos los años',
+        window: 'Observaciones públicas silvestres dentro de la misma celda geohash-5, en el mes actual, todos los años',
         settings_label: 'Editar perfil (ubicación y predeterminados)',
       },
     },


### PR DESCRIPTION
## Summary

Part 2 of 7 for issue #942. Low-risk `CREATE OR REPLACE` — schema-only, idempotent, independently revertible.

## Changes

### `suggest_nearby_species()` — two targeted changes

**1. `AND o.establishment_means = 'wild'`** added to the `nearby` CTE.

Excludes `cultivated`, `captive`, `uncertain` from contextual suggestions.
Fixes the reported bug where `Canis familiaris` and `Gerbera spp.` (domestic/cultivated) were appearing as "probable here" species.
Backed by `idx_obs_establishment_means` index (schema.sql:3082) — no performance regression.

**2. `photo_url` always returns `NULL::text`** (was a correlated subquery fetching a stranger's photo URL).

Eliminates the privacy/framing concern of showing other users' photos without context.
`ContextualSpeciesChips.astro` will degrade gracefully to a kingdom emoji fallback (implemented in PR5).

### `algorithms.ts` — description update

`contextual_species_chips` description updated in EN/ES to reflect the wild-only filter. Required by the v1.1.5 WhyAmISeeingThis invariant: the algorithm description must match what it actually does.

## Rollback
```sql
-- Restore previous body of suggest_nearby_species (in git history)
-- git checkout HEAD~1 -- docs/specs/infra/supabase-schema.sql
```

## Part of
- [x] PR1 (#945) — Schema deltas (last_observation_defaults, is_first_in_sector)
- [ ] **PR2 (this)** — suggest_nearby_species wild filter + photo_url null
- [ ] PR3 — observation-defaults.ts lib + form pre-fill
- [ ] PR4 — PipelineStepper.astro + feature flag
- [ ] PR5 — ObserveView2.astro block reorder (highest risk)
- [ ] PR6 — ObservationSuccess.astro celebration
- [ ] PR7 — Save/skip consolidation + active observers footer

Closes part of #942