### PR TITLE
fix(schema): trails/pits CREATE POLICY missing DROP POLICY IF EXISTS (×4)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -12413,11 +12413,13 @@ CREATE TABLE IF NOT EXISTS public.trails (
 ALTER TABLE public.trails ENABLE ROW LEVEL SECURITY;
 
 -- Public trails are readable by anyone; owner can always read their own
+DROP POLICY IF EXISTS trails_public_read ON public.trails;
 CREATE POLICY trails_public_read ON public.trails
   FOR SELECT
   USING (visibility = 'public' OR (SELECT auth.uid()) = creator_id);
 
 -- Owners can insert/update/delete their own trails
+DROP POLICY IF EXISTS trails_owner_write ON public.trails;
 CREATE POLICY trails_owner_write ON public.trails
   FOR ALL
   TO authenticated
@@ -12443,11 +12445,13 @@ CREATE TABLE IF NOT EXISTS public.pits (
 ALTER TABLE public.pits ENABLE ROW LEVEL SECURITY;
 
 -- PITs are publicly readable (they link to public QR codes)
+DROP POLICY IF EXISTS pits_public_read ON public.pits;
 CREATE POLICY pits_public_read ON public.pits
   FOR SELECT
   USING (true);
 
 -- Only authenticated users can create/manage PITs (future: karma gate)
+DROP POLICY IF EXISTS pits_authenticated_write ON public.pits;
 CREATE POLICY pits_authenticated_write ON public.pits
   FOR ALL
   TO authenticated


### PR DESCRIPTION
## Summary

PR #995 (v1.5 Biodiversity Trails / PITs) shipped four \`CREATE POLICY\` statements without preceding \`DROP POLICY IF EXISTS\` guards:

- \`trails_public_read\`
- \`trails_owner_write\`
- \`pits_public_read\`
- \`pits_authenticated_write\`

Per CLAUDE.md "Idempotent everything", every policy must ship paired. Without the DROP guard, validate's second idempotency pass fails with "policy already exists".

**Fix:** add four matching \`DROP POLICY IF EXISTS\` lines.

## Test plan

- [ ] db-validate's second pass advances past the trails/pits block (requires #1005 merged first)

Extracted from #994 close-out. Original bug: #995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)