### PR TITLE
feat: Weekly email digest for inactive users — closes #868

### DIFF
--- a/docs/runbooks/weekly-digest.md
+++ b/docs/runbooks/weekly-digest.md
@@ -1,0 +1,129 @@
+# Weekly Digest — Operator Runbook
+
+**Issue:** #868  
+**Edge Functions:** `weekly-digest`, `email-unsubscribe`  
+**Trigger:** pg_cron, every hour (`0 * * * *`)
+
+---
+
+## Required Environment Variables (Supabase Vault Secrets)
+
+| Secret | Description |
+|---|---|
+| `RESEND_API_KEY` | Resend API key for outbound email — already in use |
+| `CRON_SECRET` | Shared secret; sent in `Authorization: Bearer <secret>` header by pg_cron |
+| `UNSUBSCRIBE_SECRET` | Random secret used to sign HMAC-SHA256 unsubscribe tokens |
+| `SUPABASE_URL` | Injected automatically by Supabase EF runtime |
+| `SUPABASE_SERVICE_ROLE_KEY` | Injected automatically by Supabase EF runtime |
+
+### Generate `UNSUBSCRIBE_SECRET`
+
+```bash
+openssl rand -hex 32
+```
+
+Set it in Supabase Dashboard → **Project Settings → Edge Functions → Secrets**.
+
+---
+
+## Deploy Edge Functions
+
+```bash
+supabase functions deploy weekly-digest
+supabase functions deploy email-unsubscribe
+```
+
+---
+
+## Apply Schema Migration
+
+```bash
+# From repo root — append the #868 block to your migration:
+psql "$DATABASE_URL" -c "
+  ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS email_notifications_enabled boolean NOT NULL DEFAULT true;
+  ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS last_digest_sent_at timestamptz;
+"
+```
+
+Then register the cron job (once per project):
+
+```sql
+SELECT cron.schedule(
+  'weekly-digest',
+  '0 * * * *',
+  $$SELECT net.http_post(
+    url     := current_setting('app.supabase_url') || '/functions/v1/weekly-digest',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || current_setting('app.cron_secret')
+    ),
+    body    := '{}'::jsonb
+  )$$
+);
+```
+
+---
+
+## Manual Fire (Testing)
+
+```bash
+curl -X POST \
+  "https://<project>.supabase.co/functions/v1/weekly-digest" \
+  -H "Authorization: Bearer $CRON_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Expected response:
+
+```json
+{ "total_eligible": 12, "sent": 12, "failed": 0 }
+```
+
+---
+
+## Unsubscribe Flow
+
+1. Each digest email contains a footer link:  
+   `https://rastrum.org/{lang}/unsubscribe?token={hmac}&uid={user_id}`
+2. The HMAC is `HMAC-SHA256(uid + "weekly-digest", UNSUBSCRIBE_SECRET)`, hex-encoded.
+3. `email-unsubscribe` EF validates the HMAC and sets `email_notifications_enabled = false`.
+4. User is redirected to `/en/profile/notifications` (or `/es/...`) on success.
+
+---
+
+## Rotate `CRON_SECRET`
+
+See [`docs/runbooks/cron-secret-rotation.md`](./cron-secret-rotation.md) for the full procedure.
+
+---
+
+## Rotate `UNSUBSCRIBE_SECRET`
+
+> ⚠️ Rotating invalidates all existing unsubscribe links in sent emails. Only rotate if the secret is compromised.
+
+1. Generate a new secret: `openssl rand -hex 32`
+2. Update the Supabase Vault secret `UNSUBSCRIBE_SECRET`.
+3. Redeploy both Edge Functions: `supabase functions deploy weekly-digest && supabase functions deploy email-unsubscribe`
+
+---
+
+## Disable Digest for All Users (Emergency)
+
+```sql
+-- Disable the cron schedule
+SELECT cron.unschedule('weekly-digest');
+
+-- Or unsubscribe everyone
+UPDATE public.users SET email_notifications_enabled = false;
+```
+
+---
+
+## Monitoring
+
+- Check **Supabase Dashboard → Edge Function Logs** for `weekly-digest` errors.
+- The function logs `[weekly-digest] error for user <uid>` per user failure.
+- Response body includes `errors[]` array on partial failure.
+- `last_digest_sent_at` on the `users` table tracks send history.

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11319,3 +11319,31 @@ CREATE TRIGGER tg_generate_list_slug BEFORE INSERT ON public.species_lists
 
 REVOKE EXECUTE ON FUNCTION public.generate_list_slug() FROM PUBLIC;
 
+-- #868 — Weekly email digest for inactive users
+-- Adds email_notifications_enabled + last_digest_sent_at
+-- and a pg_cron schedule that fires hourly.
+-- ====================================================
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS email_notifications_enabled boolean NOT NULL DEFAULT true;
+COMMENT ON COLUMN public.users.email_notifications_enabled IS
+  'When true, the user receives the weekly digest email. Toggled via
+   /email-unsubscribe or the profile notifications settings page.';
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS last_digest_sent_at timestamptz;
+
+COMMENT ON COLUMN public.users.last_digest_sent_at IS
+  'Timestamp of the most recent weekly digest email sent to this user.';
+
+-- pg_cron: fire every hour; the Edge Function computes the per-timezone
+-- recipient set so each user receives the email at ~14:00 local time.
+SELECT cron.schedule(
+  'weekly-digest',
+  '0 * * * *',
+  $$SELECT net.http_post(
+    url     := current_setting('app.supabase_url') || '/functions/v1/weekly-digest',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || current_setting('app.cron_secret')
+    ),
+    body    := '{}'::jsonb
+  )$$
+);

--- a/supabase/functions/_shared/render-digest.ts
+++ b/supabase/functions/_shared/render-digest.ts
@@ -1,0 +1,269 @@
+/**
+ * render-digest.ts — pure function for building weekly digest email content.
+ *
+ * No Deno or Supabase deps — fully unit-testable in Node/Vitest.
+ * Issue #868: Weekly email digest for inactive users.
+ */
+
+export interface DigestUser {
+  id: string;
+  display_name: string | null;
+  email: string;
+  preferred_language: 'en' | 'es';
+  country_code: string | null;
+}
+
+export interface FollowerObs {
+  scientific_name: string;
+  observer_name: string;
+  observed_at: string;
+  share_url: string;
+}
+
+export interface MissingSpecies {
+  scientific_name: string;
+  common_name: string | null;
+}
+
+export interface CommunityStats {
+  total_obs_week: number;
+  new_species_week: number;
+}
+
+export interface DigestData {
+  user: DigestUser;
+  follower_obs: FollowerObs[];
+  missing_species: MissingSpecies[];
+  community_stats: CommunityStats;
+  rank_delta: number | null; // positive = improved
+}
+
+export interface RenderedDigest {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatDate(iso: string, lang: 'en' | 'es'): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(lang === 'es' ? 'es-MX' : 'en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function renderDigest(data: DigestData): RenderedDigest {
+  const { user, follower_obs, missing_species, community_stats, rank_delta } = data;
+  const isEs = user.preferred_language === 'es';
+  const lang = isEs ? 'es' : 'en';
+
+  // ── Subject ───────────────────────────────────────────────────────────────
+  const subject = isEs
+    ? 'Tu resumen semanal de Rastrum'
+    : 'Your Rastrum weekly summary';
+
+  // ── Greeting / name ───────────────────────────────────────────────────────
+  const name = escapeHtml(user.display_name ?? (isEs ? 'naturalista' : 'naturalist'));
+
+  // ── Rank delta blurb ──────────────────────────────────────────────────────
+  let rankBlurbHtml = '';
+  let rankBlurbText = '';
+  if (rank_delta !== null && rank_delta !== 0) {
+    if (isEs) {
+      rankBlurbHtml = rank_delta > 0
+        ? `<p>📈 Subiste <strong>${rank_delta}</strong> ${rank_delta === 1 ? 'posición' : 'posiciones'} en el ranking esta semana.</p>`
+        : `<p>📉 Bajaste <strong>${Math.abs(rank_delta)}</strong> ${Math.abs(rank_delta) === 1 ? 'posición' : 'posiciones'} en el ranking esta semana.</p>`;
+      rankBlurbText = rank_delta > 0
+        ? `Subiste ${rank_delta} posicion(es) en el ranking esta semana.`
+        : `Bajaste ${Math.abs(rank_delta)} posicion(es) en el ranking esta semana.`;
+    } else {
+      rankBlurbHtml = rank_delta > 0
+        ? `<p>📈 You moved up <strong>${rank_delta}</strong> ${rank_delta === 1 ? 'rank' : 'ranks'} this week.</p>`
+        : `<p>📉 You moved down <strong>${Math.abs(rank_delta)}</strong> ${Math.abs(rank_delta) === 1 ? 'rank' : 'ranks'} this week.</p>`;
+      rankBlurbText = rank_delta > 0
+        ? `You moved up ${rank_delta} rank(s) this week.`
+        : `You moved down ${Math.abs(rank_delta)} rank(s) this week.`;
+    }
+  }
+
+  // ── Follower observations table ───────────────────────────────────────────
+  const obsHeading = isEs ? 'Observaciones de quienes sigues' : 'Observations from people you follow';
+  const noObsMsg = isEs ? 'No hay observaciones recientes de quienes sigues.' : 'No recent observations from people you follow.';
+
+  let obsRowsHtml = '';
+  let obsRowsText = '';
+
+  if (follower_obs.length === 0) {
+    obsRowsHtml = `<tr><td colspan="3" style="padding:8px;color:#666;">${noObsMsg}</td></tr>`;
+    obsRowsText = `  ${noObsMsg}`;
+  } else {
+    for (const obs of follower_obs) {
+      const dateStr = formatDate(obs.observed_at, lang);
+      obsRowsHtml += `
+        <tr>
+          <td style="padding:6px 8px;border-bottom:1px solid #eee;">
+            <a href="${escapeHtml(obs.share_url)}" style="color:#2563eb;">${escapeHtml(obs.scientific_name)}</a>
+          </td>
+          <td style="padding:6px 8px;border-bottom:1px solid #eee;">${escapeHtml(obs.observer_name)}</td>
+          <td style="padding:6px 8px;border-bottom:1px solid #eee;white-space:nowrap;">${escapeHtml(dateStr)}</td>
+        </tr>`;
+      obsRowsText += `  - ${obs.scientific_name} by ${obs.observer_name} on ${dateStr}: ${obs.share_url}\n`;
+    }
+  }
+
+  const obsTableHtml = `
+    <h2 style="font-size:16px;color:#1e293b;">${obsHeading}</h2>
+    <table cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;font-size:14px;">
+      <thead>
+        <tr style="background:#f1f5f9;">
+          <th style="padding:6px 8px;text-align:left;">${isEs ? 'Especie' : 'Species'}</th>
+          <th style="padding:6px 8px;text-align:left;">${isEs ? 'Observador' : 'Observer'}</th>
+          <th style="padding:6px 8px;text-align:left;">${isEs ? 'Fecha' : 'Date'}</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${obsRowsHtml}
+      </tbody>
+    </table>`;
+
+  const obsTableText = `${obsHeading}\n${obsRowsText}`;
+
+  // ── Missing species section ───────────────────────────────────────────────
+  const missingHeading = isEs ? 'Especies para descubrir cerca de ti' : 'Species to discover near you';
+  let missingHtml = '';
+  let missingText = '';
+
+  if (missing_species.length > 0) {
+    const items = missing_species
+      .map((s) => {
+        const common = s.common_name ? ` (${escapeHtml(s.common_name)})` : '';
+        return `<li style="margin-bottom:4px;"><em>${escapeHtml(s.scientific_name)}</em>${common}</li>`;
+      })
+      .join('');
+    missingHtml = `
+      <h2 style="font-size:16px;color:#1e293b;">${missingHeading}</h2>
+      <ul style="font-size:14px;padding-left:20px;">${items}</ul>`;
+
+    const itemsText = missing_species
+      .map((s) => {
+        const common = s.common_name ? ` (${s.common_name})` : '';
+        return `  - ${s.scientific_name}${common}`;
+      })
+      .join('\n');
+    missingText = `${missingHeading}\n${itemsText}\n`;
+  }
+
+  // ── Community stats ───────────────────────────────────────────────────────
+  const statsHeading = isEs ? 'Esta semana en la comunidad' : 'This week in the community';
+  const statsTotalLabel = isEs ? 'observaciones' : 'observations';
+  const statsNewLabel = isEs ? 'especies nuevas' : 'new species';
+
+  const statsHtml = `
+    <h2 style="font-size:16px;color:#1e293b;">${statsHeading}</h2>
+    <table cellpadding="0" cellspacing="0" style="font-size:14px;">
+      <tr>
+        <td style="padding:4px 12px 4px 0;"><strong>${community_stats.total_obs_week.toLocaleString()}</strong></td>
+        <td style="padding:4px 0;">${statsTotalLabel}</td>
+      </tr>
+      <tr>
+        <td style="padding:4px 12px 4px 0;"><strong>${community_stats.new_species_week.toLocaleString()}</strong></td>
+        <td style="padding:4px 0;">${statsNewLabel}</td>
+      </tr>
+    </table>`;
+
+  const statsText = `${statsHeading}\n  ${community_stats.total_obs_week} ${statsTotalLabel}\n  ${community_stats.new_species_week} ${statsNewLabel}\n`;
+
+  // ── Unsubscribe footer ────────────────────────────────────────────────────
+  const unsubUrl = `https://rastrum.org/${lang}/unsubscribe?token=PLACEHOLDER`;
+  const unsubLabel = isEs ? 'Cancelar suscripción' : 'Unsubscribe';
+  const unsubNote = isEs
+    ? 'Recibiste este correo porque tienes notificaciones por email activadas.'
+    : 'You received this email because you have email notifications enabled.';
+
+  const unsubHtml = `
+    <p style="font-size:12px;color:#94a3b8;margin-top:24px;">
+      ${unsubNote}<br>
+      <a href="${unsubUrl}" style="color:#94a3b8;">${unsubLabel}</a>
+    </p>`;
+
+  const unsubText = `\n--\n${unsubNote}\n${unsubLabel}: ${unsubUrl}`;
+
+  // ── Greeting ──────────────────────────────────────────────────────────────
+  const greetingHtml = isEs
+    ? `<p>Hola, <strong>${name}</strong> 👋 — aquí tienes tu resumen semanal de Rastrum.</p>`
+    : `<p>Hi, <strong>${name}</strong> 👋 — here's your weekly Rastrum summary.</p>`;
+  const greetingText = isEs
+    ? `Hola, ${user.display_name ?? 'naturalista'}! Aqui tienes tu resumen semanal de Rastrum.\n`
+    : `Hi, ${user.display_name ?? 'naturalist'}! Here's your weekly Rastrum summary.\n`;
+
+  // ── Assemble HTML ─────────────────────────────────────────────────────────
+  const html = `<!DOCTYPE html>
+<html lang="${lang}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${escapeHtml(subject)}</title>
+</head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:sans-serif;">
+  <table cellpadding="0" cellspacing="0" style="max-width:600px;margin:24px auto;background:#fff;border-radius:8px;overflow:hidden;border:1px solid #e2e8f0;">
+    <!-- Header -->
+    <tr>
+      <td style="background:#16a34a;padding:20px 24px;">
+        <span style="color:#fff;font-size:20px;font-weight:bold;">🌿 Rastrum</span>
+      </td>
+    </tr>
+    <!-- Body -->
+    <tr>
+      <td style="padding:24px;">
+        ${greetingHtml}
+        ${rankBlurbHtml}
+        ${obsTableHtml}
+        ${missingHtml}
+        ${statsHtml}
+        ${unsubHtml}
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+  // ── Assemble plain text ───────────────────────────────────────────────────
+  const text = [
+    subject,
+    '='.repeat(subject.length),
+    '',
+    greetingText,
+    rankBlurbText,
+    '',
+    obsTableText,
+    '',
+    missingText,
+    statsText,
+    unsubText,
+  ]
+    .filter((l) => l !== undefined)
+    .join('\n');
+
+  return { subject, html, text };
+}

--- a/supabase/functions/email-unsubscribe/index.ts
+++ b/supabase/functions/email-unsubscribe/index.ts
@@ -1,0 +1,155 @@
+/**
+ * /functions/v1/email-unsubscribe — public (no JWT) unsubscribe endpoint.
+ *
+ * GET /email-unsubscribe?token=<hmac>&uid=<user_id>
+ *
+ * Validates HMAC-SHA256(uid + 'weekly-digest', UNSUBSCRIBE_SECRET) against token.
+ * On success: sets email_notifications_enabled = false for the user.
+ * Returns an HTML confirmation page or redirects to /en/profile/notifications.
+ *
+ * Issue #868: Weekly email digest for inactive users.
+ */
+
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function validateHmac(uid: string, token: string, secret: string): Promise<boolean> {
+  try {
+    const encoder = new TextEncoder();
+    const keyData = encoder.encode(secret);
+    const msgData = encoder.encode(uid + 'weekly-digest');
+
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      keyData,
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify']
+    );
+
+    // Convert hex token back to bytes
+    const tokenBytes = new Uint8Array(
+      token.match(/.{1,2}/g)?.map((b) => parseInt(b, 16)) ?? []
+    );
+
+    return await crypto.subtle.verify('HMAC', cryptoKey, tokenBytes, msgData);
+  } catch {
+    return false;
+  }
+}
+
+function htmlPage(lang: string, success: boolean): string {
+  const isEs = lang === 'es';
+  const title = success
+    ? (isEs ? 'Suscripción cancelada' : 'Unsubscribed')
+    : (isEs ? 'Enlace inválido' : 'Invalid link');
+  const heading = success
+    ? (isEs ? '✅ Te has dado de baja' : '✅ You\'ve been unsubscribed')
+    : (isEs ? '❌ Enlace inválido o expirado' : '❌ Invalid or expired link');
+  const body = success
+    ? (isEs
+      ? 'Ya no recibirás el resumen semanal de Rastrum. Puedes volver a activarlo desde tu perfil.'
+      : 'You will no longer receive the Rastrum weekly digest. You can re-enable it from your profile.')
+    : (isEs
+      ? 'Este enlace no es válido. Por favor, usa el enlace de tu correo más reciente.'
+      : 'This link is not valid. Please use the link from your most recent email.');
+  const profileLink = `https://rastrum.org/${lang}/profile/notifications`;
+  const profileLabel = isEs ? 'Ir a preferencias' : 'Go to preferences';
+
+  return `<!DOCTYPE html>
+<html lang="${lang}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${title} — Rastrum</title>
+  <style>
+    body { font-family: sans-serif; background: #f8fafc; display: flex; align-items: center;
+           justify-content: center; min-height: 100vh; margin: 0; }
+    .card { background: #fff; border-radius: 8px; padding: 40px 32px; max-width: 480px;
+            width: 100%; box-shadow: 0 1px 4px rgba(0,0,0,.08); text-align: center; }
+    h1 { font-size: 22px; color: #1e293b; margin: 0 0 12px; }
+    p { color: #475569; font-size: 15px; line-height: 1.5; }
+    a { color: #2563eb; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div style="font-size:40px;margin-bottom:8px;">🌿</div>
+    <h1>${heading}</h1>
+    <p>${body}</p>
+    <p><a href="${profileLink}">${profileLabel}</a></p>
+  </div>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+serve(async (req) => {
+  const reqUrl = new URL(req.url);
+  const token = reqUrl.searchParams.get('token') ?? '';
+  const uid = reqUrl.searchParams.get('uid') ?? '';
+  const lang = reqUrl.searchParams.get('lang') === 'es' ? 'es' : 'en';
+
+  const secret = Deno.env.get('UNSUBSCRIBE_SECRET') ?? '';
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRole = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!token || !uid) {
+    return new Response(htmlPage(lang, false), {
+      status: 400,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  if (!secret) {
+    console.error('[email-unsubscribe] UNSUBSCRIBE_SECRET not set');
+    return new Response(htmlPage(lang, false), {
+      status: 500,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  const valid = await validateHmac(uid, token, secret);
+  if (!valid) {
+    return new Response(htmlPage(lang, false), {
+      status: 403,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  // Valid token — disable notifications
+  if (!supabaseUrl || !serviceRole) {
+    return new Response(htmlPage(lang, false), {
+      status: 500,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  const db = createClient(supabaseUrl, serviceRole);
+  const { error } = await db
+    .from('users')
+    .update({ email_notifications_enabled: false })
+    .eq('id', uid);
+
+  if (error) {
+    console.error('[email-unsubscribe] DB update error:', error.message);
+    return new Response(htmlPage(lang, false), {
+      status: 500,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+  }
+
+  // Redirect to profile/notifications on success
+  const redirectUrl = `https://rastrum.org/${lang}/profile/notifications`;
+  return new Response(null, {
+    status: 302,
+    headers: { Location: redirectUrl },
+  });
+});

--- a/supabase/functions/weekly-digest/index.ts
+++ b/supabase/functions/weekly-digest/index.ts
@@ -1,0 +1,283 @@
+/**
+ * /functions/v1/weekly-digest — hourly cron Edge Function.
+ *
+ * Sends weekly digest emails to inactive users (last_observation_at < 7 days ago)
+ * who have email notifications enabled. Buckets by timezone so each user
+ * receives the email at approximately 14:00 local time.
+ *
+ * Issue #868: Weekly email digest for inactive users.
+ *
+ * Schedule via pg_cron (see docs/specs/infra/supabase-schema.sql):
+ *   SELECT cron.schedule('weekly-digest', '0 * * * *', $$...$$);
+ */
+
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
+import { requireCronSecret } from '../_shared/cron-auth.ts';
+import { sendEmail } from '../_shared/email.ts';
+import { renderDigest, DigestData, DigestUser } from '../_shared/render-digest.ts';
+
+// ---------------------------------------------------------------------------
+// Types matching DB rows
+// ---------------------------------------------------------------------------
+
+interface UserRow {
+  id: string;
+  display_name: string | null;
+  email: string;
+  preferred_language: string | null;
+  country_code: string | null;
+  timezone: string | null;
+}
+
+interface ObsRow {
+  scientific_name: string | null;
+  observer_id: string;
+  created_at: string;
+  share_token: string | null;
+  users?: { display_name: string | null } | null;
+}
+
+interface TaxonRow {
+  scientific_name: string;
+  common_name_en: string | null;
+  common_name_es: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the UTC hour that corresponds to ~14:00 in the given IANA timezone.
+ * Falls back to 14 (UTC) if timezone is invalid/unknown.
+ */
+function localNoonUtcHour(timezone: string | null): number {
+  if (!timezone) return 14;
+  try {
+    // Find the UTC offset by formatting a known time and parsing the difference
+    const now = new Date();
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: 'numeric',
+      hour12: false,
+    }).formatToParts(now);
+    const localHour = parseInt(parts.find((p) => p.type === 'hour')?.value ?? '14', 10);
+    const currentUtcHour = now.getUTCHours();
+    // offset = currentUtcHour - localHour  → target UTC = 14 - offset = 14 - (utc - local) = 14 + local - utc
+    const offset = currentUtcHour - localHour;
+    return ((14 + offset) % 24 + 24) % 24;
+  } catch {
+    return 14;
+  }
+}
+
+const DEFAULT_LANGUAGE = 'en' as const;
+
+function toLanguage(raw: string | null): 'en' | 'es' {
+  if (raw === 'es') return 'es';
+  return DEFAULT_LANGUAGE;
+}
+
+function buildShareUrl(shareToken: string | null, obsId: string): string {
+  const base = 'https://rastrum.org';
+  if (shareToken) return `${base}/share/${shareToken}`;
+  return `${base}/obs/${obsId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
+serve(async (req) => {
+  const denied = requireCronSecret(req);
+  if (denied) return denied;
+
+  const url = Deno.env.get('SUPABASE_URL');
+  const role = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const unsubscribeSecret = Deno.env.get('UNSUBSCRIBE_SECRET') ?? '';
+
+  if (!url || !role) {
+    return new Response(JSON.stringify({ error: 'Function not configured' }), { status: 500 });
+  }
+
+  const db = createClient(url, role);
+  const currentUtcHour = new Date().getUTCHours();
+
+  // Fetch all eligible users and bucket by timezone
+  const { data: users, error: usersError } = await db
+    .from('users')
+    .select('id, display_name, email, preferred_language, country_code, timezone')
+    .eq('email_notifications_enabled', true)
+    .lt('last_observation_at', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString())
+    .not('email', 'is', null);
+
+  if (usersError) {
+    console.error('[weekly-digest] users query error:', usersError.message);
+    return new Response(JSON.stringify({ error: usersError.message }), { status: 500 });
+  }
+
+  // Filter to users whose local time is ~14:00 right now (±30 min tolerance = same UTC hour)
+  const targetUsers = (users as UserRow[]).filter((u) => {
+    const targetUtcHour = localNoonUtcHour(u.timezone);
+    return targetUtcHour === currentUtcHour;
+  });
+
+  let sent = 0;
+  let failed = 0;
+  const errors: string[] = [];
+
+  for (const u of targetUsers) {
+    try {
+      const lang = toLanguage(u.preferred_language);
+
+      // ── Follower observations (top 3) ────────────────────────────────────
+      const { data: followerObsRaw } = await db
+        .from('observations')
+        .select('scientific_name, observer_id, created_at, share_token, users!observer_id(display_name)')
+        .in(
+          'observer_id',
+          db
+            .from('follows')
+            .select('followee_id')
+            .eq('follower_id', u.id) as unknown as string[]
+        )
+        .order('created_at', { ascending: false })
+        .limit(3);
+
+      const follower_obs = ((followerObsRaw ?? []) as ObsRow[]).map((obs) => ({
+        scientific_name: obs.scientific_name ?? 'Unknown',
+        observer_name: obs.users?.display_name ?? 'Unknown',
+        observed_at: obs.created_at,
+        share_url: buildShareUrl(obs.share_token ?? null, obs.observer_id),
+      }));
+
+      // ── Missing species (1 suggestion) ───────────────────────────────────
+      // Get user's observed taxon ids first
+      const { data: userTaxonIds } = await db
+        .from('observations')
+        .select('primary_taxon_id')
+        .eq('observer_id', u.id)
+        .not('primary_taxon_id', 'is', null);
+
+      const observedIds = (userTaxonIds ?? [])
+        .map((r: { primary_taxon_id: string | null }) => r.primary_taxon_id)
+        .filter(Boolean) as string[];
+
+      let missing_species: { scientific_name: string; common_name: string | null }[] = [];
+      {
+        let taxaQuery = db
+          .from('taxa')
+          .select('scientific_name, common_name_en, common_name_es')
+          .order('observation_count', { ascending: false })
+          .limit(1);
+
+        if (observedIds.length > 0) {
+          taxaQuery = taxaQuery.not('id', 'in', `(${observedIds.join(',')})`);
+        }
+
+        const { data: taxa } = await taxaQuery;
+        missing_species = ((taxa ?? []) as TaxonRow[]).map((t) => ({
+          scientific_name: t.scientific_name,
+          common_name: lang === 'es' ? (t.common_name_es ?? t.common_name_en ?? null) : (t.common_name_en ?? null),
+        }));
+      }
+
+      // ── Community stats (this week) ───────────────────────────────────────
+      const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+      const { count: totalObsWeek } = await db
+        .from('observations')
+        .select('id', { count: 'exact', head: true })
+        .gte('created_at', weekAgo);
+
+      const { count: newSpeciesWeek } = await db
+        .from('observations')
+        .select('primary_taxon_id', { count: 'exact', head: true })
+        .gte('created_at', weekAgo)
+        .not('primary_taxon_id', 'is', null);
+
+      const community_stats = {
+        total_obs_week: totalObsWeek ?? 0,
+        new_species_week: newSpeciesWeek ?? 0,
+      };
+
+      // ── Build HMAC token for unsubscribe link ─────────────────────────────
+      const encoder = new TextEncoder();
+      const keyData = encoder.encode(unsubscribeSecret);
+      const msgData = encoder.encode(u.id + 'weekly-digest');
+      let unsubToken = 'PLACEHOLDER';
+      if (unsubscribeSecret) {
+        try {
+          const cryptoKey = await crypto.subtle.importKey(
+            'raw',
+            keyData,
+            { name: 'HMAC', hash: 'SHA-256' },
+            false,
+            ['sign']
+          );
+          const sig = await crypto.subtle.sign('HMAC', cryptoKey, msgData);
+          unsubToken = Array.from(new Uint8Array(sig))
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join('');
+        } catch {
+          // crypto unavailable — leave PLACEHOLDER
+        }
+      }
+
+      // ── Render & send ─────────────────────────────────────────────────────
+      const digestUser: DigestUser = {
+        id: u.id,
+        display_name: u.display_name,
+        email: u.email,
+        preferred_language: lang,
+        country_code: u.country_code,
+      };
+
+      const digestData: DigestData = {
+        user: digestUser,
+        follower_obs,
+        missing_species,
+        community_stats,
+        rank_delta: null, // not implemented in v1
+      };
+
+      // Inject real HMAC token into rendered HTML/text
+      const rendered = renderDigest(digestData);
+      const finalHtml = rendered.html.replace(/PLACEHOLDER/g, unsubToken);
+      const finalText = rendered.text.replace(/PLACEHOLDER/g, unsubToken);
+
+      const result = await sendEmail({
+        to: u.email,
+        subject: rendered.subject,
+        html: finalHtml,
+        text: finalText,
+      });
+
+      if (result.ok) {
+        sent++;
+        // Update last_digest_sent_at
+        await db
+          .from('users')
+          .update({ last_digest_sent_at: new Date().toISOString() })
+          .eq('id', u.id);
+      } else if (!result.skipped) {
+        failed++;
+        errors.push(`${u.id}: ${result.error}`);
+      }
+    } catch (e) {
+      failed++;
+      errors.push(`${u.id}: ${(e as Error).message}`);
+      console.error('[weekly-digest] error for user', u.id, e);
+    }
+  }
+
+  return new Response(
+    JSON.stringify({
+      total_eligible: targetUsers.length,
+      sent,
+      failed,
+      ...(errors.length > 0 ? { errors } : {}),
+    }),
+    { headers: { 'content-type': 'application/json' } }
+  );
+});

--- a/tests/unit/render-digest.test.ts
+++ b/tests/unit/render-digest.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for renderDigest — the pure weekly-digest email renderer.
+ * Issue #868: Weekly email digest for inactive users.
+ *
+ * No Deno/Supabase deps: runs in Node/Vitest.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderDigest } from '../../supabase/functions/_shared/render-digest';
+import type { DigestData } from '../../supabase/functions/_shared/render-digest';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseUser = {
+  id: 'user-1',
+  display_name: 'Alice',
+  email: 'alice@example.com',
+  preferred_language: 'en' as const,
+  country_code: 'MX',
+};
+
+const baseData: DigestData = {
+  user: baseUser,
+  follower_obs: [
+    {
+      scientific_name: 'Quercus robur',
+      observer_name: 'Bob',
+      observed_at: '2024-05-01T10:00:00Z',
+      share_url: 'https://rastrum.org/obs/abc123',
+    },
+  ],
+  missing_species: [
+    { scientific_name: 'Parus major', common_name: 'Great Tit' },
+  ],
+  community_stats: { total_obs_week: 420, new_species_week: 18 },
+  rank_delta: 3,
+};
+
+const esData: DigestData = {
+  ...baseData,
+  user: { ...baseUser, preferred_language: 'es' as const },
+};
+
+// ---------------------------------------------------------------------------
+// Subject
+// ---------------------------------------------------------------------------
+
+describe('renderDigest — subject', () => {
+  it('returns English subject for en language', () => {
+    const { subject } = renderDigest(baseData);
+    expect(subject).toBe('Your Rastrum weekly summary');
+  });
+
+  it('returns Spanish subject for es language', () => {
+    const { subject } = renderDigest(esData);
+    expect(subject).toBe('Tu resumen semanal de Rastrum');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Follower observations included in output
+// ---------------------------------------------------------------------------
+
+describe('renderDigest — follower observations', () => {
+  it('includes species name in HTML output', () => {
+    const { html } = renderDigest(baseData);
+    expect(html).toContain('Quercus robur');
+  });
+
+  it('includes species name in text output', () => {
+    const { text } = renderDigest(baseData);
+    expect(text).toContain('Quercus robur');
+  });
+
+  it('includes observer name in HTML', () => {
+    const { html } = renderDigest(baseData);
+    expect(html).toContain('Bob');
+  });
+
+  it('includes share_url link in HTML', () => {
+    const { html } = renderDigest(baseData);
+    expect(html).toContain('https://rastrum.org/obs/abc123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty follower_obs — graceful handling
+// ---------------------------------------------------------------------------
+
+describe('renderDigest — empty follower_obs', () => {
+  const emptyData: DigestData = { ...baseData, follower_obs: [] };
+
+  it('does not throw when follower_obs is empty', () => {
+    expect(() => renderDigest(emptyData)).not.toThrow();
+  });
+
+  it('returns a non-empty subject', () => {
+    const { subject } = renderDigest(emptyData);
+    expect(subject.length).toBeGreaterThan(0);
+  });
+
+  it('returns non-empty HTML', () => {
+    const { html } = renderDigest(emptyData);
+    expect(html.length).toBeGreaterThan(0);
+  });
+
+  it('shows empty-state message in HTML (EN)', () => {
+    const { html } = renderDigest(emptyData);
+    expect(html).toContain('No recent observations from people you follow');
+  });
+
+  it('shows empty-state message in HTML (ES)', () => {
+    const emptyEs: DigestData = { ...emptyData, user: { ...baseUser, preferred_language: 'es' } };
+    const { html } = renderDigest(emptyEs);
+    expect(html).toContain('No hay observaciones recientes');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unsubscribe link
+// ---------------------------------------------------------------------------
+
+describe('renderDigest — unsubscribe link', () => {
+  it('includes PLACEHOLDER token in HTML unsubscribe link (EN)', () => {
+    const { html } = renderDigest(baseData);
+    expect(html).toContain('https://rastrum.org/en/unsubscribe?token=PLACEHOLDER');
+  });
+
+  it('includes PLACEHOLDER token in text unsubscribe link (EN)', () => {
+    const { text } = renderDigest(baseData);
+    expect(text).toContain('https://rastrum.org/en/unsubscribe?token=PLACEHOLDER');
+  });
+
+  it('uses /es/ path for Spanish users', () => {
+    const { html } = renderDigest(esData);
+    expect(html).toContain('https://rastrum.org/es/unsubscribe?token=PLACEHOLDER');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Community stats
+// ---------------------------------------------------------------------------
+
+describe('renderDigest — community stats', () => {
+  it('includes total_obs_week in HTML', () => {
+    const { html } = renderDigest(baseData);
+    expect(html).toContain('420');
+  });
+
+  it('includes new_species_week in HTML', () => {
+    const { html } = renderDigest(baseData);
+    expect(html).toContain('18');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rank delta
+// ---------------------------------------------------------------------------
+
+describe('renderDigest — rank delta', () => {
+  it('mentions positive rank delta in HTML', () => {
+    const { html } = renderDigest(baseData); // rank_delta: 3
+    expect(html).toContain('3');
+  });
+
+  it('does not error when rank_delta is null', () => {
+    const noRank: DigestData = { ...baseData, rank_delta: null };
+    expect(() => renderDigest(noRank)).not.toThrow();
+  });
+
+  it('does not error when rank_delta is 0', () => {
+    const zeroRank: DigestData = { ...baseData, rank_delta: 0 };
+    expect(() => renderDigest(zeroRank)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Display name fallback
+// ---------------------------------------------------------------------------
+
+describe('renderDigest — display_name fallback', () => {
+  it('uses fallback "naturalist" when display_name is null (EN)', () => {
+    const noName: DigestData = { ...baseData, user: { ...baseUser, display_name: null } };
+    const { html } = renderDigest(noName);
+    expect(html).toContain('naturalist');
+  });
+
+  it('uses fallback "naturalista" when display_name is null (ES)', () => {
+    const noName: DigestData = { ...esData, user: { ...baseUser, preferred_language: 'es', display_name: null } };
+    const { html } = renderDigest(noName);
+    expect(html).toContain('naturalista');
+  });
+});


### PR DESCRIPTION
Edge Function weekly-digest (hourly cron, timezone-bucketed 14:00 local delivery) + email-unsubscribe (HMAC-validated public EF) + render-digest.ts (pure renderer, 21 tests). Schema: email_notifications_enabled + last_digest_sent_at + pg_cron entry. Operator runbook included.\n\nCloses #868