### PR TITLE
fix(e2e): onboarding tour step count 6 → 7 (after first-observation-demo step)

### DIFF
--- a/tests/e2e/journey-observer-first-obs.spec.ts
+++ b/tests/e2e/journey-observer-first-obs.spec.ts
@@ -14,9 +14,9 @@ test.describe('J2: Observer first observation journey', () => {
     const dialog = page.locator('#onboarding-tour');
     await expect(dialog).toBeVisible();
 
-    // Walk through all 6 steps
-    for (let i = 0; i < 6; i++) {
-      await expect(page.locator('#onb-step-label')).toContainText(`${i + 1}`);
+    // Walk through all 7 steps
+    for (let i = 0; i < 7; i++) {
+      await expect(page.locator('#onb-step-label')).toContainText(`${i + 1} of 7`);
       await page.locator('#onb-next').click();
     }
     // Dialog should close after final step

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -21,9 +21,9 @@ async function openTour(page: Page) {
 }
 
 test.describe('OnboardingTour', () => {
-  test('replay event opens the dialog and shows step 1 of 5', async ({ page }) => {
+  test('replay event opens the dialog and shows step 1 of 7', async ({ page }) => {
     const dialog = await openTour(page);
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 1 of 6/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 1 of 7/);
     await expect(dialog.locator('#onb-tooltip-title')).toBeVisible();
     await expect(dialog.locator('#onb-tooltip')).toHaveAttribute('aria-modal', 'true');
   });
@@ -48,29 +48,19 @@ test.describe('OnboardingTour', () => {
     await expect(dialog).toBeVisible();
   });
 
-  test('next advances through all 6 steps', async ({ page }) => {
+  test('next advances through all 7 steps', async ({ page }) => {
     const dialog = await openTour(page);
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 1 of 6/);
-    // Step 1 has a "Start tour" button (labelStart), click it
-    await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 2 of 6/);
-    await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 3 of 6/);
-    await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 4 of 6/);
-    await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 5 of 6/);
-    await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 6 of 6/);
-    // Step 6 "Done" should close the dialog
-    await dialog.locator('#onb-next').click();
+    for (let i = 1; i <= 7; i++) {
+      await expect(dialog.locator('#onb-step-label')).toHaveText(new RegExp(`Step ${i} of 7`));
+      await dialog.locator('#onb-next').click();
+    }
     await expect(page.locator('#onboarding-tour')).toBeHidden();
   });
 
   test('skip button closes the dialog on non-final steps', async ({ page }) => {
     const dialog = await openTour(page);
     await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 2 of 6/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 2 of 7/);
     await dialog.locator('#onb-skip').click();
     await expect(page.locator('#onboarding-tour')).toBeHidden();
   });


### PR DESCRIPTION
## Summary

OnboardingTour grew from 6 to 7 steps when #974 added the \`first_observation_demo\` step. Two e2e specs were not updated and have been failing since #1015 restored the e2e workflow:

- \`tests/e2e/onboarding.spec.ts\` — 3 tests asserted \`/Step N of 6/\`
- \`tests/e2e/journey-observer-first-obs.spec.ts\` — loop iterated 6 times

Verified against \`src/components/OnboardingTour.astro\`: \`data-step-count="7"\` and 7 entries in the stepsData JSON literal.

Also tightened the \`journey-observer\` assertion from \`toContainText(\\\`\${i + 1}\\\`)\` (loose substring match, would pass coincidentally on digit overlap) to \`toContainText(\\\`\${i + 1} of 7\\\`)\` (verbatim format) — so a future drift to 8 steps fails loudly.

## Closes / supersedes

Closes #999 (which had this fix among other commits, most of which became redundant after #1018, #1019, #1004 merged equivalent fixes elsewhere; this is the only remaining real delta).

## Test plan

- [ ] CI \`test\` workflow (Playwright e2e) green
- [ ] All 5 specs in \`tests/e2e/onboarding.spec.ts\` pass
- [ ] J2 journey \"onboarding tour opens and can be completed\" passes
- [ ] No regression in passing sibling tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)