### PR TITLE
chore: actions v5 bump, HF transformers mock doc, identifier-state/AI-tab/spec fixes (#686 #648 #717 #718 #719)

### DIFF
--- a/.github/workflows/admin-observability-dryrun.yml
+++ b/.github/workflows/admin-observability-dryrun.yml
@@ -24,7 +24,7 @@ jobs:
   dryrun:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install psql client
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -94,8 +94,8 @@ jobs:
   #       image: supabase/postgres:17.6.0.0
   #       ports: ['5432:5432']
   #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v4
+  #     - uses: actions/checkout@v5
+  #     - uses: actions/setup-node@v5
   #       with: { node-version: '22', cache: npm }
   #     - run: npm ci
   #     - run: npm run lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -34,7 +34,7 @@ jobs:
           queries: security-extended
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/db-apply.yml
+++ b/.github/workflows/db-apply.yml
@@ -63,7 +63,7 @@ jobs:
     env:
       PGCONNECT_TIMEOUT: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/db-validate.yml
+++ b/.github/workflows/db-validate.yml
@@ -65,7 +65,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/rastrum_test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Stub Supabase auth schema and helpers
         # The schema references auth.uid() and auth.users (Supabase managed).

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -65,7 +65,7 @@ jobs:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       PROJECT_REF: reppvlqejgoqvitturxp
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Need at least 2 commits so we can diff against the parent on push.
           fetch-depth: 2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -108,7 +108,7 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Smoke-test model asset URLs
         run: bash infra/smoke-model-assets.sh
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always() && failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload LHCI artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lighthouseci
           path: .lighthouseci/

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nightly-smoke-results
           path: |

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Apply labels from .github/labels.yml
         uses: crazy-max/ghaction-github-labeler@v5

--- a/.github/workflows/tauri-android.yml
+++ b/.github/workflows/tauri-android.yml
@@ -31,12 +31,12 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm
@@ -174,7 +174,7 @@ jobs:
           status: completed
 
       - name: Upload AAB artifact (CI archive)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rastrum-android-aab
           path: src-tauri/gen/android/app/build/outputs/bundle/**/*.aab

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run GitHub Models classifier
         id: classify

--- a/.github/workflows/vision-providers-smoke.yml
+++ b/.github/workflows/vision-providers-smoke.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2

--- a/.github/workflows/wdpa-import.yml
+++ b/.github/workflows/wdpa-import.yml
@@ -36,12 +36,12 @@ jobs:
     timeout-minutes: 60    # WDPA archive is ~500 MB; allow generous time
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install GDAL (ogr2ogr)
         run: sudo apt-get install -y --no-install-recommends gdal-bin
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: npm

--- a/docs/superpowers/specs/2026-05-07-ai-tab-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-07-ai-tab-redesign-design.md
@@ -57,11 +57,17 @@ A TypeScript template function `renderPluginCard(props): string` lives in `src/l
 export interface PluginCardProps {
   lang: 'en' | 'es';
   plugin: Identifier;                    // from src/lib/identifiers/types.ts
-  availability: AvailabilityResult;      // pre-resolved by paintRegistry
-  isDisabled: boolean;                   // from rastrum.disabledPlugins
-  cacheStatus?: ModelCacheStatus | null; // for on-device plugins
+  // NOTE (#719): the implementation uses `state: CardState` (pre-derived via
+  // deriveCardState()) instead of raw `availability: AvailabilityResult`.
+  // This was refined during implementation — state derivation was extracted
+  // into identifier-state.ts so the same logic is shared between the UI and
+  // cascade gates. The spec below reflects the actual implementation.
+  state: CardState;                      // pre-derived by paintRegistry via deriveCardState()
+  isDisabled: boolean;                   // from rastrum.pipeline.disabled
+  cacheStatus: ModelCacheStatus | null;  // for on-device plugins
   byoKeysSet: Record<string, boolean>;   // per-key-name presence map
-  sponsorship?: ActiveSponsorship | null;// only meaningful for plugin.id === 'claude_haiku'
+  sponsorship: ActiveSponsorship | null; // only meaningful for plugin.id === 'claude_haiku'
+  plantnetQuota?: PlantNetQuota | null;  // only meaningful for plugin.id === 'plantnet'
 }
 
 export function renderPluginCard(props: PluginCardProps): string;

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -1479,6 +1479,14 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
    * (license-cost ascending, confidence_ceiling tiebreaker), not registration
    * order. Two flows shown — one for photo, one for audio — since the sort
    * differs per media type.
+   *
+   * #718: The chip strip order INTENTIONALLY differs from the section-grouped
+   * card list above. Sections group by semantic role (specialist / generalist /
+   * experimental), which helps users understand what each plugin does.
+   * The chip strip shows the actual runtime cascade execution order (free
+   * models first, then paid), which helps users understand when each plugin
+   * fires. Merging the two orderings would either hide the cascade semantics
+   * from the chip strip or force an unnatural section grouping in the card list.
    */
   async function updatePipelineFlow(plugins: Array<{ id: string; name: string; brand?: string; capabilities: { media: string[]; license: string; confidence_ceiling?: number } }>) {
     const flowItems = document.getElementById('pipeline-flow-items');

--- a/src/lib/identifier-card-html.ts
+++ b/src/lib/identifier-card-html.ts
@@ -32,6 +32,17 @@ export interface PlantNetQuota {
   reset_at?: string;
 }
 
+/**
+ * Props for a unified plugin card on the AI settings tab.
+ *
+ * @see docs/superpowers/specs/2026-05-07-ai-tab-redesign-design.md
+ *
+ * NOTE (#719): The spec originally listed `availability: AvailabilityResult`
+ * here. During implementation this was refined to `state: CardState` (pre-
+ * derived via `deriveCardState()` in identifier-state.ts) so the same logic
+ * is shared between the card renderer and the cascade gates. The spec has
+ * been updated to match.
+ */
 export interface PluginCardProps {
   lang: 'en' | 'es';
   plugin: Identifier;

--- a/tests/unit/identifier-state.test.ts
+++ b/tests/unit/identifier-state.test.ts
@@ -72,6 +72,24 @@ describe('deriveCardState', () => {
   it('disabled state takes precedence over availability', () => {
     expect(deriveCardState(input({ isDisabled: true }))).toEqual({ kind: 'disabled' });
   });
+
+  // #717 — explicit coverage for disabled-precedence edge cases
+  it('disabled=true + availability.ready=true → returns disabled', () => {
+    // The most common path: user toggled off a plugin that is fully ready.
+    const s = deriveCardState(input({ isDisabled: true, availability: { ready: true } }));
+    expect(s).toEqual({ kind: 'disabled' });
+  });
+
+  it('disabled=true + availability.ready=false (unsupported) → unsupported wins over disabled', () => {
+    // Per spec: "User-flipped Disable wins over everything EXCEPT actual unsupportedness."
+    // A device that lacks WebGPU cannot run the model regardless of the toggle state.
+    const s = deriveCardState(input({
+      isDisabled: true,
+      availability: { ready: false, reason: 'unsupported', message: 'No WebGPU' },
+    }));
+    // Unsupported takes precedence — disabled toggle is irrelevant when the hw is missing.
+    expect(s).toEqual({ kind: 'unsupported', reason: 'webgpu', message: 'No WebGPU' });
+  });
 });
 
 describe('runStorageMigration', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     // node-localstorage conflict that breaks localStorage.clear().
     environment: 'happy-dom',
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
+    // #648: gemma-vision.test.ts uses vi.mock('@huggingface/transformers') to
+    // stub onnxruntime-node (a native binary dep ~50-100 MB that ships with
+    // @huggingface/transformers v4 even in browser-only builds). The mock is
+    // defined inline in the test file — no exclusion needed here.
     coverage: {
       reporter: ['text', 'json'],
       include: ['src/lib/**/*.ts'],


### PR DESCRIPTION
- **#686** 16 workflow files bumped to actions/checkout@v5, setup-node@v5, upload-artifact@v5 (June 2026 deadline)\n- **#648** Document existing onnxruntime-node mock strategy in vitest.config.ts\n- **#717** Disabled-precedence edge cases added to identifier-state tests\n- **#718** Intentional chip-strip vs section-grouping order difference documented\n- **#719** PluginCardProps spec doc aligned with implementation\n\nCloses #686, #648, #717, #718, #719