### PR TITLE
fix(schema): reconcile two competing public.places definitions

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -10648,43 +10648,23 @@ GRANT EXECUTE ON FUNCTION public.chat_find_camera_stations(uuid, int)       TO a
 GRANT EXECUTE ON FUNCTION public.chat_find_observers(text, int)             TO authenticated;
 
 -- ═══════════════════════════════════════════════════════════════════════════
--- Locations first-class (#914) — places table + chat_find_location RPC
+-- Locations first-class (#914) — chat_find_location RPC
 -- ═══════════════════════════════════════════════════════════════════════════
+-- The places table is defined upstream at line ~7289 (WDPA-flavoured design:
+-- obs_count / species_count / observer_count, with country_code +
+-- state_province + first/last_obs_at). A second CREATE TABLE block lived
+-- here for #914's chat-locations work, but IF NOT EXISTS made it a silent
+-- no-op against the older table — and every production consumer
+-- (PlacesNearby, ExplorePlacesView, PlaceDetailView, places/compare) was
+-- already using the WDPA column names. Reconciled in #1025: the chat
+-- variant is deleted, the RPC returns obs_count directly (no alias).
 
-CREATE TABLE IF NOT EXISTS public.places (
-  id              uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  slug            text UNIQUE NOT NULL,
-  name            text NOT NULL,
-  name_local      text,
-  place_type      text NOT NULL DEFAULT 'h3_cell'
-                  CHECK (place_type IN ('protected_area','h3_cell','custom','community')),
-  geometry        geography(Geometry,4326),
-  h3_cells        text[],
-  observation_count integer NOT NULL DEFAULT 0,
-  observer_count    integer NOT NULL DEFAULT 0,
-  top_taxa          jsonb,
-  created_at      timestamptz NOT NULL DEFAULT now(),
-  updated_at      timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS places_slug_idx ON public.places(slug);
-CREATE INDEX IF NOT EXISTS places_geo_idx ON public.places USING GIST(geometry);
-
-ALTER TABLE public.places ENABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS places_public_read ON public.places;
-CREATE POLICY places_public_read ON public.places FOR SELECT USING (true);
-
-CREATE OR REPLACE FUNCTION public.chat_find_location(p_query text, p_limit int DEFAULT 5)
-RETURNS TABLE (id uuid, slug text, name text, place_type text, observation_count int)
+DROP FUNCTION IF EXISTS public.chat_find_location(text, int);
+CREATE FUNCTION public.chat_find_location(p_query text, p_limit int DEFAULT 5)
+RETURNS TABLE (id uuid, slug text, name text, place_type text, obs_count int)
 LANGUAGE sql STABLE SECURITY DEFINER
 SET search_path = public, pg_temp AS $$
-  -- #914's CREATE TABLE places (line ~10650) is a no-op because
-  -- IF NOT EXISTS yields to the earlier WDPA places table (line ~7285),
-  -- which spells the column obs_count, not observation_count. Alias here
-  -- preserves the function's RETURNS TABLE contract (clients still see
-  -- observation_count) until the two places designs are reconciled.
-  SELECT id, slug, name, place_type, obs_count AS observation_count
+  SELECT id, slug, name, place_type, obs_count
   FROM public.places
   WHERE name ILIKE '%' || p_query || '%'
      OR slug ILIKE '%' || p_query || '%'


### PR DESCRIPTION
Closes #1025.

## Summary

`docs/specs/infra/supabase-schema.sql` had two `CREATE TABLE IF NOT EXISTS public.places` blocks. The second (line ~10654, from #914) was a silent no-op — IF NOT EXISTS yielded to the WDPA-flavoured table created earlier at line ~7289, so the chat-locations work never actually got its column names. `chat_find_location` worked around the mismatch with `obs_count AS observation_count` in #1015. This PR removes the dead block and the alias.

## Decision: WDPA-flavoured `places` wins

Consumer audit of the disputed columns:

| Column                 | WDPA design | Chat design | Production consumers |
|------------------------|-------------|-------------|----------------------|
| `obs_count`            | ✓           | -           | `PlacesNearby`, `ExplorePlacesView`, `PlaceDetailView`, `explore/places/compare` |
| `species_count`        | ✓           | -           | `ExplorePlacesView`, `PlaceDetailView`, `explore/places/compare` |
| `observer_count`       | ✓           | ✓           | `PlacesNearby`, `ExplorePlacesView`, `PlaceDetailView`, `explore/places/compare` |
| `first_obs_at`/`last_obs_at` | ✓     | -           | `PlacesNearby`, `ExplorePlacesView`, `PlaceDetailView` |
| `country_code`/`state_province` | ✓  | -           | `PlaceDetailView` |
| `observation_count`    | -           | ✓           | (none on places — `users.observation_count` etc. is unrelated) |
| `top_taxa`             | -           | ✓           | (none on places — `pools.top_taxa` is unrelated) |

**Every production consumer of `public.places` already uses the WDPA columns.** The chat design's only "consumer" was `chat_find_location`'s alias.

## Changes

1. Deleted the line-10654 `CREATE TABLE` block, its two indexes, the duplicate `ENABLE ROW LEVEL SECURITY`, and the duplicate `places_public_read` policy (the original lives at line 7323).
2. Rewrote `chat_find_location` to return `obs_count int` directly (drops the `AS observation_count` alias). Used `DROP FUNCTION IF EXISTS` first because `CREATE OR REPLACE` can't change a `RETURNS TABLE` output column name. Both statements remain idempotent.
3. Replaced the workaround comment with a brief reconciliation note pointing back to this PR / #1025.

`src/lib/chat-tools.ts` forwards the RPC's JSON straight to the LLM (no field-name destructuring), so the contract rename has no client wiring to update.

## Test plan

- [x] Only one `CREATE TABLE IF NOT EXISTS public.places` remains in the schema (grep verified).
- [x] No client code reads `places.observation_count` / `places.top_taxa` (grep verified).
- [ ] `db-validate` CI applies the schema twice green (Docker daemon unavailable locally; trusting CI per CLAUDE.md guidance after #1015 restored the gate).
- [ ] `db-apply` on merge replays cleanly against the live Supabase project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)