### PR TITLE
fix(ci): db-validate runs on every PR — required check always present

### DIFF
--- a/.github/workflows/db-validate.yml
+++ b/.github/workflows/db-validate.yml
@@ -20,12 +20,14 @@ name: db-validate
 #     future PR; we only check the ENABLE flag here, not policy logic)
 
 on:
+  # No `paths:` filter — validate runs on every PR so the required status
+  # check is always present. A path-filtered required check creates a
+  # deadlock (the rule expects the check, but the workflow never fires on
+  # PRs that don't touch schema). Validate is fast (~1.5 min, parallel
+  # with other CI), and idempotent schema apply is a useful smoke test
+  # even on PRs that don't change SQL — catches any drift between the
+  # checked-in schema and what Postgres actually accepts.
   pull_request:
-    paths:
-      - 'docs/specs/infra/supabase-schema.sql'
-      - 'docs/specs/infra/cron-schedules.sql'
-      - 'tests/sql/**'
-      - '.github/workflows/db-validate.yml'
 
 concurrency:
   group: db-validate-${{ github.ref }}


### PR DESCRIPTION
## Summary

The \`db-validate\` workflow had a \`paths:\` filter that scoped it to schema/SQL/test changes only. Combined with the branch protection rule that requires \`validate\` to be present, this created a deadlock: PRs that didn't touch those paths (e.g. #999 — pure build/test fixes) couldn't merge because the workflow never fired, so the required check was never satisfied.

\`\`\`
Repository rule violations found
Required status check "validate" is expected.
\`\`\`

**Fix:** remove the \`paths:\` filter. Validate runs on every PR. Idempotent schema apply against ephemeral Postgres takes ~1.5 min and runs parallel with other CI — negligible cost.

## Why this is the right shape

The alternative was to relax the branch rule to "required when present". That would have hidden the same misconfiguration if anyone re-adds a path filter later, and breaks the principle that **every PR passes the same baseline**. Better engineering: keep the rule strict, make the workflow always run.

Schema apply on a PR that doesn't change SQL still has value — it catches any drift between the checked-in \`supabase-schema.sql\` and what Postgres actually accepts (e.g. dependency on an extension version that quietly changed).

## Out of scope

The 9 sibling PRs (#1005–#1013) extracted from #994 also unblock various validate failure modes — they fix the bugs that validate would have caught had the gate been correctly configured all along. Merge order remains:
1. **#1005** (storage.foldername stub — foundation) + **this PR** (paths removal)
2. Then #1006–#1013 in any order
3. Then #999 (now mergeable because validate becomes a real check that runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)