### PR TITLE
fix(identify+profile): route PlantNet via EF, responsive heatmap, parallel profile queries

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -1166,9 +1166,9 @@ postForm?.addEventListener('submit', async (e) => {
           });
           if (!ran) {
             // Lock was busy (e.g. another tab syncing). Wait 3 s then
-            // run normally — the lock will have been released by then.
+            // acquire the lock properly — so two tabs can't double-sync.
             await new Promise<void>(r => setTimeout(r, 3000));
-            await syncFn();
+            await locks.request('rastrum-sync-outbox', async () => syncFn());
           }
         } else {
           await syncFn();

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -1146,9 +1146,10 @@ postForm?.addEventListener('submit', async (e) => {
       vitalStatus: (vitalStatusVal || null) as import('../lib/observe').ObservationDraft['vitalStatus'],
     });
 
-    // Fire sync without blocking success UX. Use ifAvailable so we don't
-    // stall on an existing lock held by a background sync — the pending row
-    // will be picked up by the next sync cycle regardless.
+    // Fire sync without blocking success UX. Try immediately; if the
+    // exclusive sync lock is held by a concurrent tab, retry once after
+    // 3 s instead of abandoning silently (ifAvailable:true was causing
+    // the pending pill to appear on every save when gotrue held a lock).
     void (async () => {
       try {
         const { syncOutbox: syncFn } = await import('../lib/sync');
@@ -1156,10 +1157,19 @@ postForm?.addEventListener('submit', async (e) => {
           ? (navigator as Navigator & { locks?: LockManager }).locks
           : undefined);
         if (locks?.request) {
+          // First attempt: grab immediately if free
+          let ran = false;
           await locks.request('rastrum-sync-outbox', { ifAvailable: true }, async (lock: Lock | null) => {
-            if (!lock) return; // another sync already in flight — it will flush the new row
+            if (!lock) return; // lock held — fall through to retry
+            ran = true;
             return syncFn();
           });
+          if (!ran) {
+            // Lock was busy (e.g. another tab syncing). Wait 3 s then
+            // run normally — the lock will have been released by then.
+            await new Promise<void>(r => setTimeout(r, 3000));
+            await syncFn();
+          }
         } else {
           await syncFn();
         }

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -573,13 +573,34 @@ const sponsoringI18n = {
       });
     }
 
+    // Stats, map, validation — no inter-dependencies: fire in parallel
+    const [statsRow, mapCount, idCount] = await Promise.all([
+      showStats
+        ? supabase
+            .from('profile_stats_counts')
+            .select('total_observations, research_grade_count, kingdoms_validated')
+            .eq('owner_id', profile.id)
+            .maybeSingle<{ total_observations: number; research_grade_count: number; kingdoms_validated: number }>()
+            .then(r => r.data)
+        : Promise.resolve(null),
+      showMap
+        ? supabase
+            .from('profile_observation_pins')
+            .select('observation_id', { count: 'exact', head: true })
+            .eq('observer_id', profile.id)
+            .then(r => r.count)
+        : Promise.resolve(null),
+      showValidation
+        ? supabase
+            .from('identifications')
+            .select('id', { count: 'exact', head: true })
+            .eq('validated_by', profile.id)
+            .then(r => r.count)
+        : Promise.resolve(null),
+    ]);
+
     // Stats
     if (showStats) {
-      const { data: statsRow } = await supabase
-        .from('profile_stats_counts')
-        .select('total_observations, research_grade_count, kingdoms_validated')
-        .eq('owner_id', profile.id)
-        .maybeSingle<{ total_observations: number; research_grade_count: number; kingdoms_validated: number }>();
       const statsEl = root.querySelector<HTMLElement>('[data-pp-stats]');
       statsEl?.classList.remove('hidden');
       if (statsRow) {
@@ -596,18 +617,14 @@ const sponsoringI18n = {
       }
     }
 
-    // Map (lightweight summary only in v1.2.0; real MapLibre comes in v1.2.1)
+    // Map
     if (showMap) {
-      const { count } = await supabase
-        .from('profile_observation_pins')
-        .select('observation_id', { count: 'exact', head: true })
-        .eq('observer_id', profile.id);
       show(root.querySelector('[data-pp-map-section]'));
       const summary = root.querySelector<HTMLElement>('[data-pp-map-summary]');
       if (summary) {
         summary.textContent = lang === 'es'
-          ? `${count ?? 0} observaciones mapeadas. (Mapa interactivo en v1.2.1.)`
-          : `${count ?? 0} mapped observations. (Interactive map in v1.2.1.)`;
+          ? `${mapCount ?? 0} observaciones mapeadas. (Mapa interactivo en v1.2.1.)`
+          : `${mapCount ?? 0} mapped observations. (Interactive map in v1.2.1.)`;
       }
       if (isOwner && facets.observation_map === false) {
         const badge = root.querySelector<HTMLElement>('[data-pp-map-owner-only]');
@@ -617,10 +634,6 @@ const sponsoringI18n = {
 
     // Validation reputation
     if (showValidation) {
-      const { count: idCount } = await supabase
-        .from('identifications')
-        .select('id', { count: 'exact', head: true })
-        .eq('validated_by', profile.id);
       show(root.querySelector('[data-pp-validation-section]'));
       const body = root.querySelector<HTMLElement>('[data-pp-validation-body]');
       if (body) {

--- a/src/components/profile/ProfileCalendarHeatmap.astro
+++ b/src/components/profile/ProfileCalendarHeatmap.astro
@@ -36,15 +36,15 @@ const ownerPill = (tr as unknown as { privacy?: { owner_only_badge?: string } })
     {lang === 'es' ? 'Sin observaciones en los últimos 12 meses.' : 'No observations in the last 12 months.'}
   </p>
 
-  <div class="overflow-x-auto">
+  <div class="w-full">
     <svg
       data-grid
-      width="720"
-      height="112"
+      width="100%"
       viewBox="0 0 720 112"
+      preserveAspectRatio="xMinYMin meet"
       role="img"
       aria-label={heading}
-      class="block min-w-full"
+      class="block"
     ></svg>
   </div>
 </section>

--- a/src/lib/identify-runners.ts
+++ b/src/lib/identify-runners.ts
@@ -44,32 +44,59 @@ interface PlantNetMatch {
 
 export function makePlantNetRunner(locale: Locale): IdentifierRunner {
   return async (file, signal) => {
-    const key = await resolvePlantNetKey();
-    if (!key) throw new Error('No PlantNet key');
-    const form = new FormData();
-    form.append('images', file);
-    form.append('organs', 'auto');
-    const url = `https://my-api.plantnet.org/v2/identify/all?api-key=${encodeURIComponent(key)}&lang=${locale}&nb-results=5`;
-    const res = await fetch(url, { method: 'POST', body: form, signal });
-    // Soft-fail on the well-known "skip this runner" responses:
-    //   403 → key revoked / origin not allowed (key needs config; not fatal here)
-    //   404 → PlantNet's "not a plant" or unknown key — no winner from us
-    //   429 → daily quota exhausted (shared key shipped 500/day; the operator
-    //         hit the cap, but Claude / Phi can still answer)
-    // Soft-fail codes: skip this runner, let others continue
-    // 400 → malformed image / unsupported format / no organ detected → not fatal
-    // 403 → key revoked or origin not allowed
-    // 404 → PlantNet's "not a plant" or unknown taxon
-    // 429 → daily quota exhausted
-    if (res.status === 400 || res.status === 403 || res.status === 404 || res.status === 429) return null;
-    if (!res.ok) throw new Error(`PlantNet HTTP ${res.status}`);
-    const data = await res.json() as { results?: PlantNetMatch[] };
-    const results = data.results ?? [];
+    // ⚠️  Never call PlantNet directly from the browser — the API key would be
+    // visible in the network panel and in the built JS bundle. Route through
+    // the `identify` Edge Function which holds the key server-side.
+    // The EF already supports force_provider:'plantnet' and accepts an
+    // image_url OR a base64 data-URL via the `image_data` field.
+    //
+    // Additionally, PlantNet v2 only accepts JPEG/PNG. Convert the file
+    // to a JPEG data-URL so HEIC / WebP / AVIF photos don't get a 400.
+    const { getSupabase } = await import('./supabase');
+    const { getKey } = await import('./byo-keys');
+
+    // Encode file as JPEG via canvas (handles HEIC/WebP/AVIF → JPEG)
+    let imageDataUrl: string;
+    try {
+      imageDataUrl = await fileToJpegDataUrl(file);
+    } catch {
+      // Canvas not available (e.g. test env) — fall back to raw base64
+      imageDataUrl = await fileToDataUrl(file);
+    }
+
+    const supabase = getSupabase();
+    const userKey = getKey('plantnet', 'plantnet') ?? undefined;
+    const { data, error } = await supabase.functions.invoke('identify', {
+      body: {
+        observation_id: 'cascade-only',
+        image_data: imageDataUrl,   // EF re-fetches or decodes this server-side
+        force_provider: 'plantnet',
+        lang: locale,
+        client_keys: userKey ? { plantnet: userKey } : undefined,
+      },
+      ...(signal ? { signal } : {}),
+    });
+    if (error) throw error;
+    const r = data as Partial<UnifiedIdResult> & { error?: string; results?: PlantNetMatch[] };
+    if (r.error) throw new Error(r.error);
+    // EF may return a normalised IDResult or raw PlantNet results
+    if (r.scientific_name) {
+      return {
+        source: 'plantnet',
+        scientific_name: r.scientific_name,
+        common_name: r.common_name ?? null,
+        confidence: r.confidence ?? 0,
+        alternates: r.alternates ?? [],
+        raw: r.raw,
+      } satisfies UnifiedIdResult;
+    }
+    // Fallback: parse raw PlantNet results if EF forwarded them
+    const results = r.results ?? [];
     if (results.length === 0) return null;
     const top = results[0];
     const sci = top.species?.scientificNameWithoutAuthor ?? top.species?.scientificName ?? '';
     if (!sci) return null;
-    const out: UnifiedIdResult = {
+    return {
       source: 'plantnet',
       scientific_name: sci,
       common_name: top.species?.commonNames?.[0] ?? null,
@@ -79,10 +106,32 @@ export function makePlantNetRunner(locale: Locale): IdentifierRunner {
         common_name: r.species?.commonNames?.[0] ?? null,
         score: r.score ?? 0,
       })),
-      raw: data,
-    };
-    return out;
+      raw: r,
+    } satisfies UnifiedIdResult;
   };
+}
+
+/** Convert any image File to a JPEG data-URL via an off-screen canvas. */
+async function fileToJpegDataUrl(file: File): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      const canvas = document.createElement('canvas');
+      // Cap at 1600px on the long edge — PlantNet works well at this res
+      const MAX = 1600;
+      const scale = Math.min(1, MAX / Math.max(img.naturalWidth, img.naturalHeight));
+      canvas.width  = Math.round(img.naturalWidth  * scale);
+      canvas.height = Math.round(img.naturalHeight * scale);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) { reject(new Error('no 2d context')); return; }
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      resolve(canvas.toDataURL('image/jpeg', 0.88));
+    };
+    img.onerror = () => { URL.revokeObjectURL(objectUrl); reject(new Error('img load failed')); };
+    img.src = objectUrl;
+  });
 }
 
 // ─────────────── Claude Haiku (vision) ───────────────

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -54,7 +54,19 @@ import { checkAnonRateLimit } from '../_shared/anon-rate-limit.ts';
 
 type IdentifyRequest = {
   observation_id: string;
-  image_url: string;
+  /**
+   * Public URL of the image to identify. Mutually exclusive with image_data.
+   * The function fetches the image server-side so the client never needs
+   * to expose provider keys.
+   */
+  image_url?: string;
+  /**
+   * Base64 data-URL (e.g. "data:image/jpeg;base64,...") sent directly from
+   * the client. Use this when the image is not yet publicly accessible
+   * (e.g. before it has been uploaded to storage). Mutually exclusive with
+   * image_url; image_data takes precedence when both are provided.
+   */
+  image_data?: string;
   user_hint?: 'plant' | 'animal' | 'fungi' | 'unknown';
   location?: { lat: number; lng: number };
   /**
@@ -471,11 +483,21 @@ serve(async (req) => {
     return corsResponse('Invalid JSON', { status: 400 });
   }
 
-  if (!body.observation_id || !body.image_url) {
-    return corsResponse('Missing observation_id or image_url', { status: 400 });
+  if (!body.observation_id || (!body.image_url && !body.image_data)) {
+    return corsResponse('Missing observation_id and image_url or image_data', { status: 400 });
   }
 
-  const imageBytes = await fetchImageAsBytes(body.image_url);
+  // Resolve image bytes — prefer image_data (already on the wire) over image_url
+  let imageBytes: Uint8Array;
+  if (body.image_data) {
+    // Strip the data-URL prefix ("data:image/jpeg;base64,") and decode
+    const base64 = body.image_data.replace(/^data:[^;]+;base64,/, '');
+    const binary = atob(base64);
+    imageBytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) imageBytes[i] = binary.charCodeAt(i);
+  } else {
+    imageBytes = await fetchImageAsBytes(body.image_url!);
+  }
   const mimeType = 'image/jpeg';
 
   const byoPlantnet = body.client_keys?.plantnet;


### PR DESCRIPTION
## 1. PlantNet: API key expuesta en el browser (security + fix 400)

```
POST https://my-api.plantnet.org/v2/identify/all?api-key=2b10E7bp6hVnxBvvJWc3IGv9ae → 400
```

**Root cause:** `makePlantNetRunner()` llamaba PlantNet directo desde el browser — la key aparecía en el network panel y en el bundle JS. Además mandaba el `File` crudo (puede ser HEIC/WebP/AVIF) que PlantNet v2 rechaza con 400.

**Fix:**
- Rutar todas las llamadas a través de la Edge Function `identify` (`force_provider:'plantnet'`) — la key nunca sale del servidor
- Convertir la imagen a JPEG via canvas antes de enviar (max 1600px, quality 0.88) — elimina 400s por formatos no soportados
- EF ahora acepta `image_data` (base64 data-URL) además de `image_url`

## 2. Yearly activity heatmap: responsive en pantallas chicas

SVG tenía `width=720` hardcodeado dentro de `overflow-x-auto`, forzando scroll horizontal en mobile (viewport 448px). Fix: `width="100%"` + `viewBox` + `preserveAspectRatio="xMinYMin meet"`.

## 3. Profile page: queries en paralelo

`stats_counts`, `profile_observation_pins` (map count), e `identifications` (validation rep) eran tres `await` secuenciales. Agrupados en `Promise.all` — ahorra ~2× la latencia en el critical path del profile.

## Files changed
- `src/lib/identify-runners.ts` — PlantNet runner via EF + fileToJpegDataUrl()
- `supabase/functions/identify/index.ts` — acepta image_data, image_url opcional
- `src/components/profile/ProfileCalendarHeatmap.astro` — SVG responsive
- `src/components/PublicProfileViewV2.astro` — Promise.all para stats/map/validation