### PR TITLE
fix(deploy): sponsorships self-gates — skip JWT verify; refresh cron runbook

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -230,10 +230,15 @@ jobs:
           #    identify    — self-gates: auth.getUser when JWT present, else
           #                  anon IP rate-limit. Edge verify_jwt rejected the
           #                  sb_publishable_* key as a non-JWT (config.toml).
+          #    sponsorships— self-gates: validates a user JWT via auth.getUser
+          #                  for the UI paths AND a Bearer cron token for the
+          #                  weekly ai_credentials_heartbeat job. The cron
+          #                  token is not a JWT, so edge verify_jwt 401'd the
+          #                  heartbeat at the gateway before code ran.
           #
           # Module 26 functions (follow / react / report) DO verify JWT.
           CRON_ONLY="${{ steps.classify.outputs.cron_only }}"
-          OTHER_NO_JWT="share-card mcp api identify"
+          OTHER_NO_JWT="share-card mcp api identify sponsorships"
           for fn in ${{ steps.targets.outputs.fns }}; do
             EXTRA_FLAGS=""
             if echo " $CRON_ONLY " | grep -q " $fn "; then

--- a/docs/runbooks/cron-secret-rotation.md
+++ b/docs/runbooks/cron-secret-rotation.md
@@ -1,7 +1,44 @@
 # Cron Secret Rotation — `CRON_SECRET`
 
-The `CRON_SECRET` guards 5 cron-only Edge Functions against unauthenticated POST requests.
-This document describes how to rotate the secret safely.
+`CRON_SECRET` guards the cron-triggered Edge Functions (those that
+self-gate via `_shared/cron-auth.ts` `requireCronSecret`, or their own
+inline `authOk`) against unauthenticated POST requests. This document
+covers the architecture, the safe rotation order, and first-time
+bootstrap.
+
+## Architecture & invariants (read this first)
+
+`CRON_SECRET` lives in **three independent stores that must all hold the
+exact same value**:
+
+| Store | Read by | Set via |
+|---|---|---|
+| **Edge Function env secret** `CRON_SECRET` | `Deno.env.get('CRON_SECRET')` inside every cron EF (`requireCronSecret`) | Supabase dashboard → Edge Functions → Secrets |
+| **Vault** secret **`cron_secret`** (lowercase!) | pg_cron jobs: `(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'cron_secret')` builds the `X-Cron-Secret` header | Supabase dashboard → Vault |
+| **GitHub Actions** repo secret `CRON_SECRET` | `enrich-taxa.yml`, `community-backfill.yml` | `gh secret set CRON_SECRET` |
+
+Two failure modes that are NOT a secret mismatch and bite first:
+
+1. **The EF must be deployed `--no-verify-jwt`.** pg_cron sends no
+   `Authorization` bearer. If the function deploys with
+   `verify_jwt=true`, the Supabase **gateway 401s the request before
+   the function code (and the `CRON_SECRET` check) ever runs**. Every
+   cron EF must be in `CRON_ONLY` (or, if it also serves user traffic,
+   `OTHER_NO_JWT`) in `.github/workflows/deploy-functions.yml` **and**
+   `verify_jwt = false` in `supabase/config.toml`. The deploy flag wins
+   in prod; keep both sites in sync. `--no-verify-jwt` is applied at
+   deploy time and is **not retroactive** — a function only picks it up
+   when actually redeployed.
+2. **`cron.job_run_details` lies.** pg_net is async; the cron job
+   reports `succeeded` the instant the request is *enqueued*,
+   regardless of the HTTP response. **`net._http_response` is the
+   source of truth** for what the EF actually returned.
+
+The status ladder when debugging: **401** = gateway (verify_jwt still
+on) · **500 `CRON_SECRET unset on EF`** = EF env secret missing · **403
+`forbidden`** = EF env value ≠ the `X-Cron-Secret` pg_cron sent (Vault
+mismatch) · **500 `permission denied for table`** = a different bug
+(service_role table GRANT, not auth).
 
 ## ⚠️ Order matters — follow exactly
 
@@ -25,11 +62,25 @@ Save it somewhere temporary (password manager). Do NOT commit it anywhere.
 
 In the Supabase dashboard → **Project Settings → Vault**:
 
-1. Find the existing entry `cron_secret`
+1. Find the existing entry **`cron_secret`** (lowercase — the SQL reads
+   `WHERE name = 'cron_secret'`)
 2. Click **Edit** → paste the new value → **Save**
 
 The pg_cron schedules read this via `vault.decrypted_secrets` at query time, so the
 next cron run will automatically pick up the new value. No DB migration needed.
+
+> Note: the SQL editor's role usually **cannot** `SELECT` from
+> `vault.decrypted_secrets` (returns no rows even when the secret
+> exists) — pg_cron runs as a privileged role that can. Don't conclude
+> "the secret is missing" from an empty SQL-editor query; use the Vault
+> UI.
+
+### Step 2b — Sync the Edge Function env secret
+
+In the Supabase dashboard → **Edge Functions → Secrets**, set
+`CRON_SECRET` to the **same value**. This is what `requireCronSecret`
+reads (`Deno.env.get('CRON_SECRET')`); a Vault-only update leaves every
+cron EF returning `500 CRON_SECRET unset on EF` / `403`.
 
 ### Step 3 — Update the GitHub Secret
 
@@ -38,19 +89,24 @@ In the GitHub repo → **Settings → Secrets and variables → Actions**:
 1. Find `CRON_SECRET`
 2. Click **Update** → paste the new value → **Save**
 
-This updates the `community-backfill.yml` workflow so manual triggers continue to work.
+This updates the `enrich-taxa.yml` and `community-backfill.yml`
+workflows so their scheduled/manual triggers keep working.
 
 ### Step 4 — Verify
 
-After the next scheduled cron run (check Supabase cron logs):
+`cron.job_run_details` is misleading (it shows `succeeded` for an
+enqueued-but-failed request). Verify against **`net._http_response`**
+instead, after the next scheduled tick:
+
 ```sql
-SELECT jobname, last_run_status, last_run_at
-FROM cron.job_run_details
-ORDER BY last_run_at DESC
-LIMIT 10;
+SELECT status_code, left(content, 140) AS body, created
+FROM net._http_response
+WHERE created >= now() - interval '20 minutes'
+ORDER BY created DESC;
 ```
 
-All 5 jobs should show `succeeded`.
+Every recent cron EF call should be `200`. A `403` means the three
+stores are out of sync (re-check they hold the identical value).
 
 For manual verification:
 ```bash
@@ -72,34 +128,47 @@ curl -sS -X POST \
 
 ---
 
-## Protected functions
+## Protected functions (gate on `X-Cron-Secret`; in `CRON_ONLY`)
 
-| Function | Schedule | Notes |
-|---|---|---|
-| `recompute-streaks` | 07:00 UTC daily | |
-| `award-badges` | 07:30 UTC daily | |
-| `plantnet-monitor` | 23:55 UTC daily | |
-| `streak-push` | 01:55 UTC daily | |
-| `recompute-user-stats` | 08:00 UTC daily | Also used by `community-backfill.yml` |
+`recompute-streaks`, `award-badges`, `plantnet-monitor`, `streak-push`,
+`recompute-user-stats` (also used by `community-backfill.yml`),
+`retry-unidentified`, `enrich-taxon` (also `enrich-taxa.yml`),
+`refresh-taxon-ranges`, `kairos-fire`, `recompute-taxa-cache`,
+`weekly-digest`, `refresh-conservation-status`, `gc-orphan-media`.
 
-## NOT protected (intentional)
+The authoritative list is the `CRON_ONLY` string in
+`.github/workflows/deploy-functions.yml` (line ~214). **Adding a new
+cron-triggered EF means adding it there AND a `verify_jwt = false`
+block in `supabase/config.toml`** — otherwise the gateway 401s it.
+
+## NOT verify_jwt, but not pure-cron (`OTHER_NO_JWT`)
 
 | Function | Reason |
 |---|---|
 | `share-card` | Public OG scrapers (Twitter/Facebook) need anonymous access |
-| `mcp` | Uses `rst_*` token model |
-| `api` | Uses `rst_*` token model |
+| `mcp` / `api` | Gate internally on `rst_*` tokens (not JWTs) |
+| `identify` | Self-gates: `auth.getUser` when JWT present, else anon IP rate-limit |
+| `sponsorships` | Self-gates: user JWT for UI paths + Bearer cron token for the weekly `ai_credentials_heartbeat` job |
 
 ---
 
 ## Bootstrap (first-time setup)
 
-If `CRON_SECRET` doesn't exist yet:
+If `CRON_SECRET` doesn't exist yet (all three stores empty → cron EFs
+return `500 CRON_SECRET unset on EF`):
 
-1. Generate: `openssl rand -hex 32`
-2. Add to Vault: Supabase dashboard → Vault → **Add secret** → name: `cron_secret`
-3. Add to GitHub: Settings → Secrets → **New repository secret** → `CRON_SECRET`
-4. Re-run `db-apply.yml` to push the updated `cron-schedules.sql` (with Vault reads)
+1. Generate: `openssl rand -hex 32` (in your own terminal; keep it in a
+   password manager — never paste it into a transcript or commit it)
+2. **Edge Functions → Secrets**: add `CRON_SECRET` = the value
+3. **Vault → Add secret**: name **`cron_secret`** (lowercase) = the same value
+4. **GitHub → Settings → Secrets → Actions**: `gh secret set CRON_SECRET` = the same value
+5. Re-run `db-apply.yml` so `cron-schedules.sql` is (re)applied with the Vault reads
+6. Confirm every cron EF is in `CRON_ONLY`/`OTHER_NO_JWT` **and** has a
+   `verify_jwt = false` block in `config.toml`, then redeploy them
+   (`gh workflow run deploy-functions.yml -f function=all`) so the
+   `--no-verify-jwt` flag is actually applied — it is not retroactive.
+7. Verify via the `net._http_response` query in Step 4 (not
+   `cron.job_run_details`).
 
 ---
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -60,3 +60,13 @@ verify_jwt = false
 [functions.share-card]
 enabled = true
 verify_jwt = false
+
+# sponsorships self-gates both paths: a user JWT via auth.getUser for the
+# SponsoringView UI calls, and a Bearer cron token for the weekly
+# ai_credentials_heartbeat job. The cron token is not a JWT, so edge-layer
+# verify_jwt 401'd the heartbeat at the gateway. Must also be in
+# OTHER_NO_JWT in .github/workflows/deploy-functions.yml (deploy flag wins
+# in prod; both sites kept in sync).
+[functions.sponsorships]
+enabled = true
+verify_jwt = false


### PR DESCRIPTION
## Problem

Closing-out audit of the cron→EF pipeline incident found one more latent bug of the same class as #1069.

`cron.schedule('ai_credentials_heartbeat', '0 4 * * 0', …)` (Sundays 04:00 UTC) calls `sponsorships/heartbeat` with `Authorization: Bearer <sponsorships_cron_token>`. `sponsorships` had **no `config.toml` block** and was in **neither `CRON_ONLY` nor `OTHER_NO_JWT`** → deployed `verify_jwt=true`. The cron token is not a JWT, so the Supabase gateway 401s the heartbeat before the function code runs. Surfaces only weekly, so it hadn't been seen yet.

`sponsorships` already self-gates both paths (user JWT via `auth.getUser` for SponsoringView UI calls; `=== Bearer ${SPONSORSHIPS_CRON_TOKEN}` for the cron) — exactly like `identify`.

`sync-gbif-regional-baseline` and `weekly-expert-lottery` were also checked: their `net.http_post` snippets exist only in **commented-out doc examples**, not active `cron.schedule` calls — no change needed.

## Changes

- `deploy-functions.yml`: add `sponsorships` to `OTHER_NO_JWT` (+ comment).
- `config.toml`: `[functions.sponsorships] verify_jwt = false` (both-sites invariant).
- `docs/runbooks/cron-secret-rotation.md`: rewritten to match post-incident reality — the three-store model (EF env / Vault `cron_secret` / GitHub), the `--no-verify-jwt` gateway invariant, `net._http_response` as source of truth (`cron.job_run_details` lies — pg_net async), full protected-function list, corrected bootstrap.

## Test plan

- [x] `npm run typecheck` clean · `npm run test` 2358 passed
- [ ] CI green
- [ ] After merge → deploy-all (WORKFLOW_TOUCHED) → manual `sponsorships/heartbeat` probe: gateway 401 → EF self-gate response (or 200 with valid cron token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)