### PR TITLE
fix(home): disambiguate FK in featured_observers embed (300 → 200)

### DIFF
--- a/src/components/home/HomeObservadorDelMes.astro
+++ b/src/components/home/HomeObservadorDelMes.astro
@@ -108,7 +108,7 @@ const isEs = lang === 'es';
       .from('featured_observers')
       .select(`
         month_date, user_id, headline_es, headline_en,
-        users ( username, display_name, avatar_url )
+        users!user_id ( username, display_name, avatar_url )
       `)
       .eq('month_date', monthDate)
       .maybeSingle<FeaturedObserver>();


### PR DESCRIPTION
## Problem

`HomeObservadorDelMes` now gets HTTP 300 instead of 404:

```
GET /rest/v1/featured_observers?select=...users(username,display_name,avatar_url)... → 300
```

## Root Cause

`featured_observers` has **two** FKs pointing at `users`:
- `user_id` — the featured observer
- `picked_by_admin` — the admin who chose them

PostgREST can't resolve which FK to use for the `users(...)` embed and returns `300 Multiple Choices`.

## Fix

Use the PostgREST FK-hint syntax `users!user_id(...)` to pin the join:

```diff
- users ( username, display_name, avatar_url )
+ users!user_id ( username, display_name, avatar_url )
```

One-character change, no schema touch needed.