### PR TITLE
chore(identify): log PlantNet failures instead of silent null

### DIFF
--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -204,7 +204,13 @@ async function callPlantNet(
   // TODO(security): rotate PLANTNET_API_KEY — old key 2b10E7bp6hVnxBvvJWc3IGv9ae was exposed
   // in browser traffic pre-PR#1037 (window.__RASTRUM_PLANTNET_KEY__ / PUBLIC_PLANTNET_KEY).
   // Rotate via the PlantNet dashboard: https://my.plantnet.org/account/settings
-  if (!key) return null;
+  if (!key) {
+    // Why: a missing key returns null silently, which presents to the user
+    // as "no plant suggestion" indistinguishable from "PlantNet found nothing".
+    // Surface the misconfig so an operator grepping function logs sees it.
+    console.warn(`[identify] callPlantNet skipped: no key (clientKey=${clientKey ? 'set' : 'unset'}, env=unset)`);
+    return null;
+  }
 
   const form = new FormData();
   form.append('images', new Blob([imageBytes], { type: 'image/jpeg' }), 'photo.jpg');
@@ -214,7 +220,16 @@ async function callPlantNet(
     `https://my-api.plantnet.org/v2/identify/all?api-key=${encodeURIComponent(key)}&lang=es&nb-results=5`,
     { method: 'POST', body: form, signal },
   );
-  if (!res.ok) return null;
+  if (!res.ok) {
+    // Why: PlantNet failures (401 revoked key, 403 IP allowlist, 429 quota
+    // exhausted, 5xx upstream) previously returned null silently. Log status
+    // + body snippet so operators can distinguish the cases. Key itself is
+    // never logged — only whether the call used a BYO or operator key.
+    let bodySnippet = '';
+    try { bodySnippet = (await res.text()).slice(0, 200); } catch { /* ignore */ }
+    console.warn(`[identify] callPlantNet failed: HTTP ${res.status} ${res.statusText}, body=${bodySnippet}, key_source=${clientKey ? 'byo' : 'operator'}`);
+    return null;
+  }
   const json = await res.json() as {
     results: Array<{
       score: number;


### PR DESCRIPTION
## Summary

- `callPlantNet()` returned `null` without logging on (a) missing key and (b) non-OK HTTP response from PlantNet. Both modes are indistinguishable from "PlantNet found nothing", so any production failure of the operator key disappears.
- Surface both paths with `console.warn`. Status + statusText + body snippet (capped 200 chars) + `key_source=byo|operator`. The key value itself is never logged.

## Why now

We hit this today debugging why plant identifications stopped appearing in the PWA. After #1037 / #1043 moved PlantNet from a browser-side call (user IP) to a server-side EF call (Deno Deploy egress IPs), the operator key started returning **HTTP 403 `error: remote IP not allowed`** — the key has IP allowlist restrictions on the PlantNet dashboard that don't match Deno Deploy. Reproduced by hitting the key directly:

```
curl https://my-api.plantnet.org/v2/identify/all?api-key=<key>
→ HTTP 403 {"message":"error: remote IP not allowed"}
```

Nothing in the function logs hinted at this, because line 217 (`if (!res.ok) return null;`) was silent. After this PR, the same failure produces:

```
[identify] callPlantNet failed: HTTP 403 Forbidden, body={"message":"error: remote IP not allowed"}, key_source=operator
```

The operator fix (rotate / remove IP allowlist + redeploy) is separate from this PR — this just makes the next regression in this class greppable instead of silent.

## Out of scope

- Rotating `PUBLIC_PLANTNET_KEY` (separate operator action; the leaked key noted at index.ts:204 also needs rotation regardless of the IP issue).
- A unit test for the log. `callPlantNet` is file-local and the existing EF test suite is contract-smoke only; happy/sad-path tests for the cascade are deferred per the `Deno.test.ignore` at index.test.ts:38.

## Test plan

- [ ] CI: `deploy-functions.yml` redeploys `identify` and the smoke test passes (post-merge).
- [ ] Operator: trigger a PlantNet identify from the PWA, check function logs in Supabase dashboard show `[identify] callPlantNet …` warn line if/when PlantNet returns non-OK.
- [ ] Operator: with the key fixed, the warn line disappears and PlantNet results return as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)