### PR TITLE
fix(auth,onboard): callback spinner hang + onboarding tour for new signups

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2537,6 +2537,9 @@ ALTER TABLE public.users
   }'::jsonb,
   ADD COLUMN IF NOT EXISTS dismissed_privacy_intro_at timestamptz;
 
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS onboarding_completed_at timestamptz;
+
 CREATE INDEX IF NOT EXISTS idx_users_profile_privacy
   ON public.users USING gin (profile_privacy jsonb_path_ops);
 

--- a/src/components/OnboardingTour.astro
+++ b/src/components/OnboardingTour.astro
@@ -271,6 +271,12 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     try { localStorage.setItem(SEEN_KEY, SEEN_VAL); } catch { /* noop */ }
   }
 
+  // Guards: persistPreset() calls persistOnboardingDone() when the user
+  // picks a preset (they may close the modal before reaching the last step).
+  // hide() ALSO calls it when the modal actually closes. Both paths are safe
+  // because the UPDATE is idempotent — writing now() twice is a no-op effect.
+  // The paths are NOT mutually exclusive: preset → continue → last step → hide()
+  // will fire persistOnboardingDone() twice. This is intentional and harmless.
   async function persistOnboardingDone(): Promise<void> {
     let sb;
     try { sb = getSupabase(); } catch { return; }

--- a/src/components/OnboardingTour.astro
+++ b/src/components/OnboardingTour.astro
@@ -271,6 +271,16 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     try { localStorage.setItem(SEEN_KEY, SEEN_VAL); } catch { /* noop */ }
   }
 
+  async function persistOnboardingDone(): Promise<void> {
+    let sb;
+    try { sb = getSupabase(); } catch { return; }
+    try {
+      const user = await getCachedUser();
+      if (!user) return;
+      await sb.from('users').update({ onboarding_completed_at: new Date().toISOString() }).eq('id', user.id);
+    } catch { /* env not configured / column missing — fail closed */ }
+  }
+
   function resolveTarget(selector: string | null): Element | null {
     if (!selector) return null;
     const parts = selector.split(',').map(s => s.trim());
@@ -397,6 +407,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
       const user = await getCachedUser();
       if (!user) return;
       await sb.from('users').update({ profile_privacy: PRESET_DEFS[preset] }).eq('id', user.id);
+      persistOnboardingDone().catch(() => { /* env not configured */ });
     } catch { /* env not configured / column missing — fail closed */ }
   }
 
@@ -581,6 +592,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     try { returnFocusEl?.focus(); } catch { /* noop */ }
     const outcomeType = current === TOTAL - 1 ? 'completed' : 'dismissed';
     try { window.dispatchEvent(new CustomEvent('rastrum:onboarding-event', { detail: { type: outcomeType, step: current } })); } catch { /* noop */ }
+    persistOnboardingDone().catch(() => { /* env not configured */ });
     if (outcomeType === 'completed') {
       window.posthog?.capture('onboarding_completed', { steps_total: TOTAL });
     } else {
@@ -676,17 +688,17 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     try { sb = getSupabase(); } catch { return; }
     const user = await getCachedUser();
     if (!user) return;
-    // Cross-device dedupe: if this user already configured privacy on another
-    // browser/session, the server holds profile_privacy. Treat that as proof
-    // the tour ran before and skip — otherwise users hit the privacy step
-    // every time their localStorage is cleared (incognito, ITP, new device).
+    // Cross-device dedupe: if this user already resolved the tour on another
+    // browser/session, the server holds onboarding_completed_at. Treat that
+    // as proof the tour ran before and skip — otherwise users hit it every
+    // time their localStorage is cleared (incognito, ITP, new device).
     try {
       const { data: profile } = await sb
         .from('users')
-        .select('profile_privacy')
+        .select('onboarding_completed_at')
         .eq('id', user.id)
-        .maybeSingle<{ profile_privacy: Record<string, string> | null }>();
-      if (profile?.profile_privacy && Object.keys(profile.profile_privacy).length > 0) {
+        .maybeSingle<{ onboarding_completed_at: string | null }>();
+      if (profile?.onboarding_completed_at) {
         markSeen();
         return;
       }

--- a/src/pages/auth/callback.astro
+++ b/src/pages/auth/callback.astro
@@ -30,7 +30,15 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 
   <script>
     import { exchangeCode } from '../../lib/auth';
-    import { getSupabase } from '../../lib/supabase';
+    import { getSupabase, getCachedUser } from '../../lib/supabase';
+
+    function withTimeout<T>(p: Promise<T>, ms: number, fallback: T): Promise<T> {
+      return new Promise<T>((resolve) => {
+        const timer = setTimeout(() => resolve(fallback), ms);
+        p.then((v) => { clearTimeout(timer); resolve(v); },
+               ()  => { clearTimeout(timer); resolve(fallback); });
+      });
+    }
 
     const working = document.getElementById('state-working');
     const errorBox = document.getElementById('state-error');
@@ -82,7 +90,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       // already happened and we just redirect.
       const { data: { session: existing } } = await supabase.auth.getSession();
       if (existing) {
-        redirectToHome();
+        await redirectToHome();
         return;
       }
 
@@ -94,11 +102,11 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
           // by a parallel _initialize() that completed between our getSession
           // above and this exchange call. Check session one more time.
           const { data: { session: post } } = await supabase.auth.getSession();
-          if (post) { redirectToHome(); return; }
+          if (post) { await redirectToHome(); return; }
           showError(error.message);
           return;
         }
-        redirectToHome();
+        await redirectToHome();
         return;
       }
 
@@ -110,7 +118,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
           refresh_token: refreshToken,
         });
         if (error) { showError(error.message); return; }
-        redirectToHome();
+        await redirectToHome();
         return;
       }
 
@@ -121,13 +129,17 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       let lang: 'en' | 'es' = 'en';
       try {
         const supabase = getSupabase();
-        const { data: { user } } = await supabase.auth.getUser();
+        const user = await getCachedUser();
         if (user) {
-          const { data: profile } = await supabase
-            .from('users')
-            .select('preferred_lang, created_at')
-            .eq('id', user.id)
-            .maybeSingle();
+          const { data: profile } = await withTimeout(
+            supabase
+              .from('users')
+              .select('preferred_lang, created_at')
+              .eq('id', user.id)
+              .maybeSingle(),
+            3000,
+            { data: null } as { data: { preferred_lang?: string | null; created_at?: string | null } | null },
+          );
           const pl = profile?.preferred_lang;
           if (pl === 'es' || pl === 'en') {
             lang = pl;


### PR DESCRIPTION
## Summary

Two related bugs that combined to give brand-new signups the worst possible first session: stuck on the "Signing you in…" spinner forever, and even when they got through, the onboarding tour never appeared.

### Bug 1 — callback.astro hang

`redirectToHome()` was fired-and-forgotten in all 4 branches of `run()`. Because `run()` returned immediately, the outer `setTimeout(..., 8000)` was cleared by `run().finally(() => clearTimeout(timeout))` BEFORE the redirect actually completed. The 8 s safety net never fired.

Inside `redirectToHome()`, `supabase.auth.getUser()` was called directly — same gotrue navigator-lock contention surface that PRs #930 / #933 / #936 fixed elsewhere by introducing `getCachedUser()`. callback.astro was missed in that migration. When `getUser()` stalled, `window.location.replace(...)` was never reached.

**Fix:** `await redirectToHome()` in all 4 sites, switch to `getCachedUser()`, and wrap the `users` SELECT in a 3 s `withTimeout()` helper so the worst case is a redirect with `lang='en'`. The 8 s outer timeout now becomes a real safety net.

### Bug 2 — onboarding tour suppressed for new signups

`OnboardingTour.astro` `maybeShow()` checked `Object.keys(profile_privacy).length > 0` as a cross-device "user already configured privacy on another browser" signal. But the schema default for `users.profile_privacy` ships with all 19 keys pre-populated, so every brand-new user looked like an already-configured user → `markSeen()` → no tour, ever.

**Fix:** add `public.users.onboarding_completed_at timestamptz` (NULL for fresh users). Tour checks that instead. Written from `hide()` (both completed + dismissed paths) and from `persistPreset()`. `localStorage.rastrum.onboarding.seen` stays as the offline fast-path. No backfill needed — existing users who saw the tour already have the localStorage flag.

## Test plan

- [ ] db-validate CI passes (idempotent `ADD COLUMN IF NOT EXISTS` re-applies clean on the second pass)
- [ ] Manual: sign up with a fresh email → land on home in < 8 s → onboarding tour appears within 600 ms
- [ ] Manual: existing user with `localStorage.rastrum.onboarding.seen === 'v1'` → tour does NOT re-appear after this deploy
- [ ] Manual: throttle network in DevTools to simulate the original hang → callback shows the actionable error after 8 s instead of spinning forever
- [ ] Typecheck + vitest + build pass with no NEW failures (4 pre-existing TS errors in `sw-pmtiles-buffer.test.ts` and 6 pre-existing vitest failures unrelated to auth/onboarding remain the same — verified by diffing baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)