### PR TITLE
fix(e2e): journey-guides next/done specs

### DIFF
--- a/tests/e2e/journey-guides.spec.ts
+++ b/tests/e2e/journey-guides.spec.ts
@@ -6,6 +6,29 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Journey guides', () => {
+  // Two pre-conditions must hold for journey-guide click interactions to be
+  // testable on /en/observe:
+  //  1. Suppress the first-visit auto-guide so it doesn't race with the
+  //     manually-dispatched test guide and clobber its steps ~500ms later.
+  //  2. Dismiss the analytics consent banner — it sits at z-[9000] (above the
+  //     spotlight's z-[65]) and intercepts pointer events on #js-next when the
+  //     tooltip lands near the viewport bottom.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('rastrum_analytics_consent', 'false');
+        for (const key of [
+          'rastrum.guide.observe',
+          'rastrum.guide.explore',
+          'rastrum.guide.validate',
+          'rastrum.guide.export',
+          'rastrum.guide.community',
+          'rastrum.guide.console',
+        ]) localStorage.setItem(key, 'done');
+      } catch { /* noop */ }
+    });
+  });
+
   test('journey spotlight is hidden by default', async ({ page }) => {
     await page.goto('/en/');
     const spotlight = page.locator('#journey-spotlight');


### PR DESCRIPTION
Closes #1017.

## Summary

Two preconditions had to hold for `#js-next` click interactions to be testable on `/en/observe`, but the spec asserted neither:

1. **First-visit auto-guide race** — `JourneyGuideLoader` auto-starts `guide-observe` ~500ms after DOMContentLoaded (its `waitForTarget` poller finds `#obs2-post-form` and dispatches `rastrum:journey-guide-start`). The test's manually-dispatched guide started cleanly, but the auto-guide then clobbered it — "Step 1" got rewritten with the real `guides.observe.step1_title` copy before the next-click assertion fired.
2. **Consent banner z-index overlap** — `ConsentBanner` sits at `z-[9000]`, the spotlight at `z-[65]`. When the test's guide targets `'main'`, the tooltip lands near the viewport bottom and the banner intercepts pointer events on `#js-next`. The failure screenshot showed the banner directly covering the button.

Fix: `test.beforeEach` writes `'done'` to all six guide `storageKey`s and `'false'` to `rastrum_analytics_consent` via `page.addInitScript`. Both surfaces stay out of the way for the whole describe block.

The Escape and skip specs were passing by luck — the auto-guide had fired with a hidden first-step target (`#obs2-post-form.hidden`) so its tooltip centered and the buttons happened to clear the banner. The test guide with target `'main'` produced a bottom-positioned tooltip and exposed the same overlap.

## Test plan

- [x] All 8 specs in `tests/e2e/journey-guides.spec.ts` pass locally on chromium (3.6s)
- [ ] CI e2e workflow green
- [ ] No regression in passing siblings (Escape, skip, hidden-by-default, replay-button, started-via-event, telemetry-events)