### PR TITLE
fix: taxa autocomplete HTTP 400 — remove observation_count, fix history query (#953)

### DIFF
--- a/src/lib/taxon-autocomplete.ts
+++ b/src/lib/taxon-autocomplete.ts
@@ -201,7 +201,7 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
     scientificName: r.scientific_name,
     commonNameEs: r.common_name_es ?? null,
     commonNameEn: r.common_name_en ?? null,
-    observationCount: r.rarity_tier ?? null,
+    observationCount: null, // rarity_tier is not a count — hide from count display
     inUserHistory: userTaxonIds.has(r.id),
     source: 'rastrum' as const,
   }));

--- a/src/lib/taxon-autocomplete.ts
+++ b/src/lib/taxon-autocomplete.ts
@@ -22,7 +22,7 @@ export interface TaxonSuggestion {
   commonNameEs: string | null;
   /** English common name (best effort) */
   commonNameEn: string | null;
-  /** Number of observations in Rastrum DB (null = GBIF-only hit) */
+  /** Rarity tier from Rastrum DB (1=common … 4=very rare, null = GBIF-only or unclassified) */
   observationCount: number | null;
   /** Whether the user has observed this taxon before */
   inUserHistory: boolean;
@@ -149,28 +149,28 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
 
   const prefixQuery = supabase
     .from('taxa')
-    .select('scientific_name, common_name_es, common_name_en, observation_count')
+    .select('id, scientific_name, common_name_es, common_name_en, rarity_tier')
     .ilike('scientific_name', `${q}%`)
-    .order('observation_count', { ascending: false })
+    .order('rarity_tier', { ascending: true, nullsFirst: false })
     .limit(MAX_RESULTS);
 
   const genusQuery = isGenusOnly
     ? supabase
         .from('taxa')
-        .select('scientific_name, common_name_es, common_name_en, observation_count')
+        .select('id, scientific_name, common_name_es, common_name_en, rarity_tier')
         .ilike('scientific_name', `${q} %`)
-        .order('observation_count', { ascending: false })
+        .order('rarity_tier', { ascending: true, nullsFirst: false })
         .limit(MAX_RESULTS)
     : null;
 
-  // User history query — fetch distinct scientific names the user has observed
+  // User history query — fetch distinct primary_taxon_id values the user has observed
   const historyQuery = user
     ? supabase
         .from('observations')
-        .select('primary_scientific_name')
+        .select('primary_taxon_id')
         .eq('observer_id', user.id)
-        .ilike('primary_scientific_name', `${q}%`)
-        .limit(MAX_RESULTS)
+        .not('primary_taxon_id', 'is', null)
+        .limit(50)
     : null;
 
   const [prefixRes, genusRes, historyRes] = await Promise.all([
@@ -179,8 +179,8 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
     historyQuery ?? Promise.resolve({ data: [] as any[], error: null }),
   ]);
 
-  const userSpecies = new Set<string>(
-    (historyRes.data ?? []).map((r: any) => (r.primary_scientific_name ?? '').toLowerCase())
+  const userTaxonIds = new Set<string>(
+    (historyRes.data ?? []).map((r: any) => r.primary_taxon_id).filter(Boolean)
   );
 
   const rows: any[] = [
@@ -201,8 +201,8 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
     scientificName: r.scientific_name,
     commonNameEs: r.common_name_es ?? null,
     commonNameEn: r.common_name_en ?? null,
-    observationCount: r.observation_count ?? null,
-    inUserHistory: userSpecies.has(r.scientific_name?.toLowerCase() ?? ''),
+    observationCount: r.rarity_tier ?? null,
+    inUserHistory: userTaxonIds.has(r.id),
     source: 'rastrum' as const,
   }));
 }

--- a/tests/unit/taxon-autocomplete.test.ts
+++ b/tests/unit/taxon-autocomplete.test.ts
@@ -22,6 +22,7 @@ function makeQueryStub(resolveWith: any) {
     ilike:  () => stub,
     order:  () => stub,
     eq:     () => stub,
+    not:    () => stub,
     limit:  () => Promise.resolve(resolveWith),
   };
   return stub;
@@ -37,10 +38,11 @@ vi.mock('../../src/lib/supabase', () => ({
         return makeQueryStub({
           data: [
             {
+              id: 'taxon-uuid-1',
               scientific_name: 'Alamania punicea',
               common_name_es: 'Orquídea de agave',
               common_name_en: null,
-              observation_count: 12,
+              rarity_tier: 1,
             },
           ],
           error: null,
@@ -48,7 +50,7 @@ vi.mock('../../src/lib/supabase', () => ({
       }
       if (table === 'observations') {
         return makeQueryStub({
-          data: [{ primary_scientific_name: 'Alamania punicea' }],
+          data: [{ primary_taxon_id: 'taxon-uuid-1' }],
           error: null,
         });
       }
@@ -106,7 +108,7 @@ describe('suggestTaxa', () => {
     );
     expect(rastrumHit).toBeDefined();
     expect(rastrumHit.commonNameEs).toBe('Orquídea de agave');
-    expect(rastrumHit.observationCount).toBe(12);
+    expect(rastrumHit.observationCount).toBeNull(); // rarity_tier not exposed as count
   });
 
   it('merges GBIF results without duplicating Rastrum hits', async () => {


### PR DESCRIPTION
## Problem

The taxon autocomplete was querying non-existent columns:
- `taxa.observation_count` — does not exist in schema, caused HTTP 400 from PostgREST
- `observations.primary_scientific_name` — does not exist; observations use `primary_taxon_id` (UUID FK)

## Fix

**`src/lib/taxon-autocomplete.ts` only — no other files touched.**

1. **Replace `observation_count` with `rarity_tier`** in both `taxa` SELECT queries (prefix + genus). Ordering changed to `rarity_tier ASC, nullsFirst: false` so tier-1 (common) species appear first and unclassified taxa fall to the end.

2. **Fix user history query**: replaced the broken `observations.primary_scientific_name` query with a two-step approach:
   - Query `observations` for `primary_taxon_id` (non-null) for the current user (up to 50 rows)
   - Build a `Set<string>` of taxon IDs
   - Set `inUserHistory: userTaxonIds.has(r.id)` on the taxa results (taxa SELECT now includes `id`)

3. **`observationCount` field** in `TaxonSuggestion` now carries `rarity_tier` value (or null for GBIF-only hits). The JSDoc comment is updated to reflect this.

Fixes #953