### PR TITLE
test(lint): re-enable lint-schema-security regression suite

### DIFF
--- a/tests/sql/lint-schema-security.test.sql
+++ b/tests/sql/lint-schema-security.test.sql
@@ -2,255 +2,173 @@
 --
 -- Regression suite for infra/lint-schema-security.sql.
 --
--- ⚠️  MAINTENANCE NOTE: These tests duplicate the invariants from
---    infra/lint-schema-security.sql. If you change the linter (add/remove
---    a check, change error message text), update these tests too.
---    The tests do NOT import or execute the linter file directly — they
---    independently verify the same three invariants using SAVEPOINT injection.
+-- MAINTENANCE NOTE: these tests duplicate the invariants from
+-- infra/lint-schema-security.sql. If you change the linter (add/remove
+-- a check, change error message text), update these tests too. The
+-- tests do NOT \i the linter file directly — they independently
+-- re-run each check's offender query and assert that a known-bad
+-- object would have been caught.
 --
--- Strategy: inject a known-bad schema object inside a SAVEPOINT, assert
--- the linter fails (raises an exception), then ROLLBACK TO SAVEPOINT so
--- the next test case starts from a clean state. A final positive case
--- confirms the linter passes once every violation is rolled back.
+-- Strategy: inject a known-bad schema object inside a SAVEPOINT,
+-- re-run the linter's offender query, RAISE EXCEPTION if the query
+-- returns nothing (meaning the linter is broken), then ROLLBACK TO
+-- SAVEPOINT so the next test case starts from a clean state. A final
+-- positive case confirms the linter passes once every injected
+-- violation is rolled back. psql -v ON_ERROR_STOP=1 fails the whole
+-- file the moment any RAISE EXCEPTION fires.
+--
+-- SAVEPOINT / ROLLBACK TO SAVEPOINT must live at the TOP LEVEL —
+-- Postgres rejects transaction control inside anonymous DO blocks
+-- (only CREATE PROCEDURE bodies allow it, PG 11+). The DO block
+-- contents are limited to the linter-replicating offender query +
+-- the IF / RAISE.
 --
 -- Run via db-validate.yml after the schema has been applied:
 --   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
 --        -f tests/sql/lint-schema-security.test.sql
---
--- No pgTAP required — plain SQL DO blocks throughout.
 
 \set ON_ERROR_STOP on
 
--- ⚠️ TEMPORARILY DISABLED — see issue (filed by close-out PR #1015).
---
--- These test cases use SAVEPOINT … ROLLBACK TO SAVEPOINT inside anonymous
--- DO blocks, which is invalid PL/pgSQL syntax (Postgres does not allow
--- transaction control in anonymous code blocks — only in CREATE PROCEDURE
--- bodies, since PG 11). The test file has never been functional in CI;
--- the validate gate was silently broken for weeks via the missing
--- storage.foldername stub, so the parse failure here was never surfaced
--- until that gate was restored on this branch.
---
--- The linter at infra/lint-schema-security.sql itself works correctly —
--- it just caught two real bugs (#1015 layers 12 and 13). Disabling
--- this regression guard temporarily does NOT weaken the linter, only
--- the meta-test that asserts the linter itself stays correct.
---
--- Refactor path: convert each `DO $testN$ … SAVEPOINT … ROLLBACK TO …
--- $testN$` into either:
---   (a) `CREATE PROCEDURE` + `CALL` (PG 11+ allows transaction control in
---       procedure bodies), or
---   (b) Top-level SQL with explicit BEGIN/SAVEPOINT/ROLLBACK around each
---       test (no PL/pgSQL wrapping).
---
--- Re-enable by removing the `\quit` directive below.
-\quit
+BEGIN;
 
 -- ─────────────────────────────────────────────────────────────────────────
--- Helper: record pass/fail per test case in a temp table so we can print
--- a summary at the end and fail the file if anything was unexpected.
+-- Test 1: check1 catches a view without security_invoker
 -- ─────────────────────────────────────────────────────────────────────────
-CREATE TEMP TABLE IF NOT EXISTS _lint_test_results (
-  test_name   text PRIMARY KEY,
-  passed      boolean NOT NULL,
-  detail      text
-);
+SAVEPOINT t1;
 
--- ─────────────────────────────────────────────────────────────────────────
--- Test 1: Check 1 catches a view without security_invoker
--- ─────────────────────────────────────────────────────────────────────────
--- We create a plain view (no security_invoker), run the linter in a
--- nested DO block, and assert that an exception was raised.
+CREATE VIEW public._test_bad_definer_view AS SELECT 1 AS col;
+
 DO $test1$
 DECLARE
-  linter_failed boolean := false;
+  offenders text;
 BEGIN
-  -- Inject the bad object
-  SAVEPOINT bad_view;
-  EXECUTE 'CREATE VIEW public._test_bad_definer_view AS SELECT 1 AS col';
+  SELECT string_agg(format('public.%I', c.relname), E'\n  - ' ORDER BY c.relname)
+    INTO offenders
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relkind = 'v'
+     AND NOT EXISTS (
+       SELECT 1
+         FROM unnest(COALESCE(c.reloptions, ARRAY[]::text[])) opt
+        WHERE opt = 'security_invoker=true'
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = c.oid AND d.deptype = 'e'
+     );
 
-  -- Run the linter; it should raise on check1
-  BEGIN
-    -- We use a DO block to call the linter SQL; since \i doesn't work
-    -- inside PL/pgSQL we replicate check1's logic here to validate the
-    -- linter's SQL is correct.
-    DECLARE
-      offenders text;
-    BEGIN
-      SELECT string_agg(format('public.%I', c.relname), E'\n  - ' ORDER BY c.relname)
-        INTO offenders
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-       WHERE n.nspname = 'public'
-         AND c.relkind = 'v'
-         AND NOT EXISTS (
-           SELECT 1
-             FROM unnest(COALESCE(c.reloptions, ARRAY[]::text[])) opt
-            WHERE opt = 'security_invoker=true'
-         )
-         AND NOT EXISTS (
-           SELECT 1 FROM pg_depend d
-            WHERE d.objid = c.oid AND d.deptype = 'e'
-         );
-
-      IF offenders IS NULL THEN
-        RAISE EXCEPTION 'check1 did not detect _test_bad_definer_view — linter is broken';
-      END IF;
-      -- offenders is not null → linter would fail → that is what we want
-      linter_failed := true;
-    END;
-  EXCEPTION WHEN OTHERS THEN
-    linter_failed := true;
-  END;
-
-  ROLLBACK TO SAVEPOINT bad_view;
-  RELEASE SAVEPOINT bad_view;
-
-  INSERT INTO _lint_test_results VALUES (
-    'check1_detects_missing_security_invoker', linter_failed,
-    CASE WHEN linter_failed THEN 'linter correctly detected view without security_invoker'
-         ELSE 'FAIL: linter did NOT detect view without security_invoker' END
-  );
+  IF offenders IS NULL OR offenders NOT LIKE '%_test_bad_definer_view%' THEN
+    RAISE EXCEPTION 'check1 did not detect _test_bad_definer_view — linter is broken';
+  END IF;
+  RAISE NOTICE 'check1: correctly detected view without security_invoker (%)', offenders;
 END
 $test1$;
 
+ROLLBACK TO SAVEPOINT t1;
+
 -- ─────────────────────────────────────────────────────────────────────────
--- Test 2: Check 2 catches a PUBLIC-callable SECURITY DEFINER function
+-- Test 2: check2 catches a PUBLIC-callable SECURITY DEFINER function
 -- ─────────────────────────────────────────────────────────────────────────
+SAVEPOINT t2;
+
+CREATE OR REPLACE FUNCTION public._test_bad_public_definer()
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+BEGIN RETURN 1; END
+$fn$;
+-- Intentionally do NOT REVOKE EXECUTE FROM PUBLIC — that is the violation.
+
 DO $test2$
 DECLARE
-  linter_failed boolean := false;
+  offenders text;
 BEGIN
-  SAVEPOINT bad_public_definer;
+  SELECT string_agg(
+           format('public.%I(%s)',
+                  p.proname,
+                  pg_get_function_identity_arguments(p.oid)),
+           E'\n  - '
+           ORDER BY p.proname
+         )
+    INTO offenders
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public'
+     AND p.prosecdef = true
+     AND has_function_privilege('public', p.oid, 'EXECUTE')
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
+     );
 
-  -- Create a SECURITY DEFINER function without revoking PUBLIC execute
-  EXECUTE $fn$
-    CREATE OR REPLACE FUNCTION public._test_bad_public_definer()
-    RETURNS int
-    LANGUAGE plpgsql
-    SECURITY DEFINER
-    SET search_path = public, pg_temp
-    AS $$
-    BEGIN RETURN 1; END
-    $$
-  $fn$;
-  -- Do NOT revoke PUBLIC execute — this is the violation
-
-  BEGIN
-    DECLARE
-      offenders text;
-    BEGIN
-      SELECT string_agg(
-               format('public.%I(%s)',
-                      p.proname,
-                      pg_get_function_identity_arguments(p.oid)),
-               E'\n  - '
-               ORDER BY p.proname
-             )
-        INTO offenders
-        FROM pg_proc p
-        JOIN pg_namespace n ON n.oid = p.pronamespace
-       WHERE n.nspname = 'public'
-         AND p.prosecdef = true
-         AND has_function_privilege('public', p.oid, 'EXECUTE')
-         AND NOT EXISTS (
-           SELECT 1 FROM pg_depend d
-            WHERE d.objid = p.oid AND d.deptype = 'e'
-         );
-
-      IF offenders IS NULL THEN
-        RAISE EXCEPTION 'check2 did not detect _test_bad_public_definer — linter is broken';
-      END IF;
-      linter_failed := true;
-    END;
-  EXCEPTION WHEN OTHERS THEN
-    linter_failed := true;
-  END;
-
-  ROLLBACK TO SAVEPOINT bad_public_definer;
-  RELEASE SAVEPOINT bad_public_definer;
-
-  INSERT INTO _lint_test_results VALUES (
-    'check2_detects_public_callable_definer', linter_failed,
-    CASE WHEN linter_failed THEN 'linter correctly detected PUBLIC-callable SECURITY DEFINER function'
-         ELSE 'FAIL: linter did NOT detect PUBLIC-callable SECURITY DEFINER function' END
-  );
+  IF offenders IS NULL OR offenders NOT LIKE '%_test_bad_public_definer%' THEN
+    RAISE EXCEPTION 'check2 did not detect _test_bad_public_definer — linter is broken';
+  END IF;
+  RAISE NOTICE 'check2: correctly detected PUBLIC-callable SECURITY DEFINER function (%)', offenders;
 END
 $test2$;
 
+ROLLBACK TO SAVEPOINT t2;
+
 -- ─────────────────────────────────────────────────────────────────────────
--- Test 3: Check 3 catches a plpgsql function without search_path pinned
+-- Test 3: check3 catches a plpgsql function without search_path pinned
 -- ─────────────────────────────────────────────────────────────────────────
+SAVEPOINT t3;
+
+CREATE OR REPLACE FUNCTION public._test_bad_search_path()
+RETURNS int
+LANGUAGE plpgsql
+AS $fn$
+BEGIN RETURN 1; END
+$fn$;
+-- No SET search_path = ... — that is the violation.
+
 DO $test3$
 DECLARE
-  linter_failed boolean := false;
+  offenders text;
 BEGIN
-  SAVEPOINT bad_search_path;
-
-  -- Create a plpgsql function without SET search_path
-  EXECUTE $fn$
-    CREATE OR REPLACE FUNCTION public._test_bad_search_path()
-    RETURNS int
-    LANGUAGE plpgsql
-    AS $$
-    BEGIN RETURN 1; END
-    $$
-  $fn$;
-  -- No SET search_path = ... in the function definition
-
-  BEGIN
-    DECLARE
-      offenders text;
-    BEGIN
-      SELECT string_agg(
-               format('public.%I(%s)',
-                      p.proname,
-                      pg_get_function_identity_arguments(p.oid)),
-               E'\n  - '
-               ORDER BY p.proname
-             )
-        INTO offenders
-        FROM pg_proc p
-        JOIN pg_namespace n ON n.oid = p.pronamespace
-        JOIN pg_language l ON l.oid = p.prolang
-       WHERE n.nspname = 'public'
-         AND p.prokind IN ('f', 'p')
-         AND l.lanname NOT IN ('sql', 'internal', 'c')
-         AND NOT EXISTS (
-           SELECT 1
-             FROM unnest(COALESCE(p.proconfig, ARRAY[]::text[])) c
-            WHERE c LIKE 'search_path=%'
+  SELECT string_agg(
+           format('public.%I(%s)',
+                  p.proname,
+                  pg_get_function_identity_arguments(p.oid)),
+           E'\n  - '
+           ORDER BY p.proname
          )
-         AND NOT EXISTS (
-           SELECT 1 FROM pg_depend d
-            WHERE d.objid = p.oid AND d.deptype = 'e'
-         );
+    INTO offenders
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    JOIN pg_language l ON l.oid = p.prolang
+   WHERE n.nspname = 'public'
+     AND p.prokind IN ('f', 'p')
+     AND l.lanname NOT IN ('sql', 'internal', 'c')
+     AND NOT EXISTS (
+       SELECT 1
+         FROM unnest(COALESCE(p.proconfig, ARRAY[]::text[])) c
+        WHERE c LIKE 'search_path=%'
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid AND d.deptype = 'e'
+     );
 
-      IF offenders IS NULL THEN
-        RAISE EXCEPTION 'check3 did not detect _test_bad_search_path — linter is broken';
-      END IF;
-      linter_failed := true;
-    END;
-  EXCEPTION WHEN OTHERS THEN
-    linter_failed := true;
-  END;
-
-  ROLLBACK TO SAVEPOINT bad_search_path;
-  RELEASE SAVEPOINT bad_search_path;
-
-  INSERT INTO _lint_test_results VALUES (
-    'check3_detects_missing_search_path', linter_failed,
-    CASE WHEN linter_failed THEN 'linter correctly detected plpgsql function without search_path'
-         ELSE 'FAIL: linter did NOT detect plpgsql function without search_path' END
-  );
+  IF offenders IS NULL OR offenders NOT LIKE '%_test_bad_search_path%' THEN
+    RAISE EXCEPTION 'check3 did not detect _test_bad_search_path — linter is broken';
+  END IF;
+  RAISE NOTICE 'check3: correctly detected plpgsql function without search_path (%)', offenders;
 END
 $test3$;
 
+ROLLBACK TO SAVEPOINT t3;
+
 -- ─────────────────────────────────────────────────────────────────────────
--- Test 4 (positive): linter passes against the existing schema
+-- Test 4 (positive): linter passes against the already-applied schema
 -- ─────────────────────────────────────────────────────────────────────────
--- After all the above SAVEPOINTs have been rolled back, the schema should
--- be clean. Run each check logic and confirm they all find zero offenders.
+-- After all injected SAVEPOINTs have been rolled back, the schema is clean
+-- again. Re-run each check's offender query and assert each returns NULL.
+
 DO $test4_check1$
 DECLARE
   offenders text;
@@ -271,12 +189,10 @@ BEGIN
         WHERE d.objid = c.oid AND d.deptype = 'e'
      );
 
-  INSERT INTO _lint_test_results VALUES (
-    'positive_check1_clean_schema',
-    offenders IS NULL,
-    COALESCE('FAIL: views without security_invoker: ' || offenders,
-             'check1 passes on the current schema — no unprotected views ✓')
-  );
+  IF offenders IS NOT NULL THEN
+    RAISE EXCEPTION E'positive check1: schema has views without security_invoker:\n  - %', offenders;
+  END IF;
+  RAISE NOTICE 'positive check1: schema clean — no views missing security_invoker ✓';
 END
 $test4_check1$;
 
@@ -302,12 +218,10 @@ BEGIN
         WHERE d.objid = p.oid AND d.deptype = 'e'
      );
 
-  INSERT INTO _lint_test_results VALUES (
-    'positive_check2_clean_schema',
-    offenders IS NULL,
-    COALESCE('FAIL: PUBLIC-callable SECURITY DEFINER functions: ' || offenders,
-             'check2 passes on the current schema — no PUBLIC-callable definer functions ✓')
-  );
+  IF offenders IS NOT NULL THEN
+    RAISE EXCEPTION E'positive check2: schema has PUBLIC-callable SECURITY DEFINER functions:\n  - %', offenders;
+  END IF;
+  RAISE NOTICE 'positive check2: schema clean — no PUBLIC-callable definer functions ✓';
 END
 $test4_check2$;
 
@@ -339,41 +253,13 @@ BEGIN
         WHERE d.objid = p.oid AND d.deptype = 'e'
      );
 
-  INSERT INTO _lint_test_results VALUES (
-    'positive_check3_clean_schema',
-    offenders IS NULL,
-    COALESCE('FAIL: plpgsql functions without search_path: ' || offenders,
-             'check3 passes on the current schema — all pl* functions pin search_path ✓')
-  );
+  IF offenders IS NOT NULL THEN
+    RAISE EXCEPTION E'positive check3: schema has pl* functions without search_path:\n  - %', offenders;
+  END IF;
+  RAISE NOTICE 'positive check3: schema clean — all pl* functions pin search_path ✓';
 END
 $test4_check3$;
 
--- ─────────────────────────────────────────────────────────────────────────
--- Summary + fail gate
--- ─────────────────────────────────────────────────────────────────────────
-DO $summary$
-DECLARE
-  rec      record;
-  failures int := 0;
-BEGIN
-  RAISE NOTICE '═══════════════════════════════════════════════════════════════';
-  RAISE NOTICE 'lint-schema-security regression results:';
-  RAISE NOTICE '═══════════════════════════════════════════════════════════════';
-  FOR rec IN SELECT test_name, passed, detail FROM _lint_test_results ORDER BY test_name LOOP
-    IF rec.passed THEN
-      RAISE NOTICE '  PASS  %: %', rec.test_name, rec.detail;
-    ELSE
-      RAISE NOTICE '  FAIL  %: %', rec.test_name, rec.detail;
-      failures := failures + 1;
-    END IF;
-  END LOOP;
-  RAISE NOTICE '═══════════════════════════════════════════════════════════════';
+COMMIT;
 
-  IF failures > 0 THEN
-    RAISE EXCEPTION '% lint regression test(s) failed — see NOTICE output above', failures;
-  END IF;
-
-  RAISE NOTICE 'All % lint regression tests passed ✓',
-    (SELECT count(*) FROM _lint_test_results);
-END
-$summary$;
+\echo 'lint-schema-security regression suite passed: 3 negative + 3 positive checks'


### PR DESCRIPTION
Closes #1026.

## Summary

- Refactors `tests/sql/lint-schema-security.test.sql` to move `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` out of anonymous `DO` blocks (where they are invalid PL/pgSQL) to the top level — Option B from #1026.
- Removes the `\quit` directive at line 47 that has been short-circuiting the file since #1015.
- The DO blocks now contain only the linter-replicating offender query + `IF / RAISE EXCEPTION`. `psql -v ON_ERROR_STOP=1` fails the whole file on any RAISE, so the temp-table results aggregation is no longer needed.
- Adds an explicit substring match (`offenders LIKE '%_test_bad_…%'`) so an unrelated pre-existing offender can't false-pass the test.

The linter itself (`infra/lint-schema-security.sql`) is untouched. The workflow (`.github/workflows/db-validate.yml`) is untouched.

## Test plan

- [x] Verified locally against a temp `postgis/postgis:17-3.4` container with an empty schema: all 3 negative + 3 positive checks emit `NOTICE` and the file `COMMIT`s cleanly (exit 0).
- [x] Verified the test fails loudly when the linter is broken: simulating a missed-detection raises a clear `ERROR: check1 did not detect _test_bad_definer_view — linter is broken` and `psql -f` returns exit code 3.
- [x] CI `db-validate` will re-run the file against the full applied schema — the "Lint-schema-security regression suite" step on this PR is the real end-to-end signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)