### PR TITLE
docs(plans): implementation plans for #931, #804, #809, #808

### DIFF
--- a/docs/superpowers/plans/2026-05-10-804-contextual-chips-dex-filter.md
+++ b/docs/superpowers/plans/2026-05-10-804-contextual-chips-dex-filter.md
@@ -1,0 +1,231 @@
+# #804 — "Not in your dex yet" filter on Contextual Species Chips
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a toggle pill on `ContextualSpeciesChips` that filters to show only species the signed-in user hasn't observed yet, using the `has_observed_by_viewer` field already returned by `probable_taxa_at()`.
+
+**Architecture:** The RPC already returns `has_observed_by_viewer boolean` per taxon. Client-side JS already receives and renders this data (the "not in your dex yet" badge uses it). We add a `data-filter-new-only` toggle button visible only for authenticated users. On toggle, JS re-renders the chip list filtering `has_observed_by_viewer === false`. No new server query needed — filter is pure client-side over the already-fetched results.
+
+**Tech Stack:** TypeScript, Astro, Supabase (RPC already done), Vitest
+
+---
+
+## File Map
+
+- **Modify:** `src/components/ContextualSpeciesChips.astro` — add toggle button HTML + JS filter logic
+- **Modify:** `src/lib/algorithms.ts` — update `contextual_species_chips` copy to mention the filter
+- **Create:** `tests/unit/contextual-chips-filter.test.ts` — unit test for filter logic
+
+---
+
+### Task 1: Extract and test the filter logic
+
+**Files:**
+- Create: `tests/unit/contextual-chips-filter.test.ts`
+
+- [ ] **Step 1: Write failing test for filter function**
+
+```typescript
+// tests/unit/contextual-chips-filter.test.ts
+import { describe, it, expect } from 'vitest';
+import { filterChipsByDex } from '../../src/lib/contextual-chips-filter';
+
+const mockChips = [
+  { taxon_id: 'a', scientific_name: 'Sp A', has_observed_by_viewer: false },
+  { taxon_id: 'b', scientific_name: 'Sp B', has_observed_by_viewer: true },
+  { taxon_id: 'c', scientific_name: 'Sp C', has_observed_by_viewer: false },
+  { taxon_id: 'd', scientific_name: 'Sp D', has_observed_by_viewer: null },
+];
+
+describe('filterChipsByDex', () => {
+  it('returns all chips when newOnly=false', () => {
+    expect(filterChipsByDex(mockChips, false)).toHaveLength(4);
+  });
+
+  it('returns only unobserved chips when newOnly=true', () => {
+    const result = filterChipsByDex(mockChips, true);
+    expect(result).toHaveLength(2);
+    expect(result.map(c => c.taxon_id)).toEqual(['a', 'c']);
+  });
+
+  it('treats null has_observed_by_viewer as unobserved (anon user)', () => {
+    const anon = [{ taxon_id: 'x', scientific_name: 'Sp X', has_observed_by_viewer: null }];
+    expect(filterChipsByDex(anon, true)).toHaveLength(0); // null = viewer unknown, don't claim "new"
+  });
+
+  it('returns empty array if all are observed', () => {
+    const allObserved = mockChips.map(c => ({ ...c, has_observed_by_viewer: true }));
+    expect(filterChipsByDex(allObserved, true)).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run tests/unit/contextual-chips-filter.test.ts 2>&1 | tail -8
+```
+
+- [ ] **Step 3: Create `src/lib/contextual-chips-filter.ts`**
+
+```typescript
+// src/lib/contextual-chips-filter.ts
+/**
+ * Filter helpers for ContextualSpeciesChips "not in dex yet" toggle.
+ * Pure functions — no Supabase, no DOM. Testable in isolation.
+ */
+
+export interface ChipRow {
+  taxon_id: string;
+  scientific_name: string;
+  has_observed_by_viewer: boolean | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Filter chip rows.
+ * @param chips - Full chip list from probable_taxa_at() RPC
+ * @param newOnly - When true, return only species with has_observed_by_viewer === false
+ *                  (null = viewer unknown → excluded when filtering)
+ */
+export function filterChipsByDex(chips: ChipRow[], newOnly: boolean): ChipRow[] {
+  if (!newOnly) return chips;
+  return chips.filter(c => c.has_observed_by_viewer === false);
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run tests/unit/contextual-chips-filter.test.ts 2>&1 | tail -8
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/lib/contextual-chips-filter.ts tests/unit/contextual-chips-filter.test.ts
+git commit -m "feat(chips): add filterChipsByDex() helper with tests"
+```
+
+---
+
+### Task 2: Add toggle UI + wire filter in ContextualSpeciesChips
+
+**Files:**
+- Modify: `src/components/ContextualSpeciesChips.astro`
+
+- [ ] **Step 1: Add i18n keys (add to the `ctx` destructure block, with fallbacks)**
+
+In the frontmatter section where `ctx` is destructured, add:
+```typescript
+const filterNewLabel = (ctx as any).filter_new_only ?? (isEs ? 'Solo nuevas para mí' : 'New to me only');
+const filterAllLabel = (ctx as any).filter_all ?? (isEs ? 'Ver todas' : 'Show all');
+```
+
+- [ ] **Step 2: Add toggle button HTML after the heading row**
+
+Find the `<div class="flex items-start justify-between gap-3">` block. After the closing `</div>` of that block, add:
+
+```html
+<!-- New-to-me filter toggle — only shown for signed-in users (JS reveals it) -->
+<div id="obs2-chips-filter-wrap" class="hidden flex items-center gap-2">
+  <button
+    type="button"
+    id="obs2-chips-filter-btn"
+    class="inline-flex items-center gap-1.5 rounded-full border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1 text-xs font-medium text-zinc-600 dark:text-zinc-400 hover:border-emerald-400 dark:hover:border-emerald-600 hover:text-emerald-700 dark:hover:text-emerald-400 transition-colors"
+    data-active="false"
+    data-label-new={filterNewLabel}
+    data-label-all={filterAllLabel}
+    aria-pressed="false"
+  >
+    <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M12 2a7 7 0 1 0 0 14A7 7 0 0 0 12 2z"/><path d="M12 8v4l3 3"/>
+    </svg>
+    <span id="obs2-chips-filter-label">{filterNewLabel}</span>
+  </button>
+</div>
+```
+
+- [ ] **Step 3: Wire filter logic in the `<script>` block**
+
+In the script block, find where `chipRows` is stored after the RPC call. The component stores results in a module-level variable. Add:
+
+```typescript
+import { filterChipsByDex, type ChipRow } from '../lib/contextual-chips-filter';
+
+// After the existing let declarations, add:
+let allChipRows: ChipRow[] = [];
+let newOnlyActive = false;
+
+// In the renderChips() function (or wherever chips are rendered), replace:
+//   const rows = chipRows;
+// with:
+//   const rows = filterChipsByDex(allChipRows, newOnlyActive);
+
+// After fetching + storing chipRows, also store to allChipRows:
+//   allChipRows = chipRows;
+```
+
+Wire the toggle button:
+```typescript
+const filterBtn = document.getElementById('obs2-chips-filter-btn');
+const filterWrap = document.getElementById('obs2-chips-filter-wrap');
+const filterLabel = document.getElementById('obs2-chips-filter-label');
+
+filterBtn?.addEventListener('click', () => {
+  newOnlyActive = !newOnlyActive;
+  filterBtn.setAttribute('aria-pressed', newOnlyActive ? 'true' : 'false');
+  filterBtn.dataset.active = newOnlyActive ? 'true' : 'false';
+  filterBtn.classList.toggle('border-emerald-500', newOnlyActive);
+  filterBtn.classList.toggle('text-emerald-700', newOnlyActive);
+  filterBtn.classList.toggle('dark:text-emerald-400', newOnlyActive);
+  if (filterLabel) {
+    filterLabel.textContent = newOnlyActive
+      ? (filterBtn.dataset.labelAll ?? 'Show all')
+      : (filterBtn.dataset.labelNew ?? 'New to me only');
+  }
+  renderChips(filterChipsByDex(allChipRows, newOnlyActive));
+});
+
+// Show filter wrap only for authenticated users (after getCachedUser resolves)
+import { getCachedUser } from '../lib/supabase';
+getCachedUser().then(user => {
+  if (user && filterWrap) filterWrap.classList.remove('hidden');
+}).catch(() => {});
+```
+
+- [ ] **Step 4: TypeScript check**
+```bash
+cd /home/ubuntu/rastrum && npx tsc --noEmit 2>&1 | grep -v "huggingface\|onnx\|identify" | grep "error TS" | head -10
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/components/ContextualSpeciesChips.astro src/lib/contextual-chips-filter.ts
+git commit -m "feat(chips): add 'new to me only' toggle filter on contextual species chips
+
+Closes #804. Signed-in users see a toggle pill that filters chips to
+show only species not yet in their dex. Uses has_observed_by_viewer
+already returned by probable_taxa_at() — no additional server query."
+```
+
+---
+
+### Task 3: Update algorithms.ts copy
+
+**Files:**
+- Modify: `src/lib/algorithms.ts`
+
+- [ ] **Step 1: Update the `contextual_species_chips` algorithm entry**
+
+Find the `contextual_species_chips` entry in `ALGORITHMS`. Update the `inputs` array to mention the new filter:
+
+```typescript
+// In the en.inputs array, add:
+'Filter toggle: "New to me only" — hides species already in the user\'s dex (has_observed_by_viewer)',
+// In es.inputs array, add:
+'Filtro: "Solo nuevas para mí" — oculta especies ya en el dex del usuario (has_observed_by_viewer)',
+```
+
+- [ ] **Step 2: Commit**
+```bash
+git add src/lib/algorithms.ts
+git commit -m "docs(algorithms): document new-to-me filter in contextual_species_chips algorithm"
+```

--- a/docs/superpowers/plans/2026-05-10-808-why-am-i-seeing-this-surfaces.md
+++ b/docs/superpowers/plans/2026-05-10-808-why-am-i-seeing-this-surfaces.md
@@ -1,0 +1,226 @@
+# #808 — WhyAmISeeingThis: register contextual_species algorithm entry
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Register the `contextual_species` algorithm entry in `src/lib/algorithms.ts` with full EN+ES copy, confirm the WhyAmISeeingThis pill is wired in `ContextualSpeciesChips.astro`, and update the algorithms docs catalog. Buddy (#732) and mini-bioblitz (#747) entries are deferred until those parent features ship.
+
+**Architecture:** Pure frontend disclosure layer — no schema changes. The `WhyAmISeeingThisDialog` is already mounted globally and reads from `ALGORITHMS`. Adding a new entry = one object in `algorithms.ts` + mounting the `<WhyAmISeeingThis>` pill in the component. The contextual chips component already has `algorithm="contextual_species_chips"` wired — the mismatch with the issue's `contextual_species` ID needs reconciling (see Task 1).
+
+**Tech Stack:** TypeScript, Astro, Vitest
+
+---
+
+## File Map
+
+- **Modify:** `src/lib/algorithms.ts` — add `contextual_species` entry (or confirm `contextual_species_chips` is correct ID)
+- **Verify/Modify:** `src/components/ContextualSpeciesChips.astro` — ensure pill algorithm ID matches catalog
+- **Modify:** `tests/unit/algorithms.test.ts` (create if not exists) — catalog shape tests
+- **Verify:** `src/components/AlgorithmsDocView.astro` — catalog page auto-renders from ALGORITHMS, no manual update needed
+
+---
+
+### Task 1: Audit algorithm ID mismatch + add catalog entry
+
+**Files:**
+- Modify: `src/lib/algorithms.ts`
+
+- [ ] **Step 1: Check current state**
+```bash
+cd /home/ubuntu/rastrum && grep -n "contextual_species" src/lib/algorithms.ts src/components/ContextualSpeciesChips.astro
+```
+
+The component uses `algorithm="contextual_species_chips"`. The issue calls it `contextual_species`. Determine which is canonical:
+- If `contextual_species_chips` is NOT in `AlgorithmId` type → the pill renders but the dialog shows no content (graceful degradation). Need to add the entry.
+- Use `contextual_species_chips` as the ID (matches the existing component) for consistency.
+
+- [ ] **Step 2: Write failing test**
+
+Create `tests/unit/algorithms.test.ts` if it doesn't exist:
+
+```typescript
+// tests/unit/algorithms.test.ts
+import { describe, it, expect } from 'vitest';
+import { ALGORITHMS, getAlgorithm, type AlgorithmId } from '../../src/lib/algorithms';
+
+describe('ALGORITHMS catalog', () => {
+  const ids = Object.keys(ALGORITHMS) as AlgorithmId[];
+
+  it('has entries for all known ranked surfaces', () => {
+    const required: AlgorithmId[] = [
+      'explore_recent',
+      'explore_species_recent',
+      'community_observers',
+      'contextual_species_chips',
+      'falta_dex_missing',
+      'profile_percentile_cards',
+      'active_observers_today',
+      'home_recent_nearby',
+    ];
+    for (const id of required) {
+      expect(ids).toContain(id);
+    }
+  });
+
+  it('every entry has EN and ES copy with non-empty inputs', () => {
+    for (const id of ids) {
+      const entry = ALGORITHMS[id];
+      expect(entry.copy.en.inputs.length).toBeGreaterThan(0);
+      expect(entry.copy.es.inputs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('contextual_species_chips has GPS + month + density inputs', () => {
+    const entry = ALGORITHMS['contextual_species_chips'];
+    const enInputs = entry.copy.en.inputs.join(' ');
+    expect(enInputs).toMatch(/location|GPS|centroid/i);
+    expect(enInputs).toMatch(/month|season/i);
+  });
+
+  it('getAlgorithm returns entry for valid id', () => {
+    expect(getAlgorithm('explore_recent')).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect fail if contextual_species_chips missing**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run tests/unit/algorithms.test.ts 2>&1 | tail -10
+```
+
+- [ ] **Step 4: Add `contextual_species_chips` entry to `src/lib/algorithms.ts`**
+
+Add to the `AlgorithmId` union type:
+```typescript
+| 'contextual_species_chips'
+```
+(If already present, skip this step.)
+
+Add to `ALGORITHMS` object:
+```typescript
+contextual_species_chips: {
+  headline: {
+    en: 'Why am I seeing these species?',
+    es: '¿Por qué veo estas especies?',
+  },
+  summary: {
+    en: 'A density estimate from wild community observations near your current location and month.',
+    es: 'Una estimación de densidad basada en observaciones silvestres de la comunidad cerca de tu ubicación actual y mes.',
+  },
+  copy: {
+    en: {
+      inputs: [
+        'Your current GPS location (centroid, ~50 km radius)',
+        'Current calendar month ±1 (year-wrapping at Jan/Dec)',
+        'Count of wild community observations in that area + month window',
+        'Whether you have already observed each species (for the "new to me" filter)',
+        'No curated baseline — real community sightings only',
+      ],
+      window: 'Wild public observations within ~50 km, current month ±1, all years',
+      settings_label: 'Edit location in profile settings',
+    },
+    es: {
+      inputs: [
+        'Tu ubicación GPS actual (centroide, radio ~50 km)',
+        'Mes calendario actual ±1 (con ajuste en ene/dic)',
+        'Conteo de observaciones silvestres de la comunidad en esa área + ventana de mes',
+        'Si ya observaste cada especie (para el filtro "solo nuevas para mí")',
+        'Sin baseline curado — solo observaciones reales de la comunidad',
+      ],
+      window: 'Observaciones públicas silvestres dentro de ~50 km, mes actual ±1, todos los años',
+      settings_label: 'Editar ubicación en configuración de perfil',
+    },
+  },
+  settings_path: {
+    en: '/en/profile/settings',
+    es: '/es/perfil/configuracion',
+  },
+},
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run tests/unit/algorithms.test.ts 2>&1 | tail -10
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git add src/lib/algorithms.ts tests/unit/algorithms.test.ts
+git commit -m "feat(algorithms): register contextual_species_chips in algorithm catalog
+
+Closes #808 (contextual surface). Buddy (#732) and mini-bioblitz (#747)
+entries deferred until those parent features ship."
+```
+
+---
+
+### Task 2: Verify WhyAmISeeingThis pill in ContextualSpeciesChips
+
+**Files:**
+- Verify: `src/components/ContextualSpeciesChips.astro`
+
+- [ ] **Step 1: Confirm pill is mounted and ID matches**
+```bash
+cd /home/ubuntu/rastrum && grep -n "WhyAmISeeingThis\|algorithm=" src/components/ContextualSpeciesChips.astro
+```
+
+Expected output:
+```
+69:    <WhyAmISeeingThis algorithm="contextual_species_chips" lang={lang} className="shrink-0" />
+```
+
+If the ID doesn't match `contextual_species_chips`, update it to match.
+
+- [ ] **Step 2: TypeScript check — ensure AlgorithmId type includes the new ID**
+```bash
+cd /home/ubuntu/rastrum && npx tsc --noEmit 2>&1 | grep -v "huggingface\|onnx\|identify" | grep "error TS" | head -10
+```
+
+- [ ] **Step 3: Commit (if any changes needed)**
+```bash
+git add src/components/ContextualSpeciesChips.astro
+git commit -m "fix(chips): align WhyAmISeeingThis algorithm ID with catalog entry"
+```
+
+---
+
+### Task 3: Add deferred entries as stubs with comments
+
+**Files:**
+- Modify: `src/lib/algorithms.ts`
+
+Per the issue, buddy and mini-bioblitz entries should be added when those parent features ship. Add them as commented stubs so the next engineer knows where to add them:
+
+- [ ] **Step 1: Add comment stubs at end of ALGORITHMS object**
+
+```typescript
+// ── Deferred entries (wire when parent feature ships) ──────────────────────
+// buddy_suggestions: #732 — wire when buddy observation suggestions land
+// mini_bioblitz_ranking: #747 — wire when mini-bioblitz duels land
+// ──────────────────────────────────────────────────────────────────────────
+```
+
+- [ ] **Step 2: Commit**
+```bash
+git add src/lib/algorithms.ts
+git commit -m "docs(algorithms): add deferred stub comments for buddy + mini-bioblitz (#808)"
+```
+
+---
+
+### Task 4: Run full test suite + build check
+
+- [ ] **Step 1: Run all tests**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run 2>&1 | tail -15
+```
+
+- [ ] **Step 2: TypeScript check**
+```bash
+cd /home/ubuntu/rastrum && npx tsc --noEmit 2>&1 | grep -v "huggingface\|onnx\|identify" | grep "error TS" | head -10
+```
+
+- [ ] **Step 3: Final commit if any cleanup**
+```bash
+git add -A && git diff --cached --stat
+# Only commit if there are changes
+```

--- a/docs/superpowers/plans/2026-05-10-809-active-observers-realtime.md
+++ b/docs/superpowers/plans/2026-05-10-809-active-observers-realtime.md
@@ -1,0 +1,265 @@
+# #809 — Real-time presence in ActiveObserversBanner
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Subscribe to a Supabase Realtime broadcast channel so the active-observers count updates live when observers come online during the same session, without polling.
+
+**Architecture:** On mount, the banner fetches the initial count via `community_active_observers_today(p_country)` RPC (unchanged). It then subscribes to a Realtime Broadcast channel `active-observers:{country}`. A Postgres `AFTER INSERT` trigger on `observations` broadcasts a `{count}` payload whenever a new synced observation lands. The client receives it and re-fetches or updates the displayed count. Privacy: the channel payload contains only the aggregate count integer — no user IDs or usernames ever transit the channel.
+
+**Alternative considered:** Postgres Changes (row-level CDC) — rejected because it would leak observer_ids. Broadcast is the right primitive: server-controlled payload, no row data.
+
+**Tech Stack:** TypeScript, Astro, Supabase Realtime (Broadcast), Vitest
+
+---
+
+## File Map
+
+- **Modify:** `src/components/ActiveObserversBanner.astro` — subscribe + update on broadcast
+- **Modify:** `src/lib/active-observers.ts` — add `subscribeToActiveObservers()` helper
+- **Modify:** `tests/unit/active-observers.test.ts` — extend with subscription tests
+- **Modify:** `docs/specs/infra/supabase-schema.sql` — add trigger + Realtime policy
+
+---
+
+### Task 1: Add `subscribeToActiveObservers()` helper + tests
+
+**Files:**
+- Modify: `src/lib/active-observers.ts`
+- Modify: `tests/unit/active-observers.test.ts`
+
+- [ ] **Step 1: Check existing tests**
+```bash
+cd /home/ubuntu/rastrum && cat tests/unit/active-observers.test.ts | head -40
+```
+
+- [ ] **Step 2: Write failing tests for subscription helper**
+
+Add to `tests/unit/active-observers.test.ts`:
+
+```typescript
+import { subscribeToActiveObservers } from '../../src/lib/active-observers';
+
+describe('subscribeToActiveObservers', () => {
+  it('returns an unsubscribe function', () => {
+    const mockChannel = {
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnThis(),
+      unsubscribe: vi.fn(),
+    };
+    const mockSupabase = { channel: vi.fn().mockReturnValue(mockChannel) };
+
+    const unsub = subscribeToActiveObservers(mockSupabase as any, 'MX', vi.fn());
+    expect(typeof unsub).toBe('function');
+    expect(mockSupabase.channel).toHaveBeenCalledWith('active-observers:MX');
+  });
+
+  it('calls onCount callback when broadcast received', () => {
+    let broadcastHandler: ((payload: any) => void) | null = null;
+    const mockChannel = {
+      on: vi.fn().mockImplementation((_type, _opts, handler) => {
+        broadcastHandler = handler;
+        return mockChannel;
+      }),
+      subscribe: vi.fn().mockReturnThis(),
+      unsubscribe: vi.fn(),
+    };
+    const mockSupabase = { channel: vi.fn().mockReturnValue(mockChannel) };
+    const onCount = vi.fn();
+
+    subscribeToActiveObservers(mockSupabase as any, 'MX', onCount);
+    broadcastHandler?.({ payload: { count: 7 } });
+
+    expect(onCount).toHaveBeenCalledWith(7);
+  });
+
+  it('unsubscribes channel on returned function call', () => {
+    const mockChannel = {
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnThis(),
+      unsubscribe: vi.fn(),
+    };
+    const mockSupabase = { channel: vi.fn().mockReturnValue(mockChannel) };
+
+    const unsub = subscribeToActiveObservers(mockSupabase as any, 'MX', vi.fn());
+    unsub();
+    expect(mockChannel.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect fail**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run tests/unit/active-observers.test.ts 2>&1 | tail -10
+```
+
+- [ ] **Step 4: Implement `subscribeToActiveObservers()` in `src/lib/active-observers.ts`**
+
+Add after the existing exports:
+
+```typescript
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Subscribe to realtime active-observers count for a country.
+ *
+ * Privacy: the broadcast payload contains only `{ count: number }` —
+ * no user IDs or PII ever transit this channel.
+ *
+ * @returns unsubscribe function — call on component unmount
+ */
+export function subscribeToActiveObservers(
+  supabase: SupabaseClient,
+  country: string,
+  onCount: (count: number) => void,
+): () => void {
+  const channel = supabase
+    .channel(`active-observers:${country}`)
+    .on('broadcast', { event: 'count' }, (payload: { payload?: { count?: number } }) => {
+      const count = payload?.payload?.count;
+      if (typeof count === 'number') onCount(count);
+    })
+    .subscribe();
+
+  return () => { channel.unsubscribe(); };
+}
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run tests/unit/active-observers.test.ts 2>&1 | tail -10
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git add src/lib/active-observers.ts tests/unit/active-observers.test.ts
+git commit -m "feat(active-observers): add subscribeToActiveObservers() realtime helper"
+```
+
+---
+
+### Task 2: Wire subscription in `ActiveObserversBanner.astro`
+
+**Files:**
+- Modify: `src/components/ActiveObserversBanner.astro`
+
+- [ ] **Step 1: Read current script block**
+```bash
+cd /home/ubuntu/rastrum && sed -n '55,97p' src/components/ActiveObserversBanner.astro
+```
+
+- [ ] **Step 2: Add subscription after initial fetch**
+
+In the `<script>` block, after the initial `supabase.rpc(...)` fetch that populates the banner, add:
+
+```typescript
+import { subscribeToActiveObservers } from '../lib/active-observers';
+
+// After the initial fetch:
+let unsubscribe: (() => void) | null = null;
+
+if (country) {
+  unsubscribe = subscribeToActiveObservers(supabase, country, (newCount) => {
+    const output = formatActiveObserversBanner({ count: newCount, region });
+    if (output.text) {
+      bannerEl.textContent = output.text;
+      wrap.classList.remove('hidden');
+    }
+  });
+}
+
+// Clean up on page navigation (Astro view transitions)
+document.addEventListener('astro:before-swap', () => {
+  unsubscribe?.();
+}, { once: true });
+```
+
+- [ ] **Step 3: TypeScript check**
+```bash
+cd /home/ubuntu/rastrum && npx tsc --noEmit 2>&1 | grep -v "huggingface\|onnx\|identify" | grep "error TS" | head -10
+```
+
+- [ ] **Step 4: Commit**
+```bash
+git add src/components/ActiveObserversBanner.astro
+git commit -m "feat(active-observers): subscribe to realtime count updates in banner
+
+Closes #809. Banner now updates live via Supabase Realtime Broadcast
+channel 'active-observers:{country}'. Payload is count-only — no PII."
+```
+
+---
+
+### Task 3: Schema — broadcast trigger
+
+**Files:**
+- Modify: `docs/specs/infra/supabase-schema.sql`
+
+- [ ] **Step 1: Add trigger + Realtime policy to schema**
+
+Append at the end of `docs/specs/infra/supabase-schema.sql`:
+
+```sql
+-- ====================================================
+-- #809 — Active observers realtime broadcast trigger
+-- ====================================================
+
+-- Enable Realtime for broadcast (no row data — broadcast only)
+-- The channel 'active-observers:{country}' is used by ActiveObserversBanner.
+
+CREATE OR REPLACE FUNCTION public.broadcast_active_observer_count()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_country text;
+  v_count   bigint;
+BEGIN
+  -- Only broadcast for synced observations (ignore drafts)
+  IF NEW.sync_status != 'synced' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Get observer's country
+  SELECT region_primary INTO v_country
+  FROM public.users
+  WHERE id = NEW.observer_id;
+
+  IF v_country IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Re-compute today's count for that country
+  SELECT count(DISTINCT o.observer_id)::bigint INTO v_count
+  FROM public.observations o
+  WHERE o.sync_status = 'synced'
+    AND o.observer_id IN (
+      SELECT id FROM public.users WHERE region_primary = v_country
+    )
+    AND date_trunc('day', o.observed_at AT TIME ZONE 'UTC') = date_trunc('day', now() AT TIME ZONE 'UTC');
+
+  -- Broadcast count-only payload — no PII
+  PERFORM pg_notify(
+    'active_observers_' || lower(v_country),
+    json_build_object('count', v_count)::text
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS tg_broadcast_active_observer ON public.observations;
+CREATE TRIGGER tg_broadcast_active_observer
+  AFTER INSERT OR UPDATE OF sync_status ON public.observations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.broadcast_active_observer_count();
+
+REVOKE EXECUTE ON FUNCTION public.broadcast_active_observer_count() FROM PUBLIC;
+```
+
+- [ ] **Step 2: Commit**
+```bash
+git add docs/specs/infra/supabase-schema.sql
+git commit -m "feat(schema): add broadcast_active_observer_count() trigger for #809"
+```

--- a/docs/superpowers/plans/2026-05-10-931-cached-session-console.md
+++ b/docs/superpowers/plans/2026-05-10-931-cached-session-console.md
@@ -1,0 +1,238 @@
+# #931 — getCachedSession() for Console Components
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate repeated `auth.getSession()` lock contention in Console components by introducing `getCachedSession()` — a short-lived in-memory cache for the full session object (including `access_token`), analogous to `getCachedUser()`.
+
+**Architecture:** Console components need `session.access_token` to call Edge Functions via `adminClient`. All Console* components call `getSession()` independently on mount AND on every admin action. We add `getCachedSession()` to `src/lib/supabase.ts` (30s TTL, same pattern as `getCachedUser()`), then replace every `supabase.auth.getSession()` call in Console components with it. `SuggestIdModal` and `CommunityView` only need `user.id` → use `getCachedUser()` directly.
+
+**Tech Stack:** TypeScript, Supabase JS v2, Astro, Vitest
+
+---
+
+## File Map
+
+- **Modify:** `src/lib/supabase.ts` — add `getCachedSession()` + session cache + invalidation
+- **Modify:** `tests/unit/supabase-cache.test.ts` (create) — unit tests for both cache functions
+- **Modify:** `src/components/ConsoleAnomaliesView.astro` — getSession → getCachedSession
+- **Modify:** `src/components/ConsoleAppealsView.astro`
+- **Modify:** `src/components/ConsoleBadgesView.astro`
+- **Modify:** `src/components/ConsoleBansView.astro`
+- **Modify:** `src/components/ConsoleCommentsView.astro`
+- **Modify:** `src/components/ConsoleCredentialsView.astro`
+- **Modify:** `src/components/ConsoleErrorsView.astro`
+- **Modify:** `src/components/ConsoleFeatureFlagsView.astro`
+- **Modify:** `src/components/ConsoleFlagQueueView.astro`
+- **Modify:** `src/components/ConsoleForensicsView.astro`
+- **Modify:** `src/components/ConsoleHealthView.astro`
+- **Modify:** `src/components/ConsoleObservationsView.astro`
+- **Modify:** `src/components/ConsoleProposalsView.astro`
+- **Modify:** `src/components/ConsoleSlideOver.astro`
+- **Modify:** `src/components/ConsoleTaxaView.astro`
+- **Modify:** `src/components/ConsoleUsersView.astro`
+- **Modify:** `src/components/ConsoleWebhooksView.astro`
+- **Modify:** `src/components/ExportView.astro`
+- **Modify:** `src/components/SuggestIdModal.astro` — getCachedUser() (no token needed)
+- **Modify:** `src/components/CommunityView.astro` — getCachedUser() (no token needed)
+- **Modify:** `src/components/console/ExpertApplicationsBrowser.astro`
+- **Modify:** `src/components/console/PlantNetQuotaPanel.astro`
+
+---
+
+### Task 1: Add `getCachedSession()` to `src/lib/supabase.ts`
+
+**Files:**
+- Modify: `src/lib/supabase.ts`
+- Create: `tests/unit/supabase-cache.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// tests/unit/supabase-cache.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We test the cache logic in isolation by mocking the supabase client
+vi.mock('../../src/lib/supabase', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../src/lib/supabase')>();
+  return {
+    ...mod,
+    getSupabase: () => ({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } } }),
+        getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 'tok-1', user: { id: 'u1' } } } }),
+        onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      },
+    }),
+  };
+});
+
+describe('getCachedSession', () => {
+  it('returns session on first call', async () => {
+    const { getCachedSession } = await import('../../src/lib/supabase');
+    const session = await getCachedSession();
+    expect(session?.access_token).toBe('tok-1');
+  });
+
+  it('returns cached session on second call without re-fetching', async () => {
+    const { getCachedSession, getSupabase } = await import('../../src/lib/supabase');
+    await getCachedSession();
+    await getCachedSession();
+    expect(getSupabase().auth.getSession).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect fail**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run tests/unit/supabase-cache.test.ts 2>&1 | tail -10
+```
+Expected: FAIL — `getCachedSession is not a function`
+
+- [ ] **Step 3: Add `getCachedSession()` to `src/lib/supabase.ts`**
+
+Add after the `getCachedUser()` function (around line 75):
+
+```typescript
+let _sessionCache: { session: import('@supabase/supabase-js').Session | null; resolvedAt: number } | null = null;
+const SESSION_CACHE_TTL_MS = 30_000;
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') _sessionCache = null;
+  });
+}
+
+/**
+ * Returns the current session (including access_token) with a short-lived
+ * in-memory cache. Use this instead of `getSupabase().auth.getSession()` in
+ * Console components that need access_token for Edge Function calls.
+ *
+ * Safe for concurrent callers — only one getSession() request fires per
+ * 30-second window, preventing navigator.lock contention.
+ */
+export async function getCachedSession() {
+  const now = Date.now();
+  if (_sessionCache && (now - _sessionCache.resolvedAt) < SESSION_CACHE_TTL_MS) {
+    return _sessionCache.session;
+  }
+  const { data: { session } } = await getSupabase().auth.getSession();
+  _sessionCache = { session, resolvedAt: now };
+  return session;
+}
+```
+
+Also add `_sessionCache = null;` inside the existing `onAuthStateChange` listener (in `ensureAuthListener`) so sign-out invalidates both caches:
+
+```typescript
+function ensureAuthListener() {
+  if (_authListenerAttached) return;
+  _authListenerAttached = true;
+  getSupabase().auth.onAuthStateChange((event) => {
+    if (event === 'SIGNED_OUT') {
+      _userCache = null;
+      _sessionCache = null; // ← add this
+    }
+  });
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run tests/unit/supabase-cache.test.ts 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/lib/supabase.ts tests/unit/supabase-cache.test.ts
+git commit -m "feat(auth): add getCachedSession() — 30s cache for access_token in Console components"
+```
+
+---
+
+### Task 2: Migrate Console components (bulk replacement)
+
+**Files:** All Console*.astro + ExportView + console/*.astro
+
+- [ ] **Step 1: Bulk replace `auth.getSession()` with `getCachedSession()` in all console components**
+
+For every file listed in the file map (except SuggestIdModal and CommunityView):
+
+Pattern to replace:
+```typescript
+// OLD — in <script> blocks
+const { data: { session } } = await supabase.auth.getSession();
+// or
+const { data: { session: s } } = await supabase.auth.getSession();
+```
+
+Replace with:
+```typescript
+const session = await getCachedSession();
+```
+
+Then update all references: `session?.access_token` stays the same; `!!session` stays the same.
+
+Add import to each `<script>` block that uses `getCachedSession`:
+```typescript
+import { getCachedSession } from '../lib/supabase'; // adjust path for console/ subdir
+```
+
+Run this script to do the bulk replacement:
+```bash
+cd /home/ubuntu/rastrum && python3 << 'EOF'
+import re, os, glob
+
+files = glob.glob('src/components/Console*.astro') + \
+        glob.glob('src/components/console/*.astro') + \
+        ['src/components/ExportView.astro']
+
+for path in files:
+    with open(path) as f: c = f.read()
+    orig = c
+    # Replace getSession patterns
+    c = re.sub(
+        r"const \{ data: \{ session(?:: \w+)? \} \} = await (?:supabase|sb)\.auth\.getSession\(\);",
+        "const session = await getCachedSession();",
+        c
+    )
+    # Add import if needed
+    if 'getCachedSession' in c and 'import { getCachedSession' not in c and 'getCachedSession }' not in c:
+        depth = '../../' if 'src/components/console/' in path else '../'
+        c = re.sub(
+            r"(import \{ get(?:Supabase|SupabaseUrl)[^}]*\} from '[^']*supabase[^']*';)",
+            lambda m: m.group(0) + f"\n  import {{ getCachedSession }} from '{depth}lib/supabase';",
+            c, count=1
+        )
+    if c != orig:
+        with open(path, 'w') as f: f.write(c)
+        print(f"FIXED: {path}")
+EOF
+```
+
+- [ ] **Step 2: Fix SuggestIdModal and CommunityView — use getCachedUser() instead**
+
+```bash
+cd /home/ubuntu/rastrum && grep -n "getSession\|getUser" src/components/SuggestIdModal.astro src/components/CommunityView.astro | head -10
+```
+
+These only use `user.id` — replace with `getCachedUser()` (already imported in CommunityView from the #956 migration; verify SuggestIdModal has the import too).
+
+- [ ] **Step 3: TypeScript check**
+```bash
+cd /home/ubuntu/rastrum && npx tsc --noEmit 2>&1 | grep -v "huggingface\|onnx-vision\|identify-runners" | grep "error TS" | head -20
+```
+Fix any errors (common: `session` could be null — add null guard `if (!session) return;`)
+
+- [ ] **Step 4: Run all tests**
+```bash
+cd /home/ubuntu/rastrum && npx vitest run 2>&1 | tail -15
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/components/
+git commit -m "fix(auth): migrate Console components to getCachedSession() — fixes lock contention
+
+Closes #931. All console components now share a single getSession() call
+per 30s window instead of each firing independently on mount."
+```


### PR DESCRIPTION
Adds 4 superpowers implementation plans to `docs/superpowers/plans/`:

- **#931** — `getCachedSession()` for Console components (auth lock fix)
- **#804** — "New to me only" filter on contextual species chips
- **#809** — Realtime presence in ActiveObserversBanner
- **#808** — Register `contextual_species_chips` in WhyAmISeeingThis catalog

No code changes — docs only.