### PR TITLE
docs: address Nyx review notes on #979 (token budget) and #978 (lint test maintenance)

### DIFF
--- a/src/lib/chat-engine.ts
+++ b/src/lib/chat-engine.ts
@@ -34,6 +34,10 @@ export interface StreamChatInput {
 const TOOL_RE = /^\s*\{\s*"tool"\s*:/;
 const ACTION_SUGGEST_RE = /^\s*\{\s*"suggest_action"\s*:/;
 const MAX_TOOL_ROUNDS = 3;
+// TOKEN_BUDGET_CHARS is a per-user-turn global budget across all tool rounds.
+// If round 0 emits 4000 chars of prose, subsequent rounds cannot emit more.
+// This is intentionally conservative for v1 — prevents runaway multi-round verbosity.
+// Raise or make per-round if users report truncated responses in deep tool chains.
 const TOKEN_BUDGET_CHARS = 4000;
 const SYSTEM_TOOLS_PROMPT = `You may emit a JSON tool call to look up data. Tools available:\n%TOOLS%\nWhen calling a tool, respond with ONLY a JSON object: {"tool": "<name>", "args": { ... }}. Otherwise reply in prose. Use tools sparingly.`;
 

--- a/tests/sql/lint-schema-security.test.sql
+++ b/tests/sql/lint-schema-security.test.sql
@@ -2,6 +2,12 @@
 --
 -- Regression suite for infra/lint-schema-security.sql.
 --
+-- ⚠️  MAINTENANCE NOTE: These tests duplicate the invariants from
+--    infra/lint-schema-security.sql. If you change the linter (add/remove
+--    a check, change error message text), update these tests too.
+--    The tests do NOT import or execute the linter file directly — they
+--    independently verify the same three invariants using SAVEPOINT injection.
+--
 -- Strategy: inject a known-bad schema object inside a SAVEPOINT, assert
 -- the linter fails (raises an exception), then ROLLBACK TO SAVEPOINT so
 -- the next test case starts from a clean state. A final positive case


### PR DESCRIPTION
Captures two review observations from Nyx as inline documentation:\n\n**#979:** `TOKEN_BUDGET_CHARS` accumulates globally across all tool rounds — if round 0 emits 4000 chars, subsequent rounds get nothing. Added 4-line comment explaining this is intentional for v1 and when to revisit.\n\n**#978:** SQL regression tests for the linter duplicate its invariants manually (no direct import of the linter file). Added maintenance warning so future engineers know to update both files if the linter changes.