### PR TITLE
feat: Add life_stage and vital_status fields to observations (#941)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11160,3 +11160,20 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.is_first_in_sector(uuid) FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION public.is_first_in_sector(uuid) TO authenticated;
+
+-- ====================================================
+-- #941 — life_stage + vital_status fields on observations
+-- ====================================================
+
+ALTER TABLE public.observations
+  ADD COLUMN IF NOT EXISTS life_stage text
+    CHECK (life_stage IN ('adult','juvenile','subadult','nestling','egg','larva','pupa','unknown'));
+
+ALTER TABLE public.observations
+  ADD COLUMN IF NOT EXISTS vital_status text
+    CHECK (vital_status IN ('alive','dead','injured','unknown'));
+
+COMMENT ON COLUMN public.observations.life_stage IS
+  'Life stage of the observed individual. Optional. Darwin Core: lifeStage.';
+COMMENT ON COLUMN public.observations.vital_status IS
+  'Vital status of the observed individual. Optional. Darwin Core: occurrenceStatus extension.';

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -521,6 +521,38 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
       </div>
     </div>
 
+    <!-- Life stage (#941) -->
+    <div data-identify-hide class="space-y-1">
+      <label for="obs-life-stage" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        {isEs ? 'Etapa de vida' : 'Life stage'} <span class="text-zinc-400 text-xs">{isEs ? '(opcional)' : '(optional)'}</span>
+      </label>
+      <select id="obs-life-stage" name="life_stage"
+        class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+        <option value="">{isEs ? 'Desconocida' : 'Unknown'}</option>
+        <option value="adult">{isEs ? 'Adulto' : 'Adult'}</option>
+        <option value="juvenile">{isEs ? 'Juvenil' : 'Juvenile'}</option>
+        <option value="subadult">{isEs ? 'Subadulto' : 'Subadult'}</option>
+        <option value="nestling">{isEs ? 'Polluelo / Cría' : 'Nestling / Chick'}</option>
+        <option value="egg">{isEs ? 'Huevo' : 'Egg'}</option>
+        <option value="larva">{isEs ? 'Larva' : 'Larva'}</option>
+        <option value="pupa">{isEs ? 'Pupa' : 'Pupa'}</option>
+      </select>
+    </div>
+
+    <!-- Vital status (#941) -->
+    <div data-identify-hide class="space-y-1">
+      <label for="obs-vital-status" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        {isEs ? 'Estado vital' : 'Vital status'} <span class="text-zinc-400 text-xs">{isEs ? '(opcional)' : '(optional)'}</span>
+      </label>
+      <select id="obs-vital-status" name="vital_status"
+        class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+        <option value="">{isEs ? 'Desconocido' : 'Unknown'}</option>
+        <option value="alive">{isEs ? 'Vivo' : 'Alive'}</option>
+        <option value="dead">{isEs ? 'Muerto' : 'Dead'}</option>
+        <option value="injured">{isEs ? 'Herido' : 'Injured'}</option>
+      </select>
+    </div>
+
     <!-- Notes -->
     <div data-identify-hide>
       <div class="flex items-end justify-between gap-2 flex-wrap mb-1">
@@ -2736,6 +2768,8 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
       cameraStationId: (document.getElementById('camera-station-id') as HTMLInputElement | null)?.value || null,
       notes: ((form.elements.namedItem('notes') as HTMLTextAreaElement).value || null),
       isRangeExtension: confirmedRangeExtension,
+      lifeStage: ((document.getElementById('obs-life-stage') as HTMLSelectElement)?.value || null) as Observation['lifeStage'],
+      vitalStatus: ((document.getElementById('obs-vital-status') as HTMLSelectElement)?.value || null) as Observation['vitalStatus'],
       asDraft,
     };
   }
@@ -2975,7 +3009,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
   (function wireFormAutoSave() {
     if (!form || form.dataset.mode === 'identify-only') return;
     const KEY = 'rastrum.formAutoSave.v1';
-    const fields = ['notes', 'habitat', 'weather', 'evidence_type'];
+    const fields = ['notes', 'habitat', 'weather', 'evidence_type', 'life_stage', 'vital_status'];
 
     type Saved = { ts: number; values: Record<string, string> };
 

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -1134,8 +1134,8 @@ postForm?.addEventListener('submit', async (e) => {
       notes,
       contentSensitive: sensitiveVal,
       license: licenseTyped,
-      lifeStage: lifeStageVal as never,
-      vitalStatus: vitalStatusVal as never,
+      lifeStage: (lifeStageVal || null) as import('../lib/observe').ObservationDraft['lifeStage'],
+      vitalStatus: (vitalStatusVal || null) as import('../lib/observe').ObservationDraft['vitalStatus'],
     });
 
     // Fire sync without blocking success UX. Use ifAvailable so we don't

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -246,6 +246,36 @@ const weathers = WEATHERS;
           </select>
           <p class="mt-1 text-xs text-zinc-400">{isEs ? "Anula tu licencia por defecto solo para esta observación" : "Overrides your default license for this observation only"}</p>
         </div>
+        <!-- Life stage (#941) -->
+        <div class="space-y-1">
+          <label for="obs2-life-stage" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            {isEs ? 'Etapa de vida' : 'Life stage'} <span class="text-zinc-400 text-xs">{isEs ? '(opcional)' : '(optional)'}</span>
+          </label>
+          <select id="obs2-life-stage"
+            class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+            <option value="">{isEs ? 'Desconocida' : 'Unknown'}</option>
+            <option value="adult">{isEs ? 'Adulto' : 'Adult'}</option>
+            <option value="juvenile">{isEs ? 'Juvenil' : 'Juvenile'}</option>
+            <option value="subadult">{isEs ? 'Subadulto' : 'Subadult'}</option>
+            <option value="nestling">{isEs ? 'Polluelo / Cría' : 'Nestling / Chick'}</option>
+            <option value="egg">{isEs ? 'Huevo' : 'Egg'}</option>
+            <option value="larva">{isEs ? 'Larva' : 'Larva'}</option>
+            <option value="pupa">{isEs ? 'Pupa' : 'Pupa'}</option>
+          </select>
+        </div>
+        <!-- Vital status (#941) -->
+        <div class="space-y-1">
+          <label for="obs2-vital-status" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            {isEs ? 'Estado vital' : 'Vital status'} <span class="text-zinc-400 text-xs">{isEs ? '(opcional)' : '(optional)'}</span>
+          </label>
+          <select id="obs2-vital-status"
+            class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500">
+            <option value="">{isEs ? 'Desconocido' : 'Unknown'}</option>
+            <option value="alive">{isEs ? 'Vivo' : 'Alive'}</option>
+            <option value="dead">{isEs ? 'Muerto' : 'Dead'}</option>
+            <option value="injured">{isEs ? 'Herido' : 'Injured'}</option>
+          </select>
+        </div>
         <!-- Content sensitivity -->
         <div class="flex items-start gap-3">
           <input id="obs2-sensitive" type="checkbox" class="mt-1 rounded border-zinc-300 dark:border-zinc-700 text-emerald-600 focus:ring-emerald-500" />
@@ -1064,6 +1094,8 @@ postForm?.addEventListener('submit', async (e) => {
     const sensitiveVal = (document.getElementById('obs2-sensitive') as HTMLInputElement | null)?.checked ?? false;
     const licenseVal = (document.getElementById('obs2-license') as HTMLSelectElement | null)?.value || null;
     const licenseTyped = licenseVal as 'CC BY 4.0' | 'CC BY-NC 4.0' | 'CC0' | null;
+    const lifeStageVal = (document.getElementById('obs2-life-stage') as HTMLSelectElement | null)?.value || null;
+    const vitalStatusVal = (document.getElementById('obs2-vital-status') as HTMLSelectElement | null)?.value || null;
     const taxonInput = (document.getElementById('obs2-taxon-input') as HTMLInputElement | null)?.value.trim();
 
     // MediaRecorder-produced Blobs sometimes have an empty `type` (notably
@@ -1102,6 +1134,8 @@ postForm?.addEventListener('submit', async (e) => {
       notes,
       contentSensitive: sensitiveVal,
       license: licenseTyped,
+      lifeStage: lifeStageVal as never,
+      vitalStatus: vitalStatusVal as never,
     });
 
     // Fire sync without blocking success UX. Use ifAvailable so we don't

--- a/src/lib/darwin-core.ts
+++ b/src/lib/darwin-core.ts
@@ -42,8 +42,8 @@ export interface DwCRecord {
   kingdom: string;
   identificationQualifier: string;
   identifiedBy: string;
-  occurrenceStatus: string;
-  lifeStage: string;
+  occurrenceStatus: 'present' | 'dead' | 'injured' | 'unknown';
+  lifeStage?: string;
   license: string;
   rightsHolder: string;
   stateProvince: string;
@@ -78,7 +78,7 @@ function formatIdentifiedBy(source: string | null): string {
  * Map vital_status to DwC occurrenceStatus.
  * alive → present, dead → dead, injured → injured, null/unknown → unknown
  */
-function mapVitalStatus(status: string | null | undefined): string {
+function mapVitalStatus(status: string | null | undefined): 'present' | 'dead' | 'injured' | 'unknown' {
   switch (status) {
     case 'alive':   return 'present';
     case 'dead':    return 'dead';
@@ -113,7 +113,7 @@ export function toDwCRecord(input: DwCInput): DwCRecord {
     identificationQualifier: qualifier,
     identifiedBy: formatIdentifiedBy(input.id_source),
     occurrenceStatus: mapVitalStatus(input.vital_status),
-    lifeStage: input.life_stage ?? '',
+    lifeStage: input.life_stage ?? undefined,
     license: input.observer_license,
     rightsHolder: input.observer_display_name ?? '',
     stateProvince: input.state_province ?? '',

--- a/src/lib/darwin-core.ts
+++ b/src/lib/darwin-core.ts
@@ -25,6 +25,8 @@ export interface DwCInput {
   habitat: string | null;
   observer_display_name: string | null;
   observer_license: string;
+  life_stage?: string | null;
+  vital_status?: string | null;
 }
 
 export interface DwCRecord {
@@ -40,7 +42,8 @@ export interface DwCRecord {
   kingdom: string;
   identificationQualifier: string;
   identifiedBy: string;
-  occurrenceStatus: 'present';
+  occurrenceStatus: string;
+  lifeStage: string;
   license: string;
   rightsHolder: string;
   stateProvince: string;
@@ -55,6 +58,7 @@ export const DWC_COLUMNS: (keyof DwCRecord)[] = [
   'decimalLatitude','decimalLongitude','geodeticDatum','coordinateUncertaintyInMeters',
   'scientificName','taxonRank','kingdom',
   'identificationQualifier','identifiedBy','occurrenceStatus',
+  'lifeStage',
   'license','rightsHolder','stateProvince','habitat',
   'informationWithheld','dataGeneralizations',
 ];
@@ -67,6 +71,19 @@ function formatIdentifiedBy(source: string | null): string {
     case 'onnx_offline': return 'Rastrum AI (on-device)';
     case 'human':        return 'Observer';
     default:             return 'Unknown';
+  }
+}
+
+/**
+ * Map vital_status to DwC occurrenceStatus.
+ * alive → present, dead → dead, injured → injured, null/unknown → unknown
+ */
+function mapVitalStatus(status: string | null | undefined): string {
+  switch (status) {
+    case 'alive':   return 'present';
+    case 'dead':    return 'dead';
+    case 'injured': return 'injured';
+    default:        return 'unknown';
   }
 }
 
@@ -95,7 +112,8 @@ export function toDwCRecord(input: DwCInput): DwCRecord {
     kingdom: input.kingdom ?? '',
     identificationQualifier: qualifier,
     identifiedBy: formatIdentifiedBy(input.id_source),
-    occurrenceStatus: 'present',
+    occurrenceStatus: mapVitalStatus(input.vital_status),
+    lifeStage: input.life_stage ?? '',
     license: input.observer_license,
     rightsHolder: input.observer_display_name ?? '',
     stateProvince: input.state_province ?? '',
@@ -129,6 +147,7 @@ export const SNIB_COLUMNS: (keyof DwCRecord)[] = [
   'occurrenceID','eventDate','decimalLatitude','decimalLongitude',
   'coordinateUncertaintyInMeters','scientificName','kingdom',
   'identificationQualifier','identifiedBy','occurrenceStatus',
+  'lifeStage',
   'license','rightsHolder','stateProvince','habitat',
 ];
 

--- a/src/lib/observe.ts
+++ b/src/lib/observe.ts
@@ -52,6 +52,16 @@ export interface ObservationDraft {
    * alert. Flips `observations.is_range_extension` on sync.
    */
   isRangeExtension?: boolean;
+
+  /**
+   * #941 — Life stage of the observed individual. Optional.
+   */
+  lifeStage?: 'adult' | 'juvenile' | 'subadult' | 'nestling' | 'egg' | 'larva' | 'pupa' | 'unknown' | null;
+
+  /**
+   * #941 — Vital status of the observed individual. Optional.
+   */
+  vitalStatus?: 'alive' | 'dead' | 'injured' | 'unknown' | null;
   appVersion?: string;
   deviceOs?: string | null;
   /**
@@ -98,6 +108,8 @@ export function buildObservation(draft: ObservationDraft): Observation {
     contentSensitive: draft.contentSensitive ?? false,
     notes:         draft.notes         ?? null,
     isRangeExtension: draft.isRangeExtension ?? false,
+    lifeStage: draft.lifeStage ?? null,
+    vitalStatus: draft.vitalStatus ?? null,
     moonPhase: null,
     moonIllumination: null,
     precipitation24hMm: null,

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -113,6 +113,9 @@ async function syncOne(record: ObservationRecord): Promise<void> {
     notes:           obs.notes,
     // M22-range (#742): user-confirmed outlier alert.
     is_range_extension: obs.isRangeExtension ?? false,
+    // #941: life stage + vital status
+    life_stage:  obs.lifeStage  ?? null,
+    vital_status: obs.vitalStatus ?? null,
     sync_status:     'synced' as const,
     app_version:     obs.appVersion,
     device_os:       obs.deviceOs,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,6 +111,18 @@ export interface Observation {
    */
   isRangeExtension?: boolean;
 
+  /**
+   * #941 — Life stage of the observed individual. Optional.
+   * Darwin Core: lifeStage.
+   */
+  lifeStage?: 'adult' | 'juvenile' | 'subadult' | 'nestling' | 'egg' | 'larva' | 'pupa' | 'unknown' | null;
+
+  /**
+   * #941 — Vital status of the observed individual. Optional.
+   * Darwin Core: occurrenceStatus extension.
+   */
+  vitalStatus?: 'alive' | 'dead' | 'injured' | 'unknown' | null;
+
   syncStatus: SyncStatus;
   syncedAt: string | null;
   appVersion: string;


### PR DESCRIPTION
## Summary

Implements issue #941 — adds `life_stage` and `vital_status` optional fields to observations for richer Darwin Core export.

## Changes

### Schema (`docs/specs/infra/supabase-schema.sql`)
- `ALTER TABLE observations ADD COLUMN IF NOT EXISTS life_stage text` with CHECK constraint (adult/juvenile/subadult/nestling/egg/larva/pupa/unknown)
- `ALTER TABLE observations ADD COLUMN IF NOT EXISTS vital_status text` with CHECK constraint (alive/dead/injured/unknown)

### Types & Core (`src/lib/types.ts`, `src/lib/observe.ts`, `src/lib/sync.ts`)
- Added optional `lifeStage` and `vitalStatus` fields to `Observation` interface
- Added same to `ObservationDraft`; passed through in `buildObservation()`
- Included in Supabase upsert payload in `sync.ts`

### UI — ObservationForm.astro
- Added **Life stage** select (`obs-life-stage`) after establishment_means section
- Added **Vital status** select (`obs-vital-status`) after life stage
- Wired both in `buildSaveDraft()`
- Added to auto-save/restore field list

### UI — ObserveView2.astro
- Added same two selects (`obs2-life-stage`, `obs2-vital-status`) in Advanced fields panel
- Wired in save handler

### Darwin Core (`src/lib/darwin-core.ts`)
- Added `life_stage` / `vital_status` to `DwCInput` interface
- Added `lifeStage` field to `DwCRecord` and column lists (DWC_COLUMNS, SNIB_COLUMNS)
- Maps `vital_status` → DwC `occurrenceStatus` (alive→present, dead→dead, injured→injured, null/unknown→unknown)
- Added `mapVitalStatus()` helper

## Testing
- `npx tsc --noEmit` passes with zero errors