### PR TITLE
fix(schema): remove broken idx_activity_target_unread (column never existed)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -12070,10 +12070,12 @@ CREATE INDEX IF NOT EXISTS idx_obs_synced_at
   ON public.observations (observer_id, observed_at DESC)
   WHERE sync_status = 'synced';
 
--- activity_events: unread notifications per target user (bell badge).
-CREATE INDEX IF NOT EXISTS idx_activity_target_unread
-  ON public.activity_events (target_user_id, created_at DESC)
-  WHERE read_at IS NULL;
+-- (Removed: idx_activity_target_unread referenced a non-existent
+-- activity_events.target_user_id column — the column was planned but
+-- never added. db-apply has been silently failing on this line, and
+-- the bell-badge query is already covered by idx_activity_unread on
+-- actor_id. Re-add this index in the same PR that introduces the
+-- target_user_id column with a real consumer.)
 
 -- ============================================================
 -- #550: Conservation status ETL — conservation_synced_at column


### PR DESCRIPTION
## Summary

An index in supabase-schema.sql (~line 12080) references \`public.activity_events.target_user_id\` — a column that **was never added to the table**. \`activity_events\` (line 1201) has only \`actor_id\` as its user link. The index has therefore been dead code since whichever PR added it; db-apply on main has been silently failing on this line.

The "unread notifications per user (bell badge)" query intent is already covered by \`idx_activity_unread\` on \`actor_id\` (line 1220), so removing the broken duplicate loses no production capability.

If a future PR genuinely needs to separate notification recipient from action actor, it should add the column AND re-add the index in the same commit.

## Test plan

- [ ] db-validate advances past line 12080 (requires #1005 merged first)
- [ ] No production query degradation — \`actor_id\`-based bell badge query still uses \`idx_activity_unread\`

Extracted from #994 close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)