### PR TITLE
feat(chat): location entity kind + places table + chat_find_location RPC (#914)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10444,12 +10444,54 @@ REVOKE EXECUTE ON FUNCTION public.chat_find_species(text, int)              FROM
 REVOKE EXECUTE ON FUNCTION public.chat_find_projects(text, int)             FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)      FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public.chat_find_observers(text, int)            FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.chat_find_location(text, int)             FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.chat_find_observations(jsonb, int)         TO authenticated;
 GRANT EXECUTE ON FUNCTION public.chat_find_species(text, int)               TO authenticated;
 GRANT EXECUTE ON FUNCTION public.chat_find_projects(text, int)              TO authenticated;
 GRANT EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)       TO authenticated;
 GRANT EXECUTE ON FUNCTION public.chat_find_observers(text, int)             TO authenticated;
+GRANT EXECUTE ON FUNCTION public.chat_find_location(text, int)              TO authenticated, anon;
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Locations first-class (#914) — places table + chat_find_location RPC
+-- ═══════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS public.places (
+  id              uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  slug            text UNIQUE NOT NULL,
+  name            text NOT NULL,
+  name_local      text,
+  place_type      text NOT NULL DEFAULT 'h3_cell'
+                  CHECK (place_type IN ('protected_area','h3_cell','custom','community')),
+  geometry        geography(Geometry,4326),
+  h3_cells        text[],
+  observation_count integer NOT NULL DEFAULT 0,
+  observer_count    integer NOT NULL DEFAULT 0,
+  top_taxa          jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS places_slug_idx ON public.places(slug);
+CREATE INDEX IF NOT EXISTS places_geo_idx ON public.places USING GIST(geometry);
+
+ALTER TABLE public.places ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS places_public_read ON public.places;
+CREATE POLICY places_public_read ON public.places FOR SELECT USING (true);
+
+CREATE OR REPLACE FUNCTION public.chat_find_location(p_query text, p_limit int DEFAULT 5)
+RETURNS TABLE (id uuid, slug text, name text, place_type text, observation_count int)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp AS $$
+  SELECT id, slug, name, place_type, observation_count
+  FROM public.places
+  WHERE name ILIKE '%' || p_query || '%'
+     OR slug ILIKE '%' || p_query || '%'
+  ORDER BY observation_count DESC
+  LIMIT p_limit;
+$$;
 
 -- ═══════════════════════════════════════════════════════════════════════════
 -- Security Advisor remediation — 2026-05-08

--- a/src/lib/chat-bubble-html.ts
+++ b/src/lib/chat-bubble-html.ts
@@ -33,6 +33,7 @@ export function canonicalEntityUrl(kind: EntityKind, id: string, lang: 'en' | 'e
     case 'observer':       return `/${lang}/${lang === 'es' ? 'perfil' : 'profile'}/u/${encodeURIComponent(id)}/`;
     case 'self_profile':   return `/${lang}/${lang === 'es' ? 'perfil' : 'profile'}/`;
     case 'camera_station': return '#';
+    case 'location':       return `/${lang}/${lang === 'es' ? 'explorar' : 'explore'}/lugares/${encodeURIComponent(id)}/`;
     default:               return '#';
   }
 }

--- a/src/lib/chat-entities/index.ts
+++ b/src/lib/chat-entities/index.ts
@@ -9,6 +9,7 @@ import { projectSpec } from './project';
 import { cameraStationSpec } from './camera-station';
 import { observerSpec } from './observer';
 import { selfProfileSpec } from './self-profile';
+import { locationSpec } from './location';
 
 export { registry } from './registry';
 export type { EntityCard, EntityKind, EntitySpec } from './types';
@@ -24,4 +25,5 @@ export function bootstrapChatEntities(): void {
   registry.register(cameraStationSpec);
   registry.register(observerSpec);
   registry.register(selfProfileSpec);
+  registry.register(locationSpec);
 }

--- a/src/lib/chat-entities/location.ts
+++ b/src/lib/chat-entities/location.ts
@@ -1,0 +1,17 @@
+import { getSupabase } from '../supabase';
+import type { EntityCard, EntitySpec } from './types';
+
+export const locationSpec: EntitySpec = {
+  kind: 'location',
+  icon: '📍',
+  label: { en: 'Location', es: 'Lugar' },
+  async fetchCard(id) {
+    const { data, error } = await getSupabase().rpc('chat_entity_card', {
+      p_kind: 'location',
+      p_id: id,
+    });
+    if (error) throw new Error(error.message);
+    return (data as EntityCard) ?? null;
+  },
+  suggestedTools: ['find_location', 'find_observations'],
+};

--- a/src/lib/chat-entities/types.ts
+++ b/src/lib/chat-entities/types.ts
@@ -10,7 +10,8 @@ export type EntityKind =
   | 'project'
   | 'camera_station'
   | 'observer'
-  | 'self_profile';
+  | 'self_profile'
+  | 'location';
 
 export interface EntityCard {
   kind: EntityKind;

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -118,12 +118,26 @@ const findObservers: ToolDef = {
   run(args) { return rpcCall('chat_find_observers', args); },
 };
 
+const findLocation: ToolDef = {
+  name: 'find_location',
+  description: 'Search places/locations by name or slug. Returns places with observation counts and type.',
+  args_schema: { p_query: 'string', p_limit: 'number — 1..50, default 5' },
+  validateArgs(args) {
+    if (!isObject(args)) return { ok: false, reason: 'args must be an object' };
+    if (typeof args.p_query !== 'string' || !args.p_query.trim()) return { ok: false, reason: 'p_query must be a non-empty string' };
+    if (args.p_limit !== undefined && typeof args.p_limit !== 'number') return { ok: false, reason: 'p_limit must be a number' };
+    return { ok: true, value: { p_query: args.p_query, p_limit: (args.p_limit as number) ?? 5 } };
+  },
+  run(args) { return rpcCall('chat_find_location', args); },
+};
+
 const REGISTRY: Record<string, ToolDef> = {
   find_observations:    findObservations,
   find_species:         findSpecies,
   find_projects:        findProjects,
   find_camera_stations: findCameraStations,
   find_observers:       findObservers,
+  find_location:        findLocation,
 };
 
 export function listTools(): ToolDef[] {

--- a/tests/unit/chat-location-entity.test.ts
+++ b/tests/unit/chat-location-entity.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the location entity kind (#914).
+ * Covers: locationSpec, find_location tool, canonicalEntityUrl, and
+ * bootstrapChatEntities registration.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- mock supabase ---
+const rpcMock = vi.fn();
+vi.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => ({ rpc: rpcMock }),
+}));
+
+import { locationSpec } from '../../src/lib/chat-entities/location';
+import { registry } from '../../src/lib/chat-entities/registry';
+import { bootstrapChatEntities } from '../../src/lib/chat-entities/index';
+import { canonicalEntityUrl } from '../../src/lib/chat-bubble-html';
+import { runTool, listTools } from '../../src/lib/chat-tools';
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  (registry as unknown as { _resetForTests: () => void })._resetForTests();
+  // Reset bootstrapped flag via re-import isn't possible with vitest cache,
+  // so directly register for registry tests.
+});
+
+// ---------------------------------------------------------------------------
+// locationSpec unit tests
+// ---------------------------------------------------------------------------
+
+describe('locationSpec', () => {
+  it('kind is "location"', () => {
+    expect(locationSpec.kind).toBe('location');
+  });
+
+  it('icon is 📍', () => {
+    expect(locationSpec.icon).toBe('📍');
+  });
+
+  it('has bilingual label', () => {
+    expect(locationSpec.label.en).toBeTruthy();
+    expect(locationSpec.label.es).toBeTruthy();
+  });
+
+  it('fetchCard calls chat_entity_card with kind=location', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: null });
+    await locationSpec.fetchCard('test-id');
+    expect(rpcMock).toHaveBeenCalledWith('chat_entity_card', {
+      p_kind: 'location',
+      p_id: 'test-id',
+    });
+  });
+
+  it('fetchCard returns null when RPC returns null data', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: null });
+    expect(await locationSpec.fetchCard('test-id')).toBeNull();
+  });
+
+  it('fetchCard returns the card when RPC returns data', async () => {
+    const card = {
+      kind: 'location',
+      id: 'loc-1',
+      label: 'Reserva Tehuacán',
+      summary_text: 'Protected area',
+      fields: { place_type: 'protected_area', observation_count: 42 },
+      suggested_questions: [],
+      related: {},
+    };
+    rpcMock.mockResolvedValue({ data: card, error: null });
+    const result = await locationSpec.fetchCard('loc-1');
+    expect(result?.label).toBe('Reserva Tehuacán');
+  });
+
+  it('fetchCard throws on RPC error', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'places rls denied' } });
+    await expect(locationSpec.fetchCard('test-id')).rejects.toThrow(/places rls denied/);
+  });
+
+  it('suggestedTools includes find_location', () => {
+    expect(locationSpec.suggestedTools).toContain('find_location');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canonicalEntityUrl for location
+// ---------------------------------------------------------------------------
+
+describe('canonicalEntityUrl location', () => {
+  it('generates es URL with explorar/lugares slug', () => {
+    const url = canonicalEntityUrl('location', 'reserva-tehuacan', 'es');
+    expect(url).toContain('explorar');
+    expect(url).toContain('lugares');
+    expect(url).toContain('reserva-tehuacan');
+  });
+
+  it('generates en URL with explore slug', () => {
+    const url = canonicalEntityUrl('location', 'reserva-tehuacan', 'en');
+    expect(url).toContain('explore');
+    expect(url).toContain('reserva-tehuacan');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// find_location tool
+// ---------------------------------------------------------------------------
+
+describe('find_location tool', () => {
+  it('is registered in listTools()', () => {
+    const names = listTools().map(t => t.name);
+    expect(names).toContain('find_location');
+  });
+
+  it('runTool returns unknown_tool for unknown name', async () => {
+    const result = await runTool({ name: 'find_location_unknown', args: {} });
+    expect(result).toEqual({ error: 'unknown_tool' });
+  });
+
+  it('runTool validates missing p_query', async () => {
+    const result = await runTool({ name: 'find_location', args: {} });
+    expect(result).toMatchObject({ error: 'invalid_args' });
+  });
+
+  it('runTool validates empty p_query string', async () => {
+    const result = await runTool({ name: 'find_location', args: { p_query: '  ' } });
+    expect(result).toMatchObject({ error: 'invalid_args' });
+  });
+
+  it('runTool calls chat_find_location RPC with correct args', async () => {
+    rpcMock.mockResolvedValue({ data: [], error: null });
+    const result = await runTool({ name: 'find_location', args: { p_query: 'tehuacan' } });
+    expect(rpcMock).toHaveBeenCalledWith('chat_find_location', {
+      p_query: 'tehuacan',
+      p_limit: 5,
+    });
+    expect(result).toMatchObject({ ok: true });
+  });
+
+  it('runTool respects explicit p_limit', async () => {
+    rpcMock.mockResolvedValue({ data: [], error: null });
+    await runTool({ name: 'find_location', args: { p_query: 'oaxaca', p_limit: 3 } });
+    expect(rpcMock).toHaveBeenCalledWith('chat_find_location', {
+      p_query: 'oaxaca',
+      p_limit: 3,
+    });
+  });
+
+  it('runTool returns network error on RPC failure', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'connection refused' } });
+    const result = await runTool({ name: 'find_location', args: { p_query: 'oaxaca' } });
+    expect(result).toMatchObject({ error: 'network' });
+  });
+});


### PR DESCRIPTION
- **#914** places table (RLS public read), chat_find_location() SECURITY DEFINER RPC, locationSpec entity registered, findLocation ToolDef, card renderer with /explore/lugares/ URL, 17 tests\n\nCloses #914