### PR TITLE
fix(security): remove PlantNet key from browser bundle, always route via EF

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -1322,15 +1322,14 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
 
     // Build the runner set based on what's actually available.
     const { runParallelIdentify, filterRunnersByHint } = await import('../lib/identify-cascade-client');
-    const { makePlantNetRunner, makeClaudeRunner, makePhiRunner, makeGemmaRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
+    const { makePlantNetRunner, makeClaudeRunner, makePhiRunner, makeGemmaRunner } = await import('../lib/identify-runners');
     const { claudeAvailable } = await import('../lib/claude-availability');
 
     const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
     const locale = isEs ? 'es' : 'en';
 
-    if (await resolvePlantNetKey()) {
-      runners.plantnet = makePlantNetRunner(locale);
-    }
+    // PlantNet always works via the Edge Function (operator key server-side).
+    runners.plantnet = makePlantNetRunner(locale);
     if (await claudeAvailable()) {
       runners.claude_haiku = makeClaudeRunner(locale);
     }

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -840,7 +840,7 @@ async function detectRunners() {
 // ── Pipeline runner ────────────────────────────────────────────────────────
 async function runPipeline(state: PipelineState) {
   const { runParallelIdentify } = await import('../lib/identify-cascade-client');
-  const { makePlantNetRunner, makeClaudeRunner, makePhiRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
+  const { makePlantNetRunner, makeClaudeRunner, makePhiRunner } = await import('../lib/identify-runners');
   const { hasAnthropicKey } = await import('../lib/anthropic-key');
   const { claudeAvailable } = await import('../lib/claude-availability');
 
@@ -867,12 +867,14 @@ async function runPipeline(state: PipelineState) {
       if (pf.kind === 'photo') {
         if (aiMode === 'local') { setNodeState(state, node.id, 'skipped', undefined, 'Local-only mode'); continue; }
         const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
+        // PlantNet always works via the Edge Function (operator key server-side);
+        // include it unconditionally. A BYO key (if present) is forwarded to the
+        // EF as client_keys.plantnet for user's own quota, but is not required.
+        runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
         if (aiMode === 'own-key') {
           const { hasKeysForPlugin } = await import('../lib/byo-keys');
-          if (hasKeysForPlugin('plantnet') && await resolvePlantNetKey()) runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
           if (hasKeysForPlugin('claude_haiku') && await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
         } else {
-          if (await resolvePlantNetKey()) runners.plantnet = (await import('../lib/identify-runners')).makePlantNetRunner(lang as 'en' | 'es');
           // Sponsored mode: BYO key OR server-side sponsor/pool unlocks Claude.
           if (await claudeAvailable()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
         }

--- a/src/components/QuickObserveSheet.astro
+++ b/src/components/QuickObserveSheet.astro
@@ -240,10 +240,11 @@ async function handleFiles(files: File[]) {
     try {
       if (file.kind === 'photo') {
         const { runParallelIdentify } = await import('../lib/identify-cascade-client');
-        const { makePlantNetRunner, makeClaudeRunner, resolvePlantNetKey } = await import('../lib/identify-runners');
+        const { makePlantNetRunner, makeClaudeRunner } = await import('../lib/identify-runners');
         const { claudeAvailable } = await import('../lib/claude-availability');
         const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
-        if (await resolvePlantNetKey()) runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
+        // PlantNet always works via the Edge Function (operator key server-side).
+        runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
         if (await claudeAvailable()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
         if (Object.keys(runners).length > 0) {
           const out = await runParallelIdentify(file.file as File, { runners }, new AbortController().signal);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -10,7 +10,8 @@ interface ImportMetaEnv {
   readonly PUBLIC_ONNX_BASE_URL?: string;
   readonly PUBLIC_PMTILES_MX_URL?: string;
   readonly PUBLIC_MEGADETECTOR_ENDPOINT?: string;
-  readonly PUBLIC_PLANTNET_KEY?: string;
+  // PUBLIC_PLANTNET_KEY removed — key is server-side only (Edge Function env var).
+  // See fix/plantnet-key-cleanup PR.
   readonly PUBLIC_ANTHROPIC_KEY?: string;
   readonly PUBLIC_VAPID_PUBLIC_KEY?: string;
   readonly PUBLIC_POSTHOG_PROJECT_TOKEN?: string;

--- a/src/lib/identify-runners.ts
+++ b/src/lib/identify-runners.ts
@@ -16,13 +16,20 @@ export type Locale = 'en' | 'es';
 
 // ─────────────── PlantNet ───────────────
 
+/**
+ * Returns the user's BYO PlantNet key, or '' if none is configured.
+ *
+ * NOTE: The operator PlantNet key is server-side only (Edge Function env var
+ * PLANTNET_API_KEY). It was previously also injected into the browser via
+ * window.__RASTRUM_PLANTNET_KEY__ and PUBLIC_PLANTNET_KEY — those paths have
+ * been removed (PR #1037 / fix/plantnet-key-cleanup) because they leaked the
+ * key into browser network traffic and the JS bundle.
+ *
+ * PlantNet identification always works via the Edge Function regardless of
+ * whether this function returns a key. A non-empty return value here only
+ * means the *user* has supplied their own BYO key.
+ */
 export async function resolvePlantNetKey(): Promise<string> {
-  if (typeof window !== 'undefined') {
-    const w = window as unknown as { __RASTRUM_PLANTNET_KEY__?: string };
-    if (w.__RASTRUM_PLANTNET_KEY__) return w.__RASTRUM_PLANTNET_KEY__;
-  }
-  const env = (import.meta.env.PUBLIC_PLANTNET_KEY as string | undefined) ?? '';
-  if (env) return env;
   try {
     const { getKey } = await import('./byo-keys');
     return getKey('plantnet', 'plantnet') ?? '';

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -201,6 +201,9 @@ async function callPlantNet(
   signal?: AbortSignal,
 ): Promise<IDResult | null> {
   const key = clientKey || Deno.env.get('PLANTNET_API_KEY');
+  // TODO(security): rotate PLANTNET_API_KEY — old key 2b10E7bp6hVnxBvvJWc3IGv9ae was exposed
+  // in browser traffic pre-PR#1037 (window.__RASTRUM_PLANTNET_KEY__ / PUBLIC_PLANTNET_KEY).
+  // Rotate via the PlantNet dashboard: https://my.plantnet.org/account/settings
   if (!key) return null;
 
   const form = new FormData();


### PR DESCRIPTION
## Summary

Closes the security leak introduced before PR #1037 where the operator PlantNet API key was exposed in browser network traffic via `window.__RASTRUM_PLANTNET_KEY__` and `PUBLIC_PLANTNET_KEY`.

## Changes

### `src/lib/identify-runners.ts`
- **Simplified `resolvePlantNetKey()`** — now only checks BYO keys (user's own key stored locally). Removed `window.__RASTRUM_PLANTNET_KEY__` and `PUBLIC_PLANTNET_KEY` paths.
- Added clear comment explaining the key is server-side only since PR #1037.

### `src/env.d.ts`
- Removed `PUBLIC_PLANTNET_KEY` type declaration (key no longer injected into browser env).

### `src/components/ObserveView2.astro`, `ObservationForm.astro`, `QuickObserveSheet.astro`
- **Always include PlantNet runner** regardless of BYO key presence. The Edge Function holds the operator key server-side, so PlantNet identification always works. Previously the `if (await resolvePlantNetKey())` guard would return `false` with the simplified function (no BYO key), silently disabling PlantNet for all users.
- Removed unused `resolvePlantNetKey` from destructured imports where no longer needed.

### `supabase/functions/identify/index.ts`
- Added `TODO(security)` comment flagging that `PLANTNET_API_KEY` must be rotated — old key `2b10E7bp6hVnxBvvJWc3IGv9ae` was exposed in browser traffic pre-PR #1037.

## Security Notes

- The old operator key `2b10E7bp6hVnxBvvJWc3IGv9ae` **must be rotated** in the PlantNet dashboard after this PR merges.
- No client-side code references the operator key anymore — only the Edge Function env var `PLANTNET_API_KEY`.
- `resolvePlantNetKey()` is kept (not deleted) as it correctly serves as a BYO-key feature-detect for the AI mode selector UI.