### PR TITLE
fix(schema): mv_recent_species selects primary_taxon_id (not taxon_id)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -12811,13 +12811,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS mv_user_obs_counts_idx
 -- Avoids a full-table scan on the explore / trending-species page.
 CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_recent_species AS
   SELECT
-    taxon_id,
+    primary_taxon_id AS taxon_id,
     COUNT(*) AS recent_count,
     MAX(observed_at) AS last_seen
   FROM public.observations
   WHERE sync_status = 'synced'
     AND observed_at > now() - interval '30 days'
-  GROUP BY taxon_id
+    AND primary_taxon_id IS NOT NULL
+  GROUP BY primary_taxon_id
   ORDER BY recent_count DESC;
 
 CREATE UNIQUE INDEX IF NOT EXISTS mv_recent_species_idx


### PR DESCRIPTION
## Summary

PR #1002 added \`mv_recent_species\` materialized view that selects \`taxon_id\` from \`public.observations\` — but the column is named \`primary_taxon_id\` (the denormalised primary identification column, kept in sync by \`sync_primary_id_trigger\`).

**Fix:** alias \`primary_taxon_id AS taxon_id\` in the SELECT so downstream consumers' expectation of a column named \`taxon_id\` is preserved; the existing \`CREATE UNIQUE INDEX … ON mv_recent_species(taxon_id)\` continues to work. Added an \`IS NOT NULL\` guard so observations without an accepted identification don't pollute the cache.

## Test plan

- [ ] db-validate advances past line 12821 (requires #1005 merged first)
- [ ] \`REFRESH MATERIALIZED VIEW public.mv_recent_species\` succeeds and contains rows
- [ ] Downstream queries against \`mv_recent_species.taxon_id\` still resolve

Extracted from #994 close-out. Original bug: #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)