### PR TITLE
fix(date): UTC accessors in 3 EF TZ-leaks (#1031 Tier 1c follow-up)

### DIFF
--- a/supabase/functions/_shared/sponsorship.ts
+++ b/supabase/functions/_shared/sponsorship.ts
@@ -98,7 +98,8 @@ export async function recordUsage(
   });
   if (insErr) throw new Error(`recordUsage insert failed: ${insErr.message}`);
 
-  const monthStart = new Date(new Date().getFullYear(), new Date().getMonth(), 1).toISOString();
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
   const { count: usedThisMonth, error: cntErr } = await supabase
     .from('ai_usage')
     .select('id', { count: 'exact', head: true })
@@ -129,7 +130,8 @@ export async function maybeNotifyThreshold(
   const threshold = pickThreshold(pctUsed);
   if (!threshold) return;
 
-  const yearMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1)
+  const now = new Date();
+  const yearMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
     .toISOString().slice(0, 10);
 
   const { error: insErr } = await supabase

--- a/supabase/functions/generate-wrapped/index.ts
+++ b/supabase/functions/generate-wrapped/index.ts
@@ -48,7 +48,7 @@ serve(async (req) => {
     return new Response('Missing year or user_id', { status: 400 });
   }
   const year = parseInt(yearStr, 10);
-  if (isNaN(year) || year < 2020 || year > new Date().getFullYear()) {
+  if (isNaN(year) || year < 2020 || year > new Date().getUTCFullYear()) {
     return new Response('Invalid year', { status: 400 });
   }
 

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -543,7 +543,8 @@ serve(async (req) => {
         .order('year_month', { ascending: false })
         .limit(12);
 
-      const monthStart = new Date(new Date().getFullYear(), new Date().getMonth(), 1).toISOString();
+      const now = new Date();
+      const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
       const { data: currentMonth } = await supabase
         .from('ai_usage')
         .select('occurred_at, tokens_in, tokens_out')


### PR DESCRIPTION
## Summary

Follow-up to #1049 (Tier 1c of #1031). Three lower-severity TZ leaks in Edge Functions that I noted but left out of #1049's scope. All produce wrong-by-intent results under a non-UTC runtime; production Supabase Edge runs UTC so they're hidden today, but they break under local Deno dev and would silently regress if the runtime TZ ever changes.

- **`supabase/functions/_shared/sponsorship.ts`** — `recordUsage()` and `maybeNotifyThreshold()` both built `monthStart` / `yearMonth` from local-TZ `new Date(year, month, 1)` then converted to UTC ISO. On CST that's "first of CST month at 00:00 CST" = previous day 18:00 UTC, shifting the `ai_usage` billing window by ~6h.
- **`supabase/functions/sponsorships/index.ts:546`** — same `monthStart` pattern in the sponsorship-status handler.
- **`supabase/functions/generate-wrapped/index.ts:51`** — `year > new Date().getFullYear()` check for "not in the future"; edge case at Dec/Jan boundary in non-UTC TZ.

All three switch to `getUTCFullYear()` / `Date.UTC(...)` constructor. Same pattern as #1049.

## Test plan

- [x] `npm test` (UTC default): 2358/2358 pass.
- [x] `TZ=America/Chicago npm test`: 2358/2358 pass.
- [x] `npx tsc --noEmit`: clean.
- [ ] CI green.

Refs #1031 (Tier 1c follow-up). Closes the loose ends from #1049's review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
