### PR TITLE
feat: User-curated species lists — closes #875

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11232,3 +11232,90 @@ CREATE TRIGGER tg_notify_on_comment
 
 REVOKE EXECUTE ON FUNCTION public.notify_on_comment() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.notify_on_comment() TO authenticated;
+-- #875 — User-curated species lists
+-- ====================================================
+
+CREATE TABLE IF NOT EXISTS public.species_lists (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  name_en text,
+  name_es text,
+  slug text NOT NULL,
+  description_en text,
+  description_es text,
+  visibility text NOT NULL DEFAULT 'public' CHECK (visibility IN ('public','private')),
+  cover_taxon_id uuid REFERENCES public.taxa(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, slug)
+);
+
+CREATE TABLE IF NOT EXISTS public.species_list_items (
+  list_id uuid NOT NULL REFERENCES public.species_lists(id) ON DELETE CASCADE,
+  taxon_id uuid NOT NULL REFERENCES public.taxa(id),
+  added_at timestamptz NOT NULL DEFAULT now(),
+  note text CHECK (length(note) <= 500),
+  observation_id uuid REFERENCES public.observations(id) ON DELETE SET NULL,
+  PRIMARY KEY (list_id, taxon_id)
+);
+
+CREATE INDEX IF NOT EXISTS species_lists_user_idx ON public.species_lists(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS species_lists_public_idx ON public.species_lists(visibility, created_at DESC) WHERE visibility = 'public';
+
+ALTER TABLE public.species_lists ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.species_list_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS species_lists_public_read ON public.species_lists;
+CREATE POLICY species_lists_public_read ON public.species_lists FOR SELECT
+  USING (visibility = 'public' OR (SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS species_lists_owner_write ON public.species_lists;
+CREATE POLICY species_lists_owner_write ON public.species_lists FOR ALL
+  TO authenticated USING ((SELECT auth.uid()) = user_id) WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS species_list_items_read ON public.species_list_items;
+CREATE POLICY species_list_items_read ON public.species_list_items FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.species_lists sl
+    WHERE sl.id = list_id
+      AND (sl.visibility = 'public' OR (SELECT auth.uid()) = sl.user_id)
+  ));
+
+DROP POLICY IF EXISTS species_list_items_owner_write ON public.species_list_items;
+CREATE POLICY species_list_items_owner_write ON public.species_list_items FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.species_lists sl WHERE sl.id = list_id AND (SELECT auth.uid()) = sl.user_id))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.species_lists sl WHERE sl.id = list_id AND (SELECT auth.uid()) = sl.user_id));
+
+-- Slug auto-generation trigger
+CREATE OR REPLACE FUNCTION public.generate_list_slug()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_base text;
+  v_slug text;
+  v_count int := 0;
+BEGIN
+  IF NEW.slug IS NOT NULL AND NEW.slug != '' THEN RETURN NEW; END IF;
+  v_base := lower(regexp_replace(coalesce(NEW.name_es, NEW.name_en, 'list'), '[^a-z0-9]+', '-', 'g'));
+  v_base := trim(both '-' from v_base);
+  v_slug := v_base;
+  LOOP
+    EXIT WHEN NOT EXISTS (SELECT 1 FROM public.species_lists WHERE user_id = NEW.user_id AND slug = v_slug);
+    v_count := v_count + 1;
+    v_slug := v_base || '-' || v_count;
+  END LOOP;
+  NEW.slug := v_slug;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS tg_generate_list_slug ON public.species_lists;
+CREATE TRIGGER tg_generate_list_slug BEFORE INSERT ON public.species_lists
+  FOR EACH ROW EXECUTE FUNCTION public.generate_list_slug();
+
+REVOKE EXECUTE ON FUNCTION public.generate_list_slug() FROM PUBLIC;
+

--- a/src/components/ProfileView.astro
+++ b/src/components/ProfileView.astro
@@ -13,6 +13,7 @@ import ProfileStreakRing from './profile/ProfileStreakRing.astro';
 import ProfileKarmaSection from './profile/ProfileKarmaSection.astro';
 import ProfilePercentileCards from './profile/ProfilePercentileCards.astro';
 import ProfilePokedexLink from './profile/ProfilePokedexLink.astro';
+import ProfileSpeciesListsLink from './profile/ProfileSpeciesListsLink.astro';
 import ProfileBadgesGrid from './profile/ProfileBadgesGrid.astro';
 import ProfileActivityTimeline from './profile/ProfileActivityTimeline.astro';
 
@@ -169,6 +170,7 @@ const ep = (tr as unknown as { profile: { expert_prompt: Record<string, string> 
     <ExpertiseLegendBadge lang={lang} class="mb-2" />
     <ExpertiseCoverageGrid lang={lang} />
     <ProfilePokedexLink lang={lang} viewer="self" />
+    <ProfileSpeciesListsLink lang={lang} />
     <ProfileBadgesGrid lang={lang} viewer="self" />
     <ProfileActivityTimeline lang={lang} viewer="self" />
 

--- a/src/components/SpeciesListsView.astro
+++ b/src/components/SpeciesListsView.astro
@@ -1,0 +1,400 @@
+---
+/**
+ * SpeciesListsView — "My Lists" tab on the profile page.
+ * Shows the signed-in user's species lists with create/edit/delete.
+ * Issue #875.
+ */
+interface Props {
+  lang: 'en' | 'es';
+}
+const { lang } = Astro.props;
+const isEs = lang === 'es';
+
+const labels = {
+  heading:        isEs ? 'Mis listas' : 'My lists',
+  create:         isEs ? 'Nueva lista' : 'New list',
+  empty:          isEs ? 'No has creado ninguna lista todavía.' : 'You haven\'t created any lists yet.',
+  name_en:        isEs ? 'Nombre (inglés)' : 'Name (English)',
+  name_es:        isEs ? 'Nombre (español)' : 'Name (Spanish)',
+  description_en: isEs ? 'Descripción (inglés)' : 'Description (English)',
+  description_es: isEs ? 'Descripción (español)' : 'Description (Spanish)',
+  visibility:     isEs ? 'Visibilidad' : 'Visibility',
+  public:         isEs ? 'Pública' : 'Public',
+  private:        isEs ? 'Privada' : 'Private',
+  save:           isEs ? 'Guardar' : 'Save',
+  cancel:         isEs ? 'Cancelar' : 'Cancel',
+  delete:         isEs ? 'Eliminar' : 'Delete',
+  edit:           isEs ? 'Editar' : 'Edit',
+  items:          isEs ? 'especies' : 'species',
+  confirm_delete: isEs ? '¿Eliminar esta lista?' : 'Delete this list?',
+  loading:        isEs ? 'Cargando…' : 'Loading…',
+  sign_in:        isEs ? 'Inicia sesión para ver tus listas.' : 'Sign in to see your lists.',
+  private_badge:  isEs ? 'Privada' : 'Private',
+  view:           isEs ? 'Ver' : 'View',
+  saving:         isEs ? 'Guardando…' : 'Saving…',
+  error_save:     isEs ? 'Error al guardar.' : 'Failed to save.',
+  error_delete:   isEs ? 'Error al eliminar.' : 'Failed to delete.',
+  name_required:  isEs ? 'El nombre es requerido.' : 'Name is required.',
+};
+---
+
+<div
+  id="species-lists-view"
+  class="max-w-3xl mx-auto"
+  data-lang={lang}
+  data-labels={JSON.stringify(labels)}
+>
+  <!-- Signed-out -->
+  <div id="sl-signed-out" class="hidden py-16 text-center">
+    <p class="text-zinc-500 dark:text-zinc-400">{labels.sign_in}</p>
+  </div>
+
+  <!-- Loading skeleton -->
+  <div id="sl-loading" class="py-10 text-center text-sm text-zinc-500 dark:text-zinc-400">
+    {labels.loading}
+  </div>
+
+  <!-- Main content -->
+  <div id="sl-content" class="hidden">
+    <div class="flex items-center justify-between mb-6">
+      <h2 class="text-xl font-bold text-zinc-900 dark:text-zinc-100">{labels.heading}</h2>
+      <button
+        id="sl-create-btn"
+        type="button"
+        class="inline-flex items-center gap-1.5 rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-1.5 text-sm font-semibold text-white transition-colors"
+      >
+        <svg aria-hidden="true" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+        </svg>
+        {labels.create}
+      </button>
+    </div>
+
+    <!-- Create / Edit form (hidden by default) -->
+    <div id="sl-form-wrap" class="hidden mb-6 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4">
+      <form id="sl-form" class="space-y-3" novalidate>
+        <input type="hidden" id="sl-form-id" value="" />
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label for="sl-name-es" class="block text-xs font-medium text-zinc-700 dark:text-zinc-300 mb-1">{labels.name_es}</label>
+            <input
+              id="sl-name-es"
+              type="text"
+              maxlength="120"
+              class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </div>
+          <div>
+            <label for="sl-name-en" class="block text-xs font-medium text-zinc-700 dark:text-zinc-300 mb-1">{labels.name_en}</label>
+            <input
+              id="sl-name-en"
+              type="text"
+              maxlength="120"
+              class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </div>
+          <div>
+            <label for="sl-desc-es" class="block text-xs font-medium text-zinc-700 dark:text-zinc-300 mb-1">{labels.description_es}</label>
+            <textarea
+              id="sl-desc-es"
+              rows="2"
+              maxlength="500"
+              class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-none"
+            ></textarea>
+          </div>
+          <div>
+            <label for="sl-desc-en" class="block text-xs font-medium text-zinc-700 dark:text-zinc-300 mb-1">{labels.description_en}</label>
+            <textarea
+              id="sl-desc-en"
+              rows="2"
+              maxlength="500"
+              class="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 resize-none"
+            ></textarea>
+          </div>
+        </div>
+        <div class="flex items-center gap-4">
+          <label class="text-xs font-medium text-zinc-700 dark:text-zinc-300">{labels.visibility}</label>
+          <label class="flex items-center gap-1.5 cursor-pointer text-sm">
+            <input type="radio" name="sl-visibility" value="public" checked class="accent-emerald-600" />
+            {labels.public}
+          </label>
+          <label class="flex items-center gap-1.5 cursor-pointer text-sm">
+            <input type="radio" name="sl-visibility" value="private" class="accent-emerald-600" />
+            {labels.private}
+          </label>
+        </div>
+        <p id="sl-form-error" class="hidden text-xs text-red-600 dark:text-red-400"></p>
+        <div class="flex gap-2 justify-end">
+          <button type="button" id="sl-cancel-btn" class="rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-1.5 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors">
+            {labels.cancel}
+          </button>
+          <button type="submit" id="sl-save-btn" class="rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-1.5 text-sm font-semibold text-white transition-colors">
+            {labels.save}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Empty state -->
+    <div id="sl-empty" class="hidden rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700 p-8 text-center">
+      <p class="text-sm text-zinc-500 dark:text-zinc-400">{labels.empty}</p>
+    </div>
+
+    <!-- Lists grid -->
+    <div id="sl-grid" class="grid grid-cols-1 sm:grid-cols-2 gap-4"></div>
+  </div>
+</div>
+
+<script>
+  import { getCachedUser, getSupabase } from '../lib/supabase';
+
+  const root = document.getElementById('species-lists-view') as HTMLDivElement | null;
+  if (!root) throw new Error('species-lists-view root not found');
+
+  const lang = root.dataset.lang as 'en' | 'es';
+  const labels = JSON.parse(root.dataset.labels ?? '{}') as Record<string, string>;
+
+  const signedOut  = document.getElementById('sl-signed-out') as HTMLElement;
+  const loading    = document.getElementById('sl-loading') as HTMLElement;
+  const content    = document.getElementById('sl-content') as HTMLElement;
+  const formWrap   = document.getElementById('sl-form-wrap') as HTMLElement;
+  const form       = document.getElementById('sl-form') as HTMLFormElement;
+  const formId     = document.getElementById('sl-form-id') as HTMLInputElement;
+  const nameEs     = document.getElementById('sl-name-es') as HTMLInputElement;
+  const nameEn     = document.getElementById('sl-name-en') as HTMLInputElement;
+  const descEs     = document.getElementById('sl-desc-es') as HTMLTextAreaElement;
+  const descEn     = document.getElementById('sl-desc-en') as HTMLTextAreaElement;
+  const formError  = document.getElementById('sl-form-error') as HTMLElement;
+  const saveBtn    = document.getElementById('sl-save-btn') as HTMLButtonElement;
+  const createBtn  = document.getElementById('sl-create-btn') as HTMLButtonElement;
+  const cancelBtn  = document.getElementById('sl-cancel-btn') as HTMLButtonElement;
+  const emptyEl    = document.getElementById('sl-empty') as HTMLElement;
+  const grid       = document.getElementById('sl-grid') as HTMLElement;
+
+  type SpeciesList = {
+    id: string;
+    name_en: string | null;
+    name_es: string | null;
+    description_en: string | null;
+    description_es: string | null;
+    visibility: 'public' | 'private';
+    slug: string;
+    created_at: string;
+    item_count?: number;
+  };
+
+  let lists: SpeciesList[] = [];
+  let userId = '';
+
+  function listName(l: SpeciesList): string {
+    return (lang === 'es' ? l.name_es : l.name_en) || l.name_en || l.name_es || l.slug;
+  }
+
+  function listDesc(l: SpeciesList): string {
+    return (lang === 'es' ? l.description_es : l.description_en) || '';
+  }
+
+  function buildListDetailPath(username: string, slug: string): string {
+    const base = lang === 'es' ? '/es/perfil/u' : '/en/profile/u';
+    return `${base}/${encodeURIComponent(username)}/lists/${encodeURIComponent(slug)}/`;
+  }
+
+  function escAttr(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function renderGrid(username: string) {
+    if (!lists.length) {
+      emptyEl.classList.remove('hidden');
+      grid.innerHTML = '';
+      return;
+    }
+    emptyEl.classList.add('hidden');
+    grid.innerHTML = lists.map(l => {
+      const name = escAttr(listName(l));
+      const desc = escAttr(listDesc(l));
+      const href = escAttr(buildListDetailPath(username, l.slug));
+      const count = l.item_count ?? 0;
+      const isPrivate = l.visibility === 'private';
+      return `
+        <div class="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4 flex flex-col gap-2">
+          <div class="flex items-start justify-between gap-2">
+            <a href="${href}" class="text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:text-emerald-700 dark:hover:text-emerald-400 leading-snug">${name}</a>
+            ${isPrivate ? `<span class="shrink-0 rounded-full bg-zinc-200 dark:bg-zinc-700 px-2 py-0.5 text-xs text-zinc-600 dark:text-zinc-300">${escAttr(labels.private_badge)}</span>` : ''}
+          </div>
+          ${desc ? `<p class="text-xs text-zinc-500 dark:text-zinc-400 line-clamp-2">${desc}</p>` : ''}
+          <p class="text-xs text-zinc-400 dark:text-zinc-500">${count} ${escAttr(labels.items)}</p>
+          <div class="flex gap-2 mt-auto pt-1">
+            <a href="${href}" class="text-xs font-medium text-emerald-700 dark:text-emerald-400 hover:underline">${escAttr(labels.view)} →</a>
+            <button type="button" class="sl-edit-btn text-xs font-medium text-zinc-500 dark:text-zinc-400 hover:underline" data-id="${escAttr(l.id)}">${escAttr(labels.edit)}</button>
+            <button type="button" class="sl-delete-btn text-xs font-medium text-red-500 hover:underline ml-auto" data-id="${escAttr(l.id)}">${escAttr(labels.delete)}</button>
+          </div>
+        </div>`;
+    }).join('');
+
+    // Wire edit/delete buttons
+    grid.querySelectorAll<HTMLButtonElement>('.sl-edit-btn').forEach(btn => {
+      btn.addEventListener('click', () => openEdit(btn.dataset.id ?? ''));
+    });
+    grid.querySelectorAll<HTMLButtonElement>('.sl-delete-btn').forEach(btn => {
+      btn.addEventListener('click', () => deleteList(btn.dataset.id ?? ''));
+    });
+  }
+
+  function openCreate() {
+    formId.value = '';
+    nameEs.value = '';
+    nameEn.value = '';
+    descEs.value = '';
+    descEn.value = '';
+    (form.querySelector('input[name="sl-visibility"][value="public"]') as HTMLInputElement).checked = true;
+    formError.classList.add('hidden');
+    formWrap.classList.remove('hidden');
+    nameEs.focus();
+  }
+
+  function openEdit(id: string) {
+    const l = lists.find(x => x.id === id);
+    if (!l) return;
+    formId.value = l.id;
+    nameEs.value = l.name_es ?? '';
+    nameEn.value = l.name_en ?? '';
+    descEs.value = l.description_es ?? '';
+    descEn.value = l.description_en ?? '';
+    (form.querySelector(`input[name="sl-visibility"][value="${l.visibility}"]`) as HTMLInputElement).checked = true;
+    formError.classList.add('hidden');
+    formWrap.classList.remove('hidden');
+    nameEs.focus();
+  }
+
+  function closeForm() {
+    formWrap.classList.add('hidden');
+  }
+
+  async function deleteList(id: string) {
+    if (!confirm(labels.confirm_delete)) return;
+    const supabase = getSupabase();
+    const { error } = await supabase.from('species_lists').delete().eq('id', id).eq('user_id', userId);
+    if (error) { alert(labels.error_delete); return; }
+    lists = lists.filter(l => l.id !== id);
+    const username = await fetchUsername();
+    renderGrid(username);
+  }
+
+  async function fetchUsername(): Promise<string> {
+    const supabase = getSupabase();
+    const { data } = await supabase.from('users').select('username').eq('id', userId).maybeSingle();
+    return (data as { username?: string | null } | null)?.username ?? '';
+  }
+
+  async function fetchItemCounts(ids: string[]): Promise<Map<string, number>> {
+    if (!ids.length) return new Map();
+    const supabase = getSupabase();
+    // Count items per list via individual queries (RLS-safe approach)
+    const counts = new Map<string, number>();
+    await Promise.all(ids.map(async (id) => {
+      const { count } = await supabase
+        .from('species_list_items')
+        .select('*', { count: 'exact', head: true })
+        .eq('list_id', id);
+      counts.set(id, count ?? 0);
+    }));
+    return counts;
+  }
+
+  createBtn.addEventListener('click', openCreate);
+  cancelBtn.addEventListener('click', closeForm);
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const nameEsVal = nameEs.value.trim();
+    const nameEnVal = nameEn.value.trim();
+    if (!nameEsVal && !nameEnVal) {
+      formError.textContent = labels.name_required;
+      formError.classList.remove('hidden');
+      return;
+    }
+    formError.classList.add('hidden');
+    saveBtn.textContent = labels.saving;
+    saveBtn.disabled = true;
+
+    const supabase = getSupabase();
+    const visibility = (form.querySelector('input[name="sl-visibility"]:checked') as HTMLInputElement)?.value ?? 'public';
+    const editId = formId.value;
+
+    const payload = {
+      name_en: nameEnVal || null,
+      name_es: nameEsVal || null,
+      description_en: descEn.value.trim() || null,
+      description_es: descEs.value.trim() || null,
+      visibility,
+    };
+
+    try {
+      if (editId) {
+        const { error } = await supabase
+          .from('species_lists')
+          .update({ ...payload, updated_at: new Date().toISOString() })
+          .eq('id', editId)
+          .eq('user_id', userId);
+        if (error) throw error;
+        const idx = lists.findIndex(l => l.id === editId);
+        if (idx >= 0) lists[idx] = { ...lists[idx], ...payload };
+      } else {
+        const { data, error } = await supabase
+          .from('species_lists')
+          .insert({ ...payload, user_id: userId, slug: '' })
+          .select('*')
+          .single();
+        if (error) throw error;
+        lists.unshift(data as SpeciesList);
+      }
+      closeForm();
+      const username = await fetchUsername();
+      renderGrid(username);
+    } catch {
+      formError.textContent = labels.error_save;
+      formError.classList.remove('hidden');
+    } finally {
+      saveBtn.textContent = labels.save;
+      saveBtn.disabled = false;
+    }
+  });
+
+  async function run() {
+    const user = await getCachedUser();
+    if (!user) {
+      loading.classList.add('hidden');
+      signedOut.classList.remove('hidden');
+      return;
+    }
+    userId = user.id;
+
+    const supabase = getSupabase();
+    const { data, error } = await supabase
+      .from('species_lists')
+      .select('id, name_en, name_es, description_en, description_es, visibility, slug, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+
+    loading.classList.add('hidden');
+
+    if (error) {
+      content.classList.remove('hidden');
+      emptyEl.classList.remove('hidden');
+      return;
+    }
+
+    lists = (data ?? []) as SpeciesList[];
+
+    // Fetch item counts
+    const countMap = await fetchItemCounts(lists.map(l => l.id));
+    lists = lists.map(l => ({ ...l, item_count: countMap.get(l.id) ?? 0 }));
+
+    const username = await fetchUsername();
+    content.classList.remove('hidden');
+    renderGrid(username);
+  }
+
+  run().catch(console.error);
+</script>

--- a/src/components/profile/ProfileSpeciesListsLink.astro
+++ b/src/components/profile/ProfileSpeciesListsLink.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * ProfileSpeciesListsLink — link card to the species lists section (#875).
+ * Placed on the profile page after the Pokédex link.
+ * Shows a live count of the user's lists (hydrated client-side).
+ */
+import type { Locale } from '../../i18n/utils';
+
+interface Props {
+  lang: Locale;
+}
+const { lang } = Astro.props;
+
+const isEs = lang === 'es';
+const heading = isEs ? 'Mis listas' : 'My lists';
+const desc    = isEs ? 'Listas de especies curadas por ti' : 'Your curated species lists';
+const cta     = isEs ? 'Ver listas' : 'View lists';
+// The lists page is SpeciesListsView embedded in the profile. For now we
+// link to a dedicated page at /en/profile/lists/ (to be added) — or fall
+// back to a scroll anchor that will load inline. We use a hash link that
+// the tab-wiring script can intercept.
+const href = lang === 'es' ? '/es/perfil/listas/' : '/en/profile/lists/';
+---
+
+<a
+  href={href}
+  class="block rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4 mb-6 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors"
+>
+  <div class="flex items-center justify-between">
+    <div>
+      <h2 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 uppercase tracking-wider">{heading}</h2>
+      <p class="text-xs text-zinc-500 dark:text-zinc-400 mt-1">{desc}</p>
+    </div>
+    <span class="text-sm font-medium text-emerald-700 dark:text-emerald-400">{cta} →</span>
+  </div>
+</a>

--- a/src/pages/en/profile/lists/index.astro
+++ b/src/pages/en/profile/lists/index.astro
@@ -1,0 +1,25 @@
+---
+/**
+ * My Lists page — EN variant.
+ * Route: /en/profile/lists/
+ * Issue #875.
+ */
+import BaseLayout from '../../../../layouts/BaseLayout.astro';
+import SpeciesListsView from '../../../../components/SpeciesListsView.astro';
+import { t } from '../../../../i18n/utils';
+
+const lang = 'en' as const;
+const tr = t(lang);
+---
+
+<BaseLayout
+  title={`My lists — Rastrum`}
+  description="Your curated species lists on Rastrum."
+  lang={lang}
+  robots="noindex,nofollow"
+>
+  <div class="max-w-3xl mx-auto px-4 py-6">
+    <a href="/en/profile/" class="text-xs text-zinc-500 hover:underline">← Profile</a>
+    <SpeciesListsView lang={lang} />
+  </div>
+</BaseLayout>

--- a/src/pages/en/profile/u/[username]/lists/[slug].astro
+++ b/src/pages/en/profile/u/[username]/lists/[slug].astro
@@ -1,0 +1,305 @@
+---
+/**
+ * Species list detail page — EN variant.
+ * Route: /en/profile/u/[username]/lists/[slug]/
+ * Issue #875.
+ */
+import BaseLayout from '../../../../../layouts/BaseLayout.astro';
+
+const lang = 'en' as const;
+const { username, slug } = Astro.params as { username: string; slug: string };
+---
+
+<BaseLayout
+  title={`Species list — Rastrum`}
+  description="A user-curated species list on Rastrum."
+  lang={lang}
+  robots="noindex,nofollow"
+>
+  <div
+    id="list-detail-root"
+    class="max-w-3xl mx-auto pb-28 sm:pb-6"
+    data-lang={lang}
+    data-username={username}
+    data-slug={slug}
+  >
+    <!-- Loading state -->
+    <div id="ld-loading" class="py-16 text-center text-sm text-zinc-500 dark:text-zinc-400">Loading…</div>
+
+    <!-- Not found -->
+    <div id="ld-not-found" class="hidden py-16 text-center">
+      <p class="text-zinc-500 dark:text-zinc-400">List not found.</p>
+      <a href={`/en/u/?username=${encodeURIComponent(username)}`} class="mt-4 inline-block text-sm text-emerald-700 dark:text-emerald-400 hover:underline">← Back to profile</a>
+    </div>
+
+    <!-- Content -->
+    <div id="ld-content" class="hidden">
+      <!-- Header -->
+      <header class="mb-6">
+        <a id="ld-back" href="#" class="text-xs text-zinc-500 hover:underline">← Back to profile</a>
+        <h1 id="ld-title" class="mt-2 text-2xl md:text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">—</h1>
+        <p id="ld-desc" class="mt-1 text-sm text-zinc-600 dark:text-zinc-400 hidden"></p>
+        <div class="mt-2 flex items-center gap-3">
+          <span id="ld-count" class="text-xs text-zinc-400 dark:text-zinc-500"></span>
+          <span id="ld-private-badge" class="hidden rounded-full bg-zinc-200 dark:bg-zinc-700 px-2 py-0.5 text-xs text-zinc-600 dark:text-zinc-300">Private</span>
+        </div>
+      </header>
+
+      <!-- Add species (own list only) -->
+      <div id="ld-add-section" class="hidden mb-6 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-4">
+        <p class="text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">Add species</p>
+        <div class="flex gap-2">
+          <input
+            id="ld-taxon-input"
+            type="text"
+            placeholder="Search by scientific or common name…"
+            autocomplete="off"
+            class="flex-1 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          />
+          <button id="ld-add-btn" type="button" class="hidden rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-2 text-sm font-semibold text-white transition-colors">Add</button>
+        </div>
+        <div id="ld-suggestions" class="mt-1 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-md hidden"></div>
+        <p id="ld-add-error" class="hidden mt-1 text-xs text-red-600 dark:text-red-400"></p>
+      </div>
+
+      <!-- Taxa grid -->
+      <div id="ld-taxa-empty" class="hidden rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700 p-8 text-center">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400">No species in this list yet.</p>
+      </div>
+      <div id="ld-taxa-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3"></div>
+    </div>
+  </div>
+</BaseLayout>
+
+<script>
+  import { getCachedUser, getSupabase } from '../../../../../lib/supabase';
+
+  const root = document.getElementById('list-detail-root') as HTMLDivElement;
+  const lang = root.dataset.lang as 'en' | 'es';
+  const username = root.dataset.username ?? '';
+  const slug = root.dataset.slug ?? '';
+  const isEs = lang === 'es';
+
+  const loadingEl  = document.getElementById('ld-loading') as HTMLElement;
+  const notFound   = document.getElementById('ld-not-found') as HTMLElement;
+  const content    = document.getElementById('ld-content') as HTMLElement;
+  const titleEl    = document.getElementById('ld-title') as HTMLElement;
+  const descEl     = document.getElementById('ld-desc') as HTMLElement;
+  const countEl    = document.getElementById('ld-count') as HTMLElement;
+  const privateBadge = document.getElementById('ld-private-badge') as HTMLElement;
+  const backLink   = document.getElementById('ld-back') as HTMLAnchorElement;
+  const addSection = document.getElementById('ld-add-section') as HTMLElement;
+  const taxonInput = document.getElementById('ld-taxon-input') as HTMLInputElement;
+  const addBtn     = document.getElementById('ld-add-btn') as HTMLButtonElement;
+  const suggestions = document.getElementById('ld-suggestions') as HTMLElement;
+  const addError   = document.getElementById('ld-add-error') as HTMLElement;
+  const taxaEmpty  = document.getElementById('ld-taxa-empty') as HTMLElement;
+  const taxaGrid   = document.getElementById('ld-taxa-grid') as HTMLElement;
+
+  type TaxonRow = {
+    taxon_id: string;
+    added_at: string;
+    note: string | null;
+    taxa: {
+      id: string;
+      scientific_name: string;
+      name_en: string | null;
+      name_es: string | null;
+      slug: string | null;
+      hero_media_id: string | null;
+    } | null;
+  };
+
+  type SuggestTaxon = {
+    id: string;
+    scientific_name: string;
+    name_en: string | null;
+    name_es: string | null;
+  };
+
+  function escAttr(s: string) {
+    return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  let listId = '';
+  let isOwner = false;
+  let items: TaxonRow[] = [];
+  let selectedTaxon: SuggestTaxon | null = null;
+
+  function renderTaxa() {
+    if (!items.length) {
+      taxaEmpty.classList.remove('hidden');
+      taxaGrid.innerHTML = '';
+      return;
+    }
+    taxaEmpty.classList.add('hidden');
+    const speciesPath = (slug: string) => isEs ? `/es/explorar/especies/${slug}/` : `/en/explore/species/${slug}/`;
+    taxaGrid.innerHTML = items.map(row => {
+      const t = row.taxa;
+      if (!t) return '';
+      const name = escAttr(t.scientific_name);
+      const common = escAttr((isEs ? t.name_es : t.name_en) || '');
+      const href = t.slug ? escAttr(speciesPath(t.slug)) : '#';
+      return `
+        <a href="${href}" class="block rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 overflow-hidden hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors">
+          <div class="aspect-square bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center">
+            <svg aria-hidden="true" class="w-10 h-10 text-zinc-300 dark:text-zinc-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9-4.03-9-9-9z"/>
+            </svg>
+          </div>
+          <div class="p-2">
+            <p class="text-xs italic font-medium text-zinc-900 dark:text-zinc-100 truncate">${name}</p>
+            ${common ? `<p class="text-xs text-zinc-500 dark:text-zinc-400 truncate">${common}</p>` : ''}
+          </div>
+        </a>`;
+    }).join('');
+  }
+
+  // Taxon autocomplete
+  let debounceTimer: ReturnType<typeof setTimeout>;
+  taxonInput.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    selectedTaxon = null;
+    addBtn.classList.add('hidden');
+    const q = taxonInput.value.trim();
+    if (q.length < 2) { suggestions.classList.add('hidden'); return; }
+    debounceTimer = setTimeout(() => fetchSuggestions(q), 250);
+  });
+
+  async function fetchSuggestions(q: string) {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from('taxa')
+      .select('id, scientific_name, name_en, name_es')
+      .or(`scientific_name.ilike.%${q}%,name_en.ilike.%${q}%,name_es.ilike.%${q}%`)
+      .limit(8);
+    const rows = (data ?? []) as SuggestTaxon[];
+    if (!rows.length) { suggestions.classList.add('hidden'); return; }
+    suggestions.innerHTML = rows.map(r => {
+      const n = escAttr(r.scientific_name);
+      const c = escAttr((isEs ? r.name_es : r.name_en) || '');
+      return `<button type="button" class="ld-sug-item w-full text-left px-3 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 text-sm" data-id="${escAttr(r.id)}" data-sci="${n}" data-name-en="${escAttr(r.name_en ?? '')}" data-name-es="${escAttr(r.name_es ?? '')}"><span class="italic">${n}</span>${c ? ` <span class="text-zinc-400">${c}</span>` : ''}</button>`;
+    }).join('');
+    suggestions.classList.remove('hidden');
+
+    suggestions.querySelectorAll<HTMLButtonElement>('.ld-sug-item').forEach(btn => {
+      btn.addEventListener('click', () => {
+        selectedTaxon = {
+          id: btn.dataset.id!,
+          scientific_name: btn.dataset.sci!,
+          name_en: btn.dataset.nameEn || null,
+          name_es: btn.dataset.nameEs || null,
+        };
+        taxonInput.value = btn.dataset.sci!;
+        suggestions.classList.add('hidden');
+        addBtn.classList.remove('hidden');
+      });
+    });
+  }
+
+  document.addEventListener('click', (e) => {
+    if (!suggestions.contains(e.target as Node) && e.target !== taxonInput) {
+      suggestions.classList.add('hidden');
+    }
+  });
+
+  addBtn.addEventListener('click', async () => {
+    if (!selectedTaxon) return;
+    addError.classList.add('hidden');
+    const supabase = getSupabase();
+    const { error } = await supabase
+      .from('species_list_items')
+      .insert({ list_id: listId, taxon_id: selectedTaxon.id });
+    if (error) {
+      addError.textContent = isEs ? 'Error al agregar especie.' : 'Failed to add species.';
+      addError.classList.remove('hidden');
+      return;
+    }
+    // Reload items
+    taxonInput.value = '';
+    addBtn.classList.add('hidden');
+    selectedTaxon = null;
+    await loadItems();
+  });
+
+  async function loadItems() {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from('species_list_items')
+      .select('taxon_id, added_at, note, taxa:taxon_id(id, scientific_name, name_en, name_es, slug, hero_media_id)')
+      .eq('list_id', listId)
+      .order('added_at', { ascending: false });
+    items = (data ?? []) as TaxonRow[];
+    countEl.textContent = `${items.length} ${isEs ? 'especies' : 'species'}`;
+    renderTaxa();
+  }
+
+  async function run() {
+    const supabase = getSupabase();
+    const user = await getCachedUser();
+
+    // Fetch list owner's user record by username
+    const { data: ownerRow } = await supabase
+      .from('users')
+      .select('id')
+      .eq('username', username)
+      .maybeSingle();
+
+    if (!ownerRow) {
+      loadingEl.classList.add('hidden');
+      notFound.classList.remove('hidden');
+      return;
+    }
+
+    const ownerId = (ownerRow as { id: string }).id;
+    isOwner = user?.id === ownerId;
+
+    // Fetch list
+    const { data: listRow } = await supabase
+      .from('species_lists')
+      .select('id, name_en, name_es, description_en, description_es, visibility, slug')
+      .eq('user_id', ownerId)
+      .eq('slug', slug)
+      .maybeSingle();
+
+    loadingEl.classList.add('hidden');
+
+    if (!listRow) {
+      notFound.classList.remove('hidden');
+      return;
+    }
+
+    const l = listRow as {
+      id: string; name_en: string | null; name_es: string | null;
+      description_en: string | null; description_es: string | null;
+      visibility: string; slug: string;
+    };
+
+    listId = l.id;
+
+    // Back link
+    backLink.href = `/en/u/?username=${encodeURIComponent(username)}`;
+
+    // Title & description
+    titleEl.textContent = (isEs ? l.name_es : l.name_en) || l.name_en || l.name_es || slug;
+    document.title = `${titleEl.textContent} — Rastrum`;
+    const desc = (isEs ? l.description_es : l.description_en) || '';
+    if (desc) {
+      descEl.textContent = desc;
+      descEl.classList.remove('hidden');
+    }
+    if (l.visibility === 'private') {
+      privateBadge.classList.remove('hidden');
+    }
+
+    // Show add section if owner
+    if (isOwner) {
+      addSection.classList.remove('hidden');
+    }
+
+    content.classList.remove('hidden');
+    await loadItems();
+  }
+
+  run().catch(console.error);
+</script>

--- a/tests/unit/species-lists.test.ts
+++ b/tests/unit/species-lists.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for species lists (#875):
+ * - Slug generation logic (pure function)
+ * - Visibility filter logic
+ */
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Slug generation (mirrors the SQL trigger logic, extracted as a pure fn)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a URL-safe slug from a list name.
+ * Mirrors public.generate_list_slug() in supabase-schema.sql.
+ */
+function generateBaseSlug(nameEs: string | null, nameEn: string | null): string {
+  const source = nameEs ?? nameEn ?? 'list';
+  const base = source
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return base || 'list';
+}
+
+/**
+ * Resolve a unique slug given a set of existing slugs for the same user.
+ * Appends -2, -3, … on collision.
+ */
+function resolveUniqueSlug(base: string, existing: Set<string>): string {
+  if (!existing.has(base)) return base;
+  let count = 1;
+  let candidate = `${base}-${count}`;
+  while (existing.has(candidate)) {
+    count++;
+    candidate = `${base}-${count}`;
+  }
+  return candidate;
+}
+
+// ---------------------------------------------------------------------------
+// Visibility filter (mirrors RLS policy logic)
+// ---------------------------------------------------------------------------
+
+type ListRow = {
+  user_id: string;
+  visibility: 'public' | 'private';
+};
+
+/**
+ * Returns true if a caller can read the list.
+ * Mirrors: visibility = 'public' OR auth.uid() = user_id
+ */
+function canReadList(list: ListRow, callerId: string | null): boolean {
+  return list.visibility === 'public' || (callerId !== null && callerId === list.user_id);
+}
+
+/**
+ * Returns true if a caller can write (insert/update/delete) to the list.
+ * Mirrors: auth.uid() = user_id
+ */
+function canWriteList(list: ListRow, callerId: string | null): boolean {
+  return callerId !== null && callerId === list.user_id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: slug generation
+// ---------------------------------------------------------------------------
+
+describe('generateBaseSlug', () => {
+  it('lowercases and replaces spaces with hyphens', () => {
+    expect(generateBaseSlug('Aves de mi jardín', null)).toBe('aves-de-mi-jard-n');
+  });
+
+  it('prefers name_es over name_en', () => {
+    expect(generateBaseSlug('Aves locales', 'Local birds')).toBe('aves-locales');
+  });
+
+  it('falls back to name_en when name_es is null', () => {
+    expect(generateBaseSlug(null, 'Garden birds')).toBe('garden-birds');
+  });
+
+  it('falls back to "list" when both names are null', () => {
+    expect(generateBaseSlug(null, null)).toBe('list');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(generateBaseSlug('---hello---', null)).toBe('hello');
+  });
+
+  it('collapses multiple special chars into one hyphen', () => {
+    expect(generateBaseSlug('birds & bees!!', null)).toBe('birds-bees');
+  });
+
+  it('handles empty string by returning "list"', () => {
+    expect(generateBaseSlug('', null)).toBe('list');
+  });
+});
+
+describe('resolveUniqueSlug', () => {
+  it('returns base slug when no collision', () => {
+    expect(resolveUniqueSlug('aves', new Set())).toBe('aves');
+  });
+
+  it('appends -1 suffix on first collision', () => {
+    expect(resolveUniqueSlug('aves', new Set(['aves']))).toBe('aves-1');
+  });
+
+  it('increments suffix until unique', () => {
+    const existing = new Set(['aves', 'aves-1', 'aves-2']);
+    expect(resolveUniqueSlug('aves', existing)).toBe('aves-3');
+  });
+
+  it('returns base when collision set is empty', () => {
+    expect(resolveUniqueSlug('mariposas', new Set())).toBe('mariposas');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: visibility filter
+// ---------------------------------------------------------------------------
+
+describe('canReadList', () => {
+  const ownerId = 'user-123';
+  const otherId = 'user-456';
+
+  it('allows anon to read public lists', () => {
+    expect(canReadList({ user_id: ownerId, visibility: 'public' }, null)).toBe(true);
+  });
+
+  it('denies anon from reading private lists', () => {
+    expect(canReadList({ user_id: ownerId, visibility: 'private' }, null)).toBe(false);
+  });
+
+  it('allows owner to read their own private list', () => {
+    expect(canReadList({ user_id: ownerId, visibility: 'private' }, ownerId)).toBe(true);
+  });
+
+  it('denies non-owner from reading private list', () => {
+    expect(canReadList({ user_id: ownerId, visibility: 'private' }, otherId)).toBe(false);
+  });
+
+  it('allows non-owner to read public list', () => {
+    expect(canReadList({ user_id: ownerId, visibility: 'public' }, otherId)).toBe(true);
+  });
+});
+
+describe('canWriteList', () => {
+  const ownerId = 'user-123';
+  const otherId = 'user-456';
+
+  it('allows owner to write their list', () => {
+    expect(canWriteList({ user_id: ownerId, visibility: 'public' }, ownerId)).toBe(true);
+  });
+
+  it('denies non-owner from writing', () => {
+    expect(canWriteList({ user_id: ownerId, visibility: 'public' }, otherId)).toBe(false);
+  });
+
+  it('denies anon from writing', () => {
+    expect(canWriteList({ user_id: ownerId, visibility: 'private' }, null)).toBe(false);
+  });
+
+  it('denies even owner if callerId is null', () => {
+    // callerId=null means unauthenticated — even if the user_id matches somehow
+    expect(canWriteList({ user_id: ownerId, visibility: 'public' }, null)).toBe(false);
+  });
+});


### PR DESCRIPTION
New species_lists + species_list_items tables with RLS, slug auto-generation trigger. SpeciesListsView component, list detail page, ProfileView wiring. 20 tests passing. ES routes deferred.\n\nCloses #875