### PR TITLE
fix(e2e): mock model-cache state in chat-deep-link spec

### DIFF
--- a/tests/e2e/chat-deep-link.spec.ts
+++ b/tests/e2e/chat-deep-link.spec.ts
@@ -34,8 +34,44 @@ async function mockEntityResolution(page: import('@playwright/test').Page) {
   });
 }
 
+/** ChatView.refreshState() keeps `<form id="chat-form">` hidden until either
+ *  Llama or Gemma weights show up in the Cache API. In a fresh CI environment
+ *  neither is cached, so the form stays hidden — and the chip slot inside it.
+ *
+ *  This helper monkey-patches `caches.open('webllm/model')` so the next call
+ *  pre-seeds a tiny fake entry whose URL contains TEXT_MODEL_ID
+ *  (Llama-3.2-1B-Instruct-q4f16_1-MLC). Chat's getModelCacheStatus() then
+ *  returns `cached: true`, refreshState() unhides the form, and the chip
+ *  rendered by mockEntityResolution is visible.
+ *
+ *  Wraps caches.open instead of pre-populating up-front so the seed is
+ *  guaranteed to land before the chat code awaits the cache lookup —
+ *  no race with the init script's async body.
+ *
+ *  Closes #1003 (e2e blocked by model-cache gate). */
+async function mockChatModelCached(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    if (typeof caches === 'undefined') return;
+    const FAKE_URL = 'https://e2e.fixture/Llama-3.2-1B-Instruct-q4f16_1-MLC/shard.bin';
+    const realOpen = caches.open.bind(caches);
+    (caches as unknown as { open: typeof caches.open }).open = async (name: string) => {
+      const c = await realOpen(name);
+      if (name === 'webllm/model') {
+        const existing = await c.match(FAKE_URL);
+        if (!existing) {
+          await c.put(FAKE_URL, new Response(new Uint8Array(0), {
+            headers: { 'content-length': '0' },
+          }));
+        }
+      }
+      return c;
+    };
+  });
+}
+
 test.describe('chat deep-link (EN)', () => {
   test('entity chip renders after ?attach= navigation', async ({ authedPage: page }) => {
+    await mockChatModelCached(page);
     await mockEntityResolution(page);
     await page.goto(DEEP_LINK_EN);
 
@@ -47,6 +83,7 @@ test.describe('chat deep-link (EN)', () => {
   });
 
   test('?attach= query param is removed from URL after hydration', async ({ authedPage: page }) => {
+    await mockChatModelCached(page);
     await mockEntityResolution(page);
     await page.goto(DEEP_LINK_EN);
 
@@ -61,6 +98,7 @@ test.describe('chat deep-link (EN)', () => {
 
 test.describe('chat deep-link (ES)', () => {
   test('entity chip renders for ES locale deep-link', async ({ authedPage: page }) => {
+    await mockChatModelCached(page);
     await mockEntityResolution(page);
     await page.goto(DEEP_LINK_ES);
 
@@ -72,6 +110,7 @@ test.describe('chat deep-link (ES)', () => {
 
 test.describe('chat deep-link (mobile)', () => {
   test('entity chip renders on mobile viewport', async ({ authedPage: page }) => {
+    await mockChatModelCached(page);
     await mockEntityResolution(page);
     await page.goto(DEEP_LINK_EN);
 


### PR DESCRIPTION
## Summary

Closes #1003.

The 4 chat-deep-link e2e tests (EN, ES, mobile + URL-cleanup) cannot pass in a clean CI environment because the chat composer form stays \`hidden\` until either Llama or Gemma weights show up in the WebLLM Cache API. Fresh CI = no models cached → form hidden → chip slot inside it hidden → \`toBeVisible()\` fails. The chip rendered correctly (Playwright resolved the locator 14 times) but the hidden ancestor made it report as \`hidden\`.

This was masked on main for weeks because \`npm run build\` was failing (trails + pits BaseLayout path bugs) and the e2e never actually ran. Once those build bugs were fixed in #1000, the test surfaced as red.

## Fix

Adds a small \`mockChatModelCached(page)\` helper in the spec that monkey-patches \`caches.open('webllm/model')\`. When ChatView's \`getModelCacheStatus()\` calls it, the override seeds a fake shard URL containing \`TEXT_MODEL_ID\` (\`Llama-3.2-1B-Instruct-q4f16_1-MLC\`) before returning the cache. \`refreshState()\` then sees Llama as cached and unhides the form.

Why wrap \`caches.open\` rather than pre-populate the cache up-front in an init script: the init script's async body races with the page's own \`refreshState()\` call. Wrapping the API guarantees the seed completes inside the chat code's own \`await\` boundary — no race.

The fix is **test-side only** — zero app code touched. Mirrors option 1 from the issue.

## Verification

\`\`\`
$ npx playwright test tests/e2e/chat-deep-link.spec.ts --project=chromium --reporter=list
  ✓  3 [chromium] › tests/e2e/chat-deep-link.spec.ts:112:3 › mobile › entity chip renders on mobile viewport (454ms)
  ✓  2 [chromium] › tests/e2e/chat-deep-link.spec.ts:73:3  › EN › entity chip renders after ?attach= navigation (416ms)
  ✓  4 [chromium] › tests/e2e/chat-deep-link.spec.ts:85:3  › EN › ?attach= query param is removed from URL after hydration (430ms)
  ✓  1 [chromium] › tests/e2e/chat-deep-link.spec.ts:100:3 › ES › entity chip renders for ES locale deep-link (459ms)
  4 passed (3.2s)
\`\`\`

Plus \`npm run typecheck\`: 0 errors.

## Test plan

- [ ] CI's \`test\` (E2E Playwright) job passes — was the only red check on PR #1000
- [ ] Deploy to GitHub Pages on main turns green again (it was green for the merge of #1000; this just keeps it green)
- [ ] Future PRs no longer see the chat-deep-link false positive

## Related

- Closes #1003
- Surfaced by #1000 (the #942 implementation deviations fix) once the build was unblocked
🤖 Generated with [Claude Code](https://claude.com/claude-code)