### PR TITLE
fix(audit): frontend findings (#1070, #1072, #1073, #1074, #1075, #1077, #1080, #1081)

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,7 +3,7 @@
   "version": "__BUILD_VERSION__",
   "short_name": "Rastrum",
   "description": "Offline-first biodiversity identification for Latin America.",
-  "start_url": "/en/",
+  "start_url": "/",
   "scope": "/",
   "display": "standalone",
   "background_color": "#09090b",

--- a/src/components/CommunityMapView.astro
+++ b/src/components/CommunityMapView.astro
@@ -129,6 +129,7 @@ const stringsJson = JSON.stringify({
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';
   import { loadIsoCountries } from '../lib/community';
+  import { basemapStyleUrl } from '../lib/map-style';
 
   interface Strings {
     lang: 'en' | 'es';
@@ -350,7 +351,7 @@ const stringsJson = JSON.stringify({
         const maplibre = (await import('maplibre-gl')).default;
         map = new maplibre.Map({
           container: mapContainer,
-          style: 'https://tiles.openfreemap.org/styles/liberty',
+          style: basemapStyleUrl(),
           center: [-99.1, 19.4], // CDMX default
           zoom: 4,
           attributionControl: { compact: true },

--- a/src/components/DiscoverFeedView.astro
+++ b/src/components/DiscoverFeedView.astro
@@ -128,6 +128,7 @@ const communityHref = `/${lang}/${lang === 'es' ? 'comunidad/observadores' : 'co
 
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { pickCardImageUrl } from '../lib/media-url';
 
   // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -247,7 +248,7 @@ const communityHref = `/${lang}/${lang === 'es' ? 'comunidad/observadores' : 'co
         .in('observation_id', obsIds)
         .eq('is_primary', true),
       sb.from('media_files')
-        .select('observation_id, url, is_primary')
+        .select('observation_id, url, thumbnail_url, is_primary, deleted_at')
         .in('observation_id', obsIds),
     ]);
 
@@ -257,9 +258,11 @@ const communityHref = `/${lang}/${lang === 'es' ? 'comunidad/observadores' : 'co
       const common = r.taxa?.common_name_en ?? r.taxa?.common_name_es ?? null;
       sciByObs.set(r.observation_id, { sci: r.scientific_name ?? null, common });
     }
-    for (const m of (mediaRows ?? []) as Array<{ observation_id: string; url?: string | null; is_primary?: boolean }>) {
-      if (!m.url) continue;
-      if (m.is_primary || !photoByObs.has(m.observation_id)) photoByObs.set(m.observation_id, m.url);
+    for (const m of (mediaRows ?? []) as Array<{ observation_id: string; url?: string | null; thumbnail_url?: string | null; is_primary?: boolean; deleted_at?: string | null }>) {
+      if (m.deleted_at != null) continue;
+      const src = pickCardImageUrl(m);
+      if (!src) continue;
+      if (m.is_primary || !photoByObs.has(m.observation_id)) photoByObs.set(m.observation_id, src);
     }
 
     return (obsRows as Array<Record<string, unknown>>).map(r => {

--- a/src/components/ExploreIndexView.astro
+++ b/src/components/ExploreIndexView.astro
@@ -36,13 +36,6 @@ const cards = [
     iconPath: 'M5 4v3M19 4v3M3 12h18M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z',
   },
   {
-    href: getLocalizedPath(lang, routes.explorePlaces[lang] + '/'),
-    title: isEs ? 'Lugares' : 'Places',
-    body:  isEs ? 'Explora áreas protegidas, reservas y zonas activas. Descubre qué se ha observado cerca de ti.'
-                : 'Explore protected areas, reserves and active zones. Discover what has been observed near you.',
-    iconPath: 'M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z',
-  },
-  {
     href: getLocalizedPath(lang, routes.exploreValidate[lang] + '/'),
     title: isEs ? 'Validar' : 'Validate',
     body:  isEs ? 'Sugiere identificaciones para observaciones que necesitan ayuda. Las sugerencias de expertos pesan más en el consenso.'

--- a/src/components/ExploreMap.astro
+++ b/src/components/ExploreMap.astro
@@ -50,6 +50,7 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
     getPmtilesCacheStatus,
     getPmtilesMxUrl,
   } from '../lib/offline-map';
+  import { basemapStyleUrl } from '../lib/map-style';
 
   const isEs = document.documentElement.lang === 'es';
   const isDark = document.documentElement.classList.contains('dark');
@@ -79,9 +80,7 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
   const pmProtocol = new Protocol();
   maplibregl.addProtocol('pmtiles', pmProtocol.tile);
 
-  const REMOTE_STYLE_LIGHT = 'https://tiles.openfreemap.org/styles/liberty';
-  const REMOTE_STYLE_DARK  = 'https://tiles.openfreemap.org/styles/dark';
-  const REMOTE_STYLE = isDark ? REMOTE_STYLE_DARK : REMOTE_STYLE_LIGHT;
+  const REMOTE_STYLE = basemapStyleUrl(isDark);
 
   /**
    * Inline minimal pmtiles style spec. We don't pull in

--- a/src/components/ExplorePlacesView.astro
+++ b/src/components/ExplorePlacesView.astro
@@ -156,6 +156,8 @@ const placesIndexBase = `/${lang}/${lang === 'es' ? 'explorar/lugares' : 'explor
   };
 
   const placesBase = root.dataset.placesBase!;
+  const lang = (root.dataset.lang === 'es' ? 'es' : 'en') as 'en' | 'es';
+  const isEs = lang === 'es';
 
   // Elements
   const indexEl      = document.getElementById('places-index')!;

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -237,6 +237,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
   import { renderSpeciesCard, type CardLabels } from '../lib/species-card-html';
   import { parseChips, parseSort, buildSpeciesUrl, type ChipsState, type SortMode } from '../lib/species-filters';
   import { deriveGenus, colorForName, buildTaxonomicTree, taxonomicDepth, type TaxonNode } from '../lib/species-display';
+  import { pickCardImageUrl } from '../lib/media-url';
 
   type Lang = 'en' | 'es';
 
@@ -263,7 +264,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     id: string;
     location: GeoJSON.Point | null;
     observed_at: string;
-    media_files: { url: string | null; is_primary: boolean | null; media_type?: string | null }[];
+    media_files: { url: string | null; thumbnail_url?: string | null; is_primary: boolean | null; media_type?: string | null; deleted_at?: string | null }[];
   };
 
   function escapeText(s: string): string {
@@ -1447,7 +1448,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     try {
       const { data, error } = await supabase
         .from('observations')
-        .select('id, location, observed_at, media_files(url, is_primary, media_type)')
+        .select('id, location, observed_at, media_files(url, thumbnail_url, is_primary, media_type, deleted_at)')
         .eq('sync_status', 'synced')
         .eq('primary_taxon_id', taxon.id)
         .order('observed_at', { ascending: false })
@@ -1460,12 +1461,12 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
 
     if (photosEl) {
       const top = obsRows
-        .filter(o => (o.media_files ?? []).some(m => m?.url && (!m.media_type || m.media_type === 'photo')))
+        .filter(o => (o.media_files ?? []).some(m => m?.deleted_at == null && pickCardImageUrl(m) && (!m.media_type || m.media_type === 'photo')))
         .slice(0, 6)
         .map(o => {
-          const media = (o.media_files ?? []).filter(m => !m?.media_type || m.media_type === 'photo');
-          const pick = media.find(m => m?.is_primary && m?.url) ?? media.find(m => m?.url);
-          const url = pick?.url ?? '';
+          const media = (o.media_files ?? []).filter(m => m?.deleted_at == null && (!m?.media_type || m.media_type === 'photo'));
+          const pick = media.find(m => m?.is_primary && pickCardImageUrl(m)) ?? media.find(m => pickCardImageUrl(m));
+          const url = pickCardImageUrl(pick) ?? '';
           return `<li><a href="${shareBase}?id=${encodeURIComponent(o.id)}" class="block aspect-square overflow-hidden rounded-lg bg-zinc-100 dark:bg-zinc-800"><img src="${escapeText(url)}" alt="${escapeText(taxon!.scientific_name)}" loading="lazy" class="w-full h-full object-cover" /></a></li>`;
         });
       photosEl.innerHTML = top.join('');

--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -119,6 +119,7 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
   import { getSupabase, getCachedUser } from '../lib/supabase';
   import { buildGreeting } from '../lib/home-greeting';
   import { loadStreak } from '../lib/home-loaders';
+  import { startOfLocalDayUTC } from '../lib/home-hero';
   import { fetchSuggestions, type SpeciesSuggestion } from '../lib/suggestions';
 
   type Lang = 'en' | 'es';
@@ -501,8 +502,12 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
       const observeBase = root.dataset.observeHref ?? (lang === 'es' ? '/es/observar/' : '/en/observe/');
       const ctaHref = `${observeBase}?taxon_id=${encodeURIComponent(ch.taxon_id)}`;
 
-      const todayStart = new Date();
-      todayStart.setUTCHours(0, 0, 0, 0);
+      const { data: tzRow } = await supabase
+        .from('users')
+        .select('timezone')
+        .eq('id', userId)
+        .maybeSingle<{ timezone: string | null }>();
+      const todayStart = startOfLocalDayUTC(new Date(), tzRow?.timezone ?? 'UTC');
 
       const { count } = await supabase
         .from('observations')

--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -509,14 +509,15 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
         .maybeSingle<{ timezone: string | null }>();
       const todayStart = startOfLocalDayUTC(new Date(), tzRow?.timezone ?? 'UTC');
 
-      const { count } = await supabase
+      const { data: doneRows } = await supabase
         .from('observations')
-        .select('id', { count: 'exact', head: true })
+        .select('id')
         .eq('observer_id', userId)
         .eq('sync_status', 'synced')
-        .gte('observed_at', todayStart.toISOString());
+        .gte('observed_at', todayStart.toISOString())
+        .limit(1);
 
-      const completed = (count ?? 0) > 0;
+      const completed = !!doneRows && doneRows.length > 0;
 
       const thumbHtml = ch.thumbnail_url
         ? `<img src="${escapeText(ch.thumbnail_url)}" alt="${escapeText(ch.scientific_name)}" class="w-14 h-14 rounded-lg object-cover flex-shrink-0" loading="lazy" />`

--- a/src/components/MapPicker.astro
+++ b/src/components/MapPicker.astro
@@ -154,13 +154,14 @@ const initialLng  = initialCoords?.lng ?? '';
 
 <script>
   import { MEXICO_DEFAULT_CENTER, isValidLatLng } from '../lib/media-helpers';
+  import { basemapStyleUrl } from '../lib/map-style';
 
   type Coords = { lat: number; lng: number };
   type MapLibreMap = import('maplibre-gl').Map;
   type MapLibreMarker = import('maplibre-gl').Marker;
   type StyleSpec = import('maplibre-gl').StyleSpecification;
 
-  const MAP_STYLE_STREET = 'https://tiles.openfreemap.org/styles/liberty';
+  const MAP_STYLE_STREET = basemapStyleUrl();
   // ESRI World Imagery — free, no API key required.
   const MAP_STYLE_SAT: StyleSpec = {
     version: 8,

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -422,6 +422,7 @@ import {
 } from '../lib/pipeline-engine';
 import { saveObservationToOutbox, resolveObserverRef } from '../lib/observe';
 import { syncOutbox } from '../lib/sync';
+import { SYNC_EVENTS, type SyncRowDetail } from '../lib/sync-events';
 import { getObservationDefaults, setObservationDefaults } from '../lib/observation-defaults';
 
 // ── State ──────────────────────────────────────────────────────────────────
@@ -1324,8 +1325,46 @@ postForm?.addEventListener('submit', async (e) => {
     successEl?.classList.remove('hidden');
     const linkEl = document.getElementById('obs2-success-link');
     if (linkEl && obs.id) {
-      const href = `/share/obs/?id=${obs.id}`;
-      linkEl.innerHTML = `<a href="${href}" class="text-emerald-700 dark:text-emerald-400 underline text-sm">${isEs ? 'Ver observaci\u00f3n' : 'View observation'}</a>`;
+      // The /share/obs/?id= page reads from Supabase, so it 404s
+      // ("Observation not found") until the outbox row reaches the
+      // server. Gate the CTA on the existing sync-row-done event
+      // (the same signal the SyncPill uses) instead of dead-linking.
+      const obsId = obs.id;
+      const href = `/share/obs/?id=${obsId}`;
+      const viewLabel = isEs ? 'Ver observaci\u00f3n' : 'View observation';
+      const syncingLabel = isEs ? 'Sincronizando\u2026' : 'Syncing\u2026';
+
+      const showLink = () => {
+        linkEl.innerHTML = `<a href="${href}" class="text-emerald-700 dark:text-emerald-400 underline text-sm">${viewLabel}</a>`;
+      };
+      const showSyncing = () => {
+        linkEl.innerHTML = `<span class="text-zinc-500 dark:text-zinc-400 text-sm" aria-live="polite">${syncingLabel}</span>`;
+      };
+
+      let resolved = false;
+      const resolveOnce = () => {
+        if (resolved) return;
+        resolved = true;
+        window.removeEventListener(SYNC_EVENTS.rowDone, onRowDone as EventListener);
+        showLink();
+      };
+      const onRowDone = (ev: Event) => {
+        const detail = (ev as CustomEvent<SyncRowDetail>).detail;
+        if (detail?.observation_id === obsId) resolveOnce();
+      };
+
+      showSyncing();
+      window.addEventListener(SYNC_EVENTS.rowDone, onRowDone as EventListener);
+
+      // The row may have synced before this listener was attached (fast
+      // online sync). Check Dexie directly; if already synced, resolve now.
+      void (async () => {
+        try {
+          const { getDB } = await import('../lib/db');
+          const rec = await getDB().observations.get(obsId);
+          if (!rec || rec.sync_status === 'synced') resolveOnce();
+        } catch { /* leave the event listener as the fallback */ }
+      })();
     }
     // Toast confirmation
     const toastEl = document.createElement('div');

--- a/src/lib/home-hero.ts
+++ b/src/lib/home-hero.ts
@@ -31,6 +31,40 @@ function localParts(d: Date, tz: string): { hour: number; minute: number; isoDay
   }
 }
 
+/**
+ * The UTC instant corresponding to 00:00 of `now`'s calendar day in the
+ * user's timezone `tz`. Used for "did the user observe *today*?" probes —
+ * `observations.observed_at` is a UTC timestamp, so the boundary must be
+ * the user's local midnight expressed as a UTC instant, not UTC midnight
+ * (which misattributes daytime observations for the Americas). Falls back
+ * to UTC midnight if the timezone is unparseable.
+ */
+export function startOfLocalDayUTC(now: Date, tz: string): Date {
+  try {
+    const { isoDay } = localParts(now, tz);
+    // Offset (minutes) of `tz` at `now`: difference between the wall-clock
+    // time the formatter reports and the same instant read as if it were UTC.
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit',
+    });
+    const p = Object.fromEntries(fmt.formatToParts(now).map(x => [x.type, x.value]));
+    const asUTC = Date.UTC(
+      Number(p.year), Number(p.month) - 1, Number(p.day),
+      Number(p.hour === '24' ? '0' : p.hour), Number(p.minute), Number(p.second),
+    );
+    const offsetMs = asUTC - (Math.floor(now.getTime() / 1000) * 1000);
+    const [y, m, d] = isoDay.split('-').map(Number);
+    const localMidnightAsUTC = Date.UTC(y, m - 1, d, 0, 0, 0);
+    return new Date(localMidnightAsUTC - offsetMs);
+  } catch {
+    const fallback = new Date(now);
+    fallback.setUTCHours(0, 0, 0, 0);
+    return fallback;
+  }
+}
+
 export function resolveHeroState(inputs: HeroInputs): HeroState {
   const { hour, minute, isoDay } = localParts(inputs.now, inputs.userTimezone);
 

--- a/src/lib/home-loaders.ts
+++ b/src/lib/home-loaders.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { HeroInputs } from './home-hero';
+import { pickCardImageUrl } from './media-url';
 
 type Client = SupabaseClient;
 
@@ -115,7 +116,7 @@ export async function loadRecent(
     observer:users!observer_id!inner(country_code),
     identifications(scientific_name, is_primary, confidence,
                     taxa(common_name_es, common_name_en)),
-    media_files(url, is_primary, media_type)
+    media_files(url, thumbnail_url, is_primary, media_type, deleted_at)
   `;
   let usedLocalScope = false;
   let rows: RecentObs[] = [];
@@ -150,15 +151,19 @@ interface RawObs {
   id: string; observed_at: string; state_province: string | null;
   observer: { country_code: string | null } | null;
   identifications: Array<{ scientific_name: string | null; is_primary: boolean | null; confidence: number | null; taxa: { common_name_en: string | null; common_name_es: string | null } | null }> | null;
-  media_files: Array<{ url: string | null; is_primary: boolean | null; media_type: string | null }> | null;
+  media_files: Array<{ url: string | null; thumbnail_url: string | null; is_primary: boolean | null; media_type: string | null; deleted_at: string | null }> | null;
 }
 
 function toRecent(lang: 'en' | 'es') {
   return (r: RawObs): RecentObs => {
     const idents = r.identifications ?? [];
     const primary = idents.find(i => i.is_primary) ?? [...idents].sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))[0];
-    const photoMedia = (r.media_files ?? []).filter(m => !m.media_type || m.media_type === 'photo');
-    const photo = photoMedia.find(m => m.is_primary)?.url ?? photoMedia.find(m => !!m.url)?.url ?? null;
+    const photoMedia = (r.media_files ?? []).filter(
+      m => m.deleted_at == null && (!m.media_type || m.media_type === 'photo'),
+    );
+    const photo = pickCardImageUrl(photoMedia.find(m => m.is_primary))
+      ?? pickCardImageUrl(photoMedia.find(m => pickCardImageUrl(m)))
+      ?? null;
     return {
       id: r.id,
       observedAt: r.observed_at,

--- a/src/lib/map-style.ts
+++ b/src/lib/map-style.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared online basemap style for every MapLibre surface (ExploreMap,
+ * MapPicker / share-obs, CommunityMapView).
+ *
+ * #1081: ExploreMap was theme-aware (OpenFreeMap `dark` in dark mode,
+ * `liberty` in light) while MapPicker and CommunityMapView were hardcoded
+ * to `liberty` — so in dark mode the explore map was dark but the
+ * community / share maps stayed bright white. Centralising the choice
+ * here keeps the three surfaces consistent and prevents future drift.
+ *
+ * ExploreMap's offline PMTiles archive path is intentionally separate and
+ * is not affected by this helper.
+ */
+
+const STREET_LIGHT = 'https://tiles.openfreemap.org/styles/liberty';
+const STREET_DARK = 'https://tiles.openfreemap.org/styles/dark';
+
+/** True when the document is in dark mode (mirrors ExploreMap's check). */
+export function isDarkTheme(): boolean {
+  return typeof document !== 'undefined'
+    && document.documentElement.classList.contains('dark');
+}
+
+/**
+ * The OpenFreeMap vector style URL matching the current theme. Pass an
+ * explicit `dark` to override the DOM check (e.g. in tests).
+ */
+export function basemapStyleUrl(dark: boolean = isDarkTheme()): string {
+  return dark ? STREET_DARK : STREET_LIGHT;
+}

--- a/src/lib/media-url.ts
+++ b/src/lib/media-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Pick the best image URL for an observation card.
+ *
+ * #1075: list/grid card surfaces (home "Ve a buscar"/"Cerca de ti",
+ * /explore/recent?view=list, /explore/species grid) selected only
+ * `media_files.url` and rendered an empty box whenever that column was
+ * null — even though the very same observation's `/share/obs/` gallery
+ * loaded fine, because the gallery falls back to `thumbnail_url`
+ * (`p.thumbnail_url ?? p.url`, PhotoGallery.astro). Cards want the small
+ * variant anyway, so prefer the thumbnail and fall back to the full URL.
+ *
+ * Returns `null` when neither is usable so callers can render their own
+ * empty/placeholder state instead of a broken `<img>`.
+ */
+export function pickCardImageUrl(
+  m: { url?: string | null; thumbnail_url?: string | null } | null | undefined,
+): string | null {
+  if (!m) return null;
+  const thumb = m.thumbnail_url?.trim();
+  if (thumb) return thumb;
+  const full = m.url?.trim();
+  return full || null;
+}

--- a/tests/unit/home-hero.test.ts
+++ b/tests/unit/home-hero.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveHeroState, type HeroInputs } from '../../src/lib/home-hero';
+import { resolveHeroState, startOfLocalDayUTC, type HeroInputs } from '../../src/lib/home-hero';
 
 const baseInputs: HeroInputs = {
   streak: null,
@@ -122,5 +122,31 @@ describe('resolveHeroState', () => {
       now: new Date('2026-05-09T20:00:00Z'),
     });
     expect(r.kind).toBe('streak_at_risk');
+  });
+});
+
+describe('startOfLocalDayUTC', () => {
+  it('returns user-local midnight as a UTC instant, distinct from UTC midnight', () => {
+    // 2026-05-09T03:00:00Z is still 2026-05-08 21:00 in Mexico City (UTC-6).
+    // UTC midnight would be 2026-05-09T00:00:00Z; the user-local day start
+    // must be 2026-05-08T06:00:00Z (00:00 local on the 8th).
+    const now = new Date('2026-05-09T03:00:00Z');
+    const utcMidnight = new Date(now);
+    utcMidnight.setUTCHours(0, 0, 0, 0);
+
+    const localStart = startOfLocalDayUTC(now, 'America/Mexico_City');
+
+    expect(localStart.toISOString()).not.toBe(utcMidnight.toISOString());
+    expect(localStart.toISOString()).toBe('2026-05-08T06:00:00.000Z');
+  });
+
+  it('matches UTC midnight for the UTC timezone', () => {
+    const now = new Date('2026-05-09T15:30:00Z');
+    expect(startOfLocalDayUTC(now, 'UTC').toISOString()).toBe('2026-05-09T00:00:00.000Z');
+  });
+
+  it('falls back to UTC midnight for an unparseable timezone', () => {
+    const now = new Date('2026-05-09T15:30:00Z');
+    expect(startOfLocalDayUTC(now, 'Not/AZone').toISOString()).toBe('2026-05-09T00:00:00.000Z');
   });
 });

--- a/tests/unit/home-widgets-wired.test.ts
+++ b/tests/unit/home-widgets-wired.test.ts
@@ -28,3 +28,23 @@ describe('home page includes HomeWidgets (#704 / #925)', () => {
     });
   }
 });
+
+describe("challenge-completed probe is a bounded existence check, not a count HEAD (#1072)", () => {
+  const src = readFileSync(
+    join(process.cwd(), 'src/components/HomeWidgets.astro'),
+    'utf8',
+  );
+
+  it('does not request an exact count or HEAD on the observations probe', () => {
+    // An unbounded RLS `count: 'exact', head: true` over observations
+    // statement-timeouts in the pooler → HTTP 503 on every signed-in home
+    // load. Regression guard: the source must not contain that pattern.
+    expect(src).not.toMatch(/count:\s*'exact'/);
+    expect(src).not.toMatch(/head:\s*true/);
+  });
+
+  it('uses a bounded .limit(1) existence probe for the daily challenge', () => {
+    expect(src).toMatch(/\.gte\('observed_at', todayStart\.toISOString\(\)\)\s*\.limit\(1\)/);
+    expect(src).toMatch(/const completed = !!doneRows && doneRows\.length > 0/);
+  });
+});

--- a/tests/unit/map-style.test.ts
+++ b/tests/unit/map-style.test.ts
@@ -1,0 +1,23 @@
+/**
+ * #1081 — ExploreMap was theme-aware (OpenFreeMap dark/liberty) while
+ * MapPicker (share-obs) and CommunityMapView were hardcoded to `liberty`,
+ * so dark mode showed an explore map that was dark next to bright-white
+ * community / share maps. `basemapStyleUrl` is the shared, theme-aware
+ * source of truth all three now consume.
+ */
+import { describe, it, expect } from 'vitest';
+import { basemapStyleUrl } from '../../src/lib/map-style';
+
+describe('basemapStyleUrl (#1081)', () => {
+  it('returns the dark OpenFreeMap style in dark mode', () => {
+    expect(basemapStyleUrl(true)).toBe('https://tiles.openfreemap.org/styles/dark');
+  });
+
+  it('returns the light (liberty) OpenFreeMap style in light mode', () => {
+    expect(basemapStyleUrl(false)).toBe('https://tiles.openfreemap.org/styles/liberty');
+  });
+
+  it('is a single source of truth — light and dark differ', () => {
+    expect(basemapStyleUrl(true)).not.toBe(basemapStyleUrl(false));
+  });
+});

--- a/tests/unit/media-url.test.ts
+++ b/tests/unit/media-url.test.ts
@@ -1,0 +1,36 @@
+/**
+ * #1075 — observation card thumbnails were empty on list/grid surfaces
+ * (home "Ve a buscar"/"Cerca de ti", /explore/recent?view=list,
+ * /explore/species grid) because those loaders only read `media_files.url`
+ * and ignored `thumbnail_url`, while the working /share/obs/ gallery falls
+ * back across both. `pickCardImageUrl` is the shared fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { pickCardImageUrl } from '../../src/lib/media-url';
+
+describe('pickCardImageUrl (#1075)', () => {
+  it('prefers thumbnail_url when present', () => {
+    expect(
+      pickCardImageUrl({ url: 'https://media.rastrum.org/full', thumbnail_url: 'https://media.rastrum.org/thumb' }),
+    ).toBe('https://media.rastrum.org/thumb');
+  });
+
+  it('falls back to url when thumbnail_url is null/empty (the bug)', () => {
+    expect(pickCardImageUrl({ url: 'https://media.rastrum.org/full', thumbnail_url: null }))
+      .toBe('https://media.rastrum.org/full');
+    expect(pickCardImageUrl({ url: 'https://media.rastrum.org/full', thumbnail_url: '   ' }))
+      .toBe('https://media.rastrum.org/full');
+  });
+
+  it('returns null when neither is usable so callers render a placeholder', () => {
+    expect(pickCardImageUrl({ url: null, thumbnail_url: null })).toBeNull();
+    expect(pickCardImageUrl({ url: '', thumbnail_url: '' })).toBeNull();
+    expect(pickCardImageUrl(null)).toBeNull();
+    expect(pickCardImageUrl(undefined)).toBeNull();
+  });
+
+  it('handles extension-less media.rastrum.org objects (still a valid 200)', () => {
+    expect(pickCardImageUrl({ url: 'https://media.rastrum.org/obs/abc123', thumbnail_url: null }))
+      .toBe('https://media.rastrum.org/obs/abc123');
+  });
+});

--- a/tests/unit/observe-success-cta-gated.test.ts
+++ b/tests/unit/observe-success-cta-gated.test.ts
@@ -1,0 +1,35 @@
+/**
+ * #1074 — the "Ver observación" / "View observation" success CTA links to
+ * /share/obs/?id=<id>, which reads from Supabase and shows "Observation not
+ * found" until the Dexie outbox row reaches the server (~25 s). The CTA must
+ * therefore be gated on the existing sync-row-done event (the same signal
+ * the SyncPill consumes) rather than rendered as an immediate dead-link.
+ *
+ * Source-assertion test (mirrors home-widgets-wired.test.ts) — the logic is
+ * DOM/event wiring inside an Astro client script, not a pure unit.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('observe success CTA is sync-gated (#1074)', () => {
+  const src = readFileSync(
+    join(process.cwd(), 'src/components/ObserveView2.astro'),
+    'utf8',
+  );
+
+  it('listens for the sync-row-done event before enabling the CTA', () => {
+    expect(src).toMatch(/SYNC_EVENTS\.rowDone/);
+    expect(src).toMatch(/addEventListener\(SYNC_EVENTS\.rowDone/);
+  });
+
+  it('renders a syncing placeholder before the row syncs', () => {
+    expect(src).toMatch(/Sincronizando\\u2026/);
+    expect(src).toMatch(/Syncing\\u2026/);
+  });
+
+  it('checks Dexie sync_status so an already-synced row resolves immediately', () => {
+    expect(src).toMatch(/getDB\(\)\.observations\.get\(obsId\)/);
+    expect(src).toMatch(/rec\.sync_status === 'synced'/);
+  });
+});


### PR DESCRIPTION
Production-audit fixes (thematic group G1). One atomic commit per issue:
- #1070 — ExplorePlacesView reads lang from DOM (unbundled-scope crash; Lugares/Places dead in prod both locales)
- #1077 — de-duplicate Lugares tile on Explore index
- #1073 — observed-today boundary uses user-local day, not UTC midnight
- #1072 — observed-today existence check instead of count HEAD (kills the home 503)
- #1074 — observe success CTA gated on outbox sync (no more dead-link to 'Observation not found')
- #1075 — card thumbnails fall back to thumbnail_url (shared pickCardImageUrl helper)
- #1080 — PWA manifest start_url → '/' (language-neutral redirect entry)
- #1081 — theme-aware shared basemap across explore/community/share

Verified at branch tip: typecheck clean, 2373 vitest tests pass, build 255 pages.

⚠️ Reviewer note — #1081: the issue's stated cause ('dark PMTiles vs OSM raster') was inaccurate; real issue was community/share maps hardcoded light `liberty` while ExploreMap is theme-aware. Fixed via a shared theme-aware `map-style.ts` (behavior change, not a no-op) — issue can be closed with this corrected context.

Do not merge yet — maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)