### PR TITLE
fix(ci): stub storage.foldername() in db-validate Postgres env

### DIFF
--- a/.github/workflows/db-validate.yml
+++ b/.github/workflows/db-validate.yml
@@ -134,6 +134,15 @@ jobs:
           GRANT ALL ON storage.buckets, storage.objects TO authenticated, service_role;
           GRANT SELECT ON storage.buckets, storage.objects TO anon;
 
+          -- storage.foldername(text) — Supabase's real impl splits a path by '/' and
+          -- returns the array of folder segments minus the final filename. For the
+          -- validate context we just need a function that lets the policy compile
+          -- and evaluate correctly; the simplest equivalent splits on '/' and returns
+          -- all segments, which the only consuming policy ([1] != '.keep') reads
+          -- positionally from. See docs/specs/infra/supabase-schema.sql media_authenticated_list.
+          CREATE OR REPLACE FUNCTION storage.foldername(name text) RETURNS text[]
+          LANGUAGE sql IMMUTABLE AS $$ SELECT string_to_array($1, '/') $$;
+
           -- Cron stubs MUST be created before supabase-schema.sql is applied,
           -- because rastrum's schema now defines SQL functions whose body
           -- references cron.job and cron.job_run_details (see


### PR DESCRIPTION
**Foundation fix — merge this first.** All other "fix(schema)" PRs extracted from #994 close-out depend on validate being able to advance past line 1326.

## Summary

\`db-validate\` has been failing on every PR for weeks at \`supabase-schema.sql:1326\` because the ephemeral Postgres container lacks Supabase's \`storage.foldername(text)\` — referenced by the \`media_authenticated_list\` policy. Once that line errors, validate exits before doing any real validation.

Add a minimal SQL equivalent (\`string_to_array(name, '/')\`) inside the existing "Stub Supabase auth schema and helpers" step in \`.github/workflows/db-validate.yml\`. The only consumer reads index \`[1]\` to gate \`.keep\` sentinel files; split-on-'/' is sufficient.

## Why this matters

The validate gate has been broken-by-design since this stub was missing. Multiple PRs (#914, #550, #803, #995, #997, #1002) merged with schema bugs that should have been caught here. Restoring the gate unblocks 8 sibling fix PRs that revert those bugs.

## Test plan

- [ ] \`db-validate\` advances past line 1326 on this PR
- [ ] After merge, sibling cleanup PRs surface remaining schema bugs one by one

Extracted from #994 (close-out — 9 separate per-author PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)