### PR TITLE
fix(schema): close institutions + weekly_validator_rewards CREATE TABLE

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -12500,6 +12500,8 @@ CREATE TABLE IF NOT EXISTS public.institutions (
   kind        text NOT NULL DEFAULT 'gov'
                 CHECK (kind IN ('gov','academic','ngo','research')),
   created_at  timestamptz NOT NULL DEFAULT now()
+);
+
 -- Admin-verified institutional affiliations for experts
 CREATE TABLE IF NOT EXISTS public.institutional_affiliations (
   id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -12584,6 +12584,8 @@ CREATE TABLE IF NOT EXISTS public.weekly_validator_rewards (
   awarded_at    timestamptz NOT NULL DEFAULT now(),
   claimed_at    timestamptz,
   UNIQUE (week_iso, user_id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_weekly_validator_rewards_user
   ON public.weekly_validator_rewards(user_id, awarded_at DESC);
 ALTER TABLE public.weekly_validator_rewards ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

PR #997 (v1.5 institutional endorsements + weekly validator lottery) introduced **two** \`CREATE TABLE\` statements that are missing their closing \`);\` before the next statement:

1. **\`public.institutions\`** (~line 12501-12510) — runs into the next \`CREATE TABLE public.institutional_affiliations\` as if the column list never ended. *(This is the bug that was actively breaking validate.)*
2. **\`public.weekly_validator_rewards\`** (~line 12586-12591) — same pattern: ends with \`UNIQUE(...)\` and runs straight into the next \`CREATE INDEX\`.

Postgres parses each as a single runaway statement until it hits an unexpected keyword 100+ lines later, then reports "syntax error at or near CREATE" against the wrong line.

**Fix:** add the missing \`);\\n\\n\` between each table's last column and the following statement. Two-line diff per table.

## Test plan

- [ ] db-validate advances past line 12715 (requires #1005 merged first)
- [ ] Both tables now applied with the intended columns

Extracted from #994 close-out. Original bugs: #997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)