### PR TITLE
fix(db): guard cron.unschedule for refresh-conservation-status (#db-apply)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -12101,7 +12101,8 @@ ALTER TABLE public.taxa
 DO $do$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
-    PERFORM cron.unschedule('refresh-conservation-status');
+    PERFORM cron.unschedule('refresh-conservation-status')
+      WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'refresh-conservation-status');
     PERFORM cron.schedule(
       'refresh-conservation-status',
       '0 3 1 * *',


### PR DESCRIPTION
## Problem

Every `db-apply` run has been failing with exit code 3 since 2026-05-11:

```
ERROR: could not find valid entry for job 'refresh-conservation-status'
CONTEXT: SQL statement "SELECT cron.unschedule('refresh-conservation-status')"
PL/pgSQL function inline_code_block line 4 at PERFORM
```

The bare `PERFORM cron.unschedule(...)` raises if the job doesn't exist yet (first run, fresh project). This blocked `featured_observers` and `nearby_observations` from actually landing in prod.

## Root Cause

The three other cron jobs in the same file already use the safe pattern:
```sql
SELECT cron.unschedule('job-name')
  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'job-name');
```

The `refresh-conservation-status` block inside a `DO $do$...$do$` was missing the guard.

## Fix

Add `WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = '...')` to make it consistent with the rest.

## Impact

- Unblocks all `db-apply` runs
- 1-line change, zero risk