### PR TITLE
fix(discover): resolve all 400s on /discover/ page

### DIFF
--- a/docs/runbooks/supabase-spatial-ref-sys-ticket.md
+++ b/docs/runbooks/supabase-spatial-ref-sys-ticket.md
@@ -1,0 +1,40 @@
+# Supabase Support Ticket — spatial_ref_sys RLS False Positive (#839)
+
+**Status:** Ticket submitted to Supabase support 2026-05-11  
+**Project:** rastrum-dev (northamerica-south1)
+
+## Problem
+
+The Database Security Advisor flags `public.spatial_ref_sys` as "RLS Disabled in Public — critical."  
+This is a **false positive** — `spatial_ref_sys` is a PostGIS extension-owned table that customers cannot ALTER.
+
+### Reproduction
+```sql
+-- All of these fail:
+ALTER TABLE spatial_ref_sys ENABLE ROW LEVEL SECURITY;
+-- ERROR 42501: must be owner of table spatial_ref_sys
+
+-- REVOKE succeeds but is a no-op (Supabase grants SELECT directly to anon/authenticated)
+REVOKE SELECT ON spatial_ref_sys FROM PUBLIC;
+```
+
+## Fix requested from Supabase
+
+Update the Advisor predicate to exempt extension-owned tables:
+```sql
+AND NOT EXISTS (
+  SELECT 1 FROM pg_depend d WHERE d.objid = c.oid AND d.deptype = 'e'
+)
+```
+
+## Current workaround
+
+- Marked as Ignored in Dashboard with rationale
+- Listed in `docs/runbooks/accepted-advisor-findings.md`
+- Our CI `db-advisor-smoke.yml` workflow skips this finding via name filter
+
+## Ticket reference
+
+Submit at: https://supabase.com/dashboard/support/new  
+Category: Database / Security Advisor  
+Copy-paste: See `/tmp/supabase-ticket-839.md` on the gateway

--- a/src/components/DiscoverFeedView.astro
+++ b/src/components/DiscoverFeedView.astro
@@ -219,40 +219,58 @@ const communityHref = `/${lang}/${lang === 'es' ? 'comunidad/observadores' : 'co
 
   async function loadFollowedObservations(sb: ReturnType<typeof getSupabase>, userId: string): Promise<FollowedObs[]> {
     const since24h = new Date(Date.now() - 24 * 60 * 60 * 1_000).toISOString();
-    // Get followed user IDs
+    // Get followed user IDs — column is followee_id (not following_id)
     const { data: follows } = await sb
       .from('follows')
-      .select('following_id')
+      .select('followee_id')
       .eq('follower_id', userId)
       .limit(200);
-    const followedIds = (follows ?? []).map((f: { following_id: string }) => f.following_id);
+    const followedIds = (follows ?? []).map((f: { followee_id: string }) => f.followee_id);
     if (!followedIds.length) return [];
 
-    const { data } = await sb
+    // Fetch observations + join identifications (scientific_name) and media_files (photo_url)
+    const { data: obsRows } = await sb
       .from('observations')
-      .select(`
-        id,
-        observer_id,
-        scientific_name,
-        common_name,
-        photo_url,
-        observed_at,
-        users!observer_id ( username, avatar_url )
-      `)
+      .select('id, observer_id, observed_at, users:observer_id ( username, avatar_url )')
       .in('observer_id', followedIds)
       .gte('observed_at', since24h)
       .eq('sync_status', 'synced')
       .order('observed_at', { ascending: false })
       .limit(12);
 
-    return (data ?? []).map((r: Record<string, unknown>) => {
+    if (!obsRows?.length) return [];
+    const obsIds = (obsRows as Array<{ id: string }>).map(o => o.id);
+
+    const [{ data: idRows }, { data: mediaRows }] = await Promise.all([
+      sb.from('identifications')
+        .select('observation_id, scientific_name, is_primary, taxa(common_name_en, common_name_es)')
+        .in('observation_id', obsIds)
+        .eq('is_primary', true),
+      sb.from('media_files')
+        .select('observation_id, url, is_primary')
+        .in('observation_id', obsIds),
+    ]);
+
+    const sciByObs    = new Map<string, { sci: string | null; common: string | null }>();
+    const photoByObs  = new Map<string, string>();
+    for (const r of (idRows ?? []) as Array<{ observation_id: string; scientific_name?: string | null; taxa?: { common_name_en?: string | null; common_name_es?: string | null } | null }>) {
+      const common = r.taxa?.common_name_en ?? r.taxa?.common_name_es ?? null;
+      sciByObs.set(r.observation_id, { sci: r.scientific_name ?? null, common });
+    }
+    for (const m of (mediaRows ?? []) as Array<{ observation_id: string; url?: string | null; is_primary?: boolean }>) {
+      if (!m.url) continue;
+      if (m.is_primary || !photoByObs.has(m.observation_id)) photoByObs.set(m.observation_id, m.url);
+    }
+
+    return (obsRows as Array<Record<string, unknown>>).map(r => {
       const u = (r.users as Record<string, string> | null) ?? {};
+      const id = r.id as string;
       return {
-        id: r.id as string,
+        id,
         observer_id: r.observer_id as string,
-        scientific_name: r.scientific_name as string | null,
-        common_name: r.common_name as string | null,
-        photo_url: r.photo_url as string | null,
+        scientific_name: sciByObs.get(id)?.sci ?? null,
+        common_name: sciByObs.get(id)?.common ?? null,
+        photo_url: photoByObs.get(id) ?? null,
         observed_at: r.observed_at as string,
         observer_username: u.username ?? null,
         observer_avatar_url: u.avatar_url ?? null,
@@ -261,31 +279,36 @@ const communityHref = `/${lang}/${lang === 'es' ? 'comunidad/observadores' : 'co
   }
 
   async function loadNearbySpecies(sb: ReturnType<typeof getSupabase>, userId: string): Promise<SpeciesTip[]> {
-    // Get user's dex (observed taxa)
+    // Get user's dex (observed taxa) — scientific_name lives in identifications, not observations
     const { data: dex } = await sb
-      .from('observations')
-      .select('scientific_name')
-      .eq('observer_id', userId)
+      .from('identifications')
+      .select('scientific_name, observations!inner(observer_id)')
+      .eq('observations.observer_id', userId)
+      .eq('is_primary', true)
       .not('scientific_name', 'is', null);
-    const observed = new Set<string>((dex ?? []).map((o: { scientific_name: string }) => o.scientific_name));
+    const observed = new Set<string>(
+      (dex ?? []).map((o: { scientific_name: string }) => o.scientific_name).filter(Boolean)
+    );
 
-    // Get trending nearby as proxy for "probable_taxa_at" (function may not exist in all envs)
+    // Get recent synced primary IDs as proxy for "probable nearby taxa"
     const { data: nearby } = await sb
-      .from('observations')
-      .select('scientific_name, common_name')
-      .eq('sync_status', 'synced')
+      .from('identifications')
+      .select('scientific_name, taxa(common_name_en, common_name_es), observations!inner(sync_status, observed_at)')
+      .eq('is_primary', true)
+      .eq('observations.sync_status', 'synced')
       .not('scientific_name', 'is', null)
-      .order('observed_at', { ascending: false })
+      .order('created_at', { ascending: false })
       .limit(100);
 
     const seen = new Set<string>();
     const result: SpeciesTip[] = [];
-    for (const r of (nearby ?? []) as Array<{ scientific_name: string; common_name: string | null }>) {
+    for (const r of (nearby ?? []) as Array<{ scientific_name: string; taxa?: { common_name_en?: string | null; common_name_es?: string | null } | null }>) {
       if (!r.scientific_name) continue;
       if (observed.has(r.scientific_name)) continue;
       if (seen.has(r.scientific_name)) continue;
       seen.add(r.scientific_name);
-      result.push({ taxon_name: r.scientific_name, common_name: r.common_name });
+      const common = r.taxa?.common_name_en ?? r.taxa?.common_name_es ?? null;
+      result.push({ taxon_name: r.scientific_name, common_name: common });
       if (result.length >= 10) break;
     }
     return result;
@@ -293,21 +316,26 @@ const communityHref = `/${lang}/${lang === 'es' ? 'comunidad/observadores' : 'co
 
   async function loadTrendingSpecies(sb: ReturnType<typeof getSupabase>): Promise<SpeciesTip[]> {
     const since7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1_000).toISOString();
+    // scientific_name and common_name live in identifications/taxa, not observations
     const { data } = await sb
-      .from('observations')
-      .select('scientific_name, common_name')
-      .eq('sync_status', 'synced')
+      .from('identifications')
+      .select('scientific_name, taxa(common_name_en, common_name_es), observations!inner(sync_status, observed_at)')
+      .eq('is_primary', true)
+      .eq('observations.sync_status', 'synced')
       .not('scientific_name', 'is', null)
-      .gte('observed_at', since7d)
-      .order('observed_at', { ascending: false })
+      .gte('observations.observed_at', since7d)
+      .order('created_at', { ascending: false })
       .limit(200);
 
     const counts = new Map<string, { common_name: string | null; count: number }>();
-    for (const r of (data ?? []) as Array<{ scientific_name: string; common_name: string | null }>) {
+    for (const r of (data ?? []) as Array<{ scientific_name: string; taxa?: { common_name_en?: string | null; common_name_es?: string | null } | null }>) {
       if (!r.scientific_name) continue;
       const entry = counts.get(r.scientific_name);
       if (entry) { entry.count++; }
-      else { counts.set(r.scientific_name, { common_name: r.common_name, count: 1 }); }
+      else {
+        const common = r.taxa?.common_name_en ?? r.taxa?.common_name_es ?? null;
+        counts.set(r.scientific_name, { common_name: common, count: 1 });
+      }
     }
     return Array.from(counts.entries())
       .sort((a, b) => b[1].count - a[1].count)


### PR DESCRIPTION
## Problem

Three separate 400 errors hitting Supabase REST API on `/en/discover/` (reported 2026-05-12):

1. `follows?select=following_id` → **400** — column is `followee_id` in schema, not `following_id`
2. `observations?select=scientific_name,common_name` → **400** — observations table has neither `scientific_name`, `common_name`, nor `photo_url` columns (these live in `identifications`/`taxa`/`media_files`)
3. Empty `order=` param in request URLs — consequence of the queries failing

## Root cause

`DiscoverFeedView.astro` was written assuming `observations` has denormalized fields it doesn't have. The correct data model (same as `ExploreRecentView` and `ProfileView`) is:
- `scientific_name` → `identifications.scientific_name` (is_primary=true)
- `common_name` → `taxa.common_name_en` / `taxa.common_name_es` (via identifications join)
- `photo_url` → `media_files.url` (batched by observation_id)

## Fix

- `loadFollowedObservations`: query `follows.followee_id` (was `following_id`), then batch-fetch `identifications` + `media_files`
- `loadNearbySpecies`: dex query now reads from `identifications` filtered by observer_id; nearby query joins `taxa` for common names  
- `loadTrendingSpecies`: queries `identifications` with inner join to `observations` for sync_status/date filters

Fixes all four failing requests logged at 2026-05-12T03:12:55Z.