### PR TITLE
fix(identify): deploy with --no-verify-jwt so the function self-gates

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -227,10 +227,13 @@ jobs:
           # 2. Other no-JWT functions — public or token-gated, not cron:
           #    share-card  — OG scrapers fetch anonymously
           #    mcp / api   — gate internally on rst_ tokens (not JWTs)
+          #    identify    — self-gates: auth.getUser when JWT present, else
+          #                  anon IP rate-limit. Edge verify_jwt rejected the
+          #                  sb_publishable_* key as a non-JWT (config.toml).
           #
           # Module 26 functions (follow / react / report) DO verify JWT.
           CRON_ONLY="${{ steps.classify.outputs.cron_only }}"
-          OTHER_NO_JWT="share-card mcp api"
+          OTHER_NO_JWT="share-card mcp api identify"
           for fn in ${{ steps.targets.outputs.fns }}; do
             EXTRA_FLAGS=""
             if echo " $CRON_ONLY " | grep -q " $fn "; then

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -11,7 +11,14 @@ verify_jwt = true
 
 [functions.identify]
 enabled = true
-verify_jwt = true
+# verify_jwt = false: identify self-gates auth (resolves the JWT via
+# auth.getUser when present, falls back to anon IP rate-limiting otherwise —
+# index.ts:451-534). Edge-layer verify_jwt rejects the sb_publishable_* key
+# as a non-JWT before the function runs, so anon + session-lock-fallback
+# calls 401 with UNAUTHORIZED_INVALID_JWT_FORMAT and never reach the code.
+# Mirrors api/mcp/share-card. Must also be in OTHER_NO_JWT in
+# .github/workflows/deploy-functions.yml or the deploy re-enables it.
+verify_jwt = false
 
 [functions.enrich-environment]
 enabled = true


### PR DESCRIPTION
## Summary

`identify` is **built to self-gate auth** but was deployed with `verify_jwt=true`, so Supabase's edge gateway rejected the request before the function ran. Fix mirrors `api`/`mcp`/`share-card`: `verify_jwt=false` in `config.toml` + `identify` added to `OTHER_NO_JWT` in `deploy-functions.yml`.

## Root cause

- The function handles **anonymous callers** (anon IP rate-limit, `index.ts:451-469`) and resolves the JWT **itself** when present (`auth.getUser`, `index.ts:525-534`). Anon + optional-JWT is a designed path.
- But edge `verify_jwt=true` parses the Bearer token as a JWT *before* the function runs. Since the project migrated to `sb_publishable_*` keys, any call sending the publishable key as Bearer — anonymous users, **and** signed-in users whose gotrue session lock stalls (`Lock "lock:rastrum-auth-v1" was not released within 5000ms`) and falls back to the apikey — is rejected at the gateway with `UNAUTHORIZED_INVALID_JWT_FORMAT`.
- Evidence: production `identify` logs show **only** `booted` / `shutdown` — the function body never executes. Reproduced by curling the EF with the publishable anon key → `401 {"code":"UNAUTHORIZED_INVALID_JWT_FORMAT"}`, zero function logs. Symptom to the user: identification silently produces nothing.
- Same failure class as the documented cron pitfall (*"publishable sb_publishable_… key not accepted as Bearer by Edge Functions → deploy --no-verify-jwt"*). `identify` was left out of that list by accident.

## Why this is not a security regression

- Anon callers are already IP rate-limited (`checkAnonRateLimit`, `ANON_LIMIT`/`WINDOW_SEC`).
- Claude still requires a valid JWT to resolve sponsorship/pool — anon cannot spend another user's credit (`beneficiaryId` comes from `auth.getUser`).
- PlantNet operator path is capped by the PlantNet provider quota.
- Identical posture to `api`/`mcp` (token-gated internally, `--no-verify-jwt` at the edge).

## Both changes are required

- `deploy-functions.yml` `OTHER_NO_JWT` — what the deploy **actually applies** (`--no-verify-jwt` flag).
- `config.toml` — documents intent + source of truth for local CLI runs. Without it, intent silently drifts.

## Test plan

- [ ] CI green.
- [ ] Merge → `deploy-functions.yml` redeploys `identify` with `--no-verify-jwt`.
- [ ] Post-deploy: upload a plant photo on https://rastrum.org/observe → species suggestion returns.
- [ ] Post-deploy: production `identify` logs now show `[identify] …` request lines (function body executing), not just boot/shutdown.
- [ ] `curl -X POST .../functions/v1/identify` with the publishable anon key no longer 401s at the gateway (reaches the function's own 400/200 handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)