### PR TITLE
test(ef): contract smoke tests for 4 media/export EFs (#1031 Tier 1a)

### DIFF
--- a/supabase/functions/export-dwca/index.test.ts
+++ b/supabase/functions/export-dwca/index.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Handler-level smoke contract tests for /functions/v1/export-dwca.
+ *
+ * Pinned by issue #1031 Tier 1a — these assert the *shape* of the contract
+ * (allowed methods, auth requirement, config requirement) without touching
+ * the real Supabase backend or invoking the DwC-A builder.
+ *
+ * The pure DwC builders (buildMetaXml / buildEmlXml / buildOccurrenceTsv)
+ * are exercised by the Vitest suite in src/lib/dwca.test.ts; this file
+ * only covers the HTTP shell.
+ */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { handler } from './index.ts';
+
+function withEnv(): void {
+  Deno.env.set('SUPABASE_URL', 'https://example.supabase.co');
+  Deno.env.set('SUPABASE_ANON_KEY', 'test-anon-key');
+  Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role-key');
+}
+
+function clearEnv(): void {
+  Deno.env.delete('SUPABASE_URL');
+  Deno.env.delete('SUPABASE_ANON_KEY');
+  Deno.env.delete('SUPABASE_SERVICE_ROLE_KEY');
+}
+
+Deno.test('export-dwca: rejects PUT with 405', async () => {
+  const res = await handler(new Request('http://localhost/', { method: 'PUT' }));
+  assertEquals(res.status, 405);
+});
+
+Deno.test('export-dwca: OPTIONS preflight returns 200 with CORS', async () => {
+  const res = await handler(new Request('http://localhost/', { method: 'OPTIONS' }));
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get('access-control-allow-origin'), '*');
+});
+
+Deno.test('export-dwca: GET without env returns 500', async () => {
+  clearEnv();
+  const res = await handler(new Request('http://localhost/', { method: 'GET' }));
+  assertEquals(res.status, 500);
+});
+
+Deno.test('export-dwca: GET without auth returns 401', async () => {
+  withEnv();
+  const res = await handler(new Request('http://localhost/', { method: 'GET' }));
+  assertEquals(res.status, 401);
+});
+
+Deno.test.ignore('export-dwca: happy-path returns ZIP with valid eml.xml', async () => {
+  // TODO: requires real service-role key + at least one synced observation.
+  // Covered by nightly smoke runs against the staging project.
+});

--- a/supabase/functions/export-dwca/index.ts
+++ b/supabase/functions/export-dwca/index.ts
@@ -289,7 +289,7 @@ const corsHeaders = {
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
 };
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
   if (req.method !== 'GET' && req.method !== 'POST') {
     return new Response('Method not allowed', { status: 405, headers: corsHeaders });
@@ -514,4 +514,6 @@ serve(async (req) => {
       'X-Rastrum-Multimedia': String(multimediaRows.length),
     },
   });
-});
+}
+
+serve(handler);

--- a/supabase/functions/export-trail-pdf/index.test.ts
+++ b/supabase/functions/export-trail-pdf/index.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Handler-level smoke contract tests for /functions/v1/export-trail-pdf.
+ *
+ * Pinned by issue #1031 Tier 1a — these assert the *shape* of the contract
+ * (missing trail_id, CORS preflight, JSON error body) without touching the
+ * real Supabase backend.
+ *
+ * Note: this EF intentionally does NOT gate by method — GET and POST both
+ * fall through to the same rendering path. Auth is optional (public trails
+ * have no auth; private trails honour Bearer JWT via RLS). The happy path
+ * needs a real `trails` row and is covered by nightly smoke.
+ */
+import { assertEquals, assertStringIncludes } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { handler } from './index.ts';
+
+Deno.test('export-trail-pdf: OPTIONS preflight returns CORS headers', async () => {
+  const res = await handler(new Request('http://localhost/', { method: 'OPTIONS' }));
+  assertEquals(res.headers.get('access-control-allow-origin'), '*');
+});
+
+Deno.test('export-trail-pdf: missing trail_id returns 400 JSON', async () => {
+  const res = await handler(new Request('http://localhost/', { method: 'GET' }));
+  assertEquals(res.status, 400);
+  assertEquals(res.headers.get('content-type'), 'application/json');
+  const body = await res.json();
+  assertStringIncludes(String(body.error), 'trail_id');
+});
+
+Deno.test('export-trail-pdf: empty trail_id query param also returns 400', async () => {
+  const res = await handler(new Request('http://localhost/?trail_id=', { method: 'GET' }));
+  assertEquals(res.status, 400);
+});
+
+Deno.test.ignore('export-trail-pdf: GET with valid trail_id renders HTML field guide', async () => {
+  // TODO: requires a seeded `trails` row + working SUPABASE_URL/ANON_KEY.
+  // Covered by the e2e journey suite (journey-guides.spec.ts).
+});

--- a/supabase/functions/export-trail-pdf/index.ts
+++ b/supabase/functions/export-trail-pdf/index.ts
@@ -26,7 +26,7 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'authorization, content-type',
 };
 
-serve(async (req: Request) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: CORS_HEADERS });
   }
@@ -80,7 +80,9 @@ serve(async (req: Request) => {
       'Cache-Control': 'no-store',
     },
   });
-});
+}
+
+serve(handler);
 
 // ---------------------------------------------------------------------------
 // HTML builder

--- a/supabase/functions/get-upload-url/index.test.ts
+++ b/supabase/functions/get-upload-url/index.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Handler-level smoke contract tests for /functions/v1/get-upload-url.
+ *
+ * Pinned by issue #1031 Tier 1a — these assert the *shape* of the contract
+ * (method allowlist, auth requirement, body validation, traversal-resistant
+ * key prefixes) without touching the real Cloudflare R2 or Supabase backend.
+ *
+ * Happy-path signing requires a real R2 + a real Supabase JWT; that flow is
+ * skipped here and covered by the nightly smoke runs.
+ */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { handler } from './index.ts';
+
+function withEnv(): void {
+  Deno.env.set('R2_ENDPOINT_URL', 'https://example.r2.cloudflarestorage.com');
+  Deno.env.set('R2_ACCESS_KEY_ID', 'test');
+  Deno.env.set('R2_SECRET_ACCESS_KEY', 'test');
+  Deno.env.set('R2_BUCKET_NAME', 'test-bucket');
+  Deno.env.set('R2_PUBLIC_URL', 'https://media.example.org');
+  Deno.env.set('SUPABASE_URL', 'https://example.supabase.co');
+  Deno.env.set('SUPABASE_ANON_KEY', 'test-anon-key');
+}
+
+Deno.test('get-upload-url: rejects GET with 405', async () => {
+  const res = await handler(new Request('http://localhost/', { method: 'GET' }));
+  assertEquals(res.status, 405);
+});
+
+Deno.test('get-upload-url: OPTIONS preflight returns 204 with CORS', async () => {
+  const res = await handler(new Request('http://localhost/', { method: 'OPTIONS' }));
+  assertEquals(res.status, 204);
+  assertEquals(res.headers.get('access-control-allow-origin'), '*');
+});
+
+Deno.test('get-upload-url: POST without auth returns 401', async () => {
+  withEnv();
+  const res = await handler(new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ key: 'avatars/foo/bar.jpg', contentType: 'image/jpeg' }),
+  }));
+  assertEquals(res.status, 401);
+});
+
+Deno.test.ignore('get-upload-url: happy-path signs presigned R2 URL', async () => {
+  // TODO: requires real R2 credentials + real Supabase JWT to validate end-to-end.
+  // Covered by infra/smoke-model-assets.sh + nightly smoke.
+});

--- a/supabase/functions/get-upload-url/index.ts
+++ b/supabase/functions/get-upload-url/index.ts
@@ -70,7 +70,7 @@ function textResponse(body: string, status: number): Response {
   });
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   // Preflight — must return CORS headers and a 2xx status BEFORE the
   // browser will dispatch the actual POST.
   if (req.method === 'OPTIONS') {
@@ -150,4 +150,6 @@ serve(async (req) => {
   const publicUrl = `${env('R2_PUBLIC_URL')!.replace(/\/$/, '')}/${safe}`;
 
   return jsonResponse({ uploadUrl: signedUrl, publicUrl, expiresIn: 300 });
-});
+}
+
+serve(handler);

--- a/supabase/functions/share-card/index.test.ts
+++ b/supabase/functions/share-card/index.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Handler-level smoke contract tests for /functions/v1/share-card.
+ *
+ * Pinned by issue #1031 Tier 1a — these assert the *shape* of the contract
+ * (missing obs_id, OPTIONS preflight, config-required) without touching the
+ * real Supabase backend.
+ *
+ * share-card is a GET-only OG/Twitter-card renderer for public observation
+ * sharing — no Bearer JWT required. It returns:
+ *   • `text/html`        (default) with OG/Twitter <meta>
+ *   • `image/svg+xml`    when ?format=svg
+ *   • 404                when the observation is fully obscured (obscure_level='full')
+ *
+ * The DB-backed rendering paths are skipped here; covered by the e2e
+ * locale-neutral share-obs smoke test in tests/e2e/smoke.spec.ts.
+ */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { handler } from './index.ts';
+
+function withEnv(): void {
+  Deno.env.set('SUPABASE_URL', 'https://example.supabase.co');
+  Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role-key');
+}
+
+function clearEnv(): void {
+  Deno.env.delete('SUPABASE_URL');
+  Deno.env.delete('SUPABASE_SERVICE_ROLE_KEY');
+}
+
+Deno.test('share-card: OPTIONS preflight returns 204 with CORS', async () => {
+  const res = await handler(new Request('http://localhost/', { method: 'OPTIONS' }));
+  assertEquals(res.status, 204);
+  assertEquals(res.headers.get('access-control-allow-origin'), '*');
+});
+
+Deno.test('share-card: GET without obs_id returns 400', async () => {
+  const res = await handler(new Request('http://localhost/', { method: 'GET' }));
+  assertEquals(res.status, 400);
+});
+
+Deno.test('share-card: legacy ?id= alias is accepted as obs_id (no 400)', async () => {
+  // Both `?obs_id=` and `?id=` are valid; with an id present the 400 branch
+  // is skipped and the handler proceeds to env/config validation.
+  clearEnv();
+  const res = await handler(new Request('http://localhost/?id=00000000-0000-0000-0000-000000000000', { method: 'GET' }));
+  assertEquals(res.status, 500);
+});
+
+Deno.test('share-card: GET with obs_id but missing env returns 500', async () => {
+  clearEnv();
+  const res = await handler(new Request('http://localhost/?obs_id=00000000-0000-0000-0000-000000000000', { method: 'GET' }));
+  assertEquals(res.status, 500);
+});
+
+Deno.test.ignore('share-card: GET with obs_id renders text/html with OG meta', async () => {
+  // TODO: requires a seeded observation row. Covered by e2e smoke test
+  // tests/e2e/smoke.spec.ts ("share/obs/ is locale-neutral").
+  withEnv();
+});
+
+Deno.test.ignore('share-card: ?format=svg renders image/svg+xml', async () => {
+  // TODO: requires a seeded observation row + working DB.
+});

--- a/supabase/functions/share-card/index.ts
+++ b/supabase/functions/share-card/index.ts
@@ -31,7 +31,7 @@ function withCors(headers: HeadersInit = {}): HeadersInit {
   return out;
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
@@ -181,4 +181,6 @@ serve(async (req) => {
       headers: { 'content-type': 'application/json', ...CORS_HEADERS },
     });
   }
-});
+}
+
+serve(handler);


### PR DESCRIPTION
## Summary

Tier 1a of #1031 — handler-level smoke contract tests for **4 media/export EFs**: `get-upload-url`, `export-dwca`, `export-trail-pdf`, `share-card`. Pattern set by #1053.

Per EF: minimal `serve(handler)` → `export async function handler` refactor + `index.test.ts` with 3-4 contract assertions.

**Peculiarities flagged in code review:**
- `get-upload-url` — strict POST-only + JWT-required.
- `export-dwca` — accepts GET and POST; service-role bearer = full corpus.
- `export-trail-pdf` — **no method gate**; GET/POST both render. Auth optional (public trails).
- `share-card` — GET-only OG renderer, **intentionally unauthenticated**. Default `content-type` is `text/html` (not `image/png` as I initially speculated); `?format=svg` returns `image/svg+xml`. Accepts both `?obs_id=` and legacy `?id=`.

Happy-path tests deferred (`Deno.test.ignore` + TODO) — covered by `nightly-smoke.yml`, `tests/e2e/smoke.spec.ts` (locale-neutral share-obs invariant), `journey-guides.spec.ts`, and `src/lib/dwca.test.ts`.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npm test` — 2358 pass.
- [ ] CI green.

Refs #1031 (Tier 1a, batch 3 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
