### PR TITLE
fix(deploy): cron-only EFs must skip Edge-layer JWT verification

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -211,7 +211,7 @@ jobs:
           # anon key, which Edge Functions reject when JWT verification is
           # enabled. These MUST be deployed with --no-verify-jwt.
           # Update this list when adding new cron-triggered functions.
-          CRON_ONLY="recompute-streaks award-badges gc-orphan-media plantnet-monitor recompute-user-stats streak-push retry-unidentified enrich-taxon refresh-taxon-ranges"
+          CRON_ONLY="recompute-streaks award-badges gc-orphan-media plantnet-monitor recompute-user-stats streak-push retry-unidentified enrich-taxon refresh-taxon-ranges kairos-fire recompute-taxa-cache weekly-digest"
           echo "cron_only=$CRON_ONLY" >> "$GITHUB_OUTPUT"
 
       - name: Deploy

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -20,17 +20,38 @@ enabled = true
 # .github/workflows/deploy-functions.yml or the deploy re-enables it.
 verify_jwt = false
 
+# enrich-environment is NOT cron-only — it is invoked from the sync pipeline
+# with a real user JWT, so Edge-layer JWT verification stays on.
 [functions.enrich-environment]
 enabled = true
 verify_jwt = true
 
+# Cron-only functions self-gate on X-Cron-Secret via _shared/cron-auth.ts
+# (requireCronSecret). pg_cron calls them with no Authorization bearer, so
+# Edge-layer verify_jwt would 401 at the gateway before the function code
+# (and the X-Cron-Secret check) ever runs. These MUST be verify_jwt = false
+# here AND listed in CRON_ONLY in .github/workflows/deploy-functions.yml —
+# the deploy flag is authoritative in prod, but both sites must agree or a
+# config-driven deploy / local serve silently re-enables JWT.
 [functions.recompute-streaks]
 enabled = true
-verify_jwt = true
+verify_jwt = false
 
 [functions.award-badges]
 enabled = true
-verify_jwt = true
+verify_jwt = false
+
+[functions.kairos-fire]
+enabled = true
+verify_jwt = false
+
+[functions.recompute-taxa-cache]
+enabled = true
+verify_jwt = false
+
+[functions.weekly-digest]
+enabled = true
+verify_jwt = false
 
 [functions.share-card]
 enabled = true


### PR DESCRIPTION
## Incident

Every `pg_cron` → Edge Function call has been returning **401 at the Supabase gateway** (never reaching function code), silently, for days. Discovered while investigating why the GBIF enrich cron was red.

`cron.job_run_details` reports these jobs as `succeeded` — misleading, because `net.http_post` only **enqueues** (pg_net is async). The real HTTP status is in `net._http_response`, which showed **401/500 across the board, zero 200s**.

Affected jobs: `streaks-nightly`, `badges-nightly`, `recompute-user-stats-nightly`, `streak-push-nightly`, `plantnet-quota-daily`, `kairos-fire-15min`, `retry-unidentified`.

## Root cause

Cron-only EFs self-gate on `X-Cron-Secret` via `_shared/cron-auth.ts` (`requireCronSecret`). pg_cron calls them with **no `Authorization` bearer**, so they must be deployed `--no-verify-jwt` or the gateway 401s *before* `requireCronSecret` ever runs. Two config drifts caused regressions:

- `supabase/config.toml` had `verify_jwt = true` for `recompute-streaks` and `award-badges`, contradicting the deploy workflow's `CRON_ONLY` classification.
- `deploy-functions.yml` `CRON_ONLY` omitted `kairos-fire`, `recompute-taxa-cache`, `weekly-digest` (all use `requireCronSecret`).

Since `deploy-functions.yml` only redeploys *changed* functions on push, EFs deployed before being classified kept their stale `verify_jwt=true` gateway setting in prod.

## Changes

- `config.toml`: `recompute-streaks` + `award-badges` → `verify_jwt = false`; added explicit `false` blocks for `kairos-fire` / `recompute-taxa-cache` / `weekly-digest`; documented the both-sites invariant. `enrich-environment` deliberately left `true` (invoked from sync pipeline with a real JWT, not cron).
- `deploy-functions.yml`: added the three missing EFs to `CRON_ONLY`.

Editing `deploy-functions.yml` trips `WORKFLOW_TOUCHED` → **merge auto-redeploys all functions** with the corrected classification.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 2358 passed
- [ ] After merge: confirm deploy-functions.yml run is green
- [ ] After deploy: re-query `net._http_response` — expect 200s (or 403 → separate `CRON_SECRET`/Vault follow-up)

## Known follow-ups (separate, out of scope here)

- GitHub Actions repo secret `CRON_SECRET` is **missing** → `enrich-taxa.yml` / `community-backfill.yml` send an empty header (403). Needs mirroring from Supabase Vault `cron_secret`.
- `weekly-digest` + `refresh-conservation-status` pg_cron SQL errors with `unrecognized configuration parameter "app.supabase_url"` (missing GUC) — independent of JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)