### PR TITLE
fix(schema): chat_find_location uses places.obs_count (not observation_count)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10678,11 +10678,16 @@ CREATE OR REPLACE FUNCTION public.chat_find_location(p_query text, p_limit int D
 RETURNS TABLE (id uuid, slug text, name text, place_type text, observation_count int)
 LANGUAGE sql STABLE SECURITY DEFINER
 SET search_path = public, pg_temp AS $$
-  SELECT id, slug, name, place_type, observation_count
+  -- #914's CREATE TABLE places (line ~10650) is a no-op because
+  -- IF NOT EXISTS yields to the earlier WDPA places table (line ~7285),
+  -- which spells the column obs_count, not observation_count. Alias here
+  -- preserves the function's RETURNS TABLE contract (clients still see
+  -- observation_count) until the two places designs are reconciled.
+  SELECT id, slug, name, place_type, obs_count AS observation_count
   FROM public.places
   WHERE name ILIKE '%' || p_query || '%'
      OR slug ILIKE '%' || p_query || '%'
-  ORDER BY observation_count DESC
+  ORDER BY obs_count DESC
   LIMIT p_limit;
 $$;
 REVOKE EXECUTE ON FUNCTION public.chat_find_location(text, int) FROM PUBLIC;


### PR DESCRIPTION
## Summary

\`chat_find_location\` (added in #914) does \`SELECT … observation_count FROM public.places\`, but the existing \`places\` table (~line 7285, WDPA-derived, predates #914) spells the column \`obs_count\`. #914's own \`CREATE TABLE IF NOT EXISTS places\` (~line 10650) is a silent no-op.

**Fix:** alias \`obs_count AS observation_count\` in the SELECT and \`ORDER BY obs_count\`. Preserves the function's \`RETURNS TABLE (..., observation_count int)\` contract — clients keep seeing \`observation_count\`.

## Out of scope

The deeper conflict — two distinct \`places\` table designs in the schema — needs the #914 author's call. This PR is the minimum to unblock validate.

## Test plan

- [ ] db-validate advances past line 10684 (requires #1005 merged first)
- [ ] \`chat_find_location('mexico')\` still returns rows with \`observation_count\` column

Extracted from #994 close-out. Original bug: #914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)