### PR TITLE
fix(test): rls.sql #866 freeze-test missing auth.users seed

### DIFF
--- a/tests/sql/rls.sql
+++ b/tests/sql/rls.sql
@@ -1064,6 +1064,10 @@ DO $$
 DECLARE
   v_uid uuid := '88880000-0000-0000-0000-000000000001';
 BEGIN
+  -- Seed auth.users first — public.users.id has a FK to auth.users(id).
+  INSERT INTO auth.users (id, email) VALUES (v_uid, 'freeze_test_user@example.test')
+  ON CONFLICT (id) DO NOTHING;
+
   -- Seed a user row (public.users has no email column — that lives in auth.users).
   INSERT INTO public.users (id, username, display_name)
   VALUES (v_uid, 'freeze_test_user', 'Freeze Test')


### PR DESCRIPTION
## Summary

The #866 streak-freeze DO block at \`tests/sql/rls.sql:1063\` inserts directly into \`public.users\` without first creating the matching \`auth.users\` row that \`public.users.id\` references via \`users_id_fkey\`. validate's RLS suite fails with "insert or update on table users violates foreign key constraint users_id_fkey".

The earlier two test users at lines 34 and 800 correctly insert into \`auth.users\` first; the #866 block missed that step.

**Fix:** mirror the existing pattern — single \`ON CONFLICT\`-guarded INSERT into \`auth.users\` with a test email, before the \`public.users\` INSERT.

## Test plan

- [ ] db-validate's RLS regression suite step passes (requires #1005 + the other schema fixes merged so schema apply gets that far)

Extracted from #994 close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)