### PR TITLE
fix: Nyx review on #984 (_offCtx cast) and #985/#716 (Llama ONNX_BASE_URL)

### DIFF
--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -902,15 +902,16 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
         return 0.62;
       }
       // Returns estimated text width in SVG user units for a string rendered at TEXT_FONT em.
-      let _offCtx: OffscreenCanvasRenderingContext2D | null = null;
+      // null = not yet tried; false = unavailable; OffscreenCanvasRenderingContext2D = ready
+      let _offCtx: OffscreenCanvasRenderingContext2D | null | false = null;
       function measureLabelWidth(s: string, leafParam: boolean): number {
         if (_offCtx === null) {
           try {
             const oc = new OffscreenCanvas(0, 0);
             _offCtx = oc.getContext('2d') as OffscreenCanvasRenderingContext2D;
-          } catch { _offCtx = undefined as unknown as null; } // mark unavailable
+          } catch { _offCtx = false; } // mark permanently unavailable
         }
-        if (_offCtx) {
+        if (_offCtx !== null && _offCtx !== false) {
           // Font string matches the SVG text attributes below (italic 600 …px system-ui).
           // pxPerVbu: arbitrary px→vbu scale; what matters is the ratio.
           const PX = 100; // 100px gives enough precision for subpixel measurements

--- a/src/lib/onnx-vision.ts
+++ b/src/lib/onnx-vision.ts
@@ -382,6 +382,9 @@ async function decodeGeneration(
 // offline chat). Shares the transformers-cache bucket with Gemma.
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Llama uses the same HuggingFace Hub endpoint as Gemma (from_pretrained with no
+// custom baseURL). Both download from https://huggingface.co/<model-id>/resolve/main/.
+// No separate ONNX_BASE_URL needed — transformers.js handles caching via Cache API.
 export const LLAMA_ONNX_MODEL_ID = 'onnx-community/Llama-3.2-1B-Instruct';
 
 interface TokenizerLike {


### PR DESCRIPTION
Two minor fixes from Nyx review:\n\n**#984 sunburst:** `_offCtx = undefined as unknown as null` → typed as `OffscreenCanvasRenderingContext2D | null | false`; catch sets `false` (permanently unavailable). Clean semantics, no unsafe cast.\n\n**#985/#716 Llama:** Added comment clarifying LLAMA_ONNX_MODEL_ID uses same HuggingFace Hub endpoint as Gemma (`from_pretrained` with no custom baseURL). No ONNX_BASE_URL needed — transformers.js Cache API handles it.