### PR TITLE
fix(security): gc-orphan-media must gate on X-Cron-Secret + fix R2 account id

### DIFF
--- a/supabase/functions/gc-orphan-media/index.ts
+++ b/supabase/functions/gc-orphan-media/index.ts
@@ -26,6 +26,7 @@
  */
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
+import { requireCronSecret } from '../_shared/cron-auth.ts';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -202,7 +203,10 @@ function chunk<T>(arr: T[], size: number): T[][] {
 
 // ── Edge Function handler ─────────────────────────────────────────────────────
 
-Deno.serve(async (_req) => {
+Deno.serve(async (req) => {
+  const denied = requireCronSecret(req);
+  if (denied) return denied;
+
   const startTime = Date.now();
 
   // Kill-switch
@@ -219,7 +223,7 @@ Deno.serve(async (_req) => {
   const cutoff = new Date(Date.now() - minAgeMs);
 
   const cfg: R2Config = {
-    accountId:       Deno.env.get('R2_ACCOUNT_ID') ?? '',
+    accountId:       Deno.env.get('R2_ACCOUNT_ID') ?? Deno.env.get('CF_ACCOUNT_ID') ?? '',
     accessKeyId:     Deno.env.get('R2_ACCESS_KEY_ID') ?? '',
     secretAccessKey: Deno.env.get('R2_SECRET_ACCESS_KEY') ?? '',
     bucketName:      Deno.env.get('R2_BUCKET_NAME') ?? '',


### PR DESCRIPTION
## Security + correctness

Same close-out sweep: `gc-orphan-media` (active weekly cron, Sun 04:30 UTC, `--no-verify-jwt`, **deletes orphan media from R2**) had a `Deno.serve(async (_req) => …)` handler with **no auth check** — any unauthenticated caller could trigger a destructive GC sweep.

It also read `R2_ACCOUNT_ID`, but the deploy workflow only syncs `CF_ACCOUNT_ID` (derived from `R2_ENDPOINT_URL`) — `R2_ACCOUNT_ID` is never set. `cfg.accountId` was always empty → `500 {"error":"Missing R2 env vars"}` on every run. The GC has **never actually executed** (consistent with its documented v1.1-followup status).

## Fix

- Add `requireCronSecret(req)` as the first thing in the handler (before kill-switch / R2 reads).
- `accountId` falls back to `CF_ACCOUNT_ID` so it works with what the deploy already provides — no secret-sync change needed.

## Test plan

- [ ] CI green
- [ ] After merge → deploy-all → no-auth probe returns `403`/`500-unset`; authed cron call gets past the R2 env check

🤖 Generated with [Claude Code](https://claude.com/claude-code)