### PR TITLE
fix(auth): cache + dedupe getUserRoles to kill user_roles fan-out (#1076)

### DIFF
--- a/src/lib/user-roles.test.ts
+++ b/src/lib/user-roles.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock supabase client ──
+// Intercept at the module boundary before the module-under-test loads so
+// getSupabase() never tries to read import.meta.env.
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockFrom = vi.fn();
+const mockOnAuthStateChange = vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } });
+const mockSupabase = {
+  from: mockFrom,
+  auth: { onAuthStateChange: mockOnAuthStateChange },
+};
+
+vi.mock('./supabase', () => ({
+  getSupabase: () => mockSupabase,
+}));
+
+// Import AFTER mock is registered.
+import { getUserRoles } from './user-roles';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset the module-level cache and in-flight state between tests by
+  // re-importing a fresh copy isn't easily possible with Vitest's ESM
+  // cache; instead we drain the cache by advancing time past TTL via
+  // Date.now mock or by calling with a unique userId each time.
+  // We use unique userIds per assertion group to sidestep the TTL issue.
+
+  // Wire up the default mock chain: from → select → eq → resolved value.
+  mockEq.mockResolvedValue({ data: [], error: null });
+  mockSelect.mockReturnValue({ eq: mockEq });
+  mockFrom.mockReturnValue({ select: mockSelect });
+});
+
+describe('getUserRoles', () => {
+  it('returns empty set for null userId', async () => {
+    const result = await getUserRoles(null);
+    expect(result).toEqual(new Set());
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns empty set for undefined userId', async () => {
+    const result = await getUserRoles(undefined);
+    expect(result).toEqual(new Set());
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('two concurrent calls for the same userId trigger only ONE fetch', async () => {
+    mockEq.mockResolvedValue({
+      data: [{ role: 'admin', revoked_at: null }],
+      error: null,
+    });
+
+    const uid = 'user-dedupe-test';
+    const [r1, r2] = await Promise.all([getUserRoles(uid), getUserRoles(uid)]);
+
+    // Both results contain the role.
+    expect(r1.has('admin')).toBe(true);
+    expect(r2.has('admin')).toBe(true);
+
+    // Only ONE network call should have been made.
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+    expect(mockFrom).toHaveBeenCalledWith('user_roles');
+  });
+
+  it('a cached result is returned for subsequent same-uid calls without fetching again', async () => {
+    mockEq.mockResolvedValue({
+      data: [{ role: 'moderator', revoked_at: null }],
+      error: null,
+    });
+
+    const uid = 'user-cache-test';
+    const r1 = await getUserRoles(uid);
+    // Second call — should hit cache, no new fetch.
+    const r2 = await getUserRoles(uid);
+
+    expect(r1.has('moderator')).toBe(true);
+    expect(r2.has('moderator')).toBe(true);
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it('a different userId bypasses the cache and fetches independently', async () => {
+    mockEq
+      .mockResolvedValueOnce({ data: [{ role: 'admin', revoked_at: null }], error: null })
+      .mockResolvedValueOnce({ data: [{ role: 'expert', revoked_at: null }], error: null });
+
+    const r1 = await getUserRoles('user-a-bypass');
+    const r2 = await getUserRoles('user-b-bypass');
+
+    expect(r1.has('admin')).toBe(true);
+    expect(r2.has('expert')).toBe(true);
+
+    // Two distinct fetches — one per userId.
+    expect(mockFrom).toHaveBeenCalledTimes(2);
+  });
+
+  it('filters out revoked roles (revoked_at in the past)', async () => {
+    const pastDate = new Date(Date.now() - 1000).toISOString();
+    mockEq.mockResolvedValue({
+      data: [
+        { role: 'admin', revoked_at: null },
+        { role: 'moderator', revoked_at: pastDate },
+      ],
+      error: null,
+    });
+
+    const roles = await getUserRoles('user-revoke-test');
+    expect(roles.has('admin')).toBe(true);
+    expect(roles.has('moderator')).toBe(false);
+  });
+
+  it('returns empty set when the fetch errors', async () => {
+    mockEq.mockResolvedValue({ data: null, error: { message: 'network error' } });
+
+    const roles = await getUserRoles('user-error-test');
+    expect(roles).toEqual(new Set());
+  });
+});

--- a/src/lib/user-roles.ts
+++ b/src/lib/user-roles.ts
@@ -1,22 +1,64 @@
 import { getSupabase } from './supabase';
 import type { UserRole } from './types';
 
+const ROLES_CACHE_TTL_MS = 30_000;
+let _rolesCache: { userId: string; roles: Set<UserRole>; resolvedAt: number } | null = null;
+let _rolesFlight: { userId: string; p: Promise<Set<UserRole>> } | null = null;
+
+let _rolesListenerAttached = false;
+function ensureRolesAuthListener() {
+  if (_rolesListenerAttached) return;
+  _rolesListenerAttached = true;
+  try {
+    getSupabase().auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_OUT') {
+        _rolesCache = null;
+        _rolesFlight = null;
+      }
+    });
+  } catch { /* env not set */ }
+}
+
+async function fetchRoles(userId: string): Promise<Set<UserRole>> {
+  try {
+    const supabase = getSupabase();
+    const { data, error } = await supabase
+      .from('user_roles')
+      .select('role, revoked_at')
+      .eq('user_id', userId);
+    if (error || !data) return new Set();
+    const now = Date.now();
+    const active = data.filter(r => !r.revoked_at || new Date(r.revoked_at).getTime() > now);
+    return new Set(active.map(r => r.role as UserRole));
+  } catch {
+    return new Set();
+  }
+}
+
 /**
  * Read the active roles for a given user from public.user_roles.
- * Filters out revoked rows. Returns an empty Set for unauthenticated callers.
- *
- * Duplicates are impossible by construction — public.user_roles has a
- * PRIMARY KEY (user_id, role), so each (user, role) pair appears at most once.
+ * Short-lived in-memory cache + in-flight dedupe (mirrors #1064's
+ * getCachedUser/getCachedSession): the chrome renders Header AND
+ * MobileDrawer islands, each calling this on cold-start and again from
+ * onAuthStateChange's INITIAL_SESSION replay -> 3-5 identical
+ * /rest/v1/user_roles requests per load (#1076). Collapsed to one.
  */
 export async function getUserRoles(userId: string | null | undefined): Promise<Set<UserRole>> {
   if (!userId) return new Set();
-  const supabase = getSupabase();
-  const { data, error } = await supabase
-    .from('user_roles')
-    .select('role, revoked_at')
-    .eq('user_id', userId);
-  if (error || !data) return new Set();
+  ensureRolesAuthListener();
   const now = Date.now();
-  const active = data.filter(r => !r.revoked_at || new Date(r.revoked_at).getTime() > now);
-  return new Set(active.map(r => r.role as UserRole));
+  if (_rolesCache && _rolesCache.userId === userId && (now - _rolesCache.resolvedAt) < ROLES_CACHE_TTL_MS) {
+    return _rolesCache.roles;
+  }
+  if (_rolesFlight && _rolesFlight.userId === userId) {
+    return _rolesFlight.p;
+  }
+  const p = fetchRoles(userId).then((roles) => {
+    _rolesCache = { userId, roles, resolvedAt: Date.now() };
+    return roles;
+  }).finally(() => {
+    if (_rolesFlight && _rolesFlight.userId === userId) _rolesFlight = null;
+  });
+  _rolesFlight = { userId, p };
+  return p;
 }


### PR DESCRIPTION
Audit spike G5.2. Central 30s TTL cache + in-flight dedupe in user-roles.ts (mirrors #1064 getCachedUser pattern), SIGNED_OUT invalidation, zero caller edits. New user-roles.test.ts (7 assertions). Verified typecheck + 2365 tests green. The gotrue lock-warning is documented on the issue as a separate follow-up. Closes #1076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)