### PR TITLE
fix(schema): self-heal sync_user_role_flags definer privilege (#1071)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -2457,6 +2457,42 @@ CREATE TRIGGER user_roles_sync_flags
 AFTER INSERT OR UPDATE OF revoked_at OR DELETE ON public.user_roles
 FOR EACH ROW EXECUTE FUNCTION public.sync_user_role_flags();
 
+-- Self-healing definer-privilege guarantee for sync_user_role_flags().
+-- The function UPDATEs the locked columns users.is_expert /
+-- .credentialed_researcher, which `REVOKE UPDATE ON public.users FROM
+-- authenticated` (see the locked-columns grants block below) gates out
+-- of the column GRANT. SECURITY DEFINER only bypasses that if the
+-- function's OWNER holds the column privilege — and CREATE OR REPLACE
+-- cannot change an existing function's owner, so a production object
+-- created under a non-owning role keeps failing every db-apply
+-- ("permission denied for table users" from the user_roles_sync_flags
+-- trigger; issue #1071). Reassert SECURITY DEFINER + search_path, force
+-- ownership to the public.users table owner, and explicitly grant the
+-- two locked columns to service_role so the bypass holds even if
+-- ownership drifts again. All statements idempotent / replay-safe.
+ALTER FUNCTION public.sync_user_role_flags()
+  SECURITY DEFINER
+  SET search_path = public, extensions, pg_temp;
+
+DO $sync_role_owner$
+DECLARE
+  tbl_owner text;
+BEGIN
+  SELECT pg_get_userbyid(c.relowner)
+    INTO tbl_owner
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relname = 'users';
+  IF tbl_owner IS NOT NULL THEN
+    EXECUTE format(
+      'ALTER FUNCTION public.sync_user_role_flags() OWNER TO %I', tbl_owner);
+  END IF;
+END
+$sync_role_owner$;
+
+GRANT UPDATE (is_expert, credentialed_researcher)
+  ON public.users TO service_role;
+
 -- 7. RLS policies
 DROP POLICY IF EXISTS user_roles_admin_or_self_read ON public.user_roles;
 CREATE POLICY user_roles_admin_or_self_read ON public.user_roles

--- a/docs/specs/infra/users-column-grants.md
+++ b/docs/specs/infra/users-column-grants.md
@@ -55,14 +55,24 @@ from `authenticated` is denied.
 | `id` | `auth.users` FK | Primary key, immutable |
 | `created_at` / `joined_at` | column DEFAULT now() on INSERT | Audit columns; immutable after creation |
 | `updated_at` | `tg_users_touch_updated_at` BEFORE UPDATE trigger | Audit column; trigger sets `NEW.updated_at = now()` so clients shouldn't touch it (and the GRANT prevents it). Bug surfaced when ProfileEditForm was setting it from the client → 403. |
-| `is_expert` | `expert_applications` admin flow + `is_expert_in()` SQL | Self-elevation would let anyone weight their votes |
-| `credentialed_researcher` / `credentialed_at` / `credentialed_by` | admin grant | Unlocks precise coords on sensitive species |
+| `is_expert` | `expert_applications` admin flow + `is_expert_in()` SQL + `sync_user_role_flags()` trigger (SECURITY DEFINER) | Self-elevation would let anyone weight their votes |
+| `credentialed_researcher` / `credentialed_at` / `credentialed_by` | admin grant + `sync_user_role_flags()` trigger (SECURITY DEFINER) | Unlocks precise coords on sensitive species |
 | `karma_total` / `karma_updated_at` / `vote_count` | karma engine triggers (SECURITY DEFINER) | Self-bump would game leaderboards + vote weighting |
 | `grace_until` | karma onboarding (SECURITY DEFINER) | Backfilled to `created_at + 30 days`; users shouldn't extend their own grace period |
 | `observation_count` | `tg_observation_count` trigger | Denormalised stat; trigger keeps it consistent |
 | `last_observation_at` | `tg_observation_count` trigger | Same |
 | `stats_cached_at` / `stats_json` | nightly stats refresh job | Server-rolled aggregates |
 | `follower_count` / `following_count` | `tg_follows_counter` trigger (SECURITY DEFINER, M26) | Self-bump would inflate social-graph signal |
+
+> **Note (#1071 — service_role column grant):** As of #1071, `service_role`
+> additionally holds `UPDATE (is_expert, credentialed_researcher) ON public.users`
+> via an explicit `GRANT` immediately after the `user_roles_sync_flags` trigger
+> definition. This makes the `sync_user_role_flags()` SECURITY DEFINER path
+> self-healing against function-owner drift (a function's OWNER must hold the
+> column privilege for SECURITY DEFINER to bypass the authenticated REVOKE).
+> This is NOT a privacy regression — `service_role` is the trusted backend role
+> used only by Edge Functions and server-side jobs, never the browser-facing
+> `authenticated` role.
 
 ## Pattern checklist for new triggers / functions
 


### PR DESCRIPTION
Audit group G3 — schema/RLS, maintainer-approved exact diff. Self-healing block after the user_roles_sync_flags trigger: ALTER FUNCTION definer+search_path, $sync_role_owner$ DO-block owner realign, GRANT UPDATE(is_expert,credentialed_researcher) to service_role. users-column-grants.md updated + privacy note. Idempotent. db-validate gate will validate on this PR. Not applied to prod. Closes #1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)