### PR TITLE
fix(schema): nested dollar-quoting in refresh-conservation-status cron block

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -12085,21 +12085,21 @@ ALTER TABLE public.taxa
 -- Monthly cron: triggers the refresh-conservation-status Edge Function.
 -- Runs on the 1st of each month at 03:00 UTC.
 -- Requires pg_cron + pg_net extensions (already enabled in Rastrum).
-DO $$
+DO $do$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
     PERFORM cron.unschedule('refresh-conservation-status');
     PERFORM cron.schedule(
       'refresh-conservation-status',
       '0 3 1 * *',
-      $$SELECT net.http_post(
+      $cron$SELECT net.http_post(
           url    := current_setting('app.supabase_url') || '/functions/v1/refresh-conservation-status',
           headers := json_build_object('x-cron-secret', current_setting('app.cron_secret'))::jsonb,
           body   := '{}'::jsonb
-      )$$
+      )$cron$
     );
   END IF;
-END $$;
+END $do$;
 
 -- ============================================================
 -- #551: Wire conservation multipliers into award_karma()


### PR DESCRIPTION
## Summary

PR #550 added the \`refresh-conservation-status\` cron schedule inside a \`DO \$\$ … \$\$\` block. Both the outer DO body AND the inner \`cron.schedule\` command literal use the default \`\$\$\` delimiter — so the SQL parser treats the inner \`\$\$SELECT net.http_post(...)\` opening as the close of the outer DO body, yielding "syntax error at or near SELECT" against the matching outer \`\$\$\` later in the file.

**Fix:** tag the outer block as \`\$do\$ … \$do\$\` and the inner command as \`\$cron\$ … \$cron\$\`. Same effective semantics; unambiguous parse.

## Test plan

- [ ] db-validate advances past line 12109 (requires #1005 merged first)
- [ ] \`SELECT * FROM cron.job WHERE jobname = 'refresh-conservation-status'\` returns the same row contents

Extracted from #994 close-out. Original bug: #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)