### PR TITLE
fix(identify): HEIC decode, visible failures, taxa upsert, EF errors

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -12996,3 +12996,71 @@ GRANT EXECUTE ON FUNCTION public.nearby_observations(numeric, numeric, numeric, 
 COMMENT ON FUNCTION public.nearby_observations IS
   '#712 Returns nearby synced observations within radius. Used by HomeNearby.astro. '
   'Uses location_obscured when set; falls back to location. Joins taxa + media_files.';
+
+-- ============================================================
+-- taxa.scientific_name UNIQUE — the identify EF upserts taxa with
+-- ON CONFLICT (scientific_name) but only a non-unique index existed,
+-- so every upsert failed: "no unique or exclusion constraint matching
+-- the ON CONFLICT specification" → identified taxa were never persisted.
+-- The whole codebase already treats scientific_name as the natural key
+-- (every trigger does WHERE scientific_name = X LIMIT 1). This aligns
+-- the schema with that intent.
+--
+-- Idempotent: the dedup is a no-op once there are no duplicates, and the
+-- unique index uses IF NOT EXISTS. The FK repoint is driven dynamically
+-- from pg_constraint so no referencing table can be missed (incl. taxa's
+-- own parent_id / current_accepted_id self-references).
+-- ============================================================
+DO $taxa_dedup$
+DECLARE
+  dup        RECORD;
+  fk         RECORD;
+  ref_schema text;
+  ref_table  text;
+  ref_col    text;
+BEGIN
+  -- Repoint every FK that references public.taxa(id) from each duplicate
+  -- row to the keeper (oldest by created_at, tiebreak smallest id), then
+  -- delete the duplicates.
+  FOR dup IN
+    SELECT t.id AS dup_id, k.keeper_id
+    FROM (
+      SELECT id, scientific_name,
+             first_value(id) OVER (
+               PARTITION BY scientific_name
+               ORDER BY created_at ASC, id ASC
+             ) AS keeper_id
+      FROM public.taxa
+    ) k
+    JOIN public.taxa t ON t.id = k.id
+    WHERE k.id <> k.keeper_id
+    GROUP BY t.id, k.keeper_id
+  LOOP
+    FOR fk IN
+      SELECT con.conrelid::regclass::text AS rel,
+             att.attname                  AS col,
+             ns.nspname                   AS nsp,
+             cl.relname                   AS tbl
+      FROM pg_constraint con
+      JOIN pg_class    cl ON cl.oid = con.conrelid
+      JOIN pg_namespace ns ON ns.oid = cl.relnamespace
+      JOIN pg_attribute att
+        ON att.attrelid = con.conrelid
+       AND att.attnum   = con.conkey[1]
+      WHERE con.contype = 'f'
+        AND con.confrelid = 'public.taxa'::regclass
+        AND array_length(con.conkey, 1) = 1
+    LOOP
+      EXECUTE format(
+        'UPDATE %I.%I SET %I = $1 WHERE %I = $2',
+        fk.nsp, fk.tbl, fk.col, fk.col
+      ) USING dup.keeper_id, dup.dup_id;
+    END LOOP;
+
+    DELETE FROM public.taxa WHERE id = dup.dup_id;
+  END LOOP;
+END
+$taxa_dedup$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS taxa_scientific_name_key
+  ON public.taxa (scientific_name);

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -382,6 +382,23 @@ const weathers = WEATHERS;
     </div>
   </div>
 
+  <!-- Identification failed — show the actual reason (#identify-reliability) -->
+  <div id="obs2-identify-error" class="hidden rounded-xl border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-4 space-y-3">
+    <div class="flex items-start gap-3">
+      <span class="text-2xl shrink-0">⚠️</span>
+      <div class="space-y-1">
+        <p class="font-semibold text-red-800 dark:text-red-300 text-sm">
+          {isEs ? "No se pudo identificar" : "Couldn't identify"}
+        </p>
+        <p id="obs2-identify-error-msg" class="text-xs text-zinc-600 dark:text-zinc-400"></p>
+      </div>
+    </div>
+    <button type="button" id="obs2-identify-error-continue"
+      class="min-h-[40px] rounded-xl border border-zinc-300 dark:border-zinc-700 text-xs px-4 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors">
+      {isEs ? "Continuar sin identificar →" : "Continue without ID →"}
+    </button>
+  </div>
+
   <!-- Success state -->
   <div id="obs2-success" class="hidden rounded-xl border border-emerald-200 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 p-6 text-center space-y-3">
     <div class="text-4xl">✅</div>
@@ -414,6 +431,7 @@ const isEs = lang === 'es';
 let pipelineState: PipelineState | null = null;
 let location: { lat: number; lng: number; accuracyM: number; altitudeM: number | null } | null = null;
 let bestResult: { scientific_name: string; common_name_en: string | null; confidence: number; source: string } | null = null;
+let identifyErrorReason: string | null = null;
 
 // ── Taxon hint chips (#ux-quick-taxon-chips) ──────────────────────────────
 import type { TaxonHint } from '../lib/identify-cascade-client';
@@ -839,6 +857,7 @@ async function detectRunners() {
 
 // ── Pipeline runner ────────────────────────────────────────────────────────
 async function runPipeline(state: PipelineState) {
+  identifyErrorReason = null;
   const { runParallelIdentify } = await import('../lib/identify-cascade-client');
   const { makePlantNetRunner, makeClaudeRunner, makePhiRunner } = await import('../lib/identify-runners');
   const { hasAnthropicKey } = await import('../lib/anthropic-key');
@@ -931,7 +950,14 @@ async function runPipeline(state: PipelineState) {
               bestResult = { scientific_name: r.scientific_name, common_name_en: r.common_name_en ?? null, confidence: r.confidence, source: r.source };
             }
           } else {
-            setNodeState(state, node.id, 'failed', undefined, 'No identification result');
+            // Surface the actual reason (e.g. unsupported photo format,
+            // PlantNet rejected the image) instead of a blank "failed".
+            // Prefer the always-on PlantNet runner's message.
+            const errs = (out as { errors?: Record<string, string> }).errors ?? {};
+            const reason = errs.plantnet ?? errs.claude_haiku ?? Object.values(errs)[0]
+              ?? (isEs ? 'Sin resultado de identificación' : 'No identification result');
+            identifyErrorReason = reason;
+            setNodeState(state, node.id, 'failed', undefined, reason);
           }
         }
       } else if (pf.kind === 'audio') {
@@ -1008,6 +1034,21 @@ async function runPipeline(state: PipelineState) {
     noRunnersEl?.classList.add('hidden');
     document.getElementById('obs2-audio-skip-continue')?.addEventListener('click', () => {
       audioWarnEl?.classList.add('hidden');
+      showPostForm();
+    }, { once: true });
+  } else if (identifyErrorReason && !bestResult) {
+    // Every runner failed and nothing else got identified (e.g. unsupported
+    // photo format). Show the reason instead of dropping the user into the
+    // post-form with no explanation. If some other photo did get an ID
+    // (bestResult set) we fall through — the stepper ✕ + popover shows why.
+    noRunnersEl?.classList.add('hidden');
+    audioWarnEl?.classList.add('hidden');
+    const errEl = document.getElementById('obs2-identify-error');
+    const msgEl = document.getElementById('obs2-identify-error-msg');
+    if (msgEl) msgEl.textContent = identifyErrorReason;
+    errEl?.classList.remove('hidden');
+    document.getElementById('obs2-identify-error-continue')?.addEventListener('click', () => {
+      errEl?.classList.add('hidden');
       showPostForm();
     }, { once: true });
   } else {
@@ -1307,6 +1348,7 @@ postForm?.addEventListener('submit', async (e) => {
 document.getElementById('obs2-new-btn')?.addEventListener('click', () => {
   location = null;
   bestResult = null;
+  identifyErrorReason = null;
   pipelineState = null;
   // Reset taxon hint chip selection
   selectedTaxonHint = null;

--- a/src/components/PipelineStepper.astro
+++ b/src/components/PipelineStepper.astro
@@ -160,6 +160,9 @@ const labels = {
     save: 1500,
   };
 
+  const escapeHtml = (s: string) => s.replace(/[&<>"]/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c] as string));
+
   // ── DOM ────────────────────────────────────────────────────────────────
   const stepper = document.getElementById('pipeline-stepper');
   if (!stepper) throw new Error('pipeline-stepper not found');
@@ -238,10 +241,12 @@ const labels = {
     if (detailEl) {
       detailEl.innerHTML = nodes.map(n => {
         const stateIcon = n.state === 'done' ? '✓' : n.state === 'running' ? '⟳' : n.state === 'failed' ? '✕' : '○';
-        const output = n.output as { provider?: string; error?: string } | undefined;
+        const output = n.output as { provider?: string } | undefined;
         const provider = output?.provider ? ` · ${output.provider}` : '';
-        const error = n.state === 'failed' && output?.error
-          ? `<br><span class="text-red-500">${output.error}</span>`
+        // setNodeState writes the reason to node.error, not node.output.error
+        // — reading the wrong field meant every failure rendered blank.
+        const error = n.state === 'failed' && n.error
+          ? `<br><span class="text-red-500">${escapeHtml(n.error)}</span>`
           : '';
         return `<div class="flex items-start gap-1.5">
           <span class="shrink-0 ${n.state === 'done' ? 'text-emerald-500' : n.state === 'failed' ? 'text-red-500' : 'text-zinc-400'}">${stateIcon}</span>

--- a/src/lib/identify-runners.ts
+++ b/src/lib/identify-runners.ts
@@ -62,13 +62,18 @@ export function makePlantNetRunner(locale: Locale): IdentifierRunner {
     const { getSupabase } = await import('./supabase');
     const { getKey } = await import('./byo-keys');
 
-    // Encode file as JPEG via canvas (handles HEIC/WebP/AVIF → JPEG)
+    // PlantNet only accepts JPEG/PNG. Transcode to JPEG. The old code fell
+    // back to shipping raw bytes on decode failure, which sent un-decodable
+    // HEIC straight to PlantNet → opaque 400 + a stalled pipeline. Now a
+    // genuine decode failure surfaces a localized, actionable message.
     let imageDataUrl: string;
     try {
       imageDataUrl = await fileToJpegDataUrl(file);
-    } catch {
-      // Canvas not available (e.g. test env) — fall back to raw base64
-      imageDataUrl = await fileToDataUrl(file);
+    } catch (e) {
+      if (e instanceof ImageDecodeError) {
+        throw new Error(locale === 'es' ? e.userMessageEs : e.userMessage);
+      }
+      throw e;
     }
 
     const supabase = getSupabase();
@@ -84,8 +89,10 @@ export function makePlantNetRunner(locale: Locale): IdentifierRunner {
       ...(signal ? { signal } : {}),
     });
     if (error) throw error;
-    const r = data as Partial<UnifiedIdResult> & { error?: string; results?: PlantNetMatch[] };
-    if (r.error) throw new Error(r.error);
+    const r = data as Partial<UnifiedIdResult> & { error?: string; hint?: string; results?: PlantNetMatch[] };
+    // Surface the human-readable hint, not the machine error code — the
+    // cascade flattens this to the message the pipeline shows the user.
+    if (r.error) throw new Error(r.hint ?? r.error);
     // EF may return a normalised IDResult or raw PlantNet results
     if (r.scientific_name) {
       return {
@@ -118,25 +125,70 @@ export function makePlantNetRunner(locale: Locale): IdentifierRunner {
   };
 }
 
-/** Convert any image File to a JPEG data-URL via an off-screen canvas. */
+/**
+ * Thrown when a photo cannot be decoded to a JPEG in-browser — typically
+ * an HEIC/HEIF capture from an Android/iOS camera that no browser engine
+ * (except Safari) can decode. The cascade surfaces `.userMessage` so the
+ * pipeline shows an actionable reason instead of stalling.
+ */
+export class ImageDecodeError extends Error {
+  readonly userMessage: string;
+  readonly userMessageEs: string;
+  constructor() {
+    super('image decode failed');
+    this.name = 'ImageDecodeError';
+    this.userMessage = 'This photo’s format (often HEIC) can’t be processed in your browser. Switch your camera to "Most compatible / JPEG", or pick a JPEG/PNG.';
+    this.userMessageEs = 'El formato de esta foto (suele ser HEIC) no se puede procesar en tu navegador. Cambia tu cámara a "Más compatible / JPEG", o elige un JPEG/PNG.';
+  }
+}
+
+const MAX_EDGE = 1600;   // PlantNet works well at this res
+
+function canvasToJpegDataUrl(w: number, h: number, draw: (ctx: CanvasRenderingContext2D, cw: number, ch: number) => void): string {
+  const scale = Math.min(1, MAX_EDGE / Math.max(w, h));
+  const canvas = document.createElement('canvas');
+  canvas.width  = Math.round(w * scale);
+  canvas.height = Math.round(h * scale);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new ImageDecodeError();
+  draw(ctx, canvas.width, canvas.height);
+  return canvas.toDataURL('image/jpeg', 0.88);
+}
+
+/**
+ * Convert any image File to a JPEG data-URL.
+ *
+ * Tries `createImageBitmap` first — on Android Chrome it can decode some
+ * formats `<img>` cannot (it goes through the platform image codecs). Falls
+ * back to the `<img>` path for environments where createImageBitmap is
+ * absent or rejects. If BOTH fail the file is genuinely un-decodable here
+ * (true HEIC) → throw ImageDecodeError so the caller can tell the user.
+ */
 async function fileToJpegDataUrl(file: File): Promise<string> {
+  if (typeof createImageBitmap === 'function') {
+    try {
+      const bmp = await createImageBitmap(file);
+      try {
+        return canvasToJpegDataUrl(bmp.width, bmp.height, (ctx, cw, ch) => ctx.drawImage(bmp, 0, 0, cw, ch));
+      } finally {
+        bmp.close?.();
+      }
+    } catch {
+      /* fall through to the <img> path */
+    }
+  }
   return new Promise<string>((resolve, reject) => {
     const img = new Image();
     const objectUrl = URL.createObjectURL(file);
     img.onload = () => {
       URL.revokeObjectURL(objectUrl);
-      const canvas = document.createElement('canvas');
-      // Cap at 1600px on the long edge — PlantNet works well at this res
-      const MAX = 1600;
-      const scale = Math.min(1, MAX / Math.max(img.naturalWidth, img.naturalHeight));
-      canvas.width  = Math.round(img.naturalWidth  * scale);
-      canvas.height = Math.round(img.naturalHeight * scale);
-      const ctx = canvas.getContext('2d');
-      if (!ctx) { reject(new Error('no 2d context')); return; }
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-      resolve(canvas.toDataURL('image/jpeg', 0.88));
+      try {
+        resolve(canvasToJpegDataUrl(img.naturalWidth, img.naturalHeight, (ctx, cw, ch) => ctx.drawImage(img, 0, 0, cw, ch)));
+      } catch (e) {
+        reject(e instanceof ImageDecodeError ? e : new ImageDecodeError());
+      }
     };
-    img.onerror = () => { URL.revokeObjectURL(objectUrl); reject(new Error('img load failed')); };
+    img.onerror = () => { URL.revokeObjectURL(objectUrl); reject(new ImageDecodeError()); };
     img.src = objectUrl;
   });
 }

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -505,16 +505,34 @@ export async function handler(req: Request): Promise<Response> {
     return corsResponse('Missing observation_id and image_url or image_data', { status: 400 });
   }
 
-  // Resolve image bytes — prefer image_data (already on the wire) over image_url
+  // Resolve image bytes — prefer image_data (already on the wire) over
+  // image_url. Both paths can throw (malformed base64, non-OK fetch); a
+  // bad image is a client/input problem, not a server fault — return a
+  // clean 422 JSON instead of an opaque 500 so the caller can show why.
   let imageBytes: Uint8Array;
-  if (body.image_data) {
-    // Strip the data-URL prefix ("data:image/jpeg;base64,") and decode
-    const base64 = body.image_data.replace(/^data:[^;]+;base64,/, '');
-    const binary = atob(base64);
-    imageBytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) imageBytes[i] = binary.charCodeAt(i);
-  } else {
-    imageBytes = await fetchImageAsBytes(body.image_url!);
+  try {
+    if (body.image_data) {
+      const base64 = body.image_data.replace(/^data:[^;]+;base64,/, '');
+      const binary = atob(base64);
+      imageBytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) imageBytes[i] = binary.charCodeAt(i);
+    } else {
+      imageBytes = await fetchImageAsBytes(body.image_url!);
+    }
+  } catch (e) {
+    return corsResponse(
+      JSON.stringify({
+        error: 'image_unreadable',
+        hint: `Could not read the image (${e instanceof Error ? e.message : 'decode failed'}). Re-upload a JPEG or PNG.`,
+      }),
+      { status: 422, headers: { 'content-type': 'application/json' } },
+    );
+  }
+  if (imageBytes.byteLength === 0) {
+    return corsResponse(
+      JSON.stringify({ error: 'image_unreadable', hint: 'The image was empty. Re-upload a JPEG or PNG.' }),
+      { status: 422, headers: { 'content-type': 'application/json' } },
+    );
   }
   const mimeType = 'image/jpeg';
 
@@ -907,14 +925,24 @@ export async function handler(req: Request): Promise<Response> {
   }
 
   if (!result) {
-    const errorPayload: Record<string, unknown> = {
-      error: hasAnyCred ? 'identification_failed' : 'no_id_engine_available',
-      hint: hasAnyCred
-        ? 'PlantNet returned nothing and Claude failed to parse the response.'
-        : sponsorshipSkipReason
-          ? `Claude skipped (${sponsorshipSkipReason}). Supply a BYO key, accept a sponsorship, or wait for the rate-limit window to reset.`
-          : 'No Claude credential available. Supply a BYO key (client_keys.anthropic) or accept a sponsorship; the operator no longer provides a fallback key.',
-    };
+    // force_provider:'plantnet' callers (the PWA's PlantNet runner) get a
+    // PlantNet-specific message. The generic Claude-centric hints below are
+    // nonsensical for a forced single-provider call and previously surfaced
+    // verbatim to the user. The exact PlantNet HTTP failure is in the
+    // function logs (callPlantNet warn, #1059).
+    const errorPayload: Record<string, unknown> = body.force_provider === 'plantnet'
+      ? {
+          error: 'plantnet_no_result',
+          hint: 'PlantNet could not identify this photo. Try a sharper photo of the whole plant (leaves, flowers, or fruit), or a different angle.',
+        }
+      : {
+          error: hasAnyCred ? 'identification_failed' : 'no_id_engine_available',
+          hint: hasAnyCred
+            ? 'PlantNet returned nothing and Claude failed to parse the response.'
+            : sponsorshipSkipReason
+              ? `Claude skipped (${sponsorshipSkipReason}). Supply a BYO key, accept a sponsorship, or wait for the rate-limit window to reset.`
+              : 'No Claude credential available. Supply a BYO key (client_keys.anthropic) or accept a sponsorship; the operator no longer provides a fallback key.',
+        };
     if (cascadeAttempts) {
       errorPayload.cascade_attempts = cascadeAttempts;
     }


### PR DESCRIPTION
Root-cause fixes for "uploaded a photo and it doesn't progress / no species" + making breakage visible. Four atomic commits, reviewable individually.

## 1 — HEIC decode (`dcfe572`)
Android cameras default to HEIC/HEIF; Chrome can't `<img>`-decode it. `fileToJpegDataUrl` failed and `makePlantNetRunner` **silently shipped raw HEIC bytes mislabeled as image/jpeg** → PlantNet `400 "Unsupported file type"` (confirmed in EF logs via the #1059 logging) → `callPlantNet` null → pipeline stalled with no explanation. Now: `createImageBitmap` first (platform codecs decode more on Android), `<img>` fallback, and a typed `ImageDecodeError` with an actionable EN/ES message instead of sending undecodable bytes.

## 2 — Visible failures (`d0a1104`)
`PipelineStepper` read the reason from `node.output.error` but `setNodeState` writes `node.error` — **every failure rendered blank by construction**. The cascade also collapsed `all_failed` to a generic string, discarding the real reason. Now the stepper reads `node.error` (HTML-escaped), the cascade carries the actual runner error, and a new `obs2-identify-error` banner shows the reason + a continue path when everything fails.

## 3 — EF errors (`044ceb8`)
`force_provider:'plantnet'` returned the Claude-centric `no_id_engine_available` (nonsensical for a forced single-provider call) — now `plantnet_no_result` + actionable hint. Bad `image_data`/`image_url` threw uncaught → **HTTP 500**; now a clean `422 image_unreadable` (input problem, not server fault) + empty-bytes guard.

## 4 — taxa.scientific_name UNIQUE (`b883051`)
EF upserts taxa `ON CONFLICT (scientific_name)` but only a non-unique index existed → every upsert failed "no unique or exclusion constraint…", identified taxa silently never persisted. Idempotent dedup (dynamically repoints every FK referencing `taxa(id)` from `pg_constraint`, incl. taxa self-refs, to the oldest row; deletes dups) + `CREATE UNIQUE INDEX IF NOT EXISTS`. Aligns schema with how every trigger already keys on `scientific_name`. **Touches prod taxa rows via dedup** — user-approved approach. Goes through the required db-validate gate (applies schema twice; dedup is a no-op on the 2nd pass).

## Verification
- `tsc --noEmit` clean · `vitest` 2358/2358 · `astro build` 255 pages
- Server already proven working (EF returns `Hypoxis hirsuta` on a valid JPEG); these fixes address the *client-side* HEIC failure + every silent-failure surface around it.

## Test plan
- [ ] CI green incl. db-validate (schema applied twice)
- [ ] Android HEIC photo → clear "format not supported, switch camera to JPEG" message, not a stall
- [ ] Valid JPEG → identifies; taxon now persists (no "taxa upsert failed" log)
- [ ] `image_url` to a 404 → `422 image_unreadable`, not 500
- [ ] force PlantNet, no match → `plantnet_no_result` hint shown, not Claude text

🤖 Generated with [Claude Code](https://claude.com/claude-code)