### PR TITLE
fix(audit): copy/i18n/docs findings (#1078, #1079, #1083)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,9 +398,11 @@ Failure modes + fixes in [`docs/runbooks/ci-smoke-checks.md`](docs/runbooks/ci-s
 The Explore MegaMenu is split into two columns: **Biodiversity** (the
 existing flat dropdown — Map / Recent / Watchlist / Species / Validate)
 and **Community** (Observers / Top / Nearby / Experts by taxon / By
-country). All Community items land on `/{en,es}/{community,comunidad}/observers/`
-with composable filter chips; the MegaMenu items just preset different
-URL params.
+country). Community items land on locale-paired routes with composable filter
+chips; the MegaMenu items just preset different URL params. Slug pairs:
+`/community/observers/` ↔ `/comunidad/observadores/`,
+`/community/leaderboard/` ↔ `/comunidad/tabla-de-lideres/`,
+`/community/map/` ↔ `/comunidad/mapa/`.
 
 Three load-bearing rules:
 

--- a/src/components/ContextualSpeciesChips.astro
+++ b/src/components/ContextualSpeciesChips.astro
@@ -57,6 +57,7 @@ const filterAllLabel = (ctx as any).filter_all ?? (isEs ? 'Ver todas' : 'Show al
   class="hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/40 p-4 space-y-3"
   data-lang={lang}
   data-target-input={targetInputId}
+  data-not-in-dex={notInDexText}
   aria-label={headingText}
 >
   <div class="flex items-start justify-between gap-3">
@@ -191,6 +192,13 @@ const filterAllLabel = (ctx as any).filter_all ?? (isEs ? 'Ver todas' : 'Show al
     white-space: nowrap;
   }
   .dark .ctx-chip-pill { background: rgb(63 63 70); color: rgb(161 161 170); }
+  .ctx-chip-sep {
+    font-size: 0.625rem;
+    color: rgb(161 161 170);
+    line-height: 1;
+    user-select: none;
+  }
+  .dark .ctx-chip-sep { color: rgb(113 113 122); }
   .ctx-chip-pill-missing {
     background: rgb(254 243 199);
     color: rgb(146 64 14);
@@ -315,7 +323,7 @@ const filterAllLabel = (ctx as any).filter_all ?? (isEs ? 'Ver todas' : 'Show al
       listEl!.classList.remove('hidden');
       listEl!.innerHTML = '';
 
-      const notInDexLabel = lang === 'es' ? 'aún no en tu dex' : 'not in your dex yet';
+      const notInDexLabel = container.dataset.notInDex ?? (lang === 'es' ? 'aún no en tu dex' : 'not in your dex yet');
       const useLabelTpl = lang === 'es' ? 'Usar {name} como identificación' : 'Use {name} as identification';
 
       for (const r of rows) {
@@ -376,6 +384,13 @@ const filterAllLabel = (ctx as any).filter_all ?? (isEs ? 'Ver todas' : 'Show al
         }
 
         if (r.has_observed_by_viewer === false) {
+          if (distLabel) {
+            const sep = document.createElement('span');
+            sep.className = 'ctx-chip-sep';
+            sep.setAttribute('aria-hidden', 'true');
+            sep.textContent = '·';
+            meta.appendChild(sep);
+          }
           const pill = document.createElement('span');
           pill.className = 'ctx-chip-pill ctx-chip-pill-missing';
           pill.textContent = notInDexLabel;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2316,7 +2316,7 @@
     "title": "Your Pokédex",
     "subtitle": "Every species you've observed or correctly identified.",
     "subheading": "Grouped by kingdom, with rarity tiers from your community's data.",
-    "empty": "No species yet — log your first observation to start the dex.",
+    "empty": "No confirmed species yet — your observations need community verification to appear here.",
     "rarity_label": "Rarity",
     "first_seen": "First seen",
     "count_one": "{n} observation",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2316,7 +2316,7 @@
     "title": "Tu Pokédex",
     "subtitle": "Cada especie que has observado o identificado correctamente.",
     "subheading": "Agrupado por reino, con niveles de rareza calculados con datos de la comunidad.",
-    "empty": "Aún no hay especies — registra tu primera observación para abrir el dex.",
+    "empty": "Aún no tienes especies confirmadas — tus observaciones necesitan verificación de la comunidad para aparecer aquí.",
     "rarity_label": "Rareza",
     "first_seen": "Primera vez",
     "count_one": "{n} observación",


### PR DESCRIPTION
Production-audit fixes (thematic group G2). One atomic commit per issue:
- #1078 — separator between distance and dex badge in ContextualSpeciesChips
- #1079 — accurate Pokédex empty-state copy (EN+ES) for users with unconfirmed obs
- #1083 — correct CLAUDE.md M28 community route slugs

Verified: typecheck clean, full vitest suite green, build OK. Do not merge yet — maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)