### PR TITLE
feat(ci): nightly smoke-test workflow + tests/smoke/home.spec.ts

### DIFF
--- a/.github/workflows/smoke-nightly.yml
+++ b/.github/workflows/smoke-nightly.yml
@@ -1,0 +1,49 @@
+name: Smoke Test – Nightly
+
+on:
+  schedule:
+    # 08:00 UTC daily (02:00 CST)
+    - cron: '0 8 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: smoke-nightly
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Smoke – Chromium vs production
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests against production
+        env:
+          BASE_URL: https://rastrum.org
+          PLAYWRIGHT_BASE_URL: https://rastrum.org
+        run: npx playwright test --project=chromium tests/smoke/
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-nightly-results
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,10 +5,10 @@ import { defineConfig, devices } from '@playwright/test';
 const PORT = Number(process.env.E2E_PORT ?? 4329);
 const LOCAL_BASE_URL = `http://127.0.0.1:${PORT}`;
 
-// When PLAYWRIGHT_BASE_URL is set we hit a real deployment instead of
-// spinning up `astro preview` locally. The nightly smoke workflow uses
-// this against https://rastrum.org/.
-const REMOTE_BASE_URL = process.env.PLAYWRIGHT_BASE_URL?.replace(/\/$/, '');
+// When PLAYWRIGHT_BASE_URL or BASE_URL is set we hit a real deployment instead
+// of spinning up `astro preview` locally. The smoke-nightly workflow uses
+// BASE_URL (GitHub standard) while the older nightly-smoke uses PLAYWRIGHT_BASE_URL.
+const REMOTE_BASE_URL = (process.env.PLAYWRIGHT_BASE_URL ?? process.env.BASE_URL)?.replace(/\/$/, '');
 const BASE_URL = REMOTE_BASE_URL || LOCAL_BASE_URL;
 
 export default defineConfig({

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Nightly production smoke tests for rastrum.org
+ *
+ * These run against the live site (BASE_URL=https://rastrum.org) via the
+ * smoke-nightly.yml workflow. They are intentionally minimal — the goal is
+ * to detect outright crashes or CDN/deploy failures, not to replicate the
+ * full E2E suite.
+ *
+ * Keep total runtime under 30 s.
+ */
+import { test, expect, type ConsoleMessage } from '@playwright/test';
+
+/** Console errors that are acceptable on a live production site. */
+const IGNORED_CONSOLE = [
+  /Failed to load resource/i,
+  /supabase/i,
+  /sw\.js/i,
+  /favicon/i,
+  /maplibre/i,
+  /webgl/i,
+];
+
+function isFatalConsoleError(msg: ConsoleMessage): boolean {
+  if (msg.type() !== 'error') return false;
+  const text = msg.text();
+  return !IGNORED_CONSOLE.some(rx => rx.test(text));
+}
+
+test.describe('production smoke', () => {
+  test('home page loads and title contains Rastrum', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', msg => {
+      if (isFatalConsoleError(msg)) errors.push(`[console] ${msg.text()}`);
+    });
+    page.on('pageerror', err => errors.push(`[pageerror] ${err.message}`));
+
+    const response = await page.goto('/en/', { waitUntil: 'domcontentloaded' });
+    expect(response, 'Navigation returned no response').not.toBeNull();
+    expect(response!.status(), 'Home page returned non-2xx status').toBeLessThan(400);
+
+    await expect(page).toHaveTitle(/Rastrum/i);
+
+    // Best-effort: fail only on clear JS errors
+    expect(errors, 'Unexpected console errors on home page').toEqual([]);
+  });
+
+  test('explore/recent page loads', async ({ page }) => {
+    const response = await page.goto('/en/explore/recent/', {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(response, 'Navigation returned no response').not.toBeNull();
+    expect(response!.status(), '/en/explore/recent/ returned non-2xx status').toBeLessThan(400);
+    await expect(page).toHaveTitle(/\S/);
+  });
+
+  test('observation share page loads', async ({ page }) => {
+    const obsId = '320351cb-fa3b-45d5-b979-5cfb9ccac469';
+    const response = await page.goto(`/share/obs/?id=${obsId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(response, 'Navigation returned no response').not.toBeNull();
+    expect(response!.status(), `share/obs/?id=${obsId} returned non-2xx status`).toBeLessThan(400);
+    await expect(page).toHaveTitle(/\S/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a dedicated **nightly production smoke test** that runs every day at 08:00 UTC against `https://rastrum.org`.

## What's added

### `.github/workflows/smoke-nightly.yml`
- Triggers: `schedule: cron: '0 8 * * *'` + `workflow_dispatch`
- Concurrency guard: `cancel-in-progress: true`
- Runs on `ubuntu-latest`, Node 22, Chromium only
- Uploads playwright-report + test-results as an artifact on failure (7-day retention)

### `tests/smoke/home.spec.ts`
Three minimal checks (<30 s total):
1. **Home page** — `/en/` loads, title contains `Rastrum`, no fatal console errors
2. **Explore/recent** — `/en/explore/recent/` returns HTTP <400
3. **Observation share** — `/share/obs/?id=320351cb-fa3b-45d5-b979-5cfb9ccac469` returns HTTP <400

### `playwright.config.ts`
- `REMOTE_BASE_URL` now falls back to the `BASE_URL` env var (GitHub standard) in addition to `PLAYWRIGHT_BASE_URL`, so the new workflow's `env: BASE_URL: https://rastrum.org` is picked up without changes to the existing nightly-smoke workflow.

## Relationship to existing `nightly-smoke.yml`
The existing workflow runs the full `tests/e2e/smoke.spec.ts` suite (16 routes, lang checks, share/obs regression, Pokédex, etc.) at 06:00 UTC. This PR adds a *lighter* parallel check at 08:00 UTC focused on the three highest-signal pages, as a separate signal that's easy to grep in the Actions tab.