### PR TITLE
fix(cron): weekly-digest + refresh-conservation-status use Vault, not unset GUCs

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11634,14 +11634,20 @@ COMMENT ON COLUMN public.users.last_digest_sent_at IS
 
 -- pg_cron: fire every hour; the Edge Function computes the per-timezone
 -- recipient set so each user receives the email at ~14:00 local time.
+-- Canonical cron→EF call shape: hardcoded function URL + X-Cron-Secret
+-- read from the Vault at query time (matches cron-schedules.sql). The
+-- old current_setting('app.supabase_url')/('app.cron_secret') GUCs were
+-- never set, so this job failed every hour with
+-- "unrecognized configuration parameter". The EF gates on the
+-- X-Cron-Secret header (requireCronSecret), not Authorization Bearer.
 SELECT cron.schedule(
   'weekly-digest',
   '0 * * * *',
   $$SELECT net.http_post(
-    url     := current_setting('app.supabase_url') || '/functions/v1/weekly-digest',
-    headers := jsonb_build_object(
-      'Authorization', 'Bearer ' || current_setting('app.cron_secret')
-    ),
+    url     := 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/weekly-digest',
+    headers := ('{"Content-Type":"application/json","X-Cron-Secret":"'
+                 || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'cron_secret')
+                 || '"}')::jsonb,
     body    := '{}'::jsonb
   )$$
 );
@@ -12124,9 +12130,14 @@ BEGIN
     PERFORM cron.schedule(
       'refresh-conservation-status',
       '0 3 1 * *',
+      -- Canonical shape: hardcoded URL + X-Cron-Secret from the Vault.
+      -- The old current_setting('app.*') GUCs were never set, so this
+      -- monthly job errored with "unrecognized configuration parameter".
       $cron$SELECT net.http_post(
-          url    := current_setting('app.supabase_url') || '/functions/v1/refresh-conservation-status',
-          headers := json_build_object('x-cron-secret', current_setting('app.cron_secret'))::jsonb,
+          url    := 'https://reppvlqejgoqvitturxp.supabase.co/functions/v1/refresh-conservation-status',
+          headers := ('{"Content-Type":"application/json","X-Cron-Secret":"'
+                       || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'cron_secret')
+                       || '"}')::jsonb,
           body   := '{}'::jsonb
       )$cron$
     );


### PR DESCRIPTION
## Problem

Two pg_cron jobs defined in `supabase-schema.sql` built their `net.http_post` call from `current_setting('app.supabase_url')` / `current_setting('app.cron_secret')`. **Neither GUC was ever set** on the database, so every run failed in Postgres with:

```
ERROR: unrecognized configuration parameter "app.supabase_url"
```

The Edge Function was never even called.

- `weekly-digest` — hourly (`0 * * * *`)
- `refresh-conservation-status` — monthly (`0 3 1 * *`)

`weekly-digest` additionally sent the secret as `Authorization: Bearer …`, but the EF gates on the **`X-Cron-Secret`** header (`requireCronSecret`) — so it would 403 even if the GUC existed.

Discovered while resolving the cron→EF pipeline incident (#1066 / CRON_SECRET bootstrap / #1067). Independent of those — this is a Postgres-side error that fires before any HTTP call.

## Fix

Rewrite both to the **canonical cron→EF shape** used by every working job in `cron-schedules.sql`:

- Hardcoded function URL (`https://reppvlqejgoqvitturxp.supabase.co/functions/v1/<name>`)
- `X-Cron-Secret` header read from `vault.decrypted_secrets WHERE name = 'cron_secret'` at query time

No external GUC state that can be forgotten. Idempotent: `cron.schedule` upserts by name; the conservation block keeps its existing `pg_cron`-guarded unschedule/schedule.

## Test plan

- [ ] `db-validate` gate (ephemeral PG, double-apply) green
- [ ] After merge → `db-apply` → next ticks: `weekly-digest` (hourly) returns 200 in `net._http_response`; `refresh-conservation-status` verified at next monthly run or via manual fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)