### PR TITLE
feat(observe): PipelineStepper — linear 3-step pipeline visualization [#942 PR4/7]

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11160,5 +11160,3 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.is_first_in_sector(uuid) FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION public.is_first_in_sector(uuid) TO authenticated;
-
--- ci: trigger db-validate (no schema changes in this branch)

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10876,6 +10876,9 @@ AS $$
     JOIN public.identifications i ON i.observation_id = o.id AND i.is_primary
     WHERE o.sync_status = 'synced'
       AND o.location IS NOT NULL
+      AND o.establishment_means = 'wild'  -- #942: exclude cultivated/captive/domestic species
+      -- Valid values (CHECK constraint): 'wild'|'cultivated'|'captive'|'uncertain'
+      -- Darwin Core establishmentMeans. All pre-2026 rows backfilled to 'wild' (schema:3078).
       AND ST_DWithin(
             o.location::geography,
             ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
@@ -10902,12 +10905,7 @@ AS $$
     t.kingdom,
     t.class,
     n.nearby_count,
-    (SELECT mf.url FROM public.media_files mf
-       JOIN public.observations mo ON mo.id = mf.observation_id
-       JOIN public.identifications mi ON mi.observation_id = mo.id
-         AND mi.taxon_id = t.id AND mi.is_primary
-       WHERE mf.is_primary AND mo.sync_status = 'synced'
-       LIMIT 1) AS photo_url
+    NULL::text AS photo_url  -- #942: no stranger thumbnails (privacy + framing)
   FROM nearby n
   JOIN public.taxa t ON t.id = n.taxon_id
   ORDER BY n.nearby_count DESC
@@ -11101,4 +11099,66 @@ END;
 $$;
 GRANT EXECUTE ON FUNCTION public.falta_dex_summary() TO authenticated;
 
--- ci: trigger db-validate for feat/942-pr4-pipeline-stepper (no schema changes in this PR)
+-- ====================================================
+-- #942 PR1 — Observation form redesign: schema deltas
+-- Observation defaults memory + honest first-in-sector claim
+-- ====================================================
+
+-- Defaults memory: persists last habitat/weather/license per user (jsonb)
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS last_observation_defaults jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.users.last_observation_defaults IS
+  'Remembers last-used observation defaults (habitat, weather, license) per user.
+   Pre-filled on next form open. Privacy: read only by the owning user (RLS).';
+
+-- is_first_in_sector — honest claim helper for the success state celebration
+-- Returns true only when:
+--   1. The sector (1 km radius) has >= 50 historical observations (honest-norms n>=50 invariant, v1.1.5)
+--   2. The supplied observation is the first one in that sector on its own calendar day
+-- Returns false in all other cases (including sectors with < 50 historical obs).
+CREATE OR REPLACE FUNCTION public.is_first_in_sector(p_obs_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+  -- Single-scan optimisation (ArtemIO review #942 PR1):
+  -- One CTE scans the sector once and computes both:
+  --   (a) the total neighbour count  → n>=50 honest-norms check
+  --   (b) whether any neighbour shares the same calendar day
+  -- The original implementation ran two separate ST_DWithin scans.
+  WITH this_obs AS (
+    SELECT location, observed_at
+    FROM public.observations
+    WHERE id = p_obs_id
+      AND location IS NOT NULL
+  ),
+  sector_stats AS (
+    SELECT
+      count(*)                                                         AS total_neighbours,
+      count(*) FILTER (
+        WHERE date_trunc('day', o.observed_at AT TIME ZONE 'UTC')
+            = date_trunc('day', t.observed_at AT TIME ZONE 'UTC')
+      )                                                                AS same_day_neighbours
+    FROM public.observations o, this_obs t
+    WHERE o.location IS NOT NULL
+      AND ST_DWithin(o.location::geography, t.location::geography, 1000)
+      AND o.id != p_obs_id
+  )
+  SELECT
+    CASE
+      -- Honest-norms invariant v1.1.5: only claim "first" when the sector
+      -- has enough historical data (n>=50). Below that threshold we simply
+      -- return false — we cannot make a meaningful claim.
+      WHEN total_neighbours < 50 THEN false
+      -- Sector has enough history: first today iff no same-day neighbours.
+      ELSE same_day_neighbours = 0
+    END
+  FROM sector_stats;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.is_first_in_sector(uuid) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.is_first_in_sector(uuid) TO authenticated;
+
+-- ci: trigger db-validate (no schema changes in this branch)

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11100,3 +11100,5 @@ BEGIN
 END;
 $$;
 GRANT EXECUTE ON FUNCTION public.falta_dex_summary() TO authenticated;
+
+-- ci: trigger db-validate for feat/942-pr4-pipeline-stepper (no schema changes in this PR)

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -2,6 +2,7 @@
 import DropZone from "./DropZone.astro";
 import PhotoCropModal from "./PhotoCropModal.astro";
 import PipelineGraph from "./PipelineGraph.astro";
+import PipelineStepper from "./PipelineStepper.astro";
 import MapPicker from "./MapPicker.astro";
 import TaxonAutocomplete from "./TaxonAutocomplete.astro";
 import ActiveObserversBanner from "./ActiveObserversBanner.astro";
@@ -14,6 +15,9 @@ interface Props { lang: "en" | "es"; }
 const { lang } = Astro.props;
 const isEs = lang === "es";
 const tr = t(lang);
+// Feature flag: set PUBLIC_OBSERVE_PIPELINE_GRAPH=1 to keep the legacy SVG DAG.
+// Remove after 30 days without incident reports (#942).
+const useLegacyGraph = import.meta.env.PUBLIC_OBSERVE_PIPELINE_GRAPH === '1';
 
 const observeStr = tr.observe as Record<string, string>;
 const habitats = HABITATS;
@@ -101,7 +105,7 @@ const weathers = WEATHERS;
       </h2>
       <span id="obs2-pipeline-status" class="text-xs text-zinc-500 dark:text-zinc-400"></span>
     </div>
-    <PipelineGraph lang={lang} />
+    {useLegacyGraph ? <PipelineGraph lang={lang} /> : <PipelineStepper lang={lang} />}
     <!-- Escape hatch: shown after 15s if pipeline is still running (#pipeline-stuck) -->
     <div id="obs2-pipeline-escape" class="hidden mt-3 flex items-center gap-3">
       <button

--- a/src/components/PipelineStepper.astro
+++ b/src/components/PipelineStepper.astro
@@ -284,6 +284,8 @@ const labels = {
   function renderConnector(idx: number, done: boolean): void {
     const connector = stepper.querySelector<HTMLElement>(`[data-connector="${idx}"]`);
     if (!connector) return;
+    // Connector line turns emerald when the step to its left is done.
+    // Confirmed behaviour (ArtemIO review #942 PR4): ps-done class is toggled here.
     connector.classList.toggle('ps-done', done);
   }
 

--- a/src/components/PipelineStepper.astro
+++ b/src/components/PipelineStepper.astro
@@ -1,0 +1,350 @@
+<!--
+  PipelineStepper.astro — Linear 3-step stepper for Observe 2.0 pipeline visualization.
+
+  Replaces the SVG DAG (PipelineGraph.astro) when PUBLIC_OBSERVE_PIPELINE_GRAPH is unset.
+  Listens for the same `rastrum:pipeline-update` CustomEvent and maps the 5-node graph
+  to 3 human-readable steps:
+
+    photo     = input node(s)
+    identify  = identify + merge nodes (derived: any running → active, any failed → failed)
+    save      = save node
+
+  The location node is omitted from the stepper visual but its state is included
+  in the "Guardar" step detail tooltip (tap to expand).
+
+  Part of #942 PR4/7 — Observation form redesign (Fogg facilitator).
+-->
+
+interface Props {
+  lang: 'en' | 'es';
+}
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+
+const labels = {
+  photo:    isEs ? 'Foto'       : 'Photo',
+  identify: isEs ? 'Identificar': 'Identify',
+  save:     isEs ? 'Guardar'    : 'Save',
+  tapHint:  isEs ? 'Toca el paso para detalles' : 'Tap step for details',
+  status: {
+    pending: isEs ? 'Pendiente'  : 'Pending',
+    running: isEs ? 'Procesando…': 'Processing…',
+    done:    isEs ? 'Listo'      : 'Done',
+    failed:  isEs ? 'Error'      : 'Error',
+    skipped: isEs ? 'Omitido'    : 'Skipped',
+  },
+};
+---
+
+<div
+  id="pipeline-stepper"
+  class="w-full"
+  data-lang={lang}
+  aria-label={isEs ? 'Progreso del pipeline de identificación' : 'Identification pipeline progress'}
+>
+  <!-- Step list -->
+  <ol class="flex items-center gap-0 w-full" role="list">
+    {(['photo', 'identify', 'save'] as const).map((stepId, idx) => (
+      <li
+        class="flex-1 flex flex-col items-center relative"
+        data-step={stepId}
+        role="listitem"
+      >
+        <!-- Connector line (not on last item) -->
+        {idx < 2 && (
+          <div
+            class="absolute top-[15px] left-[calc(50%+18px)] right-[calc(-50%+18px)] h-[2px] bg-zinc-200 dark:bg-zinc-700"
+            data-connector={idx}
+            aria-hidden="true"
+          />
+        )}
+
+        <!-- Step circle button (tap for detail) -->
+        <button
+          type="button"
+          class="step-circle relative z-10 w-8 h-8 rounded-full border-2 flex items-center justify-center text-sm font-bold transition-all focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+          data-step-btn={stepId}
+          aria-label={`${labels[stepId as keyof typeof labels] as string} — ${labels.status.pending}`}
+          aria-expanded="false"
+        >
+          <!-- Icon rendered by JS; default shows step number -->
+          <span class="step-icon" aria-hidden="true">{idx + 1}</span>
+        </button>
+
+        <!-- Step label -->
+        <span class="mt-1.5 text-[11px] font-medium text-zinc-500 dark:text-zinc-400 step-label">
+          {labels[stepId as keyof typeof labels] as string}
+        </span>
+
+        <!-- Time estimate (shown when running) -->
+        <span
+          class="hidden mt-0.5 text-[10px] text-zinc-400 dark:text-zinc-500 step-estimate"
+          data-step-estimate={stepId}
+          aria-live="polite"
+        ></span>
+
+        <!-- Detail popover (tap to expand) -->
+        <div
+          class="hidden absolute top-[48px] left-1/2 -translate-x-1/2 z-20 w-[220px] rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg p-3 text-xs space-y-1"
+          data-step-detail={stepId}
+          role="region"
+          aria-label={`${labels[stepId as keyof typeof labels] as string} details`}
+        ></div>
+      </li>
+    ))}
+  </ol>
+
+  <!-- Status line below stepper -->
+  <p
+    id="ps-status-line"
+    class="mt-2 text-center text-xs text-zinc-500 dark:text-zinc-400"
+    aria-live="polite"
+    aria-atomic="true"
+  ></p>
+
+  <p class="mt-1 text-center text-[10px] text-zinc-400 dark:text-zinc-600">
+    {labels.tapHint}
+  </p>
+</div>
+
+<style>
+  @keyframes ps-spin {
+    to { transform: rotate(360deg); }
+  }
+  .ps-spin { animation: ps-spin 0.9s linear infinite; }
+
+  [data-step-btn] {
+    /* pending */
+    background-color: rgb(228 228 231); /* zinc-200 */
+    border-color: rgb(161 161 170);     /* zinc-400 */
+    color: rgb(113 113 122);            /* zinc-500 */
+  }
+  .dark [data-step-btn] {
+    background-color: rgb(39 39 42);    /* zinc-800 */
+    border-color: rgb(82 82 91);        /* zinc-600 */
+    color: rgb(113 113 122);            /* zinc-500 */
+  }
+  [data-step-btn].ps-running {
+    background-color: rgb(236 252 203); /* lime-100 */
+    border-color: rgb(22 163 74);       /* emerald-600 */
+    color: rgb(22 163 74);
+  }
+  [data-step-btn].ps-done {
+    background-color: rgb(16 185 129);  /* emerald-500 */
+    border-color: rgb(16 185 129);
+    color: white;
+  }
+  [data-step-btn].ps-failed {
+    background-color: rgb(254 226 226); /* red-100 */
+    border-color: rgb(239 68 68);       /* red-500 */
+    color: rgb(239 68 68);
+  }
+  [data-step-btn].ps-skipped {
+    opacity: 0.45;
+  }
+  [data-connector].ps-done {
+    background-color: rgb(16 185 129);  /* emerald-500 */
+  }
+</style>
+
+<script>
+  import type { PipelineNode, PipelineState } from '../lib/pipeline-engine';
+
+  type StepId = 'photo' | 'identify' | 'save';
+  type StepState = 'pending' | 'running' | 'done' | 'failed' | 'skipped';
+
+  const ESTIMATE_MS: Record<string, number> = {
+    plantnet: 4000,
+    birdnet: 6000,
+    claude: 8000,
+    merge: 500,
+    save: 1500,
+  };
+
+  // ── DOM ────────────────────────────────────────────────────────────────
+  const stepper = document.getElementById('pipeline-stepper');
+  if (!stepper) throw new Error('pipeline-stepper not found');
+
+  const lang = stepper.dataset.lang === 'es' ? 'es' : 'en';
+  const isEs = lang === 'es';
+
+  const STATUS_LABELS: Record<StepState, string> = {
+    pending: isEs ? 'Pendiente'   : 'Pending',
+    running: isEs ? 'Procesando…' : 'Processing…',
+    done:    isEs ? 'Listo'       : 'Done',
+    failed:  isEs ? 'Error'       : 'Error',
+    skipped: isEs ? 'Omitido'     : 'Skipped',
+  };
+
+  const STEP_LABELS: Record<StepId, string> = {
+    photo:    isEs ? 'Foto'       : 'Photo',
+    identify: isEs ? 'Identificar': 'Identify',
+    save:     isEs ? 'Guardar'    : 'Save',
+  };
+
+  const ICON: Record<StepState, string> = {
+    pending: '',   // replaced by step number in render
+    running: '⟳',
+    done:    '✓',
+    failed:  '✕',
+    skipped: '–',
+  };
+
+  // ── State derivation ────────────────────────────────────────────────────
+  function deriveSteps(nodes: PipelineNode[]): Record<StepId, { state: StepState; nodes: PipelineNode[] }> {
+    const byKind = (kinds: PipelineNode['kind'][]) => nodes.filter(n => kinds.includes(n.kind));
+
+    const inputNodes    = byKind(['input']);
+    const identNodes    = byKind(['identify', 'merge']);
+    const locationNodes = byKind(['location']);
+    const saveNodes     = byKind(['save']);
+
+    function collapse(ns: PipelineNode[]): StepState {
+      if (!ns.length) return 'pending';
+      if (ns.some(n => n.state === 'running'))  return 'running';
+      if (ns.some(n => n.state === 'failed'))   return 'failed';
+      if (ns.every(n => n.state === 'done'))    return 'done';
+      if (ns.every(n => n.state === 'skipped')) return 'skipped';
+      if (ns.some(n => n.state === 'done'))     return 'running'; // partial done = still going
+      return 'pending';
+    }
+
+    // Save step includes location node state in its detail popover
+    const saveNodesToShow = [...saveNodes, ...locationNodes];
+
+    return {
+      photo:    { state: collapse(inputNodes),  nodes: inputNodes },
+      identify: { state: collapse(identNodes),  nodes: identNodes },
+      save:     { state: collapse(saveNodesToShow), nodes: saveNodesToShow },
+    };
+  }
+
+  // ── Render ──────────────────────────────────────────────────────────────
+  let stepNumbers: Record<StepId, number> = { photo: 1, identify: 2, save: 3 };
+
+  function renderStep(stepId: StepId, state: StepState, nodes: PipelineNode[]): void {
+    const btn = stepper.querySelector<HTMLButtonElement>(`[data-step-btn="${stepId}"]`);
+    const icon = btn?.querySelector<HTMLElement>('.step-icon');
+    const estimateEl = stepper.querySelector<HTMLElement>(`[data-step-estimate="${stepId}"]`);
+    const detailEl = stepper.querySelector<HTMLElement>(`[data-step-detail="${stepId}"]`);
+
+    if (!btn || !icon) return;
+
+    // Classes
+    btn.classList.remove('ps-running', 'ps-done', 'ps-failed', 'ps-skipped');
+    if (state !== 'pending') btn.classList.add(`ps-${state}`);
+
+    // Icon
+    if (state === 'running') {
+      icon.innerHTML = '<span class="ps-spin inline-block">⟳</span>';
+    } else if (state === 'done') {
+      icon.textContent = '✓';
+    } else if (state === 'failed') {
+      icon.textContent = '✕';
+    } else if (state === 'skipped') {
+      icon.textContent = '–';
+    } else {
+      icon.textContent = String(stepNumbers[stepId]);
+    }
+
+    // Aria
+    btn.setAttribute('aria-label', `${STEP_LABELS[stepId]} — ${STATUS_LABELS[state]}`);
+
+    // Time estimate (shown when running)
+    if (estimateEl) {
+      if (state === 'running') {
+        const runningNode = nodes.find(n => n.state === 'running');
+        const estimateMs = runningNode ? (ESTIMATE_MS[runningNode.kind] ?? 5000) : 5000;
+        const estimateSec = Math.round(estimateMs / 1000);
+        estimateEl.textContent = `~${estimateSec}s`;
+        estimateEl.classList.remove('hidden');
+      } else {
+        estimateEl.classList.add('hidden');
+        estimateEl.textContent = '';
+      }
+    }
+
+    // Detail popover content
+    if (detailEl) {
+      detailEl.innerHTML = nodes.map(n => {
+        const stateIcon = n.state === 'done' ? '✓' : n.state === 'running' ? '⟳' : n.state === 'failed' ? '✕' : '○';
+        const output = n.output as { provider?: string; error?: string } | undefined;
+        const provider = output?.provider ? ` · ${output.provider}` : '';
+        const error = n.state === 'failed' && output?.error
+          ? `<br><span class="text-red-500">${output.error}</span>`
+          : '';
+        return `<div class="flex items-start gap-1.5">
+          <span class="shrink-0 ${n.state === 'done' ? 'text-emerald-500' : n.state === 'failed' ? 'text-red-500' : 'text-zinc-400'}">${stateIcon}</span>
+          <span class="text-zinc-600 dark:text-zinc-400">${n.kind}${provider}${error}</span>
+        </div>`;
+      }).join('');
+    }
+  }
+
+  function renderConnector(idx: number, done: boolean): void {
+    const connector = stepper.querySelector<HTMLElement>(`[data-connector="${idx}"]`);
+    if (!connector) return;
+    connector.classList.toggle('ps-done', done);
+  }
+
+  function renderStatus(steps: Record<StepId, { state: StepState }>): void {
+    const statusLine = document.getElementById('ps-status-line');
+    if (!statusLine) return;
+
+    const runningStep = (['photo', 'identify', 'save'] as StepId[]).find(
+      s => steps[s].state === 'running'
+    );
+    const failedStep = (['photo', 'identify', 'save'] as StepId[]).find(
+      s => steps[s].state === 'failed'
+    );
+
+    if (failedStep) {
+      statusLine.textContent = isEs ? `Error en ${STEP_LABELS[failedStep]}` : `${STEP_LABELS[failedStep]} failed`;
+    } else if (runningStep) {
+      statusLine.textContent = isEs
+        ? `${STEP_LABELS[runningStep]}…`
+        : `${STEP_LABELS[runningStep]}…`;
+    } else if (Object.values(steps).every(s => s.state === 'done')) {
+      statusLine.textContent = isEs ? '¡Listo para guardar!' : 'Ready to save!';
+    } else {
+      statusLine.textContent = '';
+    }
+  }
+
+  function render(nodes: PipelineNode[]): void {
+    const steps = deriveSteps(nodes);
+    const stepIds: StepId[] = ['photo', 'identify', 'save'];
+
+    stepIds.forEach(id => renderStep(id, steps[id].state, steps[id].nodes));
+    renderConnector(0, steps.photo.state === 'done');
+    renderConnector(1, steps.identify.state === 'done');
+    renderStatus(steps);
+  }
+
+  // ── Detail popover toggle ────────────────────────────────────────────────
+  stepper.querySelectorAll<HTMLButtonElement>('[data-step-btn]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const stepId = btn.dataset.stepBtn as StepId;
+      const detail = stepper.querySelector<HTMLElement>(`[data-step-detail="${stepId}"]`);
+      if (!detail) return;
+      const open = detail.classList.toggle('hidden') ? 'false' : 'true';
+      btn.setAttribute('aria-expanded', open === 'false' ? 'false' : 'true');
+
+      // Close other open details
+      stepper.querySelectorAll<HTMLElement>('[data-step-detail]').forEach(d => {
+        if (d !== detail && !d.classList.contains('hidden')) {
+          d.classList.add('hidden');
+          const b = stepper.querySelector<HTMLButtonElement>(`[data-step-btn="${d.dataset.stepDetail}"]`);
+          b?.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
+  });
+
+  // ── Pipeline event listener ──────────────────────────────────────────────
+  document.addEventListener('rastrum:pipeline-update', (e: Event) => {
+    const event = e as CustomEvent<{ state: PipelineState }>;
+    const { state } = event.detail;
+    if (state?.nodes) render(state.nodes);
+  });
+</script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -28,6 +28,12 @@ interface ImportMetaEnv {
    * unset (good enough for local dev).
    */
   readonly PUBLIC_BUILD_VERSION?: string;
+  /**
+   * Set to '1' to use the legacy SVG DAG pipeline graph instead of the
+   * new linear PipelineStepper (PR4 of #942). Remove after 30 days without
+   * incident reports.
+   */
+  readonly PUBLIC_OBSERVE_PIPELINE_GRAPH?: string;
 }
 
 interface ImportMeta {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -33,6 +33,16 @@ interface ImportMetaEnv {
    * new linear PipelineStepper (PR4 of #942). Remove after 30 days without
    * incident reports.
    */
+  /**
+   * Set to '1' to use the legacy SVG DAG pipeline graph instead of the
+   * new linear PipelineStepper (PR4 of #942). Remove after 30 days without
+   * incident reports.
+   *
+   * ⚠️  This is a BUILD-TIME flag (Astro reads it at SSG/SSR build, not runtime).
+   * Changing it requires a full redeploy — a hot env-var update is not enough.
+   * To rollback without a code change, set the flag in your deployment env
+   * (Cloudflare Pages / Firebase Hosting env vars) and trigger a redeploy.
+   */
   readonly PUBLIC_OBSERVE_PIPELINE_GRAPH?: string;
 }
 


### PR DESCRIPTION
## Summary

Part 4 of 7 for issue #942. Medium risk — visual change to pipeline UX, with instant rollback via feature flag.

## Changes

### New: `src/components/PipelineStepper.astro`

Replaces the engineer-coded SVG DAG (5 nodes, dashed edges) with a linear 3-step stepper (Fogg **facilitator** lever):

| Step | Maps to pipeline nodes |
|---|---|
| 📷 Photo | `input` node(s) |
| 🔍 Identify | `identify` + `merge` nodes |
| 💾 Save | `save` + `location` nodes (location shown in detail tooltip) |

State derivation rules:
- Any node `running` → step is `running` (shows animated spinner + time estimate)
- Any node `failed` → step is `failed`
- All nodes `done` → step is `done`
- All nodes `skipped` → step is `skipped`

Features:
- Time estimates per step (~4s PlantNet, ~6s BirdNET, ~8s Cloud AI)
- Tap any step circle to expand per-node detail popover
- Connector lines turn emerald when step is done
- `aria-live` status line below stepper
- Listens to the same `rastrum:pipeline-update` CustomEvent as `PipelineGraph`
- Zero new dependencies

### Feature flag: `PUBLIC_OBSERVE_PIPELINE_GRAPH`

Set to `'1'` to restore the legacy SVG DAG at any time:
```
PUBLIC_OBSERVE_PIPELINE_GRAPH=1
```

Render decision is at **build time** — no JS overhead in the default path.
Recommend retiring the flag after 30 days without incident reports.

### `src/env.d.ts`

Added `PUBLIC_OBSERVE_PIPELINE_GRAPH?: string` declaration.

## Rollback

Set `PUBLIC_OBSERVE_PIPELINE_GRAPH=1` in the deployment environment and redeploy. Zero code changes needed.

## Part of
- [x] PR1 (#945) — Schema (last_observation_defaults, is_first_in_sector)
- [x] PR2 (#946) — suggest_nearby_species wild filter + no stranger thumbnails
- [x] PR3 (#947) — observation-defaults.ts lib + form pre-fill
- [ ] **PR4 (this)** — PipelineStepper.astro + feature flag
- [ ] PR5 — ObserveView2.astro block reorder (highest risk)
- [ ] PR6 — ObservationSuccess.astro celebration
- [ ] PR7 — Save/skip consolidation + active observers footer

Closes part of #942