### PR TITLE
fix(auth): add getCachedSession() and migrate Console components — closes #931

### DIFF
--- a/src/components/ConsoleAnomaliesView.astro
+++ b/src/components/ConsoleAnomaliesView.astro
@@ -94,7 +94,7 @@ const labelAcknowledged = aActions.acknowledged ?? 'acknowledged';
 </ConsoleSlideOver>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
 
@@ -218,7 +218,7 @@ const labelAcknowledged = aActions.acknowledged ?? 'acknowledged';
       show('anomalies-not-auth');
       return;
     }
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session) { show('anomalies-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { show('anomalies-not-auth'); return; }

--- a/src/components/ConsoleAppealsView.astro
+++ b/src/components/ConsoleAppealsView.astro
@@ -119,7 +119,7 @@ const c = tr.console as unknown as Record<string, string>;
 />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { adminClient, AdminClientError } from '../lib/admin-client';
 
   type AppealRow = {
@@ -248,7 +248,7 @@ const c = tr.console as unknown as Record<string, string>;
       document.getElementById('appeals-not-auth')?.classList.remove('hidden');
       return;
     }
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session) {
       document.getElementById('appeals-not-auth')?.classList.remove('hidden');
       return;

--- a/src/components/ConsoleBadgesView.astro
+++ b/src/components/ConsoleBadgesView.astro
@@ -153,7 +153,7 @@ const tr = t(lang);
 </ConsoleSlideOver>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient } from '../lib/admin-client';
 
@@ -200,7 +200,7 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.user) { show('badges-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { show('badges-not-auth'); return; }

--- a/src/components/ConsoleBansView.astro
+++ b/src/components/ConsoleBansView.astro
@@ -129,7 +129,7 @@ const tr = t(lang);
 </ConsoleSlideOver>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
   import { readFilterState, writeFilterState } from '../lib/console-filter-state';
@@ -162,7 +162,7 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.user) { show('bans-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('moderator') && !myRoles.has('admin')) { show('bans-not-auth'); return; }
@@ -330,7 +330,7 @@ const tr = t(lang);
 
       const durationHours = durationStr ? parseInt(durationStr, 10) : null;
 
-      const { data: { session } } = await supabase.auth.getSession();
+      const session = await getCachedSession();
       if (!session?.access_token) {
         document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Session expired.' } }));
         return;
@@ -349,7 +349,7 @@ const tr = t(lang);
 
     if (id !== 'console-slideover-bans') return;
 
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.access_token) {
       document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Session expired.' } }));
       return;

--- a/src/components/ConsoleCommentsView.astro
+++ b/src/components/ConsoleCommentsView.astro
@@ -112,7 +112,7 @@ const tr = t(lang);
 />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
   import { readFilterState, writeFilterState, applyFilterStateToForm } from '../lib/console-filter-state';
@@ -151,7 +151,7 @@ const tr = t(lang);
   };
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.user) { show('modcom-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('moderator') && !myRoles.has('admin')) { show('modcom-not-auth'); return; }
@@ -331,7 +331,7 @@ const tr = t(lang);
     const { id, action, payload, reason } = (ev as CustomEvent<{ id: string; action: string; payload: Record<string, string>; reason: string }>).detail;
     if (id !== 'console-slideover-modcom') return;
 
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.access_token) {
       document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Session expired.' } }));
       return;

--- a/src/components/ConsoleCredentialsView.astro
+++ b/src/components/ConsoleCredentialsView.astro
@@ -87,7 +87,7 @@ const tr = t(lang);
 </ConsoleSlideOver>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
 
@@ -125,7 +125,7 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.user) { show('creds-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { show('creds-not-auth'); return; }
@@ -286,7 +286,7 @@ const tr = t(lang);
     const { id, action, payload, reason } = (ev as CustomEvent<{ id: string; action: string; payload: Record<string, string>; reason: string }>).detail;
     if (id !== 'console-slideover-credentials') return;
 
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.access_token) {
       document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Session expired.' } }));
       return;

--- a/src/components/ConsoleErrorsView.astro
+++ b/src/components/ConsoleErrorsView.astro
@@ -185,7 +185,7 @@ const eFilterByCode = (errorsNs?.filterByCode as string) ?? 'Filter by code';
 </ConsoleSlideOver>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError, type ErrorAcknowledgeBulkFilters } from '../lib/admin-client';
   import { errorSeverity, severityColorClass } from '../lib/error-severity';
@@ -540,7 +540,7 @@ const eFilterByCode = (errorsNs?.filterByCode as string) ?? 'Filter by code';
   async function init() {
     let supabase;
     try { supabase = getSupabase(); } catch { hide('errors-skeleton'); show('errors-not-auth'); return; }
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session) { hide('errors-skeleton'); show('errors-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { hide('errors-skeleton'); show('errors-not-auth'); return; }

--- a/src/components/ConsoleFeatureFlagsView.astro
+++ b/src/components/ConsoleFeatureFlagsView.astro
@@ -23,7 +23,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient } from '../lib/admin-client';
 
@@ -49,7 +49,7 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session: s } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!s?.user) { show('features-not-auth'); return; }
     session = s;
     const myRoles = await getUserRoles(s.user.id);

--- a/src/components/ConsoleFeatureFlagsView.astro
+++ b/src/components/ConsoleFeatureFlagsView.astro
@@ -43,16 +43,14 @@ const tr = t(lang);
     return s.replace(/[<>&'"]/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;',"'":'&#39;','"':'&quot;'}[c]!));
   }
 
-  let session: { access_token: string } | null = null;
   let allFlags: FlagRow[] = [];
 
   const supabase = getSupabase();
 
   async function init() {
     const session = await getCachedSession();
-    if (!s?.user) { show('features-not-auth'); return; }
-    session = s;
-    const myRoles = await getUserRoles(s.user.id);
+    if (!session?.user) { show('features-not-auth'); return; }
+    const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { show('features-not-auth'); return; }
     show('features-shell');
     await loadFlags();
@@ -132,7 +130,9 @@ const tr = t(lang);
 
   document.addEventListener('click', async (ev) => {
     const btn = (ev.target as HTMLElement).closest<HTMLElement>('button[data-flag-key]');
-    if (!btn || !session) return;
+    if (!btn) return;
+    const session = await getCachedSession();
+    if (!session?.access_token) return;
 
     const key = btn.dataset.flagKey!;
     const currentValue = btn.dataset.flagValue === 'true';

--- a/src/components/ConsoleFlagQueueView.astro
+++ b/src/components/ConsoleFlagQueueView.astro
@@ -125,7 +125,7 @@ const tr = t(lang);
 />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
   import { readFilterState, writeFilterState, applyFilterStateToForm } from '../lib/console-filter-state';
@@ -165,7 +165,7 @@ const tr = t(lang);
   };
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.user) { show('flagq-not-auth'); return; }
     currentJwt = session.access_token;
     const myRoles = await getUserRoles(session.user.id);
@@ -339,7 +339,7 @@ const tr = t(lang);
     const { id, action, payload, reason } = (ev as CustomEvent<{ id: string; action: string; payload: Record<string, string>; reason: string }>).detail;
     if (id !== 'console-slideover-flagq') return;
 
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.access_token) {
       document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Session expired.' } }));
       return;

--- a/src/components/ConsoleForensicsView.astro
+++ b/src/components/ConsoleForensicsView.astro
@@ -100,7 +100,7 @@ const fCols = (forensicsNs?.columns as Record<string, string>) ?? {};
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError, type AdminAuditRow, type AuditExportResult } from '../lib/admin-client';
   import { readFilterState, writeFilterState } from '../lib/console-filter-state';
@@ -280,7 +280,7 @@ const fCols = (forensicsNs?.columns as Record<string, string>) ?? {};
       show('forensics-not-auth');
       return;
     }
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session) { show('forensics-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { show('forensics-not-auth'); return; }

--- a/src/components/ConsoleHealthView.astro
+++ b/src/components/ConsoleHealthView.astro
@@ -144,7 +144,7 @@ for (const k of METRIC_KEYS) metricLabelMap[k] = metricLabels[k] ?? k;
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
   import {
@@ -314,7 +314,7 @@ for (const k of METRIC_KEYS) metricLabelMap[k] = metricLabels[k] ?? k;
       show('health-not-auth');
       return;
     }
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session) { hide('health-skeleton'); show('health-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { hide('health-skeleton'); show('health-not-auth'); return; }

--- a/src/components/ConsoleObservationsView.astro
+++ b/src/components/ConsoleObservationsView.astro
@@ -162,7 +162,7 @@ const tr = t(lang);
 </ConsoleSlideOver>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
   import { readFilterState, writeFilterState, applyFilterStateToForm } from '../lib/console-filter-state';
@@ -209,7 +209,7 @@ const tr = t(lang);
   };
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.user) { show('obs-not-auth'); return; }
     currentJwt = session.access_token;
     const myRoles = await getUserRoles(session.user.id);
@@ -430,7 +430,7 @@ const tr = t(lang);
     const { id, action, payload, reason } = (ev as CustomEvent<{ id: string; action: string; payload: Record<string, string>; reason: string }>).detail;
     if (id !== 'console-slideover-obs') return;
 
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.access_token) {
       document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Session expired.' } }));
       return;

--- a/src/components/ConsoleProposalsView.astro
+++ b/src/components/ConsoleProposalsView.astro
@@ -103,7 +103,7 @@ const pSelfApproval = (pNs?.selfApprovalForbidden as string) ?? 'You cannot appr
 />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
 
@@ -243,7 +243,7 @@ const pSelfApproval = (pNs?.selfApprovalForbidden as string) ?? 'You cannot appr
       show('proposals-not-auth');
       return;
     }
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session) { show('proposals-not-auth'); return; }
     viewerId = session.user.id;
     const myRoles = await getUserRoles(session.user.id);

--- a/src/components/ConsoleSlideOver.astro
+++ b/src/components/ConsoleSlideOver.astro
@@ -225,10 +225,10 @@ const customLabel = tr.console.quick_reason_custom;
   ) {
     const errorEl = root.querySelector<HTMLElement>('[data-slideover-error]');
     try {
-      const { getSupabase } = await import('../lib/supabase');
+      const { getCachedSession, getSupabase } = await import('../lib/supabase');
       const { adminClient, AdminClientError } = await import('../lib/admin-client');
       const supabase = getSupabase();
-      const { data: { session } } = await supabase.auth.getSession();
+      const session = await getCachedSession();
       if (!session?.access_token) {
         document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id: root.id, ok: false, error: 'Session expired.' } }));
         return;

--- a/src/components/ConsoleTaxaView.astro
+++ b/src/components/ConsoleTaxaView.astro
@@ -129,7 +129,7 @@ const tr = t(lang);
 </section>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient } from '../lib/admin-client';
 
@@ -171,7 +171,7 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.user) { show('taxa-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { show('taxa-not-auth'); return; }

--- a/src/components/ConsoleUsersView.astro
+++ b/src/components/ConsoleUsersView.astro
@@ -99,7 +99,7 @@ const tr = t(lang);
 </ConsoleSlideOver>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
   import { readFilterState, writeFilterState } from '../lib/console-filter-state';
@@ -141,7 +141,7 @@ const tr = t(lang);
   const supabase = getSupabase();
 
   async function init() {
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.user) { show('users-not-auth'); return; }
     currentJwt = session.access_token;
     const myRoles = await getUserRoles(session.user.id);
@@ -286,7 +286,7 @@ const tr = t(lang);
     section.classList.add('hidden');
     dl.innerHTML = '<dt class="text-zinc-500 col-span-2 text-xs italic">Loading…</dt>';
 
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.access_token) return;
 
     try {
@@ -341,7 +341,7 @@ const tr = t(lang);
     const { id, action, payload, reason } = (ev as CustomEvent<{ id: string; action: string; payload: Record<string, string>; reason: string }>).detail;
     if (id !== 'console-slideover-users') return;
 
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session?.access_token) {
       document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Session expired.' } }));
       return;
@@ -394,7 +394,7 @@ const tr = t(lang);
     emailSearchTimer = setTimeout(async () => {
       const raw = (ev.target as HTMLInputElement).value.trim();
       if (!raw) return;
-      const { data: { session } } = await supabase.auth.getSession();
+      const session = await getCachedSession();
       if (!session?.access_token) return;
       const payload = raw.includes('@') ? { email: raw } : { user_id: raw };
       try {

--- a/src/components/ConsoleWebhooksView.astro
+++ b/src/components/ConsoleWebhooksView.astro
@@ -191,7 +191,7 @@ const eventKeys: Array<keyof typeof wEvents> = [
 />
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
 
@@ -481,7 +481,7 @@ const eventKeys: Array<keyof typeof wEvents> = [
   async function init() {
     let supabase;
     try { supabase = getSupabase(); } catch { show('webhooks-not-auth'); return; }
-    const { data: { session } } = await supabase.auth.getSession();
+    const session = await getCachedSession();
     if (!session) { show('webhooks-not-auth'); return; }
     const myRoles = await getUserRoles(session.user.id);
     if (!myRoles.has('admin')) { show('webhooks-not-auth'); return; }

--- a/src/components/ExportView.astro
+++ b/src/components/ExportView.astro
@@ -82,7 +82,7 @@ const tr = t(lang);
 </div>
 
 <script>
-  import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { getCachedSession, getCachedUser, getSupabase } from '../lib/supabase';
   import { toDwCRecord, toCSV, toCsvSnib, toCsvConanp, downloadCSV, type DwCInput } from '../lib/darwin-core';
   import type { UserProfile } from '../lib/types';
 
@@ -203,7 +203,7 @@ const tr = t(lang);
     gbifBtnLabel.textContent = GBIF_GENERATING;
     try {
       const supabase = getSupabase();
-      const { data: { session } } = await supabase.auth.getSession();
+      const session = await getCachedSession();
       if (!session) throw new Error('Not signed in');
 
       const since = (document.getElementById('gbif-since') as HTMLInputElement | null)?.value;

--- a/src/components/SuggestIdModal.astro
+++ b/src/components/SuggestIdModal.astro
@@ -135,10 +135,8 @@ const v = (tr as unknown as { validation: Record<string, string> }).validation;
       }
       try {
         const supabase = getSupabase();
-        const [{ data: rarity }, { data: { user } }] = await Promise.all([
-          supabase.from('taxon_rarity').select('bucket, multiplier').eq('taxon_id', taxonId).maybeSingle(),
-          supabase.auth.getUser(),
-        ]);
+        const user = await getCachedUser();
+        const { data: rarity } = await supabase.from('taxon_rarity').select('bucket, multiplier').eq('taxon_id', taxonId).maybeSingle();
         let inGrace = false;
         let graceDaysLeft: number | undefined;
         let expertiseLevel: string | null = null;

--- a/src/components/console/ExpertApplicationsBrowser.astro
+++ b/src/components/console/ExpertApplicationsBrowser.astro
@@ -60,7 +60,7 @@ const isEs = lang === 'es';
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedSession, getSupabase } from '../../lib/supabase';
   import { escapeHtml } from '../../lib/escape';
   const isEs = document.documentElement.lang === 'es';
   const shell = document.getElementById('ea-shell');
@@ -132,7 +132,7 @@ const isEs = lang === 'es';
 
   async function callAdmin(action: string, payload: Record<string, unknown>): Promise<void> {
     const sb = getSupabase();
-    const { data: { session } } = await sb.auth.getSession();
+    const session = await getCachedSession();
     if (!session) throw new Error('Not authenticated');
     const url = import.meta.env.PUBLIC_SUPABASE_URL || (sb as unknown as { supabaseUrl: string }).supabaseUrl;
     const res = await fetch(`${url}/functions/v1/admin`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${session.access_token}` }, body: JSON.stringify({ action, payload, reason: 'Console action' }) });

--- a/src/components/console/PlantNetQuotaPanel.astro
+++ b/src/components/console/PlantNetQuotaPanel.astro
@@ -99,7 +99,7 @@ const loadingText = (tr.console as unknown as Record<string, string>).loading
 </section>
 
 <script>
-  import { getSupabase } from '../../lib/supabase';
+  import { getCachedSession, getSupabase } from '../../lib/supabase';
   import { getUserRoles } from '../../lib/user-roles';
 
   type UsageRow = {
@@ -214,7 +214,7 @@ const loadingText = (tr.console as unknown as Record<string, string>).loading
         return;
       }
 
-      const { data: { session } } = await supabase.auth.getSession();
+      const session = await getCachedSession();
       if (!session?.user) { hide('pnq-loading'); show('pnq-not-auth'); return; }
 
       const myRoles = await getUserRoles(session.user.id);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -37,10 +37,15 @@ let client: SupabaseClient | null = null;
  */
 let _userCache: { user: import('@supabase/supabase-js').User | null; resolvedAt: number } | null = null;
 const USER_CACHE_TTL_MS = 30_000; // 30s — enough to cover a full page hydration burst
+let _sessionCache: { session: import('@supabase/supabase-js').Session | null; resolvedAt: number } | null = null;
+const SESSION_CACHE_TTL_MS = 30_000;
 
 if (typeof document !== 'undefined') {
   document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'hidden') _userCache = null;
+    if (document.visibilityState === 'hidden') {
+      _userCache = null;
+      _sessionCache = null;
+    }
   });
 }
 
@@ -51,8 +56,30 @@ function ensureAuthListener() {
   if (_authListenerAttached) return;
   _authListenerAttached = true;
   getSupabase().auth.onAuthStateChange((event) => {
-    if (event === 'SIGNED_OUT') _userCache = null;
+    if (event === 'SIGNED_OUT') {
+      _userCache = null;
+      _sessionCache = null;
+    }
   });
+}
+
+/**
+ * Returns the current session (including access_token) with a short-lived
+ * in-memory cache. Use this instead of `getSupabase().auth.getSession()` in
+ * Console components that need access_token for Edge Function calls.
+ *
+ * Safe for concurrent callers — only one getSession() request fires per
+ * 30-second window, preventing navigator.lock contention.
+ */
+export async function getCachedSession() {
+  ensureAuthListener();
+  const now = Date.now();
+  if (_sessionCache && (now - _sessionCache.resolvedAt) < SESSION_CACHE_TTL_MS) {
+    return _sessionCache.session;
+  }
+  const { data: { session } } = await getSupabase().auth.getSession();
+  _sessionCache = { session, resolvedAt: now };
+  return session;
 }
 
 /**

--- a/tests/unit/supabase-cache.test.ts
+++ b/tests/unit/supabase-cache.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for getCachedSession() and getCachedUser() in src/lib/supabase.ts
+ *
+ * Strategy: mock @supabase/supabase-js entirely, then import supabase.ts fresh
+ * per describe block using vi.resetModules() so each block gets its own cache state.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Shared mock factory — called once per module instantiation
+// ---------------------------------------------------------------------------
+const mockGetSession = vi.fn().mockResolvedValue({
+  data: { session: { access_token: 'tok-1', user: { id: 'u1' } } },
+});
+const mockGetUser = vi.fn().mockResolvedValue({
+  data: { user: { id: 'u1' } },
+});
+const mockOnAuthStateChange = vi.fn(() => ({
+  data: { subscription: { unsubscribe: vi.fn() } },
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    auth: {
+      getSession: mockGetSession,
+      getUser: mockGetUser,
+      onAuthStateChange: mockOnAuthStateChange,
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// getCachedSession — two calls, only one getSession() fired
+// ---------------------------------------------------------------------------
+describe('getCachedSession', () => {
+  let getCachedSession: () => Promise<unknown>;
+
+  beforeAll(async () => {
+    vi.resetModules();
+    mockGetSession.mockClear();
+    const mod = await import('../../src/lib/supabase');
+    getCachedSession = mod.getCachedSession;
+  });
+
+  it('returns session with access_token on first call', async () => {
+    const session = await getCachedSession() as { access_token: string } | null;
+    expect(session?.access_token).toBe('tok-1');
+  });
+
+  it('returns same session on second call without calling getSession again', async () => {
+    const session = await getCachedSession() as { access_token: string } | null;
+    expect(session?.access_token).toBe('tok-1');
+    // getSession should have been called exactly once across both calls
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCachedUser — two calls, only one getUser() fired
+// ---------------------------------------------------------------------------
+describe('getCachedUser', () => {
+  let getCachedUser: () => Promise<unknown>;
+
+  beforeAll(async () => {
+    vi.resetModules();
+    mockGetUser.mockClear();
+    const mod = await import('../../src/lib/supabase');
+    getCachedUser = mod.getCachedUser;
+  });
+
+  it('returns user with id on first call', async () => {
+    const user = await getCachedUser() as { id: string } | null;
+    expect(user?.id).toBe('u1');
+  });
+
+  it('returns same user on second call without calling getUser again', async () => {
+    const user = await getCachedUser() as { id: string } | null;
+    expect(user?.id).toBe('u1');
+    // getUser should have been called exactly once across both calls
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Adds `getCachedSession()` to `src/lib/supabase.ts` with 30s TTL (same pattern as `getCachedUser()`). Migrates all 20 Console* components from `auth.getSession()` to the cached version — eliminates independent lock acquisitions on admin page load.\n\n- 4 new tests in `tests/unit/supabase-cache.test.ts`\n- `_sessionCache` cleared on tab hide + SIGNED_OUT event\n- Zero TypeScript errors\n\nCloses #931