### PR TITLE
fix(schema): blanket GRANT to service_role on all tables/seqs/funcs

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -586,6 +586,24 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
 
+-- Service role (trusted backend / Edge Functions) — full access; it bypasses
+-- RLS by design and is never exposed to the browser. The block above grants
+-- anon/authenticated in bulk but omitted service_role, so any table without
+-- a piecemeal per-table grant (kairos_subscriptions, push_subscriptions,
+-- observations writes, …) returned "permission denied for table" to cron
+-- Edge Functions using the service_role key. Blanket + default privileges so
+-- current AND future tables are covered idempotently on every db-apply,
+-- instead of relying on someone remembering a per-table grant.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES    IN SCHEMA public TO service_role;
+GRANT USAGE,  SELECT                  ON ALL SEQUENCES IN SCHEMA public TO service_role;
+GRANT EXECUTE                         ON ALL FUNCTIONS IN SCHEMA public TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO service_role;
+
 -- Defensive: revoke privileges that Supabase's legacy project init may have
 -- granted to anon. None are reachable via PostgREST today, but minimal
 -- privilege is a basic hygiene principle.


### PR DESCRIPTION
## Problem

After #1066 (verify_jwt) + the `CRON_SECRET` bootstrap let pg_cron requests actually reach Edge Function code, three cron EFs started returning `500 {"error":"permission denied for table …"}`:

| EF | Table |
|---|---|
| `kairos-fire` | `kairos_subscriptions` |
| `streak-push` | `push_subscriptions` |
| `retry-unidentified` | `observations` |

## Root cause

The custom grant block in `supabase-schema.sql` exists because the project has *"automatically expose new tables"* turned **off**. It grants `anon` + `authenticated` in bulk (incl. `ALTER DEFAULT PRIVILEGES` for future tables) — but **never grants `service_role` anything beyond schema `USAGE`**. `service_role` only had the piecemeal per-table grants added by hand over time, so any table without one is invisible to the service-role key the cron EFs use.

This was latent for weeks behind the gateway 401s; fixing the upper layers exposed it.

## Fix

Mirror the `authenticated` block for `service_role`, including `ALTER DEFAULT PRIVILEGES`, so **current and future** tables/sequences/functions are covered idempotently on every `db-apply` — no longer dependent on someone remembering a per-table grant.

- Idempotent / replay-safe (`GRANT` + `ALTER DEFAULT PRIVILEGES` are no-ops on replay).
- No RLS/privacy change: `service_role` bypasses RLS by design and is never exposed to the browser. Does not touch anon/authenticated or the BYO-key model.
- Does not trip `lint-schema-security.sql` (that gate checks `PUBLIC`, not `service_role`; the security invariants explicitly sanction granting definer functions to `service_role`).

## Test plan

- [ ] `db-validate` gate (ephemeral PG, double-apply idempotency) green
- [ ] After merge → `db-apply` → next cron tick: `net._http_response` shows 200 for kairos-fire / streak-push / retry-unidentified (no more permission-denied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)