### PR TITLE
fix(security): streak-push + retry-unidentified must gate on X-Cron-Secret

### DIFF
--- a/supabase/functions/retry-unidentified/index.test.ts
+++ b/supabase/functions/retry-unidentified/index.test.ts
@@ -1,15 +1,21 @@
 /**
  * Contract smoke tests for retry-unidentified Edge Function.
  *
- * Auth model: cron-only — the function is deployed with JWT verification
- * enabled and called from pg_cron via a service-role bearer. The handler
- * itself only checks method + env config; the auth burden is delegated to
- * the gateway. We assert the public method/env contract.
+ * Auth model: cron-only — deployed --no-verify-jwt (in CRON_ONLY), so the
+ * gateway does NOT gate it. The handler self-gates on X-Cron-Secret via
+ * requireCronSecret. We assert the method + auth + env contract.
  *
  * Happy-path (real Supabase scan + identify EF fan-out) is skipped.
  */
 import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
 import { handler } from './index.ts';
+
+const CRON = 'test-cron-secret';
+const authedPost = () =>
+  new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'x-cron-secret': CRON },
+  });
 
 Deno.test('retry-unidentified: rejects GET with 405', async () => {
   const res = await handler(new Request('http://localhost/', { method: 'GET' }));
@@ -26,10 +32,17 @@ Deno.test('retry-unidentified: rejects OPTIONS with 405 (no CORS preflight)', as
   assertEquals(res.status, 405);
 });
 
-Deno.test('retry-unidentified: POST with missing env → 500', async () => {
+Deno.test('retry-unidentified: POST without X-Cron-Secret → 403', async () => {
+  Deno.env.set('CRON_SECRET', CRON);
+  const res = await handler(new Request('http://localhost/', { method: 'POST' }));
+  assertEquals(res.status, 403);
+});
+
+Deno.test('retry-unidentified: authed POST with missing env → 500', async () => {
+  Deno.env.set('CRON_SECRET', CRON);
   Deno.env.delete('SUPABASE_URL');
   Deno.env.delete('SUPABASE_SERVICE_ROLE_KEY');
-  const res = await handler(new Request('http://localhost/', { method: 'POST' }));
+  const res = await handler(authedPost());
   assertEquals(res.status, 500);
 });
 

--- a/supabase/functions/retry-unidentified/index.ts
+++ b/supabase/functions/retry-unidentified/index.ts
@@ -19,6 +19,7 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
 import { deriveHint } from './_helpers.ts';
+import { requireCronSecret } from '../_shared/cron-auth.ts';
 
 const BATCH_SIZE = 20;
 const MIN_AGE_MINUTES = 10;
@@ -29,6 +30,9 @@ export async function handler(req: Request): Promise<Response> {
   if (req.method !== 'POST') {
     return new Response('Method Not Allowed', { status: 405 });
   }
+
+  const denied = requireCronSecret(req);
+  if (denied) return denied;
 
   const supabaseUrl  = Deno.env.get('SUPABASE_URL') ?? '';
   const serviceRole  = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';

--- a/supabase/functions/streak-push/index.ts
+++ b/supabase/functions/streak-push/index.ts
@@ -152,7 +152,10 @@ function tzYesterday(tz: string, when = new Date()): string {
 
 // ─────────────── HTTP handler ───────────────
 
-serve(async () => {
+serve(async (req) => {
+  const denied = requireCronSecret(req);
+  if (denied) return denied;
+
   const url = Deno.env.get('SUPABASE_URL');
   const role = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
   const vapidPub = Deno.env.get('VAPID_PUBLIC_KEY');


### PR DESCRIPTION
## Security issue (P1)

Close-out audit of the cron→EF incident ran a no-auth sweep of every cron EF. `streak-push` and `retry-unidentified` returned **HTTP 200 and did real work for an unauthenticated request**:

- `streak-push` imports `requireCronSecret` but `serve(async () => {…})` takes no `req` and never calls it — dead import. Anyone can POST to fan out web-push to all users.
- `retry-unidentified`'s handler only checked HTTP method. An anonymous `curl` triggered a real requeue of 15 observations (`{"queued":15}`). It feeds the identify cascade → **paid AI / sponsorship-pool cost amplification by an anonymous caller**.

Both are deployed `--no-verify-jwt` (correct — pg_cron sends no bearer), so the gateway doesn't gate them either. Latent since written; masked while they deployed `verify_jwt=true` (gateway 401'd everything). The verify_jwt fix correctly opened the gateway for the legit cron and exposed the missing internal gate.

## Fix

Add `requireCronSecret(req)` to both — the pattern the other ~10 cron EFs already use. Update `retry-unidentified`'s contract test for the new auth-first ordering, add a `403`-without-secret case, and correct its stale header doc.

## Test plan

- [ ] CI green (incl. `deno test` — retry-unidentified contract suite updated)
- [ ] After merge → deploy-all → no-auth probe returns `403`/`500-unset` (not 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)