### PR TITLE
fix(deploy): refresh-conservation-status is cron-only — skip JWT verify

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -211,7 +211,7 @@ jobs:
           # anon key, which Edge Functions reject when JWT verification is
           # enabled. These MUST be deployed with --no-verify-jwt.
           # Update this list when adding new cron-triggered functions.
-          CRON_ONLY="recompute-streaks award-badges gc-orphan-media plantnet-monitor recompute-user-stats streak-push retry-unidentified enrich-taxon refresh-taxon-ranges kairos-fire recompute-taxa-cache weekly-digest"
+          CRON_ONLY="recompute-streaks award-badges gc-orphan-media plantnet-monitor recompute-user-stats streak-push retry-unidentified enrich-taxon refresh-taxon-ranges kairos-fire recompute-taxa-cache weekly-digest refresh-conservation-status"
           echo "cron_only=$CRON_ONLY" >> "$GITHUB_OUTPUT"
 
       - name: Deploy

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -53,6 +53,10 @@ verify_jwt = false
 enabled = true
 verify_jwt = false
 
+[functions.refresh-conservation-status]
+enabled = true
+verify_jwt = false
+
 [functions.share-card]
 enabled = true
 verify_jwt = false


### PR DESCRIPTION
## Problem

Manually firing `refresh-conservation-status` (after #1068 fixed its unset-GUC error) returned:

```
401 {"code":"UNAUTHORIZED_NO_AUTH_HEADER","message":"Missing authorization header"}
```

That is the Supabase **gateway** rejecting the request (no `Authorization` bearer) before the function code runs — i.e. the EF is deployed `verify_jwt=true`.

`refresh-conservation-status` self-gates on `X-Cron-Secret` (its own `authOk` reading `Deno.env.get('CRON_SECRET')`) and the monthly pg_cron job calls it with no bearer. It was **missing from `CRON_ONLY`** in `deploy-functions.yml` and had no `config.toml` block, so it deployed JWT-verified.

Masked until now: the job built its URL from an unset `current_setting('app.supabase_url')` GUC (#1068), so it errored in Postgres before ever reaching the gateway. Fixing the GUC exposed this — same class as #1066.

## Fix

- Add `refresh-conservation-status` to `CRON_ONLY` (deploy-time `--no-verify-jwt`).
- Mirror `verify_jwt = false` in `config.toml` (both-sites invariant).

## Test plan

- [ ] CI green
- [ ] After merge → deploy-all (WORKFLOW_TOUCHED) → manual fire returns 200, not 401

## Out of scope (separate bug, flagged)

`weekly-digest` now authenticates+runs but 500s with `column users.email does not exist` — its EF selects `email` from `public.users`, which has no such column (email lives in `auth.users`). Feature #868 has never worked. Needs a design decision on email sourcing; not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)