### PR TITLE
fix: PipelineStepper.astro missing opening frontmatter --- (hotfix)

### DIFF
--- a/src/components/PipelineStepper.astro
+++ b/src/components/PipelineStepper.astro
@@ -15,6 +15,7 @@
   Part of #942 PR4/7 — Observation form redesign (Fogg facilitator).
 -->
 
+---
 interface Props {
   lang: 'en' | 'es';
 }


### PR DESCRIPTION
Hotfix for broken E2E + Deploy workflows on main.

**Error:** `CompilerError: The closing frontmatter fence (---) is missing an opening fence` in `PipelineStepper.astro:37`

**Cause:** The squash merge of #948 produced a malformed `.astro` file — the HTML comment block at the top was not properly wrapped in frontmatter delimiters. Only the closing `---` existed; the opening `---` was missing.

**Fix:** Insert `---` on line 18 (after the HTML comment block, before `interface Props`).