### PR TITLE
test(ef): Deno-test CI infra + contract smoke tests for 5 critical EFs (#1031 Tier 1a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,20 @@ jobs:
       - name: Unit tests (Vitest)
         run: npm test
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v1.x
+
+      - name: Edge Function contract tests (Deno)
+        # --no-check because EF files import from `npm:` and remote URLs
+        # whose types we don't ship locally; typechecking them would force
+        # network fetches at test time. The contract tests assert
+        # request-shape behaviour at the handler boundary — type
+        # correctness is enforced by tsc on the PWA side and by deploy
+        # smoke on the EF side (issue #1031 Tier 1a).
+        run: npm run test:functions
+
       - name: CLI build + tests (cli/, M30)
         # Skipped if cli/ is missing on the branch; otherwise installs,
         # builds, and runs the Node native test runner. Matches what

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:functions": "deno test --allow-all --no-check supabase/functions/",
     "test:e2e": "playwright test --project=chromium --project=mobile-chrome",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:mobile": "playwright test --project=mobile-chrome",

--- a/supabase/functions/admin/index.test.ts
+++ b/supabase/functions/admin/index.test.ts
@@ -1,0 +1,57 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { handler } from './index.ts';
+
+const URL = 'http://localhost/functions/v1/admin';
+
+Deno.test('admin: GET → 405 (POST-only)', async () => {
+  const res = await handler(new Request(URL, { method: 'GET' }));
+  assertEquals(res.status, 405);
+});
+
+Deno.test('admin: OPTIONS → 200 (CORS preflight)', async () => {
+  const res = await handler(new Request(URL, { method: 'OPTIONS' }));
+  assertEquals(res.status, 200);
+});
+
+Deno.test('admin: malformed JSON → 400', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{bad',
+  }));
+  assertEquals(res.status, 400);
+  const body = await res.json();
+  assertEquals(body.error, 'invalid json');
+});
+
+Deno.test('admin: missing action → 400', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ reason: 'because tests are good' }),
+  }));
+  assertEquals(res.status, 400);
+});
+
+Deno.test('admin: missing reason → 400', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ action: 'role.grant' }),
+  }));
+  assertEquals(res.status, 400);
+});
+
+Deno.test('admin: unknown action → 400', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ action: 'nope.fake', reason: 'because tests are good' }),
+  }));
+  assertEquals(res.status, 400);
+});
+
+// TODO: missing-auth + role-gate tests require supabase env + a JWT —
+// dispatcher constructs a real client before auth check. Covered by
+// admin/_shared/rate-limit.test.ts (existing) and the e2e admin runbook.
+Deno.test.ignore('admin: missing Authorization → 401', () => {});

--- a/supabase/functions/admin/index.ts
+++ b/supabase/functions/admin/index.ts
@@ -68,7 +68,7 @@ function json(body: unknown, status = 200, req: Request): Response {
   });
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders(req) });
   if (req.method !== 'POST') return json({ error: 'method not allowed' }, 405, req);
 
@@ -158,4 +158,6 @@ serve(async (req) => {
     await reportFunctionError(admin, 'admin', 'handler_exception', actorId, { op: action }, err);
     return json({ error: (err as Error).message }, 500, req);
   }
-});
+}
+
+serve(handler);

--- a/supabase/functions/api/index.test.ts
+++ b/supabase/functions/api/index.test.ts
@@ -15,29 +15,44 @@ Deno.test('api: OPTIONS → 200 (CORS preflight)', async () => {
   assertEquals(res.status, 200);
 });
 
-Deno.test('api: missing Authorization → 401', async () => {
-  const res = await handler(new Request(URL, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ lat: 0, lng: 0 }),
-  }));
-  assertEquals(res.status, 401);
+Deno.test({
+  name: 'api: missing Authorization → 401',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const res = await handler(new Request(URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lat: 0, lng: 0 }),
+    }));
+    assertEquals(res.status, 401);
+  },
 });
 
-Deno.test('api: non-rst_ token → 401', async () => {
-  const res = await handler(new Request(URL, {
-    method: 'POST',
-    headers: { authorization: 'Bearer not-an-rst-token', 'content-type': 'application/json' },
-    body: JSON.stringify({}),
-  }));
-  assertEquals(res.status, 401);
+Deno.test({
+  name: 'api: non-rst_ token → 401',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const res = await handler(new Request(URL, {
+      method: 'POST',
+      headers: { authorization: 'Bearer not-an-rst-token', 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    }));
+    assertEquals(res.status, 401);
+  },
 });
 
-Deno.test('api: GET without token → 401', async () => {
-  const res = await handler(new Request('http://localhost/functions/v1/api/observations', {
-    method: 'GET',
-  }));
-  assertEquals(res.status, 401);
+Deno.test({
+  name: 'api: GET without token → 401',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const res = await handler(new Request('http://localhost/functions/v1/api/observations', {
+      method: 'GET',
+    }));
+    assertEquals(res.status, 401);
+  },
 });
 
 // TODO: happy-path POST /api/observe requires a real supabase fixture

--- a/supabase/functions/api/index.test.ts
+++ b/supabase/functions/api/index.test.ts
@@ -1,0 +1,45 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+
+// supabase-js refuses to instantiate with undefined URL/key; the
+// dispatcher constructs the client at the top of every request, so
+// fixtures here pin both before the import.
+Deno.env.set('SUPABASE_URL', 'http://localhost:54321');
+Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'test-anon-key');
+
+const { handler } = await import('./index.ts');
+
+const URL = 'http://localhost/functions/v1/api/observe';
+
+Deno.test('api: OPTIONS → 200 (CORS preflight)', async () => {
+  const res = await handler(new Request(URL, { method: 'OPTIONS' }));
+  assertEquals(res.status, 200);
+});
+
+Deno.test('api: missing Authorization → 401', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ lat: 0, lng: 0 }),
+  }));
+  assertEquals(res.status, 401);
+});
+
+Deno.test('api: non-rst_ token → 401', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { authorization: 'Bearer not-an-rst-token', 'content-type': 'application/json' },
+    body: JSON.stringify({}),
+  }));
+  assertEquals(res.status, 401);
+});
+
+Deno.test('api: GET without token → 401', async () => {
+  const res = await handler(new Request('http://localhost/functions/v1/api/observations', {
+    method: 'GET',
+  }));
+  assertEquals(res.status, 401);
+});
+
+// TODO: happy-path POST /api/observe requires a real supabase fixture
+// (valid token row + RLS-passing insert). Out of scope for Tier 1a.
+Deno.test.ignore('api: POST /api/observe with valid token → 201', () => {});

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -50,7 +50,7 @@ async function verifyToken(
   return { user_id: data.user_id, scopes: data.scopes };
 }
 
-Deno.serve(async (req: Request) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
   try {
 
@@ -315,7 +315,9 @@ Deno.serve(async (req: Request) => {
     console.error('[api] unhandled error', e);
     return json({ error: 'internal_error', detail: (e as Error).message }, 500);
   }
-});
+}
+
+Deno.serve(handler);
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {

--- a/supabase/functions/delete-photo/index.test.ts
+++ b/supabase/functions/delete-photo/index.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+
+// delete-photo checks env vars before auth and returns 500 if any are
+// missing — pin all three to local fixtures before import so the
+// auth/validation paths are reachable.
+Deno.env.set('SUPABASE_URL', 'http://localhost:54321');
+Deno.env.set('SUPABASE_ANON_KEY', 'test-anon-key');
+Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'test-service-key');
+
+const { handler } = await import('./index.ts');
+
+const URL = 'http://localhost/functions/v1/delete-photo';
+
+Deno.test('delete-photo: GET → 405 (POST-only)', async () => {
+  const res = await handler(new Request(URL, { method: 'GET' }));
+  assertEquals(res.status, 405);
+});
+
+Deno.test('delete-photo: OPTIONS → 204 (CORS preflight)', async () => {
+  const res = await handler(new Request(URL, { method: 'OPTIONS' }));
+  assertEquals(res.status, 204);
+});
+
+Deno.test('delete-photo: POST missing Authorization → 401', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ observation_id: 'x', media_id: 'y' }),
+  }));
+  assertEquals(res.status, 401);
+});
+
+// TODO: malformed-JSON + missing-fields paths require a valid JWT
+// (the handler runs supaUser.auth.getUser() before validation). Without
+// a real Supabase to verify against, the getUser() call will reject. A
+// proper fixture test belongs in Tier 2; smoke contract here covers the
+// pre-auth method + header gates.
+Deno.test.ignore('delete-photo: POST with JWT but malformed body → 400', () => {});

--- a/supabase/functions/delete-photo/index.ts
+++ b/supabase/functions/delete-photo/index.ts
@@ -59,7 +59,7 @@ function textResponse(body: string, status: number): Response {
   });
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
@@ -131,4 +131,6 @@ serve(async (req) => {
     media_id: mediaId,
     demoted: demote,
   });
-});
+}
+
+serve(handler);

--- a/supabase/functions/identify/index.test.ts
+++ b/supabase/functions/identify/index.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals, assert } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { handler } from './index.ts';
+
+const URL = 'http://localhost/functions/v1/identify';
+
+Deno.test('identify: GET → 405 (POST-only)', async () => {
+  const res = await handler(new Request(URL, { method: 'GET' }));
+  assertEquals(res.status, 405);
+});
+
+Deno.test('identify: OPTIONS → 204 (CORS preflight)', async () => {
+  const res = await handler(new Request(URL, { method: 'OPTIONS' }));
+  assertEquals(res.status, 204);
+  assert(res.headers.get('access-control-allow-methods')?.includes('POST'));
+});
+
+Deno.test('identify: POST with malformed JSON → 400', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer fake' },
+    body: '{not json',
+  }));
+  assertEquals(res.status, 400);
+});
+
+Deno.test('identify: POST missing observation_id/image → 400', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer fake' },
+    body: JSON.stringify({}),
+  }));
+  assertEquals(res.status, 400);
+});
+
+// TODO: happy-path (cascade success) requires a real PlantNet/Claude/supabase
+// stub — out of scope for Tier 1a smoke. Covered by vision-providers-smoke
+// nightly probe + the existing _shared/vision-provider.test.ts unit tests.
+Deno.test.ignore('identify: happy path → 200 with cascade_attempts', () => {});

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -438,7 +438,7 @@ function corsResponse(body: BodyInit | null, init: ResponseInit = {}): Response 
   return new Response(body, { ...init, headers });
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
@@ -988,4 +988,6 @@ serve(async (req) => {
   return corsResponse(JSON.stringify(responsePayload), {
     headers: { 'content-type': 'application/json' },
   });
-});
+}
+
+serve(handler);

--- a/supabase/functions/mcp/index.test.ts
+++ b/supabase/functions/mcp/index.test.ts
@@ -20,40 +20,55 @@ Deno.test('mcp: PUT → 405 (POST or GET only)', async () => {
   assertEquals(res.status, 405);
 });
 
-Deno.test('mcp: POST malformed JSON → -32700 parse error', async () => {
-  const res = await handler(new Request(URL, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: '{not json',
-  }));
-  assertEquals(res.status, 200);
-  const body = await res.json();
-  assertEquals(body.jsonrpc, '2.0');
-  assertEquals(body.error?.code, -32700);
+Deno.test({
+  name: 'mcp: POST malformed JSON → -32700 parse error',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const res = await handler(new Request(URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{not json',
+    }));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.jsonrpc, '2.0');
+    assertEquals(body.error?.code, -32700);
+  },
 });
 
-Deno.test('mcp: POST initialize (no auth) → 200 with result', async () => {
-  const res = await handler(new Request(URL, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
-  }));
-  assertEquals(res.status, 200);
-  const body = await res.json();
-  assertEquals(body.jsonrpc, '2.0');
-  assertEquals(body.id, 1);
-  assertEquals(typeof body.result?.protocolVersion, 'string');
+Deno.test({
+  name: 'mcp: POST initialize (no auth) → 200 with result',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const res = await handler(new Request(URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+    }));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.jsonrpc, '2.0');
+    assertEquals(body.id, 1);
+    assertEquals(typeof body.result?.protocolVersion, 'string');
+  },
 });
 
-Deno.test('mcp: POST tools/list without token → -32001 auth error', async () => {
-  const res = await handler(new Request(URL, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
-  }));
-  assertEquals(res.status, 200);
-  const body = await res.json();
-  assertEquals(body.error?.code, -32001);
+Deno.test({
+  name: 'mcp: POST tools/list without token → -32001 auth error',
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const res = await handler(new Request(URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+    }));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.error?.code, -32001);
+  },
 });
 
 // TODO: tools/call happy-path requires a valid rst_ token row in

--- a/supabase/functions/mcp/index.test.ts
+++ b/supabase/functions/mcp/index.test.ts
@@ -1,0 +1,62 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+
+// The JSON-RPC dispatcher constructs a service-role supabase client at
+// the top of every POST request; pin env before import so the client
+// can instantiate.
+Deno.env.set('SUPABASE_URL', 'http://localhost:54321');
+Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'test-anon-key');
+
+const { handler } = await import('./index.ts');
+
+const URL = 'http://localhost/functions/v1/mcp';
+
+Deno.test('mcp: OPTIONS → 200', async () => {
+  const res = await handler(new Request(URL, { method: 'OPTIONS' }));
+  assertEquals(res.status, 200);
+});
+
+Deno.test('mcp: PUT → 405 (POST or GET only)', async () => {
+  const res = await handler(new Request(URL, { method: 'PUT' }));
+  assertEquals(res.status, 405);
+});
+
+Deno.test('mcp: POST malformed JSON → -32700 parse error', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{not json',
+  }));
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.jsonrpc, '2.0');
+  assertEquals(body.error?.code, -32700);
+});
+
+Deno.test('mcp: POST initialize (no auth) → 200 with result', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' }),
+  }));
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.jsonrpc, '2.0');
+  assertEquals(body.id, 1);
+  assertEquals(typeof body.result?.protocolVersion, 'string');
+});
+
+Deno.test('mcp: POST tools/list without token → -32001 auth error', async () => {
+  const res = await handler(new Request(URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+  }));
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.error?.code, -32001);
+});
+
+// TODO: tools/call happy-path requires a valid rst_ token row in
+// user_api_tokens — covered by mcp e2e probes once a real fixture
+// exists. Out of scope for Tier 1a.
+Deno.test.ignore('mcp: POST tools/call identify_species → 200', () => {});

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -373,7 +373,7 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
-Deno.serve(async (req: Request) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
 
   // ── SSE keep-alive for clients that require GET-based SSE transport ──────
@@ -512,4 +512,6 @@ Deno.serve(async (req: Request) => {
   }
 
   return rpcError(body.id, -32601, `Method not found: ${body.method}`);
-});
+}
+
+Deno.serve(handler);


### PR DESCRIPTION
## Summary

Tier 1a of #1031 — **pattern-setter PR**. Adds the Deno-test CI infrastructure that runs Edge Function contract tests on every PR, plus contract smoke tests for the 5 highest-risk EFs.

**CI plumbing** (one commit, lands first):
- `denoland/setup-deno@v2` step in the `verify` job
- `npm run test:functions` → `deno test --allow-all --no-check supabase/functions/`
- `--no-check` because EF files `import` from `npm:` and remote URLs; typechecking would force network fetches at test time. Comment explains in `ci.yml`.

**EF contract tests** (5 commits, one per EF):
- `identify` — photo cascade entry point (5 tests: method gate, OPTIONS CORS, malformed JSON, missing required fields, +1 ignored happy-path)
- `admin` — privileged dispatcher (6 pre-`createClient` validation paths covered)
- `api` — `rst_*` token auth surface (CLI / MCP consumers depend on this contract)
- `mcp` — JSON-RPC over HTTP (method routing, malformed JSON-RPC)
- `delete-photo` — atomic soft-delete + ID demote + material-edit bump

Each EF gets a **minimal handler-export refactor** — `serve(async (req) => {...})` → `export async function handler(req)... ; serve(handler)`. No behavior change.

**Coverage shape:** 23 active contract assertions + ~5 `Deno.test.ignore` placeholders for happy-paths that need supabase/external-API mocks (covered by `vision-providers-smoke.yml` nightly probe and existing `_shared/*.test.ts` unit tests).

## Why this matters

Per #1031 diagnosis: this seam is where the `karma_events.reason` CHECK regression and `taxon_id` vs `primary_taxon_id` drift bugs lived. Without contract tests, EF method/auth/body-shape changes ship silently and break the PWA + CLI consumers.

Sibling worktrees adding contract tests for the other 4 batches (social/media/misc/billing) will rebase onto this PR's merged commit so the deno-test CI step runs on each.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test` (Vitest unchanged) — 2358/2358 pass.
- [ ] CI green (this PR adds the Deno test runner; first time it runs).
- [ ] Once green, sibling Tier 1a PRs rebased and merged in any order.

**Per-EF notes** worth scanning:
- `admin` — service-role supabase client constructed BEFORE auth gate, so "missing-auth" tests would crash. Test only the 6 pre-`createClient` validation paths.
- `admin/index.ts:132` has a pre-existing minor bug (`json({...}, 400)` missing `req` arg used by sibling calls) — left alone, out of scope for Tier 1a.
- `mcp` SSE GET path opens a 25s-ping stream — left untested (needs fake clock).

Refs #1031 (Tier 1a, batch 1 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
