### PR TITLE
fix(weekly-digest): source recipients via digest_recipients() RPC

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -11652,6 +11652,41 @@ SELECT cron.schedule(
   )$$
 );
 
+-- weekly-digest recipient set. Email lives in auth.users and is
+-- deliberately NOT denormalised into public.users, so the Edge Function
+-- cannot select it from public.users (that selected a non-existent
+-- users.email and 500'd every run). This SECURITY DEFINER RPC joins the
+-- two tables and applies the eligibility filter in one place. preferred_lang
+-- is aliased to preferred_language to match the EF's existing row shape.
+CREATE OR REPLACE FUNCTION public.digest_recipients()
+RETURNS TABLE (
+  id                 uuid,
+  display_name       text,
+  email              text,
+  preferred_language text,
+  country_code       text,
+  timezone           text
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, auth, pg_temp
+AS $$
+  SELECT u.id,
+         u.display_name,
+         au.email::text,
+         u.preferred_lang AS preferred_language,
+         u.country_code,
+         u.timezone
+  FROM public.users u
+  JOIN auth.users au ON au.id = u.id
+  WHERE u.email_notifications_enabled = true
+    AND u.last_observation_at < now() - interval '7 days'
+    AND au.email IS NOT NULL
+$$;
+
+REVOKE ALL    ON FUNCTION public.digest_recipients() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.digest_recipients() TO service_role;
+
 -- ============================================================
 -- #866 — Streak freeze / skip-day mechanic
 -- ============================================================

--- a/supabase/functions/weekly-digest/index.ts
+++ b/supabase/functions/weekly-digest/index.ts
@@ -104,16 +104,13 @@ serve(async (req) => {
   const db = createClient(url, role);
   const currentUtcHour = new Date().getUTCHours();
 
-  // Fetch all eligible users and bucket by timezone
-  const { data: users, error: usersError } = await db
-    .from('users')
-    .select('id, display_name, email, preferred_language, country_code, timezone')
-    .eq('email_notifications_enabled', true)
-    .lt('last_observation_at', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString())
-    .not('email', 'is', null);
+  // Fetch all eligible users and bucket by timezone. Email lives in
+  // auth.users (not denormalised into public.users), so the eligibility
+  // filter + join are done server-side by the digest_recipients() RPC.
+  const { data: users, error: usersError } = await db.rpc('digest_recipients');
 
   if (usersError) {
-    console.error('[weekly-digest] users query error:', usersError.message);
+    console.error('[weekly-digest] digest_recipients RPC error:', usersError.message);
     return new Response(JSON.stringify({ error: usersError.message }), { status: 500 });
   }
 


### PR DESCRIPTION
## Problem

After #1068 unblocked the weekly-digest cron (was failing on an unset GUC), the EF now runs but 500s every hour:

```
{"error":"column users.email does not exist"}
```

The EF did `from('users').select('id, display_name, email, preferred_language, country_code, timezone')`. Two schema mismatches:

- `email` is in **`auth.users`**, deliberately *not* denormalised into `public.users` (see the existing join note in schema).
- the column is **`preferred_lang`**, not `preferred_language` (PostgREST only reported the first miss).

Feature #868 (weekly digest) has **never functioned** — first masked by the GUC error, then this.

## Fix (Option A — chosen for best engineering + 0 cost + most reliable)

Add a `SECURITY DEFINER` SQL function `digest_recipients()` that joins `public.users` + `auth.users`, applies the eligibility filter server-side, and aliases `preferred_lang → preferred_language` so the EF's existing `UserRow` shape and downstream logic are unchanged.

- Email stays single-source in `auth.users` — no duplication, no sync trigger, no drift (rejected denormalising into public.users and the admin-API approach).
- `REVOKE ALL FROM PUBLIC` + `GRANT EXECUTE TO service_role` + pinned `search_path = public, auth, pg_temp` per the schema security invariants.
- EF change is one line: `db.rpc('digest_recipients')`. Timezone bucketing etc. untouched.
- Idempotent (`CREATE OR REPLACE` + idempotent REVOKE/GRANT).

## Test plan

- [x] `npm run typecheck` clean · `npm run test` 2358 passed
- [ ] `db-validate` gate (ephemeral PG, double-apply, lint-schema-security) green
- [ ] After merge → db-apply + EF redeploy → next hourly tick: `weekly-digest` returns 200 with real `{"sent":…}` payload in `net._http_response`

🤖 Generated with [Claude Code](https://claude.com/claude-code)