### PR TITLE
fix(schema): probable_taxa_cache CREATE POLICY missing DROP POLICY IF EXISTS

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11814,6 +11814,7 @@ CREATE INDEX IF NOT EXISTS probable_taxa_cache_geohash5_month_score_idx
 
 -- RLS: public read (anon may read suggestions), no direct write from clients.
 ALTER TABLE public.probable_taxa_cache ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "probable_taxa_cache: anon can read" ON public.probable_taxa_cache;
 CREATE POLICY "probable_taxa_cache: anon can read"
   ON public.probable_taxa_cache FOR SELECT
   USING (true);


### PR DESCRIPTION
## Summary

Per CLAUDE.md "Idempotent everything", every \`CREATE POLICY\` must be paired with a preceding \`DROP POLICY IF EXISTS\`. \`probable_taxa_cache\`'s policy (~line 11823) ships from #803 without the DROP guard — validate's second-pass idempotency check fails with "policy already exists".

**Fix:** one-line \`DROP POLICY IF EXISTS\` before the \`CREATE POLICY\`.

## Test plan

- [ ] db-validate's second pass (idempotency) advances past line 11823 (requires #1005 merged first)

Extracted from #994 close-out. Original bug: #803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)