### PR TITLE
fix(deploy): delete-observation self-gates — skip Edge-layer JWT verify (#1093)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -235,10 +235,14 @@ jobs:
           #                  weekly ai_credentials_heartbeat job. The cron
           #                  token is not a JWT, so edge verify_jwt 401'd the
           #                  heartbeat at the gateway before code ran.
+          #    delete-observation — self-gates: extracts Authorization header,
+          #                  calls auth.getUser(), returns 401 itself. Edge
+          #                  verify_jwt gated the OPTIONS preflight before code
+          #                  ran → browser "Failed to fetch" (#1093).
           #
           # Module 26 functions (follow / react / report) DO verify JWT.
           CRON_ONLY="${{ steps.classify.outputs.cron_only }}"
-          OTHER_NO_JWT="share-card mcp api identify sponsorships"
+          OTHER_NO_JWT="share-card mcp api identify sponsorships delete-observation"
           for fn in ${{ steps.targets.outputs.fns }}; do
             EXTRA_FLAGS=""
             if echo " $CRON_ONLY " | grep -q " $fn "; then

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -61,6 +61,20 @@ verify_jwt = false
 enabled = true
 verify_jwt = false
 
+# delete-observation self-gates auth in-handler: extracts the Authorization
+# header, calls auth.getUser(), and returns 401 itself (index.ts:82-88).
+# With Edge-layer verify_jwt = true (the default), the Supabase gateway
+# rejects both the OPTIONS preflight and the POST before the function code
+# runs → the browser sees "Failed to fetch" / "Failed to send a request to
+# the Edge Function". Disabling Edge-layer verification here does NOT
+# weaken security — the handler enforces ownership (observer_id check) and
+# uses service_role only after that gate passes. Must also be in
+# OTHER_NO_JWT in .github/workflows/deploy-functions.yml (deploy flag wins
+# in prod; both sites kept in sync). Ref #1093.
+[functions.delete-observation]
+enabled = true
+verify_jwt = false
+
 # sponsorships self-gates both paths: a user JWT via auth.getUser for the
 # SponsoringView UI calls, and a Bearer cron token for the weekly
 # ai_credentials_heartbeat job. The cron token is not a JWT, so edge-layer


### PR DESCRIPTION
Fixes #1093 (P1 — users cannot delete observations in prod).

**Root cause (confirmed):** `delete-observation` self-authenticates in-handler (Authorization → `auth.getUser()` → `observer_id` ownership → 401/403; index.ts:82-88), but had **no `[functions.delete-observation]` block in `supabase/config.toml`** and was **missing from `OTHER_NO_JWT` in `deploy-functions.yml:241`**. Supabase defaults `verify_jwt=true` when no block exists → the Edge gateway rejects the OPTIONS preflight + POST before the handler runs → browser `TypeError: Failed to fetch` / 'Failed to send a request to the Edge Function'. Same class as identify/sponsorships/share-card/mcp/api (#1066/#1069/#1085).

**Fix:** add the config block (`verify_jwt=false`, rationale comment mirroring `[functions.identify]`) + add `delete-observation` to `OTHER_NO_JWT` — both config sites must agree per the documented invariant.

**Security:** no regression — the handler enforces auth + ownership before using the service-role key; disabling Edge-layer verify only lets the handler's own 401/403 path run.

typecheck clean (TOML/YAML only). **For review — not merged.** Post-merge, CI auto-redeploys `delete-observation` with `--no-verify-jwt`; recommend verifying with the OPTIONS curl from #1093 + a real delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)