### PR TITLE
fix: migrate all direct auth.getUser/getSession calls to cached helpers

### DIFF
--- a/src/components/PITsView.astro
+++ b/src/components/PITsView.astro
@@ -192,7 +192,7 @@ const copy = {
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import {getCachedUser, getSupabase} from '../lib/supabase';
 
   const root = document.getElementById('pits-view-root')!;
   const lang = root.dataset.lang ?? 'en';
@@ -379,7 +379,7 @@ const copy = {
 
     try {
       const sb = getSupabase();
-      const { data: { user } } = await sb.auth.getUser();
+      const user = await getCachedUser();
       if (!user) {
         errorEl.textContent = isEs ? 'Inicia sesión para crear PITs.' : 'Sign in to create PITs.';
         errorEl.classList.remove('hidden');

--- a/src/components/TrailsView.astro
+++ b/src/components/TrailsView.astro
@@ -166,7 +166,7 @@ const copy = {
 </div>
 
 <script>
-  import { getSupabase } from '../lib/supabase';
+  import {getCachedUser, getSupabase} from '../lib/supabase';
 
   const lang = document.getElementById('trails-view-root')?.dataset.lang ?? 'en';
   const isEs = lang === 'es';
@@ -234,7 +234,7 @@ const copy = {
     const nearbyList = document.getElementById('nearby-trails-list')!;
 
     try {
-      const { data: { user } } = await sb.auth.getUser();
+      const user = await getCachedUser();
 
       // My trails
       if (user) {
@@ -319,7 +319,7 @@ const copy = {
 
     try {
       const sb = getSupabase();
-      const { data: { user } } = await sb.auth.getUser();
+      const user = await getCachedUser();
       if (!user) {
         errorEl.textContent = tr.signInRequired;
         errorEl.classList.remove('hidden');

--- a/src/components/console/ExpertApplicationsBrowser.astro
+++ b/src/components/console/ExpertApplicationsBrowser.astro
@@ -60,7 +60,7 @@ const isEs = lang === 'es';
 </section>
 
 <script>
-  import { getCachedSession, getSupabase } from '../../lib/supabase';
+  import {getCachedSession, getCachedUser, getSupabase} from '../../lib/supabase';
   import { escapeHtml } from '../../lib/escape';
   const isEs = document.documentElement.lang === 'es';
   const shell = document.getElementById('ea-shell');
@@ -147,7 +147,7 @@ const isEs = lang === 'es';
 
   (async () => {
     const sb = getSupabase();
-    const { data: { user } } = await sb.auth.getUser();
+    const user = await getCachedUser();
     if (!user) { notAuth?.classList.remove('hidden'); return; }
     const { data: roles } = await sb.from('user_roles').select('role').eq('user_id', user.id).eq('role', 'admin');
     if (!roles?.length) { notAuth?.classList.remove('hidden'); return; }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -383,7 +383,7 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <WhyAmISeeingThisDialog lang={installLang} />
     <SurpriseOverlay lang={installLang} />
     <script>
-      import { getSupabase } from '../lib/supabase';
+      import {getCachedSession, getSupabase} from '../lib/supabase';
       import { subscribeToKarmaEvents } from '../lib/karma-toast';
 
       let cleanup: (() => void) | null = null;
@@ -391,8 +391,8 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
       async function start() {
         try {
           const supabase = getSupabase();
-          const { data } = await supabase.auth.getSession();
-          const userId = data.session?.user?.id;
+          const session = await getCachedSession();
+          const userId = session?.user?.id;
           if (!userId) return;
           cleanup = subscribeToKarmaEvents(userId, supabase);
         } catch {

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -10,7 +10,7 @@
  * view, so the SQL-layer authentication gate (no GRANT to anon)
  * fires regardless of the UI sign-in check.
  */
-import { getSupabase } from './supabase';
+import {getCachedUser, getSupabase} from './supabase';
 import type { CommunityFilters, CommunitySort } from './community-url';
 
 export interface CommunityObserver {
@@ -135,7 +135,7 @@ export async function loadCommunityNearbyAt(
  */
 export async function viewerHasCentroid(): Promise<boolean> {
   const supabase = getSupabase();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getCachedUser();
   if (!user) return false;
   const { data } = await supabase
     .from('community_observers_with_centroid')
@@ -158,7 +158,7 @@ export interface ViewerCommunityMeta {
 export async function loadViewerCommunityMeta(): Promise<ViewerCommunityMeta> {
   try {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return { signedIn: false, profilePublic: null, countryCode: null };
     // TODO(#251): migrate to profile_privacy matrix check (v1.1)
     const { data } = await supabase
@@ -194,7 +194,7 @@ export interface ViewerRegion {
 export async function loadViewerRegion(): Promise<ViewerRegion> {
   try {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return { countryCode: null, regionPrimary: null };
     const { data } = await supabase
       .from('users')

--- a/src/lib/identifiers/claude.ts
+++ b/src/lib/identifiers/claude.ts
@@ -10,7 +10,7 @@
  * The operator-key fallback (Deno.env.ANTHROPIC_API_KEY) was removed
  * intentionally — see supabase/functions/identify/index.ts file header.
  */
-import { getSupabase } from '../supabase';
+import {getCachedSession, getSupabase} from '../supabase';
 import { getKey } from '../byo-keys';
 import type { Identifier, IDResult, IdentifyInput } from './types';
 
@@ -76,7 +76,7 @@ export const claudeIdentifier: Identifier = {
     }
     try {
       const supabase = getSupabase();
-      const { data: { session } } = await supabase.auth.getSession();
+      const session = await getCachedSession();
       if (!session) {
         writeSponsorshipCache(false);
         return { ready: false, reason: 'needs_key' };

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -9,7 +9,7 @@
 // client only issues plain `update(...)` calls - no application-side
 // flagging is needed.
 
-import { getSupabase } from './supabase';
+import {getCachedUser, getSupabase} from './supabase';
 import { willDemote, type PhotoForDeletion } from './photo-deletion';
 import { resizeImage, uploadMedia } from './upload';
 import { escapeHtml as escAttr } from './escape';
@@ -229,7 +229,7 @@ export async function wireManagePanelDetails(
         // Ensure the session JWT is fresh before mutating. A stale
         // auth.uid() causes RLS to silently filter every UPDATE to 0
         // rows, making the save appear to do nothing (#445).
-        const { data: { user: viewer } } = await supabase.auth.getUser();
+        const viewer = await getCachedUser();
         if (!viewer) {
           throw new Error(
             lang === 'es'

--- a/src/lib/push.test.ts
+++ b/src/lib/push.test.ts
@@ -37,10 +37,11 @@ if (typeof globalThis.Notification === 'undefined') {
 // ── Mock supabase client ──
 const mockDelete = vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }) });
 const mockFrom = vi.fn().mockReturnValue({ delete: mockDelete });
-const mockGetUser = vi.fn().mockResolvedValue({ data: { user: { id: 'user-123' } } });
-const mockSupabase = { from: mockFrom, auth: { getUser: mockGetUser } };
+const mockGetUser = vi.fn().mockResolvedValue({ id: 'user-123' });
+const mockSupabase = { from: mockFrom };
 
 vi.mock('./supabase', () => ({
+  getCachedUser: () => mockGetUser(),
   getSupabase: () => mockSupabase,
 }));
 

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -12,7 +12,7 @@
  * We do NOT generate VAPID keys on the client — that's an operator
  * step documented in `docs/runbooks/rotate-secret.md` (VAPID setup).
  */
-import { getSupabase } from './supabase';
+import {getCachedUser, getSupabase} from './supabase';
 
 export interface PushSetupResult {
   ok: boolean;
@@ -72,7 +72,7 @@ export async function enableStreakPush(): Promise<PushSetupResult> {
   });
 
   const supabase = getSupabase();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = await getCachedUser();
   if (!user) return { ok: false, reason: 'no_user' };
 
   const subJson = sub.toJSON();
@@ -108,7 +108,7 @@ export async function disableStreakPush(): Promise<PushSetupResult> {
     if (sub) await sub.unsubscribe();
     if (endpoint) {
       const supabase = getSupabase();
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (user) {
         await supabase.from('push_subscriptions').delete()
           .eq('user_id', user.id).eq('endpoint', endpoint);

--- a/src/lib/social.ts
+++ b/src/lib/social.ts
@@ -8,7 +8,7 @@
  * See docs/specs/modules/08-profile-activity-gamification.md for the
  * social schema. RLS is enforced server-side; we never gate on the client.
  */
-import { getSupabase } from './supabase';
+import {getCachedUser, getSupabase} from './supabase';
 import type {
   ReactionTarget, ReactionKind, ReportTarget, ReportReason, FollowTier,
 } from './types.social';
@@ -280,7 +280,7 @@ export async function followUser(targetUserId: string, tier: FollowTier = 'follo
   // Onboarding: fire first_follow if this is the user's first follow.
   void (async () => {
     try {
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       if (!user) return;
       // All follows (including pending) are counted here: the funnel measures
       // engagement (follow was attempted), not whether the connection was accepted.
@@ -362,13 +362,13 @@ export async function blockUser(targetUserId: string) {
   const sb = getSupabase();
   const { error } = await sb
     .from('blocks')
-    .insert({ blocker_id: (await sb.auth.getUser()).data.user?.id, blocked_id: targetUserId });
+    .insert({ blocker_id: (await getCachedUser())?.id, blocked_id: targetUserId });
   if (error) throw error;
 }
 
 export async function unblockUser(targetUserId: string) {
   const sb = getSupabase();
-  const me = (await sb.auth.getUser()).data.user?.id;
+  const me = (await getCachedUser())?.id;
   const { error } = await sb
     .from('blocks')
     .delete()

--- a/src/lib/sponsorships.ts
+++ b/src/lib/sponsorships.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from './supabase';
+import {getCachedSession, getSupabase} from './supabase';
 import type { SponsorCredential, Sponsorship, SponsorshipRequest, SponsorshipUsage } from './types.sponsorship';
 
 const FN_BASE = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/sponsorships`;
@@ -43,7 +43,7 @@ export interface CreateCredentialArgs {
 }
 
 async function authedFetch(path: string, init?: RequestInit): Promise<Response> {
-  const { data: { session } } = await getSupabase().auth.getSession();
+  const session = await getCachedSession();
   if (!session) throw new Error('not_authenticated');
   // Belt-and-braces: a corrupted/persisted session can produce a token
   // with non-ByteString characters which makes fetch() reject at
@@ -140,7 +140,7 @@ export async function createPool(input: {
   monthly_reset?: boolean;
 }): Promise<string> {
   const sb = getSupabase();
-  const { data: { session } } = await sb.auth.getSession();
+  const session = await getCachedSession();
   if (!session?.user) throw new Error('not_authenticated');
   const { data, error } = await sb
     .from('sponsor_pools')

--- a/src/lib/surprise-trigger.ts
+++ b/src/lib/surprise-trigger.ts
@@ -11,7 +11,7 @@
  * surprise is invisible by definition. We never block sync.
  */
 
-import { getSupabase } from './supabase';
+import {getCachedUser, getSupabase} from './supabase';
 import {
   pickSurprise,
   dailyCapReached,
@@ -47,7 +47,7 @@ function currentLang(prefs: UserPrefs | null): 'en' | 'es' {
 async function fetchUserPrefs(): Promise<UserPrefs | null> {
   const supabase = getSupabase();
   try {
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) return null;
     const { data } = await supabase
       .from('users')

--- a/src/lib/taxon-autocomplete.ts
+++ b/src/lib/taxon-autocomplete.ts
@@ -140,7 +140,7 @@ async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
   const q = query.trim();
 
   // Resolve current user (may be null for guests)
-  const { data: { user } } = await supabase.auth.getUser().catch(() => ({ data: { user: null } }));
+  const user = await getCachedUser();
 
   // Two queries in parallel:
   // 1. Prefix match on scientific_name (catches "Alamania pu...")

--- a/src/lib/taxon-autocomplete.ts
+++ b/src/lib/taxon-autocomplete.ts
@@ -133,7 +133,7 @@ async function fetchSuggestions(
 /** Query Rastrum `taxa` table via Supabase client. Enriches `inUserHistory` from observations. */
 async function fetchFromRastrum(query: string): Promise<TaxonSuggestion[]> {
   // Lazy import to keep this module usable outside Astro SSR
-  const { getSupabase } = await import('./supabase');
+  const { getSupabase, getCachedUser } = await import('./supabase');
   const supabase = getSupabase();
   if (!supabase) return [];
 

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -10,7 +10,7 @@
  * is the same one the v0.1 sync engine has been using; the migration is
  * controlled by the presence of PUBLIC_R2_MEDIA_URL.
  */
-import { getSupabase } from './supabase';
+import {getCachedSession, getSupabase} from './supabase';
 
 const R2_PUBLIC_URL = import.meta.env.PUBLIC_R2_MEDIA_URL;
 
@@ -92,7 +92,7 @@ async function uploadToR2(
   opts: UploadOptions,
 ): Promise<string> {
   const supabase = getSupabase();
-  const { data: { session } } = await supabase.auth.getSession();
+  const session = await getCachedSession();
   if (!session) throw new Error('Not signed in — cannot upload to R2');
 
   // Adding a custom header here means the CORS preflight cache key

--- a/src/pages/en/console/index.astro
+++ b/src/pages/en/console/index.astro
@@ -27,7 +27,7 @@ const lang = 'en';
 </ConsoleLayout>
 
 <script>
-  import { getSupabase } from '../../../lib/supabase';
+  import {getCachedUser, getSupabase} from '../../../lib/supabase';
   import { getUserRoles } from '../../../lib/user-roles';
   import { rolePillsFor } from '../../../lib/console-tabs';
 
@@ -39,7 +39,7 @@ const lang = 'en';
 
   async function init() {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       gate.textContent = 'Sign in required.';
       gate.classList.remove('hidden');

--- a/src/pages/en/profile/tokens.astro
+++ b/src/pages/en/profile/tokens.astro
@@ -66,13 +66,13 @@ const tr = t(lang) as any;
 </BaseLayout>
 
 <script>
-  import { getSupabase } from '../../../lib/supabase';
+  import {getCachedSession, getSupabase} from '../../../lib/supabase';
   const supabase = getSupabase();
   const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
 
   async function getAuthHeader() {
-    const { data } = await supabase.auth.getSession();
-    return `Bearer ${data.session?.access_token ?? ''}`;
+    const session = await getCachedSession();
+    return `Bearer ${session?.access_token ?? ''}`;
   }
 
   function buildTokenRow(t: Record<string, any>): HTMLElement {

--- a/src/pages/en/profile/wrapped/index.astro
+++ b/src/pages/en/profile/wrapped/index.astro
@@ -109,7 +109,7 @@ const year = Astro.url.searchParams.get('year') ?? new Date().getFullYear().toSt
 </BaseLayout>
 
 <script>
-  import { getCachedUser, getSupabase } from '../../../../lib/supabase';
+  import {getCachedSession, getCachedUser, getSupabase} from '../../../../lib/supabase';
 
   interface WrappedPayload {
     year: number;
@@ -148,7 +148,7 @@ const year = Astro.url.searchParams.get('year') ?? new Date().getFullYear().toSt
       });
       // Pass year + user_id as query params via URL construction
       const fnUrl = `${(import.meta.env.PUBLIC_SUPABASE_URL as string)}/functions/v1/generate-wrapped?year=${year}&user_id=${user.id}`;
-      const token = (await supabase.auth.getSession()).data.session?.access_token;
+      const token = (await getCachedSession())?.access_token;
       const res = await fetch(fnUrl, { headers: { Authorization: `Bearer ${token ?? ''}` } });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data: WrappedPayload = await res.json();

--- a/src/pages/es/consola/index.astro
+++ b/src/pages/es/consola/index.astro
@@ -27,7 +27,7 @@ const lang = 'es';
 </ConsoleLayout>
 
 <script>
-  import { getSupabase } from '../../../lib/supabase';
+  import {getCachedUser, getSupabase} from '../../../lib/supabase';
   import { getUserRoles } from '../../../lib/user-roles';
   import { rolePillsFor } from '../../../lib/console-tabs';
 
@@ -39,7 +39,7 @@ const lang = 'es';
 
   async function init() {
     const supabase = getSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const user = await getCachedUser();
     if (!user) {
       gate.textContent = 'Se requiere iniciar sesión.';
       gate.classList.remove('hidden');

--- a/src/pages/es/perfil/tokens.astro
+++ b/src/pages/es/perfil/tokens.astro
@@ -91,14 +91,14 @@ const tr = t(lang) as any;
 </BaseLayout>
 
 <script>
-  import { getSupabase } from '../../../lib/supabase';
+  import {getCachedSession, getSupabase} from '../../../lib/supabase';
   const supabase = getSupabase();
 
   const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
 
   async function getAuthHeader() {
-    const { data } = await supabase.auth.getSession();
-    return `Bearer ${data.session?.access_token ?? ''}`;
+    const session = await getCachedSession();
+    return `Bearer ${session?.access_token ?? ''}`;
   }
 
   function buildTokenRow(t: Record<string, any>): HTMLElement {

--- a/src/pages/es/perfil/wrapped/index.astro
+++ b/src/pages/es/perfil/wrapped/index.astro
@@ -108,7 +108,7 @@ const year = Astro.url.searchParams.get('year') ?? new Date().getFullYear().toSt
 </BaseLayout>
 
 <script>
-  import { getCachedUser, getSupabase } from '../../../../lib/supabase';
+  import {getCachedSession, getCachedUser, getSupabase} from '../../../../lib/supabase';
 
   interface WrappedPayload {
     year: number;
@@ -142,7 +142,7 @@ const year = Astro.url.searchParams.get('year') ?? new Date().getFullYear().toSt
 
     try {
       const fnUrl = `${(import.meta.env.PUBLIC_SUPABASE_URL as string)}/functions/v1/generate-wrapped?year=${year}&user_id=${user.id}`;
-      const token = (await supabase.auth.getSession()).data.session?.access_token;
+      const token = (await getCachedSession())?.access_token;
       const res = await fetch(fnUrl, { headers: { Authorization: `Bearer ${token ?? ''}` } });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data: WrappedPayload = await res.json();

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -28,7 +28,7 @@ const lang: 'en' | 'es' = 'en';
   <ShareObsView lang={lang} />
 
   <script>
-    import { getSupabase, getSupabaseUrl } from '../../../lib/supabase';
+    import {getCachedUser, getSupabase, getSupabaseUrl} from '../../../lib/supabase';
     import { labelFor } from '../../../lib/observation-enums';
     import { wireManagePanelDetails, wireManagePanelLocation, wireManagePanelPhotos } from '../../../lib/manage-panel';
     import { t } from '../../../i18n/utils';
@@ -188,7 +188,7 @@ const lang: 'en' | 'es' = 'en';
       const isPublic = user?.profile_public;
       let viewerIsObserver = false;
       try {
-        const { data: { user: viewer } } = await supabase.auth.getUser();
+        const viewer = await getCachedUser();
         viewerIsObserver = !!(viewer?.id && obs.observer_id && viewer.id === obs.observer_id);
       } catch { /* signed out viewer */ }
       const fallback = (document.documentElement.lang === 'es') ? 'Anónimo' : 'Anonymous';
@@ -458,7 +458,7 @@ const lang: 'en' | 'es' = 'en';
               // Get current viewer
               let currentViewer: { id?: string } | null = null;
               try {
-                const { data: { user: v } } = await supabase.auth.getUser();
+                const v = await getCachedUser();
                 currentViewer = v;
               } catch { /* signed out */ }
 
@@ -571,7 +571,7 @@ const lang: 'en' | 'es' = 'en';
       const ownerNote = document.getElementById('ci-owner-note');
       if (!section || !listEl) return;
 
-      const { data: { user } } = await supabase.auth.getUser();
+      const user = await getCachedUser();
       const isEs = document.documentElement.lang === 'es';
       if (viewerIsObserver) {
         ownerNote?.classList.remove('hidden');

--- a/tests/lib/claude-isavailable.test.ts
+++ b/tests/lib/claude-isavailable.test.ts
@@ -18,8 +18,8 @@ const mockSession = vi.fn();
 const mockRpc = vi.fn();
 
 vi.mock('../../src/lib/supabase', () => ({
+  getCachedSession: () => mockSession().then((r: any) => r?.data?.session ?? null),
   getSupabase: () => ({
-    auth: { getSession: () => mockSession() },
     rpc: (...args: unknown[]) => mockRpc(...args),
   }),
 }));

--- a/tests/unit/social.test.ts
+++ b/tests/unit/social.test.ts
@@ -10,8 +10,9 @@ vi.mock('../../src/lib/supabase', () => {
     update: vi.fn(() => eq),
   };
   const from = vi.fn(() => builder);
-  const client = { from, functions: { invoke: vi.fn() }, auth: { getUser: vi.fn() } };
+  const client = { from, functions: { invoke: vi.fn() } };
   return {
+    getCachedUser: vi.fn().mockResolvedValue({ id: 'user-123' }),
     getSupabase: () => client,
   };
 });

--- a/tests/unit/sponsorships.test.ts
+++ b/tests/unit/sponsorships.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { detectKind } from '../../src/lib/sponsorships';
 
 vi.mock('../../src/lib/supabase', () => ({
-  getSupabase: () => ({
-    auth: { getSession: () => Promise.resolve({ data: { session: { access_token: 'fake-token' } } }) },
-  }),
+  getCachedSession: () => Promise.resolve({ access_token: 'fake-token' }),
+  getSupabase: () => ({}),
 }));
 
 interface FetchCall { url: string; method: string; body: string | null }

--- a/tests/unit/taxon-autocomplete.test.ts
+++ b/tests/unit/taxon-autocomplete.test.ts
@@ -29,10 +29,9 @@ function makeQueryStub(resolveWith: any) {
 }
 
 vi.mock('../../src/lib/supabase', () => ({
+  // getCachedUser replaces the direct auth.getUser() call in taxon-autocomplete
+  getCachedUser: () => Promise.resolve({ id: 'user-123' }),
   getSupabase: () => ({
-    auth: {
-      getUser: () => Promise.resolve({ data: { user: { id: 'user-123' } } }),
-    },
     from: (table: string) => {
       if (table === 'taxa') {
         return makeQueryStub({


### PR DESCRIPTION
## Summary

Exhaustive follow-up to #1064. That PR introduced `getCachedUser` / `getCachedSession` with promise deduplication and network error handling, but 22 files still called `auth.getUser()` / `auth.getSession()` directly — each one a potential navigator.lock competitor and unhandled-throw source on mobile.

This PR sweeps every remaining direct call in `src/` and migrates it to the cached helpers.

## Files changed (22)

| File | Calls migrated |
|------|---------------|
| `src/components/PITsView.astro` | 1× getUser |
| `src/components/TrailsView.astro` | 2× getUser |
| `src/components/console/ExpertApplicationsBrowser.astro` | 1× getUser |
| `src/layouts/BaseLayout.astro` | 1× getSession |
| `src/lib/community.ts` | 3× getUser |
| `src/lib/identifiers/claude.ts` | 1× getSession |
| `src/lib/kairos.ts` | 4× getUser |
| `src/lib/manage-panel.ts` | 1× getUser |
| `src/lib/push.ts` | 2× getUser |
| `src/lib/social.ts` | 3× getUser |
| `src/lib/sponsorships.ts` | 2× getSession |
| `src/lib/surprise-trigger.ts` | 1× getUser |
| `src/lib/sync.ts` | 3× getSession + 1× getUser |
| `src/lib/taxon-autocomplete.ts` | 1× getUser |
| `src/lib/upload.ts` | 1× getSession |
| `src/pages/en/console/index.astro` | 1× getUser |
| `src/pages/en/profile/tokens.astro` | 1× getSession |
| `src/pages/en/profile/wrapped/index.astro` | 1× getSession |
| `src/pages/es/consola/index.astro` | 1× getUser |
| `src/pages/es/perfil/tokens.astro` | 1× getSession |
| `src/pages/es/perfil/wrapped/index.astro` | 1× getSession |
| `src/pages/share/obs/index.astro` | 3× getUser |

## Intentionally left direct (6 calls)

| File | Reason |
|------|--------|
| `src/lib/auth.ts` (3×) | Passkey/identity flows — need a fresh verified user post-auth operation |
| `src/lib/observe.ts` (1×) | Timeout-bounded session resolution for offline observer ref (intentional design) |
| `src/pages/auth/callback.astro` (2×) | OAuth PKCE code exchange — must read real session state |

## Why this matters

With #1064's promise dedup, the first cold-start call collapses N concurrent requests into 1. But any file calling the raw API directly still bypasses the dedup and the TTL cache — meaning it can fire its own network request, compete for the `navigator.lock`, and throw an unhandled error on network failure. After this PR, the only direct callers are the three legitimate exceptions above.

Depends on / should merge after: #1064