### PR TITLE
fix(observe): pipeline counter tallies files, not internal nodes

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -1040,14 +1040,20 @@ function updatePipelineUI() {
   if (!pipelineState) return;
   document.dispatchEvent(new CustomEvent('rastrum:pipeline-update', { detail: { nodes: pipelineState.nodes } }));
 
-  // Status text
+  // Status text — count uploaded files (one input node per file), not raw
+  // graph nodes. The 3-step stepper is the phase indicator; this is the
+  // per-file tally, so the denominator matches what the user uploaded
+  // instead of the internal node count (which read e.g. "2/5" for 1 photo).
   const running = pipelineState.nodes.filter(n => n.state === 'running').length;
-  const done    = pipelineState.nodes.filter(n => n.state === 'done').length;
-  const total   = pipelineState.nodes.length;
+  const total   = pipelineState.nodes.filter(n => n.kind === 'input').length;
+  const done    = pipelineState.nodes.filter(
+    n => n.kind === 'identify' && (n.state === 'done' || n.state === 'skipped'),
+  ).length;
   if (pipelineStatus) {
+    const count = total > 0 ? ` (${done}/${total})` : '';
     pipelineStatus.textContent = running > 0
-      ? (isEs ? `Procesando... (${done}/${total})` : `Processing... (${done}/${total})`)
-      : (isEs ? `Listo (${done}/${total})` : `Ready (${done}/${total})`);
+      ? (isEs ? `Procesando...${count}` : `Processing...${count}`)
+      : (isEs ? `Listo${count}` : `Ready${count}`);
   }
 }
 


### PR DESCRIPTION
## Summary

The observe pipeline status text read **"Processing... (2/5)" for a single photo** while the visual stepper only shows 3 phases (Photo / Identify / Save) — a confusing 5-vs-3 mismatch reported from the field.

Cause: `updatePipelineUI()` used `pipelineState.nodes.length`. `buildGraph` (pipeline-engine.ts:99-159) emits 5 nodes for 1 photo — `input` + `identify` + `merge` + `location` + `save`. The stepper groups those into 3.

Fix: the counter now tallies **uploaded files** — `input` nodes for the denominator (one per file), `identify` nodes in a terminal state (`done`/`skipped`) for the numerator. The 3-step stepper remains the phase indicator; the number is now an explicit per-file tally that matches what the user dragged in.

- 1 photo → `(0/1)` → `(1/1)`
- 5-photo batch (camera-trap / CLI parity) → `(3/5)` as they identify
- `total === 0` → parenthetical dropped (no `(0/0)`)

No behaviour change beyond the status string; no i18n keys (text was already inline EN/ES literals); no tests referenced the old string.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] Single photo on /observe → counter reads `(0/1)`/`(1/1)`, never `/5`
- [ ] Multi-photo upload → counter increments per identified photo

🤖 Generated with [Claude Code](https://claude.com/claude-code)