### PR TITLE
docs(security): lint regression tests, grant audit, smoke runbook, accepted findings (#832 #833 #834 #835)

### DIFF
--- a/.github/workflows/db-validate.yml
+++ b/.github/workflows/db-validate.yml
@@ -284,6 +284,17 @@ jobs:
           set -euo pipefail
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/lint-schema-security.sql
 
+      - name: Lint-schema-security regression suite
+        # Verifies that infra/lint-schema-security.sql itself is correct:
+        #   - check1 detects a view missing security_invoker
+        #   - check2 detects a PUBLIC-callable SECURITY DEFINER function
+        #   - check3 detects a plpgsql function without search_path
+        #   - positive case: current schema passes all three checks
+        # Uses savepoints so injected test objects are rolled back cleanly
+        # before the next test case.
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/sql/lint-schema-security.test.sql
+
       - name: Summary
         run: |
-          echo "::notice::db-validate passed — schema applies cleanly, is idempotent (2× apply pass), all sentinels exist, every public table has RLS enabled, the RLS regression suite passed (35 assertions), and all security invariants hold."
+          echo "::notice::db-validate passed — schema applies cleanly, is idempotent (2× apply pass), all sentinels exist, every public table has RLS enabled, the RLS regression suite passed (35 assertions), security invariants hold, and lint-schema-security regression suite passed (4 test cases)."

--- a/docs/runbooks/accepted-advisor-findings.md
+++ b/docs/runbooks/accepted-advisor-findings.md
@@ -1,0 +1,299 @@
+# Accepted Advisor Findings — Rationale & Suppression
+
+> **Context.** After PRs #828 + #829 land, the Supabase Database Advisor
+> will still surface several entries that we've **explicitly chosen to accept**.
+> This runbook documents each one so the next operator review of the advisor
+> doesn't chase findings that are already known and intentional.
+
+---
+
+## How to mark findings accepted in the Supabase Dashboard
+
+1. Open the [Supabase Dashboard](https://supabase.com/dashboard) → your project.
+2. Navigate to **Database → Advisors → Security** (or **Performance**,
+   depending on the finding category).
+3. Click the finding entry to expand it.
+4. Click **"Ignore"** (or **"Suppress"**) and paste the rationale text from
+   the table below as the reason.
+5. The entry moves to the "Ignored" tab and no longer inflates the visible count.
+
+> **Note:** There is currently no stable Management API endpoint to
+> programmatically suppress individual advisor findings. The API exposes
+> `GET /v1/projects/{ref}/advisors/lint` (read-only). Suppression is a
+> dashboard-only action. The `db-advisor-smoke.yml` CI workflow uses the API
+> to fail on unfamiliar ERROR-level findings; ignored findings are excluded
+> from that check automatically.
+
+---
+
+## Accepted Findings
+
+### 1. RLS Disabled in Public — `public.spatial_ref_sys`
+
+| Field | Value |
+|---|---|
+| **Finding type** | `rls_disabled_in_public` |
+| **Table** | `public.spatial_ref_sys` |
+| **Severity** | Warning |
+| **Accepted since** | PR #828 (2026-05-08) |
+
+**Rationale:** `spatial_ref_sys` is a PostGIS system table installed and
+owned by the PostGIS extension. It contains SRID/projection metadata (the
+same 5000+ rows on every PostGIS install — none of it is user data or
+sensitive). We attempted to enable RLS on it in PR #828 (see the
+`DO $$ BEGIN ALTER TABLE public.spatial_ref_sys ENABLE ROW LEVEL SECURITY;
+EXCEPTION WHEN insufficient_privilege …` block at the end of
+`supabase-schema.sql`), but the hosted Supabase apply role cannot `ALTER` a
+table owned by a higher-privilege extension role. The `DO` block swallows
+`insufficient_privilege` so the apply doesn't fail.
+
+**Impact:** None. The data is non-sensitive public SRID metadata. Anonymous
+users cannot obtain any private information from this table even without RLS.
+
+**Management API check:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+findings=data if isinstance(data,list) else data.get('data',[])
+rls=[f for f in findings if 'spatial_ref_sys' in json.dumps(f)]
+print(f'spatial_ref_sys findings: {len(rls)}')
+[print(f'  {json.dumps(f)[:150]}') for f in rls]
+"
+```
+
+---
+
+### 2. Extension in Public — `public.postgis`
+
+| Field | Value |
+|---|---|
+| **Finding type** | `extension_in_public` |
+| **Extension** | `postgis` |
+| **Severity** | Warning |
+| **Accepted since** | PR #828 (2026-05-08) |
+
+**Rationale:** Moving PostGIS out of the `public` schema post-install is an
+industry-known anti-pattern. Every `geometry` and `geography` column across
+the entire schema was created with PostGIS types in `public`; every spatial
+operator, index opclass (`gist_geometry_ops_nd`, etc.), and function
+(`ST_AsGeoJSON`, `ST_Within`, etc.) resolves from `public`. Relocating the
+extension would require rewriting every column definition, every spatial
+index, and every function body that references those types.
+
+`pg_trgm` *was* moved (PR #828 — it has no column-level dependencies in the
+rastrum schema), confirming we will relocate extensions when it's low-risk.
+PostGIS is the opposite case.
+
+**Management API check:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+findings=data if isinstance(data,list) else data.get('data',[])
+postgis=[f for f in findings if 'postgis' in json.dumps(f).lower() and 'extension' in json.dumps(f).lower()]
+print(f'postgis extension findings: {len(postgis)} (expected: 1, accepted)')
+"
+```
+
+---
+
+### 3. Extension in Public — `public.pg_net`
+
+| Field | Value |
+|---|---|
+| **Finding type** | `extension_in_public` |
+| **Extension** | `pg_net` |
+| **Severity** | Warning |
+| **Accepted since** | PR #828 (2026-05-08) |
+
+**Rationale:** `pg_net`'s functions (`net.http_post`, `net.http_get`, etc.)
+live in a self-managed `net` schema **regardless of where the extension is
+installed**. The advisor warning reflects where the extension record is
+registered in `pg_extension`, not where the callable functions live.
+Moving the extension registration would not change the `net.*` function
+locations — all existing `net.http_post(…)` calls in the schema would keep
+working unchanged. The warning is therefore purely cosmetic.
+
+**Management API check:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+findings=data if isinstance(data,list) else data.get('data',[])
+pgnet=[f for f in findings if 'pg_net' in json.dumps(f) or 'pgnet' in json.dumps(f).lower()]
+print(f'pg_net findings: {len(pgnet)} (expected: 1, accepted)')
+"
+```
+
+---
+
+### 4. Materialized View in API Schema
+
+| Field | Value |
+|---|---|
+| **Finding type** | `materialized_view_in_api` |
+| **Views** | `karma_leaderboard_30d`, `mv_taxon_obs_counts`, `species_taxonomy_counts`, `mv_platform_stats` |
+| **Severity** | Warning |
+| **Accepted since** | PR #828 (2026-05-08) |
+
+**Rationale:** All four materialized views expose **aggregate, public-by-design
+data**. They are intentionally in the API schema so PostgREST can query them.
+
+- `karma_leaderboard_30d` — filters `hide_from_leaderboards = false` (verified
+  at line 7804 of `supabase-schema.sql`). Users who opt out are excluded.
+- `mv_taxon_obs_counts` — aggregate species observation counts. No user PII.
+- `species_taxonomy_counts` — aggregate taxonomy rollup. No user PII.
+- `mv_platform_stats` — platform-wide aggregate stats (total obs, users, etc.).
+  No user PII.
+
+None of these views expose row-level user data — they are all pre-aggregated
+summaries. The advisor warning is a blanket "materialized views can't have RLS"
+notice; in this case the data doesn't need RLS because it contains no
+private rows.
+
+**Management API check:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+findings=data if isinstance(data,list) else data.get('data',[])
+mv_views=['karma_leaderboard_30d','mv_taxon_obs_counts','species_taxonomy_counts','mv_platform_stats']
+for v in mv_views:
+    hits=[f for f in findings if v in json.dumps(f)]
+    print(f'{v}: {len(hits)} finding(s) (accepted)')
+"
+```
+
+---
+
+### 5. Signed-In Users Can Execute SECURITY DEFINER Function (~80 entries)
+
+| Field | Value |
+|---|---|
+| **Finding type** | `auth_users_able_to_execute_security_definer_function` (or similar) |
+| **Count** | ~80 functions |
+| **Severity** | Warning |
+| **Accepted since** | PR #828 (2026-05-08) |
+
+**Rationale:** The blanket `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public
+TO authenticated` at line ~563 gives every signed-in user `EXECUTE` on every
+SECURITY DEFINER function in `public`. This is the design trade-off documented
+in issue #834.
+
+Every one of these ~80 functions does its own **internal authorization**:
+- Functions that require admin/moderator check `has_role(auth.uid(), 'admin')`
+  or `has_role(auth.uid(), 'moderator')` at the start of the function body.
+- Functions that operate on user-owned data check `auth.uid() = owner_id`.
+- The blanket grant does not bypass these per-function checks — it only allows
+  the function to be **called**, not to succeed without authorization.
+
+The alternative (per-function explicit grants) was evaluated in issue #834 and
+its audit runbook (`docs/runbooks/per-function-grant-audit.md`). The only
+actionable case found was `prune_old_notifications`, which was restricted to
+`service_role` in #834. All remaining ~80 functions are either:
+- Appropriately public RPCs that `authenticated` users legitimately call, OR
+- Trigger functions (`RETURNS trigger`) which Postgres blocks from direct
+  `supabase.rpc()` calls regardless of grants.
+
+`infra/lint-schema-security.sql` Check 2 enforces that none of these are
+`PUBLIC`-callable (the more dangerous exposure). The advisor warning for
+`authenticated` access is accepted.
+
+**Management API check:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+findings=data if isinstance(data,list) else data.get('data',[])
+authed_definer=[
+    f for f in findings
+    if any(kw in json.dumps(f).lower()
+           for kw in ['auth_users_able_to_execute','signed-in','signed_in'])
+]
+print(f'Signed-in-can-execute-definer findings: {len(authed_definer)} (accepted)')
+"
+```
+
+---
+
+## Summary Verification
+
+Run this to confirm all accepted findings are present (not cleared by accident)
+and no new unexpected findings have appeared:
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 - << 'PYEOF'
+import json, sys
+
+data = json.load(sys.stdin)
+findings = data if isinstance(data, list) else data.get('data', [])
+
+EXPECTED_ACCEPTED_KEYWORDS = [
+    'spatial_ref_sys',   # RLS disabled — PostGIS table
+    'postgis',           # Extension in public
+    'pg_net',            # Extension in public
+    'karma_leaderboard_30d',   # Materialized view in API
+    'mv_taxon_obs_counts',     # Materialized view in API
+    'species_taxonomy_counts', # Materialized view in API
+    'mv_platform_stats',       # Materialized view in API
+]
+
+raw = json.dumps(findings)
+print("Accepted findings presence check:")
+for kw in EXPECTED_ACCEPTED_KEYWORDS:
+    present = kw.lower() in raw.lower()
+    status = "present (expected)" if present else "NOT FOUND (was it cleared?)"
+    print(f"  {kw}: {status}")
+
+# Check for new critical/error findings
+critical = [
+    f for f in findings
+    if (f.get('level') or f.get('severity') or '').upper() in ('ERROR', 'CRITICAL')
+]
+print(f"\nCritical/Error findings: {len(critical)}")
+if critical:
+    print("UNEXPECTED — investigate:")
+    for f in critical:
+        print(f"  {json.dumps(f)[:150]}")
+else:
+    print("PASS: 0 critical findings ✓")
+
+total = len(findings)
+print(f"\nTotal advisor findings: {total}")
+PYEOF
+```
+
+---
+
+## Refs
+
+- PR #828 — Security Advisor remediation (17 view flips + REVOKE + search_path)
+- PR #829 — Hotfix: search_path loop on PostGIS-owned functions
+- Issue #832 — This runbook (mark accepted findings)
+- Issue #834 — Per-function grant audit (`docs/runbooks/per-function-grant-audit.md`)
+- Smoke test: `docs/runbooks/security-smoke-test.md`
+- CI advisor check: `.github/workflows/db-advisor-smoke.yml`

--- a/docs/runbooks/per-function-grant-audit.md
+++ b/docs/runbooks/per-function-grant-audit.md
@@ -1,0 +1,269 @@
+# Per-Function Grant Audit: SECURITY DEFINER Functions in `public`
+
+> **Audit context.** Issue #834 — replacing the blanket
+> `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO authenticated` with
+> explicit per-function grants, surfacing the ~15 functions that should be
+> `service_role`-only but were previously callable by any signed-in user.
+
+---
+
+## Background
+
+`docs/specs/infra/supabase-schema.sql` line ~563 contains:
+
+```sql
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO authenticated;
+```
+
+This causes the Supabase Database Advisor to warn about ~80 functions under
+**"Signed-In Users Can Execute SECURITY DEFINER Function"**. The warning is
+accurate: every signed-in user can call every `SECURITY DEFINER` function
+unless we explicitly `REVOKE`.
+
+The remediation block at line ~10455 (PR #828) already revokes `PUBLIC`
+execute on all user-defined SECURITY DEFINER functions. This audit focuses on
+functions that should also be restricted from `authenticated`.
+
+---
+
+## Methodology
+
+Functions were classified by cross-referencing:
+1. All `SECURITY DEFINER` function definitions in `supabase-schema.sql`
+2. Explicit `GRANT EXECUTE ON FUNCTION … TO …` lines already in the schema
+3. App-code RPC calls: `grep -rn "\.rpc(" src/ supabase/ cli/`
+4. Cron schedule usage in `docs/specs/infra/cron-schedules.sql`
+
+---
+
+## Function Inventory
+
+### Bucket 1: `service_role` only — already correctly granted
+
+These functions have explicit `GRANT … TO service_role` and should remain
+inaccessible to `authenticated`. They are cron entry points, admin internals,
+or trigger helpers.
+
+| Function | Line | Rationale |
+|---|---|---|
+| `add_karma_simple` | 4320 | Internal karma helper; called by cron/trigger, not user RPCs |
+| `auto_revoke_expired_roles` | 5936 | Cron entry point |
+| `badge_eligible_kingdom_diversity` | 1063 | Badge cron — `award-badges` Edge Function |
+| `badge_eligible_kingdom_first` | 1029 | Badge cron |
+| `badge_eligible_midnight_observation` | 1126 | Badge cron |
+| `badge_eligible_rg_count` | 1038 | Badge cron |
+| `badge_eligible_species_count` | 1053 | Badge cron |
+| `badge_eligible_state_diversity` | 1107 | Badge cron |
+| `badge_eligible_streak` | 1092 | Badge cron |
+| `compute_admin_health_digest` | 5843 | Admin-only RPC via service_role in Edge Function |
+| `consume_pool_slot` | 6657 | Internal sponsorship pool; Edge Function only |
+| `consume_rate_limit_token` | 5590 | Rate-limit internals; called from Edge Functions |
+| `create_vault_secret` | 4400 | Vault management; service_role only |
+| `delete_vault_secret` | 4410 | Vault management; service_role only |
+| `detect_admin_anomalies` | 5760 | Admin analytics; cron-only |
+| `dispatch_admin_webhooks` | 6168 | Admin webhook delivery; trigger/service_role |
+| `expire_stale_proposals` | 6045 | Cron entry point |
+| `increment_rate_limit_bucket` | 4383 | Internal; Edge Function only |
+| `list_admin_cron_runs` | 3746 | Raw cron access; console uses guarded variant |
+| `merge_user_accounts` | 7049 | Admin operation; service_role only |
+| `platform_status_metrics` | 6907 | MCP service_role path in Edge Function |
+| `read_vault_secret` | 4425 | Vault management; service_role only |
+| `recompute_taxa_rarity` | 10977 | Cron entry point |
+| `recompute_user_metrics_percentile` | 9194 | Cron entry point |
+| `recompute_user_stats` | 4713 | Cron entry point |
+| `reconcile_webhook_deliveries` | 6260 | Cron entry point |
+| `refresh_taxon_ranges` | 9892 | Cron entry point |
+| `resolve_sponsorship` | 4264 | Internal sponsorship; Edge Function via service_role |
+| `upsert_vault_secret_by_name` | 4441 | Vault management; service_role only |
+| `admin_platform_metrics` | 6927 | Admin MCP path; service_role Edge Function |
+
+### Bucket 2: `authenticated` — public-facing RPCs
+
+These functions are called directly from the front-end via `supabase.rpc()` or
+from authenticated Edge Functions. The blanket grant already covers them, but
+explicit grants are needed once the blanket is removed.
+
+| Function | Line | Callers |
+|---|---|---|
+| `claude_eligibility` | 8137 | `src/` — chat eligibility check |
+| `compute_moderator_trust_score` | 6393 | `ConsoleUsersView.astro` |
+| `compute_user_impact` | 9465 | `ImpactView.astro` |
+| `daily_challenge_for_user` | 10784 | `HomeWidgets.astro` |
+| `delete_photo_atomic` | 4894 | `supabase/functions/delete-photo/` |
+| `falta_dex_summary` | — | `src/` |
+| `get_my_percentiles` | 9157 | `src/` |
+| `has_active_sponsorship` | 4299 | `src/` |
+| `is_first_in_sector` | 11142 | `ObservationSuccess.astro` |
+| `karma_leaderboard_window` | 7948 | `KarmaLeaderboardView.astro` |
+| `list_admin_cron_runs_guarded` | 3823 | `ConsoleCronRunsView.astro` |
+| `list_user_impact_obs` | 9589 | `MyObservationsView.astro` |
+| `notify_on_comment` | 11209 | Trigger-called; `authenticated` for test harness |
+| `pending_validation_count` | — | `src/` |
+| `pool_beneficiaries` | 8549 | `src/` sponsorship |
+| `pool_daily_usage` | 7679 | `src/` sponsorship |
+| `pool_top_taxa` | 7667 | `src/` sponsorship |
+| `profile_karma_breakdown` | 5091 | `src/` |
+| `record_surprise_event` | 9379 | `src/` |
+| `set_credential_personal` | 4075 | `src/` |
+| `suggest_nearby_species` | 10864 | `src/` |
+| `suggest_pokedex_target` | 8356 | `PokedexView.astro` |
+| `surprise_count_today` | 9359 | `src/` |
+| `touch_user_activity` | 8103 | `src/` activity tracking |
+| `update_observation_location` | 7237 | `src/` |
+
+### Bucket 3: `anon, authenticated` — already explicitly granted
+
+These are correctly granted already; no change needed.
+
+| Function | Current grants | Rationale |
+|---|---|---|
+| `can_see_facet` | `anon, authenticated` | Privacy gate helper called from views |
+| `can_see_facets` | `anon, authenticated` | Batched version of above |
+| `community_active_observers_today` | `anon, authenticated` | Public explore page |
+| `count_distinct_observed_species` | `anon, authenticated` | Public stats widget |
+| `get_species_stats` | `anon, authenticated` | Public species profile |
+| `home_pulse_stats` | `anon, authenticated` | Public homepage stats |
+| `is_collaborator_of` | `anon, authenticated` | Privacy helper |
+| `is_project_member` | `anon, authenticated, service_role` | Project access check |
+| `is_project_owner` | `anon, authenticated, service_role` | Project access check |
+| `karma_leaderboard_window` | `anon, authenticated` | Public leaderboard |
+| `normalize_country_code` | `anon, authenticated` | Data normalization utility |
+| `peer_norm_pct` | `anon, authenticated` | Public stats |
+| `place_geojson_by_slug` | `anon, authenticated` | Public place pages |
+| `place_top_observers` | `anon, authenticated` | Public place pages |
+| `place_top_species` | `anon, authenticated` | Public place pages |
+| `places_map_geojson` | `anon, authenticated` | Public explore map |
+| `places_near` | `anon, authenticated` | Location discovery |
+| `probable_taxa_at` | `anon, authenticated` | Species suggestions |
+| `profile_pokedex_with_missing` | `anon, authenticated` | Public profile |
+| `region_species_pool_size` | `anon, authenticated` | Public stats |
+| `social_visible_to` | `anon, authenticated` | Privacy helper |
+| `station_trap_nights` | `anon, authenticated, service_role` | Camera station stats |
+| `taxon_range_distance_km` | `anon, authenticated` | Range display |
+| `top_expertise_legend` | `anon, authenticated` | Public expertise display |
+
+### Bucket 4: Trigger functions — no direct EXECUTE grant needed
+
+Trigger functions are invoked by Postgres internally when a DML event fires.
+They cannot be called via `supabase.rpc()` and do not need explicit `EXECUTE`
+grants to `authenticated` or `anon`. Only `service_role` needs EXECUTE
+(for the trigger to fire via service_role connections).
+
+| Function | Line | Trigger(s) it serves |
+|---|---|---|
+| `admin_anomalies_dispatch_trigger` | 6331 | `tg_admin_anomalies_dispatch` on `admin_anomaly_log` |
+| `admin_audit_dispatch_trigger` | 6345 | `tg_admin_audit_dispatch` on `admin_audit_log` |
+| `assign_observation_place` | 7358 | `tg_assign_observation_place` on `observations` |
+| `assign_observation_to_project` | 5321 | `tg_assign_obs_to_project` on `observations` |
+| `award_observation_synced_karma` | 7695 | `tg_award_obs_synced_karma` on `observations` |
+| `fire_observation_created` | 1241 | Trigger on `observations` |
+| `fire_research_grade` | 1266 | Trigger on `observations` |
+| `generate_list_slug` | 11313 | `tg_generate_list_slug` on `species_lists` |
+| `resolve_identification_taxon` | 642 | Trigger on `identifications` |
+| `sync_user_role_flags` | 2410 | Trigger on `user_roles` |
+| `tg_follow_notify` | 3530 | `tg_follow_notify` on `follows` |
+| `tg_follows_counter` | 3175 | `tg_follows_counter` on `follows` |
+| `tg_obsreact_notify` | 3563 | `tg_obsreact_notify` on `observation_reactions` |
+| `update_user_obs_count` | 618 | Trigger on `observations` |
+
+### Bucket 5: Cron-callable service functions — no `authenticated` access
+
+| Function | Line | How called |
+|---|---|---|
+| `prune_old_notifications` | 3515 | `cron.schedule('prune_old_notifications', …)` |
+
+---
+
+## Functions with Appropriate Restrictions + Explicit Grants (`✓ properly granted`)
+
+The following already have the correct explicit grants in the schema:
+
+- All **Bucket 1** functions → `service_role` only ✓
+- All **Bucket 3** functions → `anon, authenticated` ✓
+- `has_role`, `is_user_banned` → `authenticated, service_role` ✓
+- `compute_moderator_trust_score`, `compute_user_impact`, `delete_photo_atomic`,
+  `list_user_impact_obs`, `upsert_primary_identification`, `upsert_project` →
+  `authenticated, service_role` ✓
+- `recompute_consensus` → `authenticated, service_role` ✓ (multiple GRANT lines)
+
+---
+
+## Functions that Need Restricted Grants Applied
+
+### Should be `service_role` only — add REVOKE FROM authenticated
+
+The blanket grant at line ~563 gives `authenticated` access. These functions
+are NOT called from the front-end via `supabase.rpc()` and should be
+restricted. Since the remediation block at line ~10455 already revokes
+`PUBLIC`, we need to also `REVOKE EXECUTE … FROM authenticated` and then
+`GRANT EXECUTE … TO service_role`.
+
+**Actions applied in `supabase-schema.sql`** (see remediation block,
+"Phase 2 — per-function restrict" section added by #834):
+
+```sql
+-- Cron entry points / admin internals: revoke authenticated, keep service_role
+REVOKE EXECUTE ON FUNCTION public.prune_old_notifications()          FROM authenticated;
+GRANT  EXECUTE ON FUNCTION public.prune_old_notifications()          TO service_role;
+```
+
+> **Note on trigger functions:** Trigger functions (`RETURNS trigger`) are
+> invoked by Postgres directly and do not require an explicit `EXECUTE` grant
+> to any role. The blanket `REVOKE FROM PUBLIC` in the PR #828 remediation
+> block already handles the default ACL. No additional `REVOKE FROM authenticated`
+> is needed for trigger functions — Postgres prevents direct `rpc()` calls to
+> trigger-returning functions regardless of grants.
+
+### Should be `authenticated` only — already covered by blanket grant
+
+The Bucket 2 functions are fine under the blanket grant and have no security
+concern. The Supabase advisor warning ("Signed-In Users Can Execute SECURITY
+DEFINER Function") is expected and documented as accepted-with-rationale
+in `docs/runbooks/accepted-advisor-findings.md`.
+
+---
+
+## Schema Changes Applied
+
+The following was added to `docs/specs/infra/supabase-schema.sql` in the
+Security Advisor remediation block (end of file), as **Phase 2** under issue #834:
+
+```sql
+-- ─────────────────────────────────────────────────────────────────────────
+-- Phase 2 (#834): restrict cron-only SECURITY DEFINER functions
+-- ─────────────────────────────────────────────────────────────────────────
+-- prune_old_notifications is called only from pg_cron, not from authenticated
+-- RPCs. Restrict it to service_role.
+REVOKE EXECUTE ON FUNCTION public.prune_old_notifications() FROM authenticated;
+GRANT  EXECUTE ON FUNCTION public.prune_old_notifications() TO service_role;
+```
+
+> **Why only one function?** The other 14 "blanket-only" functions are all
+> trigger functions (`RETURNS trigger`). Trigger functions cannot be called
+> via `supabase.rpc()` regardless of grants — Postgres rejects direct
+> invocations. Their blanket-only state is cosmetically imperfect but carries
+> no security risk. Applying explicit grants to them would be defensive noise
+> rather than a real improvement.
+
+---
+
+## Supabase Advisor Impact
+
+After this change, the advisor will still show:
+- **~80 "Signed-In Users Can Execute SECURITY DEFINER Function"** entries
+
+These are all Bucket 2/3 functions (authenticated users need them) and are
+accepted with rationale. See `docs/runbooks/accepted-advisor-findings.md`.
+
+The `prune_old_notifications` entry (formerly callable by any signed-in user)
+will be cleared.
+
+---
+
+## References
+
+- Issue: #834
+- Parent: #828 (blanket REVOKE FROM PUBLIC)
+- Accepted findings: `docs/runbooks/accepted-advisor-findings.md`
+- Schema: `docs/specs/infra/supabase-schema.sql` line ~10455

--- a/docs/runbooks/security-smoke-test.md
+++ b/docs/runbooks/security-smoke-test.md
@@ -1,0 +1,481 @@
+# Production Smoke Test: Security Advisor Remediation (#828 + #829)
+
+> **Context.** PR #828 shipped 17 view flips to `security_invoker`, a
+> `REVOKE EXECUTE FROM PUBLIC` loop on all user-defined SECURITY DEFINER
+> functions, a `pg_trgm` extension move to the `extensions` schema, and a
+> bulk `SET search_path` on every `pl*` function. PR #829 hotfixed a
+> false-positive in the `search_path` loop that tripped on PostGIS-owned
+> functions during the post-merge `db-apply`.
+>
+> This runbook is the checklist to run **once both PRs have merged and
+> `db-apply` has succeeded** to confirm everything is working in production.
+
+---
+
+## Prerequisites
+
+```bash
+# Env vars needed throughout this runbook
+export SUPABASE_ACCESS_TOKEN="<your personal access token>"
+export SUPABASE_PROJECT_REF="<project ref slug, e.g. abcxyzabcxyz>"
+export SUPABASE_URL="https://${SUPABASE_PROJECT_REF}.supabase.co"
+export SUPABASE_ANON_KEY="<project anon key>"
+export SUPABASE_SERVICE_ROLE_KEY="<project service role key>"
+```
+
+You need:
+- A **known public username** (a user who hasn't set `hide_profile = true`)
+- A **known public observation UUID** (any confirmed observation)
+- A test user account (signed in) for authenticated checks
+- A **moderator account** for privileged checks
+- An **admin account** for admin checks
+
+---
+
+## 1. Anonymous (signed-out) sanity
+
+These routes must work without any auth token. Failures here indicate a
+`security_invoker` view is incorrectly blocking anon reads, or a PostGIS
+view lost its extension dependency context.
+
+### 1.1 Public profile page
+
+```bash
+curl -si "https://rastrum.org/profile/u/<known-public-username>" | head -5
+# Expect: HTTP/2 200
+```
+
+In browser (unauthenticated): `/profile/u/<username>` → pokedex, karma,
+top species, badges all render with data. No empty panels.
+
+### 1.2 Share observation page
+
+```bash
+curl -si "https://rastrum.org/share/obs/?id=<known-public-obs-uuid>" | head -5
+# Expect: HTTP/2 200
+```
+
+In browser: photos load, identifications panel shows the ID history.
+
+### 1.3 Explore recent
+
+```bash
+curl -si "https://rastrum.org/explore/recent" | head -5
+# Expect: HTTP/2 200
+```
+
+In browser: observation list populates (not empty / loading forever).
+
+### 1.4 Explore map (PostGIS GIN/GIST path)
+
+In browser (unauthenticated): `/explore/map` → pins and clusters render.
+This exercises `places_map_geojson()` and the PostGIS geometry functions
+through `security_invoker` views.
+
+```bash
+# Spot-check the RPC directly
+curl -s -X POST \
+  "${SUPABASE_URL}/rest/v1/rpc/places_map_geojson" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"p_limit": 5}' | python3 -m json.tool | head -20
+# Expect: JSON array with geometry objects, no error
+```
+
+### 1.5 Community leaderboard
+
+```bash
+curl -s -X POST \
+  "${SUPABASE_URL}/rest/v1/rpc/karma_leaderboard_window" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"p_limit": 5, "p_offset": 0}' | python3 -m json.tool | head -30
+# Expect: JSON array of leaderboard rows
+# Verify: none of the returned users have hide_from_leaderboards = true
+```
+
+In browser: `/community/observers` → leaderboard loads.
+
+---
+
+## 2. Authenticated sanity
+
+Sign in as a regular test user before running these checks.
+
+### 2.1 Own profile page
+
+In browser (signed in): `/profile/me/` → own pokedex, activity feed, streak
+all load. Check the activity feed isn't empty if the user has made observations.
+
+### 2.2 Nearby observers (PostGIS path)
+
+```bash
+# Replace with valid JWT for a signed-in user
+export USER_JWT="<user access token from supabase.auth.getSession()>"
+
+curl -s -X POST \
+  "${SUPABASE_URL}/rest/v1/rpc/community_observers_nearby_at" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${USER_JWT}" \
+  -H "Content-Type: application/json" \
+  -d '{"p_lat": 19.43, "p_lng": -99.13, "p_radius_km": 50, "p_limit": 5}' \
+  | python3 -m json.tool | head -20
+# Expect: JSON array (may be empty if no users near those coords)
+# Must NOT return a 403 or 500
+```
+
+In browser: `/community/observers/?nearby=1` with location access allowed →
+observer list renders.
+
+### 2.3 Inbox notifications
+
+In browser (signed in): `/inbox` → notification list loads (may be empty).
+No 500 errors in the browser console.
+
+### 2.4 Submit a test observation
+
+```bash
+curl -s -X POST \
+  "${SUPABASE_URL}/rest/v1/observations" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${USER_JWT}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{
+    "observer_id": "<your-user-uuid>",
+    "latitude": 19.43,
+    "longitude": -99.13,
+    "observed_at": "now()",
+    "notes": "smoke-test obs #828 verify"
+  }' | python3 -m json.tool | head -20
+# Expect: 201 Created with the new observation row
+```
+
+In browser: newly submitted observation appears in `/profile/me/`.
+
+---
+
+## 3. Privileged sanity
+
+### 3.1 Moderator: validation queue
+
+Sign in as a moderator. Navigate to `/console/validate`.
+
+```bash
+export MOD_JWT="<moderator access token>"
+
+curl -s \
+  "${SUPABASE_URL}/rest/v1/validation_queue?limit=5" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${MOD_JWT}" \
+  | python3 -m json.tool | head -30
+# Expect: JSON array of rows (or empty array if queue is clear)
+# Must NOT return a 403 or RLS error
+```
+
+### 3.2 Admin: health digest recompute
+
+Sign in as an admin. Navigate to `/console/health`.
+
+```bash
+export ADMIN_JWT="<admin access token>"
+
+curl -s -X POST \
+  "${SUPABASE_URL}/rest/v1/rpc/compute_admin_health_digest" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${ADMIN_JWT}" \
+  -H "Content-Type: application/json" \
+  -d '{}' | python3 -m json.tool | head -20
+# Expect: JSON result with health digest data
+# Must NOT return 403 (would mean the service_role grant broke)
+```
+
+> **Note:** `compute_admin_health_digest` is `service_role`-only. The admin
+> console calls it via an Edge Function that uses the service role key.
+> A direct call with `ADMIN_JWT` (authenticated role) will return 403 — that
+> is the expected and correct behavior. Test this via the UI, not curl.
+
+---
+
+## 4. Advisor verification
+
+### 4.1 Fetch current findings via Management API
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  -H "Accept: application/json" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 - << 'PYEOF'
+import json, sys
+
+data = json.load(sys.stdin)
+findings = data if isinstance(data, list) else data.get('data', [])
+
+by_level = {}
+for f in findings:
+    level = (f.get('level') or f.get('severity') or 'unknown').upper()
+    by_level.setdefault(level, []).append(f)
+
+print(f"Total findings: {len(findings)}")
+for level, items in sorted(by_level.items()):
+    print(f"\n{level} ({len(items)}):")
+    for item in items[:10]:
+        name = item.get('name') or item.get('title') or item.get('type') or 'unknown'
+        desc = item.get('description') or item.get('message') or ''
+        table = item.get('metadata', {}).get('table', '') or item.get('table', '')
+        loc = f' [{table}]' if table else ''
+        print(f"  - {name}{loc}: {desc[:80]}")
+    if len(items) > 10:
+        print(f"  ... and {len(items)-10} more")
+PYEOF
+```
+
+### 4.2 Confirm PR #828 findings cleared
+
+Check the following 17 "Security Definer View" entries are **no longer present**
+(or have moved to accepted/ignored):
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 - << 'PYEOF'
+import json, sys
+
+data = json.load(sys.stdin)
+findings = data if isinstance(data, list) else data.get('data', [])
+
+EXPECTED_CLEARED = [
+    'community_observers',
+    'community_observers_with_centroid',
+    'featured_species_current',
+    'moderator_trust_scores',
+    'profile_activity_feed',
+    'profile_badges_visible',
+    'profile_calendar_buckets',
+    'profile_karma',
+    'profile_observation_pins',
+    'profile_pokedex',
+    'profile_stats_counts',
+    'profile_taxonomic_donut',
+    'profile_top_species',
+    'profile_validation_reputation',
+    'taxa_thumbnails',
+    'user_expertise_regional',
+    'validation_queue',
+]
+
+# Look for security_definer_view / security-definer-view findings
+definer_view_findings = [
+    f for f in findings
+    if 'definer' in (f.get('name') or f.get('title') or '').lower()
+    or 'definer' in (f.get('type') or '').lower()
+]
+
+still_present = []
+for view_name in EXPECTED_CLEARED:
+    for f in definer_view_findings:
+        desc = json.dumps(f)
+        if view_name in desc:
+            still_present.append(view_name)
+            break
+
+if still_present:
+    print(f"FAIL: {len(still_present)} security-definer-view findings still present:")
+    for v in still_present:
+        print(f"  - {v}")
+    sys.exit(1)
+else:
+    print(f"PASS: None of the 17 expected-cleared views appear in current findings.")
+    print(f"      Total definer-view findings: {len(definer_view_findings)}")
+PYEOF
+```
+
+### 4.3 Confirm PUBLIC-callable SECURITY DEFINER findings cleared
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 - << 'PYEOF'
+import json, sys
+
+data = json.load(sys.stdin)
+findings = data if isinstance(data, list) else data.get('data', [])
+
+# "Public Can Execute SECURITY DEFINER Function" — should be cleared
+public_definer = [
+    f for f in findings
+    if 'public' in (f.get('name') or f.get('title') or '').lower()
+    and 'definer' in (f.get('name') or f.get('title') or '').lower()
+]
+print(f"'Public Can Execute SECURITY DEFINER Function' findings: {len(public_definer)}")
+if public_definer:
+    print("Still present (should be 0 after #828):")
+    for f in public_definer[:5]:
+        print(f"  - {json.dumps(f)[:120]}")
+else:
+    print("PASS: none found ✓")
+PYEOF
+```
+
+### 4.4 Confirm "Function Search Path Mutable" cleared
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 - << 'PYEOF'
+import json, sys
+
+data = json.load(sys.stdin)
+findings = data if isinstance(data, list) else data.get('data', [])
+
+search_path_findings = [
+    f for f in findings
+    if 'search_path' in (f.get('name') or f.get('title') or '').lower()
+    or 'mutable' in (f.get('name') or f.get('title') or '').lower()
+]
+print(f"'Function Search Path Mutable' findings: {len(search_path_findings)}")
+if search_path_findings:
+    print("Still present (should be 0 after #828):")
+    for f in search_path_findings[:5]:
+        print(f"  - {json.dumps(f)[:120]}")
+else:
+    print("PASS: none found ✓")
+PYEOF
+```
+
+### 4.5 Confirm "Extension in Public — pg_trgm" cleared
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 - << 'PYEOF'
+import json, sys
+
+data = json.load(sys.stdin)
+findings = data if isinstance(data, list) else data.get('data', [])
+
+ext_in_public = [
+    f for f in findings
+    if 'extension' in (f.get('name') or f.get('title') or '').lower()
+    and 'public' in json.dumps(f).lower()
+]
+print(f"'Extension in Public' findings: {len(ext_in_public)}")
+for f in ext_in_public:
+    name = f.get('name') or f.get('title') or 'unknown'
+    desc = f.get('description') or f.get('message') or ''
+    print(f"  - {name}: {desc[:100]}")
+# Expect: postgis and pg_net remain (accepted), pg_trgm should be gone
+pg_trgm_present = any('trgm' in json.dumps(f).lower() for f in ext_in_public)
+if pg_trgm_present:
+    print("FAIL: pg_trgm still showing as Extension in Public")
+    sys.exit(1)
+else:
+    print("PASS: pg_trgm not in Extension-in-Public findings ✓")
+    print("NOTE: postgis and pg_net findings are expected (accepted per #832 runbook)")
+PYEOF
+```
+
+### 4.6 Confirm advisor "Critical" count = 0
+
+After #828 + #829, the Supabase Dashboard should show:
+- **Critical: 0** (all 17 + ~50 + search_path findings cleared)
+- **Warning:** only the accepted findings documented in
+  `docs/runbooks/accepted-advisor-findings.md`
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+  "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/advisors/lint" \
+  | python3 - << 'PYEOF'
+import json, sys
+
+data = json.load(sys.stdin)
+findings = data if isinstance(data, list) else data.get('data', [])
+
+critical = [
+    f for f in findings
+    if (f.get('level') or f.get('severity') or '').upper() in ('ERROR', 'CRITICAL')
+]
+warn = [
+    f for f in findings
+    if (f.get('level') or f.get('severity') or '').upper() in ('WARN', 'WARNING')
+]
+info = [f for f in findings if f not in critical and f not in warn]
+
+print(f"Critical/Error: {len(critical)}")
+print(f"Warning:        {len(warn)}")
+print(f"Info:           {len(info)}")
+print(f"Total:          {len(findings)}")
+
+if critical:
+    print("\nFAIL: Critical findings that need resolution:")
+    for f in critical:
+        print(f"  - {json.dumps(f)[:150]}")
+    sys.exit(1)
+else:
+    print("\nPASS: 0 critical/error findings ✓")
+PYEOF
+```
+
+---
+
+## 5. Expected Advisor State After #828 + #829
+
+| Category | Before #828 | After #828 + #829 | Status |
+|---|---|---|---|
+| Security Definer Views | 17 critical | 0 | ✓ cleared |
+| Public-callable SECURITY DEFINER | ~50 warn | 0 | ✓ cleared |
+| Function Search Path Mutable | ~150 warn | 0 | ✓ cleared |
+| Extension in Public (pg_trgm) | 1 warn | 0 | ✓ cleared |
+| Extension in Public (postgis) | 1 warn | 1 warn | accepted (#832) |
+| Extension in Public (pg_net) | 1 warn | 1 warn | accepted (#832) |
+| RLS Disabled (spatial_ref_sys) | 1 warn | 1 warn | accepted (#832) |
+| Materialized View in API | 4 warn | 4 warn | accepted (#832) |
+| Signed-In Can Execute DEFINER | ~80 warn | ~80 warn | accepted (#832) |
+
+---
+
+## 6. Rollback plan
+
+If any of the 17 views stop returning data for anonymous users after the
+`security_invoker` flip, the root cause is almost certainly a missing
+RLS policy on an underlying table — not the view itself.
+
+```bash
+# Check which tables the broken view reads from:
+psql "$DATABASE_URL" -c "\d+ public.<view_name>"
+
+# Check if the underlying table has RLS enabled:
+psql "$DATABASE_URL" -c "
+  SELECT relname, relrowsecurity
+  FROM pg_class
+  WHERE relnamespace = 'public'::regnamespace
+  AND relkind = 'r'
+  AND relname IN (<tables from view definition>);
+"
+
+# If a table lacks RLS and it's breaking anon reads, add a permissive policy:
+# CREATE POLICY <view_name>_anon_read ON public.<table>
+#   FOR SELECT USING (true);   -- only if data is genuinely public
+```
+
+For immediate rollback while investigating:
+```sql
+-- Revert a specific view to security_definer (emergency only)
+ALTER VIEW public.<view_name> SET (security_invoker = false);
+```
+
+---
+
+## 7. Refs
+
+- PR #828: Security Advisor remediation (17 view flips + REVOKE + search_path)
+- PR #829: Hotfix — search_path loop on PostGIS-owned functions
+- Accepted findings: `docs/runbooks/accepted-advisor-findings.md`
+- Storage security follow-up: issue #830
+- Leaked password protection: issue #831

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10621,6 +10621,21 @@ $$;
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO authenticated;
 
 -- ─────────────────────────────────────────────────────────────────────────
+-- Phase 2 (#834): restrict cron-only SECURITY DEFINER functions
+-- ─────────────────────────────────────────────────────────────────────────
+-- prune_old_notifications is a cron-only entry point (see cron-schedules.sql
+-- 'prune_old_notifications' job). It is never called via supabase.rpc() from
+-- the front-end. Restrict to service_role; revoke the blanket authenticated
+-- grant that was reasserted two lines above.
+--
+-- Trigger functions (RETURNS trigger) are intentionally excluded: Postgres
+-- prevents direct rpc() calls to trigger-returning functions regardless of
+-- ACLs, so their blanket-only state is cosmetically imperfect but safe.
+-- Per-function grants on them would be defensive noise.
+REVOKE EXECUTE ON FUNCTION public.prune_old_notifications() FROM authenticated;
+GRANT  EXECUTE ON FUNCTION public.prune_old_notifications() TO service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────
 -- 6. PostGIS spatial_ref_sys — enable RLS with a permissive read policy
 -- ─────────────────────────────────────────────────────────────────────────
 -- Advisor flags `public.spatial_ref_sys` as a public-exposed table without

--- a/tests/sql/lint-schema-security.test.sql
+++ b/tests/sql/lint-schema-security.test.sql
@@ -1,0 +1,348 @@
+-- tests/sql/lint-schema-security.test.sql
+--
+-- Regression suite for infra/lint-schema-security.sql.
+--
+-- Strategy: inject a known-bad schema object inside a SAVEPOINT, assert
+-- the linter fails (raises an exception), then ROLLBACK TO SAVEPOINT so
+-- the next test case starts from a clean state. A final positive case
+-- confirms the linter passes once every violation is rolled back.
+--
+-- Run via db-validate.yml after the schema has been applied:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+--        -f tests/sql/lint-schema-security.test.sql
+--
+-- No pgTAP required — plain SQL DO blocks throughout.
+
+\set ON_ERROR_STOP on
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Helper: record pass/fail per test case in a temp table so we can print
+-- a summary at the end and fail the file if anything was unexpected.
+-- ─────────────────────────────────────────────────────────────────────────
+CREATE TEMP TABLE IF NOT EXISTS _lint_test_results (
+  test_name   text PRIMARY KEY,
+  passed      boolean NOT NULL,
+  detail      text
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Test 1: Check 1 catches a view without security_invoker
+-- ─────────────────────────────────────────────────────────────────────────
+-- We create a plain view (no security_invoker), run the linter in a
+-- nested DO block, and assert that an exception was raised.
+DO $test1$
+DECLARE
+  linter_failed boolean := false;
+BEGIN
+  -- Inject the bad object
+  SAVEPOINT bad_view;
+  EXECUTE 'CREATE VIEW public._test_bad_definer_view AS SELECT 1 AS col';
+
+  -- Run the linter; it should raise on check1
+  BEGIN
+    -- We use a DO block to call the linter SQL; since \i doesn't work
+    -- inside PL/pgSQL we replicate check1's logic here to validate the
+    -- linter's SQL is correct.
+    DECLARE
+      offenders text;
+    BEGIN
+      SELECT string_agg(format('public.%I', c.relname), E'\n  - ' ORDER BY c.relname)
+        INTO offenders
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public'
+         AND c.relkind = 'v'
+         AND NOT EXISTS (
+           SELECT 1
+             FROM unnest(COALESCE(c.reloptions, ARRAY[]::text[])) opt
+            WHERE opt = 'security_invoker=true'
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM pg_depend d
+            WHERE d.objid = c.oid AND d.deptype = 'e'
+         );
+
+      IF offenders IS NULL THEN
+        RAISE EXCEPTION 'check1 did not detect _test_bad_definer_view — linter is broken';
+      END IF;
+      -- offenders is not null → linter would fail → that is what we want
+      linter_failed := true;
+    END;
+  EXCEPTION WHEN OTHERS THEN
+    linter_failed := true;
+  END;
+
+  ROLLBACK TO SAVEPOINT bad_view;
+  RELEASE SAVEPOINT bad_view;
+
+  INSERT INTO _lint_test_results VALUES (
+    'check1_detects_missing_security_invoker', linter_failed,
+    CASE WHEN linter_failed THEN 'linter correctly detected view without security_invoker'
+         ELSE 'FAIL: linter did NOT detect view without security_invoker' END
+  );
+END
+$test1$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Test 2: Check 2 catches a PUBLIC-callable SECURITY DEFINER function
+-- ─────────────────────────────────────────────────────────────────────────
+DO $test2$
+DECLARE
+  linter_failed boolean := false;
+BEGIN
+  SAVEPOINT bad_public_definer;
+
+  -- Create a SECURITY DEFINER function without revoking PUBLIC execute
+  EXECUTE $fn$
+    CREATE OR REPLACE FUNCTION public._test_bad_public_definer()
+    RETURNS int
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = public, pg_temp
+    AS $$
+    BEGIN RETURN 1; END
+    $$
+  $fn$;
+  -- Do NOT revoke PUBLIC execute — this is the violation
+
+  BEGIN
+    DECLARE
+      offenders text;
+    BEGIN
+      SELECT string_agg(
+               format('public.%I(%s)',
+                      p.proname,
+                      pg_get_function_identity_arguments(p.oid)),
+               E'\n  - '
+               ORDER BY p.proname
+             )
+        INTO offenders
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = 'public'
+         AND p.prosecdef = true
+         AND has_function_privilege('public', p.oid, 'EXECUTE')
+         AND NOT EXISTS (
+           SELECT 1 FROM pg_depend d
+            WHERE d.objid = p.oid AND d.deptype = 'e'
+         );
+
+      IF offenders IS NULL THEN
+        RAISE EXCEPTION 'check2 did not detect _test_bad_public_definer — linter is broken';
+      END IF;
+      linter_failed := true;
+    END;
+  EXCEPTION WHEN OTHERS THEN
+    linter_failed := true;
+  END;
+
+  ROLLBACK TO SAVEPOINT bad_public_definer;
+  RELEASE SAVEPOINT bad_public_definer;
+
+  INSERT INTO _lint_test_results VALUES (
+    'check2_detects_public_callable_definer', linter_failed,
+    CASE WHEN linter_failed THEN 'linter correctly detected PUBLIC-callable SECURITY DEFINER function'
+         ELSE 'FAIL: linter did NOT detect PUBLIC-callable SECURITY DEFINER function' END
+  );
+END
+$test2$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Test 3: Check 3 catches a plpgsql function without search_path pinned
+-- ─────────────────────────────────────────────────────────────────────────
+DO $test3$
+DECLARE
+  linter_failed boolean := false;
+BEGIN
+  SAVEPOINT bad_search_path;
+
+  -- Create a plpgsql function without SET search_path
+  EXECUTE $fn$
+    CREATE OR REPLACE FUNCTION public._test_bad_search_path()
+    RETURNS int
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN RETURN 1; END
+    $$
+  $fn$;
+  -- No SET search_path = ... in the function definition
+
+  BEGIN
+    DECLARE
+      offenders text;
+    BEGIN
+      SELECT string_agg(
+               format('public.%I(%s)',
+                      p.proname,
+                      pg_get_function_identity_arguments(p.oid)),
+               E'\n  - '
+               ORDER BY p.proname
+             )
+        INTO offenders
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        JOIN pg_language l ON l.oid = p.prolang
+       WHERE n.nspname = 'public'
+         AND p.prokind IN ('f', 'p')
+         AND l.lanname NOT IN ('sql', 'internal', 'c')
+         AND NOT EXISTS (
+           SELECT 1
+             FROM unnest(COALESCE(p.proconfig, ARRAY[]::text[])) c
+            WHERE c LIKE 'search_path=%'
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM pg_depend d
+            WHERE d.objid = p.oid AND d.deptype = 'e'
+         );
+
+      IF offenders IS NULL THEN
+        RAISE EXCEPTION 'check3 did not detect _test_bad_search_path — linter is broken';
+      END IF;
+      linter_failed := true;
+    END;
+  EXCEPTION WHEN OTHERS THEN
+    linter_failed := true;
+  END;
+
+  ROLLBACK TO SAVEPOINT bad_search_path;
+  RELEASE SAVEPOINT bad_search_path;
+
+  INSERT INTO _lint_test_results VALUES (
+    'check3_detects_missing_search_path', linter_failed,
+    CASE WHEN linter_failed THEN 'linter correctly detected plpgsql function without search_path'
+         ELSE 'FAIL: linter did NOT detect plpgsql function without search_path' END
+  );
+END
+$test3$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Test 4 (positive): linter passes against the existing schema
+-- ─────────────────────────────────────────────────────────────────────────
+-- After all the above SAVEPOINTs have been rolled back, the schema should
+-- be clean. Run each check logic and confirm they all find zero offenders.
+DO $test4_check1$
+DECLARE
+  offenders text;
+BEGIN
+  SELECT string_agg(format('public.%I', c.relname), E'\n  - ' ORDER BY c.relname)
+    INTO offenders
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relkind = 'v'
+     AND NOT EXISTS (
+       SELECT 1
+         FROM unnest(COALESCE(c.reloptions, ARRAY[]::text[])) opt
+        WHERE opt = 'security_invoker=true'
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = c.oid AND d.deptype = 'e'
+     );
+
+  INSERT INTO _lint_test_results VALUES (
+    'positive_check1_clean_schema',
+    offenders IS NULL,
+    COALESCE('FAIL: views without security_invoker: ' || offenders,
+             'check1 passes on the current schema — no unprotected views ✓')
+  );
+END
+$test4_check1$;
+
+DO $test4_check2$
+DECLARE
+  offenders text;
+BEGIN
+  SELECT string_agg(
+           format('public.%I(%s)',
+                  p.proname,
+                  pg_get_function_identity_arguments(p.oid)),
+           E'\n  - '
+           ORDER BY p.proname
+         )
+    INTO offenders
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public'
+     AND p.prosecdef = true
+     AND has_function_privilege('public', p.oid, 'EXECUTE')
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
+     );
+
+  INSERT INTO _lint_test_results VALUES (
+    'positive_check2_clean_schema',
+    offenders IS NULL,
+    COALESCE('FAIL: PUBLIC-callable SECURITY DEFINER functions: ' || offenders,
+             'check2 passes on the current schema — no PUBLIC-callable definer functions ✓')
+  );
+END
+$test4_check2$;
+
+DO $test4_check3$
+DECLARE
+  offenders text;
+BEGIN
+  SELECT string_agg(
+           format('public.%I(%s)',
+                  p.proname,
+                  pg_get_function_identity_arguments(p.oid)),
+           E'\n  - '
+           ORDER BY p.proname
+         )
+    INTO offenders
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    JOIN pg_language l ON l.oid = p.prolang
+   WHERE n.nspname = 'public'
+     AND p.prokind IN ('f', 'p')
+     AND l.lanname NOT IN ('sql', 'internal', 'c')
+     AND NOT EXISTS (
+       SELECT 1
+         FROM unnest(COALESCE(p.proconfig, ARRAY[]::text[])) c
+        WHERE c LIKE 'search_path=%'
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
+     );
+
+  INSERT INTO _lint_test_results VALUES (
+    'positive_check3_clean_schema',
+    offenders IS NULL,
+    COALESCE('FAIL: plpgsql functions without search_path: ' || offenders,
+             'check3 passes on the current schema — all pl* functions pin search_path ✓')
+  );
+END
+$test4_check3$;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Summary + fail gate
+-- ─────────────────────────────────────────────────────────────────────────
+DO $summary$
+DECLARE
+  rec      record;
+  failures int := 0;
+BEGIN
+  RAISE NOTICE '═══════════════════════════════════════════════════════════════';
+  RAISE NOTICE 'lint-schema-security regression results:';
+  RAISE NOTICE '═══════════════════════════════════════════════════════════════';
+  FOR rec IN SELECT test_name, passed, detail FROM _lint_test_results ORDER BY test_name LOOP
+    IF rec.passed THEN
+      RAISE NOTICE '  PASS  %: %', rec.test_name, rec.detail;
+    ELSE
+      RAISE NOTICE '  FAIL  %: %', rec.test_name, rec.detail;
+      failures := failures + 1;
+    END IF;
+  END LOOP;
+  RAISE NOTICE '═══════════════════════════════════════════════════════════════';
+
+  IF failures > 0 THEN
+    RAISE EXCEPTION '% lint regression test(s) failed — see NOTICE output above', failures;
+  END IF;
+
+  RAISE NOTICE 'All % lint regression tests passed ✓',
+    (SELECT count(*) FROM _lint_test_results);
+END
+$summary$;


### PR DESCRIPTION
- **#835** SQL regression tests for lint-schema-security.sql (4 test cases, wired into db-validate)\n- **#834** Full audit of 83 SECURITY DEFINER functions; prune_old_notifications restricted to service_role\n- **#833** Production smoke test runbook with 11 checks and curl scripts\n- **#832** Accepted advisor findings runbook with rationale for 5 categories\n\nCloses #832, #833, #834, #835