### PR TITLE
fix(plantnet): treat HTTP 400 as soft-fail, skip runner instead of breaking cascade

### DIFF
--- a/src/lib/identify-runners.ts
+++ b/src/lib/identify-runners.ts
@@ -56,7 +56,12 @@ export function makePlantNetRunner(locale: Locale): IdentifierRunner {
     //   404 → PlantNet's "not a plant" or unknown key — no winner from us
     //   429 → daily quota exhausted (shared key shipped 500/day; the operator
     //         hit the cap, but Claude / Phi can still answer)
-    if (res.status === 403 || res.status === 404 || res.status === 429) return null;
+    // Soft-fail codes: skip this runner, let others continue
+    // 400 → malformed image / unsupported format / no organ detected → not fatal
+    // 403 → key revoked or origin not allowed
+    // 404 → PlantNet's "not a plant" or unknown taxon
+    // 429 → daily quota exhausted
+    if (res.status === 400 || res.status === 403 || res.status === 404 || res.status === 429) return null;
     if (!res.ok) throw new Error(`PlantNet HTTP ${res.status}`);
     const data = await res.json() as { results?: PlantNetMatch[] };
     const results = data.results ?? [];


### PR DESCRIPTION
PlantNet returns 400 for malformed images, unsupported format, or no detectable organ. Previously this surfaced as an error to the user.\n\nNow treated as soft-fail (same as 404) — cascade continues with Claude/Gemma.\n\nReported by Pame on Android Chrome 147, observe page.