### PR TITLE
fix: auth fan-out storm, lock warning, and dropzone add-more button

### DIFF
--- a/src/components/DropZone.astro
+++ b/src/components/DropZone.astro
@@ -105,7 +105,22 @@ const editPhotoLabel = isEs ? 'Editar foto' : 'Edit photo';
   </div>
 
   <!-- Preview thumbnails (populated by JS) -->
-  <div id="dz-previews" class="hidden px-4 pb-4 flex flex-wrap gap-2"></div>
+  <div id="dz-previews" class="hidden px-4 pb-4 flex flex-wrap gap-2">
+    <!-- "+ add more" tile — always kept as last child by JS -->
+    <button
+      id="dz-add-more-btn"
+      type="button"
+      class="hidden w-16 h-16 rounded-lg border-2 border-dashed border-zinc-300 dark:border-zinc-600
+             flex items-center justify-center text-zinc-400 hover:border-emerald-500
+             hover:text-emerald-500 dark:hover:border-emerald-400 dark:hover:text-emerald-400
+             transition-colors shrink-0"
+      aria-label={isEs ? 'Agregar más archivos' : 'Add more files'}
+    >
+      <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/>
+      </svg>
+    </button>
+  </div>
 </div>
 
 <script>
@@ -119,11 +134,14 @@ const audBtn    = document.getElementById('dz-audio-btn');
 const capInput  = document.getElementById('dz-capture-input') as HTMLInputElement | null;
 const galInput  = document.getElementById('dz-gallery-input') as HTMLInputElement | null;
 const audInput  = document.getElementById('dz-audio-input')   as HTMLInputElement | null;
+const addMoreBtn = document.getElementById('dz-add-more-btn') as HTMLButtonElement | null;
 
 // ── Button → input wiring ──────────────────────────────────────────────────
 capBtn?.addEventListener('click', () => capInput?.click());
 galBtn?.addEventListener('click', () => galInput?.click());
 audBtn?.addEventListener('click', () => audInput?.click());
+// "+ add more" tile — opens gallery so the user can append more files after an initial drop
+addMoreBtn?.addEventListener('click', () => galInput?.click());
 
 function onInputChange(input: HTMLInputElement | null) {
   return () => {
@@ -171,6 +189,8 @@ function showPreviews(files: File[]) {
   defaultEl.classList.add('hidden');
   previews.classList.remove('hidden');
   previews.classList.add('flex');
+  // Keep the "+" tile visible and pinned to the end
+  addMoreBtn?.classList.remove('hidden');
 
   for (const file of files) {
     const thumb = document.createElement('div');
@@ -221,7 +241,12 @@ function showPreviews(files: File[]) {
       thumb.innerHTML = '<div class="w-full h-full flex items-center justify-center text-2xl">📄</div>';
     }
 
-    previews.appendChild(thumb);
+    // Insert before the "+" tile so it stays last
+    if (addMoreBtn && previews.contains(addMoreBtn)) {
+      previews.insertBefore(thumb, addMoreBtn);
+    } else {
+      previews.appendChild(thumb);
+    }
   }
 }
 </script>

--- a/src/lib/kairos.ts
+++ b/src/lib/kairos.ts
@@ -13,14 +13,14 @@
  * permission prompt and DB upsert as the streak path. Devices already
  * subscribed for streak reminders just flip the kairos row.
  */
-import { getSupabase } from './supabase';
+import { getSupabase, getCachedUser } from './supabase';
 import { enableStreakPush, disableStreakPush, type PushSetupResult } from './push';
 
 export type KairosKind = 'golden_hour' | 'after_rain' | 'migration_window' | 'lunar_event';
 
 export async function isKairosOptIn(kind: KairosKind): Promise<boolean> {
   const supabase = getSupabase();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getCachedUser();
   if (!user) return false;
   const { data } = await supabase
     .from('kairos_subscriptions')
@@ -42,7 +42,7 @@ export async function enableKairos(kind: KairosKind): Promise<PushSetupResult> {
   if (!sub.ok) return sub;
 
   const supabase = getSupabase();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getCachedUser();
   if (!user) return { ok: false, reason: 'no_user' };
 
   const { error } = await supabase
@@ -66,7 +66,7 @@ export async function enableKairos(kind: KairosKind): Promise<PushSetupResult> {
  */
 export async function disableKairos(kind: KairosKind): Promise<PushSetupResult> {
   const supabase = getSupabase();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getCachedUser();
   if (!user) return { ok: false, reason: 'no_user' };
 
   const { error } = await supabase
@@ -91,7 +91,7 @@ export async function disableKairos(kind: KairosKind): Promise<PushSetupResult> 
  */
 export async function unsubscribeAllPush(): Promise<PushSetupResult> {
   const supabase = getSupabase();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getCachedUser();
   if (user) {
     await supabase.from('kairos_subscriptions')
       .update({ opt_in: false, updated_at: new Date().toISOString() })

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -40,6 +40,13 @@ const USER_CACHE_TTL_MS = 30_000; // 30s — enough to cover a full page hydrati
 let _sessionCache: { session: import('@supabase/supabase-js').Session | null; resolvedAt: number } | null = null;
 const SESSION_CACHE_TTL_MS = 30_000;
 
+// In-flight promise deduplication: if N components call getCachedUser/getCachedSession
+// simultaneously on a cold start (cache empty), they all share the same single network
+// request instead of each firing their own. This is the main fix for the fan-out
+// "Failed to fetch" storm seen on Android Chrome when 5+ home widgets mount at once.
+let _userFlight: Promise<import('@supabase/supabase-js').User | null> | null = null;
+let _sessionFlight: Promise<import('@supabase/supabase-js').Session | null> | null = null;
+
 if (typeof document !== 'undefined') {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
@@ -77,9 +84,17 @@ export async function getCachedSession() {
   if (_sessionCache && (now - _sessionCache.resolvedAt) < SESSION_CACHE_TTL_MS) {
     return _sessionCache.session;
   }
-  const { data: { session } } = await getSupabase().auth.getSession();
-  _sessionCache = { session, resolvedAt: now };
-  return session;
+  // Dedup concurrent callers: all share one in-flight request.
+  if (!_sessionFlight) {
+    _sessionFlight = getSupabase().auth.getSession()
+      .then(({ data: { session } }) => {
+        _sessionCache = { session, resolvedAt: Date.now() };
+        return session;
+      })
+      .catch(() => null)  // Network failure — return null, don't crash callers.
+      .finally(() => { _sessionFlight = null; });
+  }
+  return _sessionFlight;
 }
 
 /**
@@ -93,9 +108,17 @@ export async function getCachedUser() {
   if (_userCache && (now - _userCache.resolvedAt) < USER_CACHE_TTL_MS) {
     return _userCache.user;
   }
-  const { data: { user } } = await getSupabase().auth.getUser();
-  _userCache = { user, resolvedAt: now };
-  return user;
+  // Dedup concurrent callers: all share one in-flight request.
+  if (!_userFlight) {
+    _userFlight = getSupabase().auth.getUser()
+      .then(({ data: { user } }) => {
+        _userCache = { user, resolvedAt: Date.now() };
+        return user;
+      })
+      .catch(() => null)  // Network failure — return null, don't crash callers.
+      .finally(() => { _userFlight = null; });
+  }
+  return _userFlight;
 }
 
 /**

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -9,7 +9,7 @@
  * PUBLIC_R2_MEDIA_URL is set) or Supabase Storage (fallback). See module 10.
  */
 import { getDB, type ObservationRecord } from './db';
-import { getSupabase } from './supabase';
+import { getSupabase, getCachedSession, getCachedUser } from './supabase';
 import { uploadMedia, resizeImage, r2Enabled } from './upload';
 import type { Observation } from './types';
 import {
@@ -82,7 +82,7 @@ async function syncOne(record: ObservationRecord): Promise<void> {
   let observerRef = obs.observerRef;
   if (observerRef.kind !== 'user') {
     try {
-      const { data: { session } } = await getSupabase().auth.getSession();
+      const session = await getCachedSession();
       if (session?.user?.id) {
         observerRef = { kind: 'user', id: session.user.id };
         const db = await getDB();
@@ -565,15 +565,9 @@ async function syncOutboxInner(): Promise<SyncResult> {
   // Auth guard: bail early when there's no valid session. Without this,
   // Supabase queries fail silently with an expired/missing JWT and the
   // UI stays in a loading state indefinitely (#342).
-  try {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
-      const noAuth: SyncResult = { synced: 0, failed: 0, skipped_guest: 0, last_error: 'no_session' };
-      emit<SyncDoneDetail>(SYNC_EVENTS.done, noAuth);
-      return noAuth;
-    }
-  } catch {
-    const noAuth: SyncResult = { synced: 0, failed: 0, skipped_guest: 0, last_error: 'session_check_failed' };
+  const session = await getCachedSession();
+  if (!session) {
+    const noAuth: SyncResult = { synced: 0, failed: 0, skipped_guest: 0, last_error: 'no_session' };
     emit<SyncDoneDetail>(SYNC_EVENTS.done, noAuth);
     return noAuth;
   }
@@ -605,7 +599,7 @@ async function syncOutboxInner(): Promise<SyncResult> {
     // saved offline before login never synced even after the user logged in.
     if (rec.observer_kind === 'guest') {
       try {
-        const { data: { session } } = await supabase.auth.getSession();
+        const session = await getCachedSession();
         if (session?.user?.id) {
           const upgradedData: Observation = {
             ...(rec.data as Observation),
@@ -733,7 +727,7 @@ async function sendSyncErrorBeacon(opts: { message: string; blob_count: number }
   if (typeof navigator === 'undefined') return;
   try {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     const supabaseUrl = (import.meta.env.PUBLIC_SUPABASE_URL as string | undefined) ?? '';
     if (!supabaseUrl) return;
     const url = `${supabaseUrl.replace(/\/$/, '')}/functions/v1/sync-error`;


### PR DESCRIPTION
## Summary

Three bugs found from mobile error reports on `/en/` and `/en/observe/` (Android Chrome 148, viewport ~448×906).

---

### Bug 1 — Auth fan-out storm (10 concurrent `auth/v1/user` requests on home load)

**Root cause:** `getCachedUser` / `getCachedSession` had a classic cold-start race: N components mounting simultaneously all see an empty cache and each fires its own `auth.getUser()` / `auth.getSession()` network request. On `/en/`, at least 5 components mount concurrently (Header + HomeHero + HomeChips + HomeRecent + HomeWidgets), producing 10 simultaneous requests to Supabase in ~70ms. During a mobile network blip, all fail together.

**Fix:** Add in-flight promise deduplication (`_userFlight` / `_sessionFlight`). All concurrent cold-start callers share one single network request; subsequent callers hit the TTL cache. Collapses N → 1 request.

---

### Bug 2 — navigator.lock warning + unhandled throws on network failure

Three sub-issues:

1. `getCachedUser` / `getCachedSession` threw unhandled exceptions on network failure instead of returning `null`, crashing callers without their own `try/catch`.
2. `sync.ts` called `auth.getSession()` directly (3×) instead of using the cache, competing for the gotrue `navigator.lock` and triggering the `Lock lock:rastrum-auth-v1 was not released within 5000ms` warning on slow Android.
3. `kairos.ts` called `auth.getUser()` directly (4×), same issue.

**Fix:** `getCachedUser` / `getCachedSession` now catch network errors and return `null` (cache intentionally not updated, so the next call retries). Migrated `sync.ts` and `kairos.ts` to `getCachedSession` / `getCachedUser`.

---

### Bug 3 — No way to add more photos after initial selection in /observe/

After selecting files in DropZone, the default state (Capture / Gallery / Audio buttons) was hidden with no replacement UI. Users on mobile had no way to add more files without refreshing the page.

**Fix:** Add a `+` tile in the previews grid that opens the gallery picker. It is always kept pinned as the last thumbnail using `insertBefore`. Standard mobile pattern (WhatsApp, Google Photos).

---

## Files changed

| File | Change |
|------|--------|
| `src/lib/supabase.ts` | Promise dedup + network error handling for `getCachedUser` / `getCachedSession` |
| `src/lib/sync.ts` | Migrate 3× `auth.getSession()` + 1× `auth.getUser()` → cached helpers |
| `src/lib/kairos.ts` | Migrate 4× `auth.getUser()` → `getCachedUser` |
| `src/components/DropZone.astro` | Add `+` tile to append more files after initial selection |