### PR TITLE
fix(dialogs): eliminate all native browser dialogs — in-UI confirm/toast/slide-over

### DIFF
--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -124,6 +124,7 @@ const sgReportLabel = sgTree.socialgraph.report.button;
   import { getCachedUser, getSupabase } from '../lib/supabase';
   import { buildCommentTree, formatTimeAgo, sanitizeCommentBody, type CommentRow, type CommentNode } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
+  import { showToast } from '../lib/toast';
   import { tierForKarma } from '../lib/karma-frame';
   import { openConfirmDialog } from '../lib/confirm-dialog';
 
@@ -360,13 +361,13 @@ const sgReportLabel = sgTree.socialgraph.report.button;
           try {
             const { blockUser } = await import('../lib/social');
             await blockUser(authorId);
-            alert(labels.blockSuccess);
+            showToast({ message: labels.blockSuccess, variant: 'success' });
             // Remove that author's comments from this thread immediately.
             listEl?.querySelectorAll<HTMLElement>(`.comment-overflow[data-author-id="${CSS.escape(authorId)}"]`).forEach(w => {
               w.closest('.comment-item')?.remove();
             });
           } catch (err) {
-            alert(labels.blockError);
+            showToast({ message: labels.blockError, variant: 'error' });
             // eslint-disable-next-line no-console
             console.warn('[comments.block]', err);
           } finally {

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -47,10 +47,12 @@ const sgReportLabel = sgTree.socialgraph.report.button;
   data-label-edited={tr.social.edited}
   data-label-deleted={tr.social.comment_deleted}
   data-label-confirm-delete={tr.social.delete_confirm}
+  data-label-confirm-delete-title={tr.social.delete_confirm_title}
   data-label-more-actions={sgCards.more_actions}
   data-label-block={sgBlockLabel}
   data-label-report={sgReportLabel}
   data-label-block-confirm={sgCards.block_user_confirm}
+  data-label-block-confirm-title={sgCards.block_user_confirm_title}
   data-label-block-success={sgCards.block_user_success}
   data-label-block-error={sgCards.block_user_error}
   data-label-report-comment-aria={sgCards.report_comment_aria}
@@ -123,6 +125,7 @@ const sgReportLabel = sgTree.socialgraph.report.button;
   import { buildCommentTree, formatTimeAgo, sanitizeCommentBody, type CommentRow, type CommentNode } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
   import { tierForKarma } from '../lib/karma-frame';
+  import { openConfirmDialog } from '../lib/confirm-dialog';
 
   const PAGE_SIZE = 20;
 
@@ -228,11 +231,13 @@ const sgReportLabel = sgTree.socialgraph.report.button;
       edited: root.dataset.labelEdited ?? 'edited',
       deleted: root.dataset.labelDeleted ?? 'deleted',
       confirmDelete: root.dataset.labelConfirmDelete ?? 'Delete this comment?',
+      confirmDeleteTitle: root.dataset.labelConfirmDeleteTitle ?? 'Delete comment?',
       empty: root.dataset.labelEmpty ?? 'No comments yet.',
       moreActions: root.dataset.labelMoreActions ?? 'More actions',
       block: root.dataset.labelBlock ?? 'Block',
       report: root.dataset.labelReport ?? 'Report',
       blockConfirm: root.dataset.labelBlockConfirm ?? 'Block @{{handle}}?',
+      blockConfirmTitle: root.dataset.labelBlockConfirmTitle ?? 'Block this user?',
       blockSuccess: root.dataset.labelBlockSuccess ?? 'User blocked.',
       blockError: root.dataset.labelBlockError ?? 'Could not block.',
       reportCommentAria: root.dataset.labelReportCommentAria ?? 'Report this comment',
@@ -344,7 +349,13 @@ const sgReportLabel = sgTree.socialgraph.report.button;
           const authorId = wrap.dataset.authorId ?? '';
           const handle = wrap.dataset.authorHandle ?? '';
           if (!authorId) return;
-          if (!confirm(labels.blockConfirm.replace('{{handle}}', handle || '?'))) return;
+          if (!(await openConfirmDialog({
+            title: labels.blockConfirmTitle,
+            message: labels.blockConfirm.replace('{{handle}}', handle || '?'),
+            variant: 'danger',
+            confirmLabel: labels.block,
+            cancelLabel: labels.cancel,
+          }))) return;
           if (blockBtn) blockBtn.disabled = true;
           try {
             const { blockUser } = await import('../lib/social');
@@ -417,7 +428,13 @@ const sgReportLabel = sgTree.socialgraph.report.button;
     }
 
     async function doDelete(id: string) {
-      if (!confirm(labels.confirmDelete)) return;
+      if (!(await openConfirmDialog({
+        title: labels.confirmDeleteTitle,
+        message: labels.confirmDelete,
+        variant: 'danger',
+        confirmLabel: labels.delete,
+        cancelLabel: labels.cancel,
+      }))) return;
       const { error } = await supabase
         .from('observation_comments')
         .update({ deleted_at: new Date().toISOString() })

--- a/src/components/ConsoleLayout.astro
+++ b/src/components/ConsoleLayout.astro
@@ -17,6 +17,7 @@ import { t, getLocalizedPath, routes } from '../i18n/utils';
 import ConsoleOnboarding from './console/ConsoleOnboarding.astro';
 import ReportIssueButton from './ReportIssueButton.astro';
 import ConfirmDialog from './ConfirmDialog.astro';
+import Toast from './Toast.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -463,5 +464,6 @@ const knownPills: Set<UserRole> | null = allRoles ?? null;
     <ReportIssueButton lang={lang} />
     <ConsoleOnboarding lang={lang} />
     <ConfirmDialog lang={lang} />
+    <Toast lang={lang} />
   </body>
 </html>

--- a/src/components/ConsoleLayout.astro
+++ b/src/components/ConsoleLayout.astro
@@ -16,6 +16,7 @@ import { CONSOLE_TABS } from '../lib/console-tabs';
 import { t, getLocalizedPath, routes } from '../i18n/utils';
 import ConsoleOnboarding from './console/ConsoleOnboarding.astro';
 import ReportIssueButton from './ReportIssueButton.astro';
+import ConfirmDialog from './ConfirmDialog.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -461,5 +462,6 @@ const knownPills: Set<UserRole> | null = allRoles ?? null;
 
     <ReportIssueButton lang={lang} />
     <ConsoleOnboarding lang={lang} />
+    <ConfirmDialog lang={lang} />
   </body>
 </html>

--- a/src/components/ConsoleTaxaView.astro
+++ b/src/components/ConsoleTaxaView.astro
@@ -6,7 +6,13 @@ const { lang } = Astro.props;
 const tr = t(lang);
 ---
 
-<section class="max-w-6xl">
+<section
+  class="max-w-6xl"
+  data-label-recompute-confirm-title={tr.console.taxa_recompute_confirm_title}
+  data-label-recompute-confirm={tr.console.taxa_recompute_confirm}
+  data-label-recompute-btn={tr.console.taxa_recompute_btn}
+  data-label-cancel={tr.console.cancel}
+>
   <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">{tr.console.taxa_intro}</p>
 
   <div id="taxa-not-auth" class="hidden rounded border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-900/20 p-3 text-sm text-amber-900 dark:text-amber-100">
@@ -132,6 +138,15 @@ const tr = t(lang);
   import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient } from '../lib/admin-client';
+  import { openConfirmDialog } from '../lib/confirm-dialog';
+
+  const taxaSection = document.querySelector<HTMLElement>('section[data-label-recompute-confirm]');
+  const TAXA_L = {
+    recomputeConfirmTitle: taxaSection?.dataset.labelRecomputeConfirmTitle ?? 'Recompute rarity scores?',
+    recomputeConfirm: taxaSection?.dataset.labelRecomputeConfirm ?? 'Recompute rarity scores for all taxa? This may take a moment.',
+    recomputeBtn: taxaSection?.dataset.labelRecomputeBtn ?? 'Recompute rarity',
+    cancel: taxaSection?.dataset.labelCancel ?? 'Cancel',
+  };
 
   type TaxonRow = {
     id: string;
@@ -307,7 +322,13 @@ const tr = t(lang);
 
     document.getElementById('taxa-btn-recompute')?.addEventListener('click', async () => {
       if (!sessionToken) return;
-      if (!confirm('Recompute rarity scores for all taxa? This may take a moment.')) return;
+      if (!(await openConfirmDialog({
+        title: TAXA_L.recomputeConfirmTitle,
+        message: TAXA_L.recomputeConfirm,
+        variant: 'danger',
+        confirmLabel: TAXA_L.recomputeBtn,
+        cancelLabel: TAXA_L.cancel,
+      }))) return;
       const btn = document.getElementById('taxa-btn-recompute') as HTMLButtonElement;
       btn.disabled = true;
       try {

--- a/src/components/ConsoleWebhooksView.astro
+++ b/src/components/ConsoleWebhooksView.astro
@@ -45,6 +45,17 @@ const wDelivTestDoneTmpl = (wDeliv?.testDeliveryDone as string) ?? 'Test deliver
 const wDelivTestFailedTmpl = (wDeliv?.testDeliveryFailed as string) ?? 'Test delivery failed: {error}';
 const labelDeliveriesBtn = (wActions?.deliveries as string) ?? 'Deliveries';
 const labelHideDeliveriesBtn = (wActions?.hideDeliveries as string) ?? 'Hide deliveries';
+const wSlide = (wNs?.slideOver as Record<string, string>) ?? {};
+const wsEnableTitle = wSlide.enableTitle ?? 'Enable webhook';
+const wsDisableTitle = wSlide.disableTitle ?? 'Disable webhook';
+const wsDeleteTitle = wSlide.deleteTitle ?? 'Delete webhook';
+const wsReplayTitle = wSlide.replayTitle ?? 'Replay last delivery';
+const wsReasonRoutine = wSlide.reasonRoutineMaintenance ?? 'Routine maintenance';
+const wsReasonMigration = wSlide.reasonEndpointMigration ?? 'Endpoint migration';
+const wsReasonNoLonger = wSlide.reasonNoLongerNeeded ?? 'No longer needed';
+const wsReasonMisconfigured = wSlide.reasonMisconfigured ?? 'Misconfigured subscription';
+const wsReasonRetry = wSlide.reasonRetryFailedDelivery ?? 'Retry failed delivery';
+const customReason = c.quick_reason_custom ?? 'Custom…';
 const eventKeys: Array<keyof typeof wEvents> = [
   'anomaly_created', 'user_banned', 'user_unbanned', 'role_granted', 'role_revoked',
 ];
@@ -83,6 +94,10 @@ const eventKeys: Array<keyof typeof wEvents> = [
   data-label-col-time={wDeliv.time ?? 'Time'}
   data-label-col-error={wDeliv.error ?? 'Error'}
   data-label-col-nonce="Nonce"
+  data-label-slide-enable-title={wsEnableTitle}
+  data-label-slide-disable-title={wsDisableTitle}
+  data-label-slide-delete-title={wsDeleteTitle}
+  data-label-slide-replay-title={wsReplayTitle}
 >
   <header>
     <h1 class="text-xl font-semibold mb-1">{wTitle}</h1>
@@ -196,8 +211,38 @@ const eventKeys: Array<keyof typeof wEvents> = [
 
 <ConsoleSlideOver
   lang={lang}
-  id="console-slideover-webhook-action"
-  titleKey="Webhook action"
+  id="console-slideover-webhook-toggle"
+  titleKey={wsEnableTitle}
+  reasonTemplates={[
+    wsReasonRoutine,
+    wsReasonMigration,
+    wsReasonMisconfigured,
+    customReason,
+  ]}
+/>
+
+<ConsoleSlideOver
+  lang={lang}
+  id="console-slideover-webhook-delete"
+  titleKey={wsDeleteTitle}
+  irreversible={true}
+  reasonTemplates={[
+    wsReasonNoLonger,
+    wsReasonMisconfigured,
+    wsReasonMigration,
+    customReason,
+  ]}
+/>
+
+<ConsoleSlideOver
+  lang={lang}
+  id="console-slideover-webhook-replay"
+  titleKey={wsReplayTitle}
+  reasonTemplates={[
+    wsReasonRetry,
+    wsReasonRoutine,
+    customReason,
+  ]}
 />
 
 <script>
@@ -205,7 +250,6 @@ const eventKeys: Array<keyof typeof wEvents> = [
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
   import { showToast } from '../lib/toast';
-  import { openConfirmDialog } from '../lib/confirm-dialog';
 
   type WebhookRow = {
     id: string;
@@ -260,6 +304,10 @@ const eventKeys: Array<keyof typeof wEvents> = [
   const labelColTime = sectionEl?.dataset.labelColTime ?? 'Time';
   const labelColError = sectionEl?.dataset.labelColError ?? 'Error';
   const labelColNonce = sectionEl?.dataset.labelColNonce ?? 'Nonce';
+  const labelSlideEnableTitle = sectionEl?.dataset.labelSlideEnableTitle ?? 'Enable webhook';
+  const labelSlideDisableTitle = sectionEl?.dataset.labelSlideDisableTitle ?? 'Disable webhook';
+  const labelSlideDeleteTitle = sectionEl?.dataset.labelSlideDeleteTitle ?? 'Delete webhook';
+  const labelSlideReplayTitle = sectionEl?.dataset.labelSlideReplayTitle ?? 'Replay last delivery';
 
   let allWebhooks: WebhookRow[] = [];
   let allDeliveries: DeliveryRow[] = [];
@@ -586,31 +634,26 @@ const eventKeys: Array<keyof typeof wEvents> = [
         if (reconcileInFlight) return;
         const id = toggleEl.dataset.toggleId!;
         const enabled = toggleEl.dataset.toggleTo === 'true';
-        const reason = prompt(`Reason for ${enabled ? 'enabling' : 'disabling'} this webhook?`);
-        if (!reason || reason.length < 5) return;
-        reconcileInFlight = true;
-        try {
-          await adminClient.webhook.update({ webhookId: id, enabled }, reason, jwt);
-          await loadAll();
-        } finally { reconcileInFlight = false; }
+        document.dispatchEvent(new CustomEvent('console:slideover-open', {
+          detail: {
+            id: 'console-slideover-webhook-toggle',
+            title: enabled ? labelSlideEnableTitle : labelSlideDisableTitle,
+            action: 'webhook.update',
+            payload: { webhookId: id, enabled },
+          },
+        }));
         return;
       }
       if (deleteId) {
         if (reconcileInFlight) return;
-        if (!(await openConfirmDialog({
-          title: labelDeleteConfirmTitle,
-          message: labelDeleteConfirm,
-          variant: 'danger',
-          confirmLabel: labelDelete,
-          cancelLabel: labelCancel,
-        }))) return;
-        const reason = prompt('Reason for deletion?');
-        if (!reason || reason.length < 5) return;
-        reconcileInFlight = true;
-        try {
-          await adminClient.webhook.delete({ webhookId: deleteId }, reason, jwt);
-          await loadAll();
-        } finally { reconcileInFlight = false; }
+        document.dispatchEvent(new CustomEvent('console:slideover-open', {
+          detail: {
+            id: 'console-slideover-webhook-delete',
+            title: labelSlideDeleteTitle,
+            action: 'webhook.delete',
+            payload: { webhookId: deleteId },
+          },
+        }));
         return;
       }
       if (deliveriesId) {
@@ -678,24 +721,14 @@ const eventKeys: Array<keyof typeof wEvents> = [
         const state = drilldown.get(replayLastId);
         const last = state?.perWebhookRows[0];
         if (!last) return;
-        const reason = prompt(labelDelivReplayConfirm);
-        if (!reason || reason.length < 5) return;
-        reconcileInFlight = true;
-        try {
-          const res = await adminClient.webhook.replayDelivery({ deliveryId: last.id }, reason, jwt);
-          const code = res.result?.statusCode;
-          if (code !== null && code !== undefined) {
-            showActionToast(labelDelivReplayDoneTmpl.replace('{status}', String(code)), true);
-          } else {
-            showActionToast(labelDelivReplayFailedTmpl.replace('{error}', res.result?.error ?? 'unknown'), false);
-          }
-          await loadDrilldown(replayLastId);
-          await loadAll();
-          renderWebhooks();
-        } catch (err) {
-          const msg = err instanceof AdminClientError ? err.message : (err as Error).message;
-          showActionToast(labelDelivReplayFailedTmpl.replace('{error}', msg), false);
-        } finally { reconcileInFlight = false; }
+        document.dispatchEvent(new CustomEvent('console:slideover-open', {
+          detail: {
+            id: 'console-slideover-webhook-replay',
+            title: labelSlideReplayTitle,
+            action: 'webhook.replayDelivery',
+            payload: { deliveryId: last.id, webhookId: replayLastId },
+          },
+        }));
         return;
       }
       if (copyNonce) {
@@ -713,6 +746,79 @@ const eventKeys: Array<keyof typeof wEvents> = [
         e.textContent = err instanceof AdminClientError ? err.message : (err as Error).message;
         e.classList.remove('hidden');
       }
+    }
+  });
+
+  document.addEventListener('console:slideover-submit', async (ev) => {
+    const { id, action, payload, reason } = (ev as CustomEvent<{
+      id: string;
+      action: string;
+      payload: Record<string, unknown>;
+      reason: string;
+    }>).detail;
+
+    if (
+      id !== 'console-slideover-webhook-toggle' &&
+      id !== 'console-slideover-webhook-delete' &&
+      id !== 'console-slideover-webhook-replay'
+    ) return;
+
+    if (!jwt) {
+      document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Session expired.' } }));
+      return;
+    }
+    if (reconcileInFlight) {
+      document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: 'Another action is in flight.' } }));
+      return;
+    }
+
+    reconcileInFlight = true;
+    try {
+      if (action === 'webhook.update') {
+        await adminClient.webhook.update(
+          { webhookId: payload.webhookId as string, enabled: payload.enabled as boolean },
+          reason,
+          jwt,
+        );
+        document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: true } }));
+        await loadAll();
+        return;
+      }
+
+      if (action === 'webhook.delete') {
+        await adminClient.webhook.delete({ webhookId: payload.webhookId as string }, reason, jwt);
+        document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: true } }));
+        await loadAll();
+        return;
+      }
+
+      if (action === 'webhook.replayDelivery') {
+        const webhookId = payload.webhookId as string;
+        const res = await adminClient.webhook.replayDelivery(
+          { deliveryId: payload.deliveryId as string },
+          reason,
+          jwt,
+        );
+        const code = res.result?.statusCode;
+        if (code !== null && code !== undefined) {
+          showActionToast(labelDelivReplayDoneTmpl.replace('{status}', String(code)), true);
+        } else {
+          showActionToast(labelDelivReplayFailedTmpl.replace('{error}', res.result?.error ?? 'unknown'), false);
+        }
+        document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: true } }));
+        await loadDrilldown(webhookId);
+        await loadAll();
+        renderWebhooks();
+        return;
+      }
+    } catch (err) {
+      const msg = err instanceof AdminClientError ? err.message : (err as Error).message;
+      if (action === 'webhook.replayDelivery') {
+        showActionToast(labelDelivReplayFailedTmpl.replace('{error}', msg), false);
+      }
+      document.dispatchEvent(new CustomEvent('console:slideover-done', { detail: { id, ok: false, error: msg } }));
+    } finally {
+      reconcileInFlight = false;
     }
   });
 

--- a/src/components/ConsoleWebhooksView.astro
+++ b/src/components/ConsoleWebhooksView.astro
@@ -41,6 +41,8 @@ const wDelivReplayDoneTmpl = (wDeliv?.replayDone as string) ?? 'Replay sent (HTT
 const wDelivReplayFailedTmpl = (wDeliv?.replayFailed as string) ?? 'Replay failed: {error}';
 const wDelivNonceCopied = (wDeliv?.nonceCopied as string) ?? 'Nonce copied.';
 const wDelivLoadFailedTmpl = (wDeliv?.loadFailed as string) ?? 'Could not load deliveries: {error}';
+const wDelivTestDoneTmpl = (wDeliv?.testDeliveryDone as string) ?? 'Test delivery: HTTP {status}.';
+const wDelivTestFailedTmpl = (wDeliv?.testDeliveryFailed as string) ?? 'Test delivery failed: {error}';
 const labelDeliveriesBtn = (wActions?.deliveries as string) ?? 'Deliveries';
 const labelHideDeliveriesBtn = (wActions?.hideDeliveries as string) ?? 'Hide deliveries';
 const eventKeys: Array<keyof typeof wEvents> = [
@@ -74,6 +76,8 @@ const eventKeys: Array<keyof typeof wEvents> = [
   data-label-deliv-replay-failed-tmpl={wDelivReplayFailedTmpl}
   data-label-deliv-nonce-copied={wDelivNonceCopied}
   data-label-deliv-load-failed-tmpl={wDelivLoadFailedTmpl}
+  data-label-test-done-tmpl={wDelivTestDoneTmpl}
+  data-label-test-failed-tmpl={wDelivTestFailedTmpl}
   data-label-col-event={wDeliv.event ?? 'Event'}
   data-label-col-status={wDeliv.status ?? 'Status'}
   data-label-col-time={wDeliv.time ?? 'Time'}
@@ -200,6 +204,7 @@ const eventKeys: Array<keyof typeof wEvents> = [
   import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
+  import { showToast } from '../lib/toast';
   import { openConfirmDialog } from '../lib/confirm-dialog';
 
   type WebhookRow = {
@@ -248,6 +253,8 @@ const eventKeys: Array<keyof typeof wEvents> = [
   const labelDelivReplayFailedTmpl = sectionEl?.dataset.labelDelivReplayFailedTmpl ?? 'Replay failed: {error}';
   const labelDelivNonceCopied = sectionEl?.dataset.labelDelivNonceCopied ?? 'Nonce copied.';
   const labelDelivLoadFailedTmpl = sectionEl?.dataset.labelDelivLoadFailedTmpl ?? 'Could not load deliveries: {error}';
+  const labelTestDoneTmpl = sectionEl?.dataset.labelTestDoneTmpl ?? 'Test delivery: HTTP {status}.';
+  const labelTestFailedTmpl = sectionEl?.dataset.labelTestFailedTmpl ?? 'Test delivery failed: {error}';
   const labelColEvent = sectionEl?.dataset.labelColEvent ?? 'Event';
   const labelColStatus = sectionEl?.dataset.labelColStatus ?? 'Status';
   const labelColTime = sectionEl?.dataset.labelColTime ?? 'Time';
@@ -568,7 +575,9 @@ const eventKeys: Array<keyof typeof wEvents> = [
         try {
           const res = await adminClient.webhook.test({ webhookId: testId }, 'manual webhook test', jwt);
           const code = res.result?.statusCode;
-          alert(code ? `Test delivery: HTTP ${code}` : `Test delivery failed: ${res.result?.error ?? 'unknown'}`);
+          showToast(code
+            ? { message: labelTestDoneTmpl.replace('{status}', String(code)), variant: 'success' }
+            : { message: labelTestFailedTmpl.replace('{error}', res.result?.error ?? 'unknown'), variant: 'error' });
           await loadAll();
         } finally { reconcileInFlight = false; }
         return;

--- a/src/components/ConsoleWebhooksView.astro
+++ b/src/components/ConsoleWebhooksView.astro
@@ -23,6 +23,9 @@ const wActions = (wNs?.actions as Record<string, string>) ?? {};
 const wDeliv  = (wNs?.deliveries as Record<string, string>) ?? {};
 const wEmpty  = (wNs?.empty as string) ?? 'No webhooks configured.';
 const wDelivEmpty = (wNs?.deliveriesEmpty as string) ?? 'No deliveries yet.';
+const wDeleteConfirmTitle = (wNs?.deleteConfirmTitle as string) ?? 'Delete webhook?';
+const wDeleteConfirm = (wNs?.deleteConfirm as string) ?? 'Delete this webhook? This cannot be undone.';
+const wCancel = (wNs?.cancel as string) ?? (c.cancel ?? 'Cancel');
 const wDelivPerWebhookHeading = (wDeliv?.perWebhookHeading as string) ?? 'Delivery history';
 const wDelivPerWebhookEmpty = (wDeliv?.perWebhookEmpty as string) ?? 'No deliveries for this webhook yet.';
 const wDelivFilters = {
@@ -51,6 +54,9 @@ const eventKeys: Array<keyof typeof wEvents> = [
   data-label-action-enable={wActions.enable ?? 'Enable'}
   data-label-action-disable={wActions.disable ?? 'Disable'}
   data-label-action-delete={wActions.delete ?? 'Delete'}
+  data-label-delete-confirm-title={wDeleteConfirmTitle}
+  data-label-delete-confirm={wDeleteConfirm}
+  data-label-cancel={wCancel}
   data-label-action-deliveries={labelDeliveriesBtn}
   data-label-action-hide-deliveries={labelHideDeliveriesBtn}
   data-label-deliv-heading={wDelivPerWebhookHeading}
@@ -194,6 +200,7 @@ const eventKeys: Array<keyof typeof wEvents> = [
   import { getCachedSession, getSupabase } from '../lib/supabase';
   import { getUserRoles } from '../lib/user-roles';
   import { adminClient, AdminClientError } from '../lib/admin-client';
+  import { openConfirmDialog } from '../lib/confirm-dialog';
 
   type WebhookRow = {
     id: string;
@@ -221,6 +228,9 @@ const eventKeys: Array<keyof typeof wEvents> = [
   const labelEnable = sectionEl?.dataset.labelActionEnable ?? 'Enable';
   const labelDisable = sectionEl?.dataset.labelActionDisable ?? 'Disable';
   const labelDelete = sectionEl?.dataset.labelActionDelete ?? 'Delete';
+  const labelDeleteConfirmTitle = sectionEl?.dataset.labelDeleteConfirmTitle ?? 'Delete webhook?';
+  const labelDeleteConfirm = sectionEl?.dataset.labelDeleteConfirm ?? 'Delete this webhook? This cannot be undone.';
+  const labelCancel = sectionEl?.dataset.labelCancel ?? 'Cancel';
   const labelDeliveries = sectionEl?.dataset.labelActionDeliveries ?? 'Deliveries';
   const labelHideDeliveries = sectionEl?.dataset.labelActionHideDeliveries ?? 'Hide deliveries';
   const labelDelivHeading = sectionEl?.dataset.labelDelivHeading ?? 'Delivery history';
@@ -578,7 +588,13 @@ const eventKeys: Array<keyof typeof wEvents> = [
       }
       if (deleteId) {
         if (reconcileInFlight) return;
-        if (!confirm('Delete this webhook? This cannot be undone.')) return;
+        if (!(await openConfirmDialog({
+          title: labelDeleteConfirmTitle,
+          message: labelDeleteConfirm,
+          variant: 'danger',
+          confirmLabel: labelDelete,
+          cancelLabel: labelCancel,
+        }))) return;
         const reason = prompt('Reason for deletion?');
         if (!reason || reason.length < 5) return;
         reconcileInFlight = true;

--- a/src/components/DisambiguationView.astro
+++ b/src/components/DisambiguationView.astro
@@ -67,6 +67,7 @@ const labels = {
   data-lang={lang}
   data-scientific-name=""
   data-trait-prompt=""
+  data-label-max-photos={labels.maxPhotos}
   class="hidden rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4 space-y-4"
 >
   <!-- Header -->
@@ -118,6 +119,7 @@ const labels = {
 <script>
   import { getSupabase } from '../lib/supabase';
   import { resolveTaxonId } from '../lib/why-this-species';
+  import { showToast } from '../lib/toast';
 
   const MAX_PHOTOS = 3;
 
@@ -337,8 +339,8 @@ const labels = {
           input.addEventListener('change', () => {
             if (!input.files || input.files.length === 0) return;
             if (selectedFiles.length >= MAX_PHOTOS) {
-              const msg = lang === 'es' ? 'Máximo 3 fotos' : 'Maximum 3 photos';
-              alert(msg);
+              const msg = root.dataset.labelMaxPhotos ?? (lang === 'es' ? 'Máximo 3 fotos' : 'Maximum 3 photos');
+              showToast({ message: msg, variant: 'error' });
               return;
             }
             const traitHint  = input.dataset.traitHint ?? 'unknown';

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -215,6 +215,7 @@ const distancePage = page as unknown as Record<string, string>;
   import { pickCardImageUrl } from '../lib/media-url';
   import { formatTimeAgo } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
+  import { showToast } from '../lib/toast';
   import { openConfirmDialog } from '../lib/confirm-dialog';
   import {
     RECENTS_VIEW_MODE_KEY,
@@ -964,14 +965,14 @@ const distancePage = page as unknown as Record<string, string>;
           try {
             const { blockUser } = await import('../lib/social');
             await blockUser(observerId);
-            alert(labels.blockSuccess);
+            showToast({ message: labels.blockSuccess, variant: 'success' });
             // Hide all cards by this observer in the current list.
             root.querySelectorAll<HTMLElement>(`.er-overflow[data-observer-id="${CSS.escape(observerId)}"]`).forEach((w) => {
               const li = w.closest('li');
               li?.classList.add('hidden');
             });
           } catch (err) {
-            alert(labels.blockError);
+            showToast({ message: labels.blockError, variant: 'error' });
             // eslint-disable-next-line no-console
             console.warn('[er.block]', err);
           } finally {

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -56,6 +56,8 @@ const distancePage = page as unknown as Record<string, string>;
   data-label-block={sgBlock}
   data-label-report={sgReport}
   data-label-block-confirm={sgCards.block_user_confirm}
+  data-label-block-confirm-title={sgCards.block_user_confirm_title}
+  data-label-cancel={tr.social.cancel}
   data-label-block-success={sgCards.block_user_success}
   data-label-block-error={sgCards.block_user_error}
   data-label-report-aria={sgCards.report_observation_aria}
@@ -213,6 +215,7 @@ const distancePage = page as unknown as Record<string, string>;
   import { pickCardImageUrl } from '../lib/media-url';
   import { formatTimeAgo } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
+  import { openConfirmDialog } from '../lib/confirm-dialog';
   import {
     RECENTS_VIEW_MODE_KEY,
     DEFAULT_VIEW_MODE,
@@ -435,6 +438,8 @@ const distancePage = page as unknown as Record<string, string>;
       block: root.dataset.labelBlock ?? 'Block',
       report: root.dataset.labelReport ?? 'Report',
       blockConfirm: root.dataset.labelBlockConfirm ?? 'Block @{{handle}}?',
+      blockConfirmTitle: root.dataset.labelBlockConfirmTitle ?? 'Block this user?',
+      cancel: root.dataset.labelCancel ?? 'Cancel',
       blockSuccess: root.dataset.labelBlockSuccess ?? 'Blocked.',
       blockError: root.dataset.labelBlockError ?? 'Could not block.',
       reportAria: root.dataset.labelReportAria ?? 'Report this observation',
@@ -948,7 +953,13 @@ const distancePage = page as unknown as Record<string, string>;
           const observerId = wrap.dataset.observerId ?? '';
           if (!observerId) return;
           const confirmCopy = labels.blockConfirm.replace('{{handle}}', handle || '?');
-          if (!confirm(confirmCopy)) return;
+          if (!(await openConfirmDialog({
+            title: labels.blockConfirmTitle,
+            message: confirmCopy,
+            variant: 'danger',
+            confirmLabel: labels.block,
+            cancelLabel: labels.cancel,
+          }))) return;
           if (blockBtn) blockBtn.disabled = true;
           try {
             const { blockUser } = await import('../lib/social');

--- a/src/components/LocalObservationView.astro
+++ b/src/components/LocalObservationView.astro
@@ -61,6 +61,7 @@ const retryLabel   = profileStrings.my_observations_retry ?? (lang === 'es' ? 'R
 </div>
 
 <script>
+  import { openConfirmDialog } from '../lib/confirm-dialog';
   type Lang = 'en' | 'es';
   const root = document.querySelector<HTMLElement>('.rastrum-local-obs');
   if (!root) throw new Error('Local observation root missing');
@@ -184,9 +185,15 @@ const retryLabel   = profileStrings.my_observations_retry ?? (lang === 'es' ? 'R
     // Discard → confirm, then delete the Dexie row + its blobs.
     const discardBtn = document.getElementById('local-obs-discard') as HTMLButtonElement | null;
     discardBtn?.addEventListener('click', async () => {
-      const ok = window.confirm(isEs
-        ? '¿Eliminar esta observación de tu dispositivo? Esta acción no se puede deshacer.'
-        : 'Delete this observation from your device? This cannot be undone.');
+      const ok = await openConfirmDialog({
+        title: isEs ? '¿Eliminar observación?' : 'Delete observation?',
+        message: isEs
+          ? '¿Eliminar esta observación de tu dispositivo? Esta acción no se puede deshacer.'
+          : 'Delete this observation from your device? This cannot be undone.',
+        variant: 'danger',
+        confirmLabel: isEs ? 'Eliminar' : 'Delete',
+        cancelLabel: isEs ? 'Cancelar' : 'Cancel',
+      });
       if (!ok) return;
       try {
         await db.mediaBlobs.where('observation_id').equals(id).delete();

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -3226,9 +3226,14 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
 
     let mode: 'replace' | 'append' = 'replace';
     if (notesEl.value.trim()) {
-      const ok = window.confirm(isEsAi
-        ? 'Ya hay una nota. ¿Reemplazarla por la generada?\nAceptar = Reemplazar · Cancelar = Añadir'
-        : 'There is already a note. Replace it with the generated one?\nOK = Replace · Cancel = Append');
+      const ok = await openConfirmDialog({
+        title: isEsAi ? 'Ya hay una nota' : 'There is already a note',
+        message: isEsAi
+          ? '¿Reemplazarla por la generada, o añadir la generada al final?'
+          : 'Replace it with the generated one, or append the generated one?',
+        confirmLabel: isEsAi ? 'Reemplazar' : 'Replace',
+        cancelLabel: isEsAi ? 'Añadir' : 'Append',
+      });
       mode = ok ? 'replace' : 'append';
     }
 

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -384,6 +384,7 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';
   import { shouldShowInferredCountryBadge, buildCommunityDiscoveryPayload } from '../lib/profile-edit';
+  import { openConfirmDialog } from '../lib/confirm-dialog';
   import type { UserProfile } from '../lib/types';
 
   const form = document.getElementById('edit-form') as HTMLFormElement | null;
@@ -703,7 +704,16 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
 
   soBtn?.addEventListener('click', async () => {
     if (!soBtn || !soLabel) return;
-    if (!confirm(isEsLang ? '¿Cerrar sesión en todos los dispositivos?' : 'Sign out from all devices?')) return;
+    const soOk = await openConfirmDialog({
+      title: isEsLang ? '¿Cerrar sesión en todos lados?' : 'Sign out everywhere?',
+      message: isEsLang
+        ? '¿Cerrar sesión en todos los dispositivos? Tendrás que volver a iniciar sesión en cada uno.'
+        : 'Sign out from all devices? You will need to sign in again on each one.',
+      variant: 'danger',
+      confirmLabel: isEsLang ? 'Cerrar sesión en todos' : 'Sign out everywhere',
+      cancelLabel: isEsLang ? 'Cancelar' : 'Cancel',
+    });
+    if (!soOk) return;
     soBtn.disabled = true;
     soLabel.textContent = SO_BUSY;
     const { signOutEverywhere } = await import('../lib/auth');

--- a/src/components/ProfileSecurityForm.astro
+++ b/src/components/ProfileSecurityForm.astro
@@ -68,6 +68,7 @@ const onb = (tr as unknown as { onboarding: Record<string, string> }).onboarding
 </div>
 
 <script>
+  import { openConfirmDialog } from '../lib/confirm-dialog';
   const isEsLang = document.documentElement.lang === 'es';
 
   // ── Security: passkey + sign-out-everywhere ──
@@ -123,7 +124,16 @@ const onb = (tr as unknown as { onboarding: Record<string, string> }).onboarding
 
   soBtn?.addEventListener('click', async () => {
     if (!soBtn || !soLabel) return;
-    if (!confirm(isEsLang ? '¿Cerrar sesión en todos los dispositivos?' : 'Sign out from all devices?')) return;
+    const soOk = await openConfirmDialog({
+      title: isEsLang ? '¿Cerrar sesión en todos lados?' : 'Sign out everywhere?',
+      message: isEsLang
+        ? '¿Cerrar sesión en todos los dispositivos? Tendrás que volver a iniciar sesión en cada uno.'
+        : 'Sign out from all devices? You will need to sign in again on each one.',
+      variant: 'danger',
+      confirmLabel: isEsLang ? 'Cerrar sesión en todos' : 'Sign out everywhere',
+      cancelLabel: isEsLang ? 'Cancelar' : 'Cancel',
+    });
+    if (!soOk) return;
     soBtn.disabled = true;
     soLabel.textContent = SO_BUSY;
     const { signOutEverywhere } = await import('../lib/auth');

--- a/src/components/ProjectDetailView.astro
+++ b/src/components/ProjectDetailView.astro
@@ -118,6 +118,7 @@ const proj = (tr as unknown as { projects: Record<string, string> }).projects;
 
 <script>
   import { getProjectBySlug, countProjectObservations } from '../lib/projects';
+  import { openConfirmDialog } from '../lib/confirm-dialog';
 
   const params = new URLSearchParams(window.location.search);
   const slug = params.get('slug') ?? '';
@@ -229,6 +230,8 @@ const proj = (tr as unknown as { projects: Record<string, string> }).projects;
         notes:         lang === 'es' ? 'Notas'                                                         : 'Notes',
         closeBtn:      lang === 'es' ? 'Cerrar periodo'                                                : 'Close period',
         closeConfirm:  lang === 'es' ? '¿Cerrar este periodo? La fecha de fin se establecerá a hoy.'   : 'Close this period? End date will be set to today.',
+        closeConfirmTitle: lang === 'es' ? '¿Cerrar periodo?'                                          : 'Close period?',
+        cancel:        lang === 'es' ? 'Cancelar'                                                      : 'Cancel',
         openBtn:       lang === 'es' ? 'Abrir nuevo periodo'                                           : 'Open new period',
         openSuccess:   lang === 'es' ? 'Periodo abierto.'                                              : 'Period opened.',
         closeSuccess:  lang === 'es' ? 'Periodo cerrado.'                                              : 'Period closed.',
@@ -396,7 +399,13 @@ const proj = (tr as unknown as { projects: Record<string, string> }).projects;
       }
 
       async function handleClosePeriod(periodId: string, stationId: string, container: HTMLElement) {
-        if (!confirm(i18nPeriods.closeConfirm)) return;
+        if (!(await openConfirmDialog({
+          title: i18nPeriods.closeConfirmTitle,
+          message: i18nPeriods.closeConfirm,
+          variant: 'danger',
+          confirmLabel: i18nPeriods.closeBtn,
+          cancelLabel: i18nPeriods.cancel,
+        }))) return;
         const today = new Date().toISOString().slice(0, 10);
         const statusEl = container.querySelector<HTMLElement>(`[data-period-status="${stationId}"]`);
         try {

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -67,6 +67,8 @@ const sponsoringI18n = {
   data-label-stat-obs={tr.profile.total_observations}
   data-label-stat-species={tr.profile.species_count}
   data-label-page-title={tr.profile.public_profile_page_title}
+  data-label-blocked={tr.socialgraph.block.blocked_toast}
+  data-label-block-error={tr.socialgraph.block.block_error}
   data-share-obs-base="/share/obs/"
 >
   <div data-pp-loading class="py-12 text-center text-sm text-zinc-500 dark:text-zinc-400">
@@ -250,6 +252,7 @@ const sponsoringI18n = {
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';
   import { wireOverflowMenu } from '../lib/overflow-menu';
+  import { showToast } from '../lib/toast';
   import { openConfirmDialog } from '../lib/confirm-dialog';
   import { tierForKarma } from '../lib/karma-frame';
 
@@ -564,9 +567,15 @@ const sponsoringI18n = {
         try {
           const { blockUser } = await import('../lib/social');
           await blockUser(profile.id);
-          alert(lang === 'es' ? 'Usuario bloqueado.' : 'User blocked.');
+          showToast({
+            message: root.dataset.labelBlocked ?? (lang === 'es' ? 'Usuario bloqueado.' : 'User blocked.'),
+            variant: 'success',
+          });
         } catch (err) {
-          alert(lang === 'es' ? 'No se pudo bloquear.' : 'Could not block.');
+          showToast({
+            message: root.dataset.labelBlockError ?? (lang === 'es' ? 'No se pudo bloquear.' : 'Could not block.'),
+            variant: 'error',
+          });
           // eslint-disable-next-line no-console
           console.warn('[profile.block]', err);
         } finally {

--- a/src/components/QuickObserveSheet.astro
+++ b/src/components/QuickObserveSheet.astro
@@ -130,6 +130,7 @@ import type { PipelineFile, PipelineState } from '../lib/pipeline-engine';
 import { saveObservationToOutbox, resolveObserverRef } from '../lib/observe';
 import { syncOutbox } from '../lib/sync';
 import { PENDING_OBSERVATION_KEY } from '../lib/chat-attachment-helpers';
+import { showToast } from '../lib/toast';
 
 const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
 const isEs = lang === 'es';
@@ -326,7 +327,7 @@ saveBtn?.addEventListener('click', async () => {
     setTimeout(closeSheet, 1800);
   } catch (err) {
     if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = isEs ? 'Confirmar y guardar' : 'Confirm & save'; }
-    alert((err as Error).message);
+    showToast({ message: (err as Error).message, variant: 'error' });
   }
 });
 

--- a/src/components/SpeciesListsView.astro
+++ b/src/components/SpeciesListsView.astro
@@ -27,6 +27,7 @@ const labels = {
   edit:           isEs ? 'Editar' : 'Edit',
   items:          isEs ? 'especies' : 'species',
   confirm_delete: isEs ? '¿Eliminar esta lista?' : 'Delete this list?',
+  confirm_delete_title: isEs ? '¿Eliminar lista?' : 'Delete list?',
   loading:        isEs ? 'Cargando…' : 'Loading…',
   sign_in:        isEs ? 'Inicia sesión para ver tus listas.' : 'Sign in to see your lists.',
   private_badge:  isEs ? 'Privada' : 'Private',
@@ -147,6 +148,7 @@ const labels = {
 
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { openConfirmDialog } from '../lib/confirm-dialog';
 
   const root = document.getElementById('species-lists-view') as HTMLDivElement | null;
   if (!root) throw new Error('species-lists-view root not found');
@@ -272,7 +274,13 @@ const labels = {
   }
 
   async function deleteList(id: string) {
-    if (!confirm(labels.confirm_delete)) return;
+    if (!(await openConfirmDialog({
+      title: labels.confirm_delete_title,
+      message: labels.confirm_delete,
+      variant: 'danger',
+      confirmLabel: labels.delete,
+      cancelLabel: labels.cancel,
+    }))) return;
     const supabase = getSupabase();
     const { error } = await supabase.from('species_lists').delete().eq('id', id).eq('user_id', userId);
     if (error) { alert(labels.error_delete); return; }

--- a/src/components/SpeciesListsView.astro
+++ b/src/components/SpeciesListsView.astro
@@ -149,6 +149,7 @@ const labels = {
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';
   import { openConfirmDialog } from '../lib/confirm-dialog';
+  import { showToast } from '../lib/toast';
 
   const root = document.getElementById('species-lists-view') as HTMLDivElement | null;
   if (!root) throw new Error('species-lists-view root not found');
@@ -283,7 +284,7 @@ const labels = {
     }))) return;
     const supabase = getSupabase();
     const { error } = await supabase.from('species_lists').delete().eq('id', id).eq('user_id', userId);
-    if (error) { alert(labels.error_delete); return; }
+    if (error) { showToast({ message: labels.error_delete, variant: 'error' }); return; }
     lists = lists.filter(l => l.id !== id);
     const username = await fetchUsername();
     renderGrid(username);

--- a/src/components/SponsoredByView.astro
+++ b/src/components/SponsoredByView.astro
@@ -30,6 +30,7 @@ const i18nBag = {
   request_status_rejected:     tr.sponsoring.request_status_rejected,
   request_status_withdrawn:    tr.sponsoring.request_status_withdrawn,
   confirm_withdraw_request:    lang === 'es' ? '¿Retirar esta solicitud?' : 'Withdraw this request?',
+  error_prefix_tmpl:           tr.sponsoring.error_prefix_tmpl,
 };
 ---
 
@@ -93,6 +94,7 @@ const i18nBag = {
 
 <script>
   import { listSponsorships, getUsage, patchSponsorship, revokeSponsorship } from '../lib/sponsorships';
+  import { showToast } from '../lib/toast';
 
   const escHtml = (s: string): string => s
     .replace(/&/g, '&amp;')
@@ -127,6 +129,7 @@ const i18nBag = {
     request_status_rejected: string;
     request_status_withdrawn: string;
     confirm_withdraw_request: string;
+    error_prefix_tmpl: string;
   };
 
   function showConfirm(message: string): Promise<boolean> {
@@ -212,7 +215,7 @@ const i18nBag = {
     const target = e.target as HTMLInputElement;
     if (target.dataset.togglePublic) {
       try { await patchSponsorship(target.dataset.togglePublic, { beneficiary_public: target.checked }); }
-      catch (err) { alert(`Error: ${(err as Error).message}`); }
+      catch (err) { showToast({ message: (i18nBag.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', (err as Error).message), variant: 'error' }); }
     }
   });
 
@@ -221,7 +224,7 @@ const i18nBag = {
     if (target.dataset.decline) {
       if (await showConfirm(i18nBag.decline_confirm ?? 'Decline this sponsorship?')) {
         try { await revokeSponsorship(target.dataset.decline); await refresh(); }
-        catch (err) { alert(`Error: ${(err as Error).message}`); }
+        catch (err) { showToast({ message: (i18nBag.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', (err as Error).message), variant: 'error' }); }
       }
     }
   });
@@ -293,7 +296,7 @@ const i18nBag = {
       (document.getElementById('req-message-input') as HTMLTextAreaElement).value = '';
       (document.getElementById('request-dialog') as HTMLDialogElement | null)?.close();
       await refreshMyRequests();
-    } catch (err) { alert((err as Error).message); }
+    } catch (err) { showToast({ message: (err as Error).message, variant: 'error' }); }
   });
   document.getElementById('my-requests-list')?.addEventListener('click', async (e) => {
     const target = e.target as HTMLElement;

--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -47,6 +47,11 @@ const i18nBag = {
   personal_enabled_toast:     tr.ai_personal_credential.enabled_toast,
   personal_disabled_toast:    tr.ai_personal_credential.disabled_toast,
   personal_error:             tr.ai_personal_credential.error,
+  error_prefix_tmpl:          tr.sponsoring.error_prefix_tmpl,
+  creds_load_failed:          tr.sponsoring.creds_load_failed,
+  add_credential_first:       tr.sponsoring.add_credential_first,
+  three_strike_msg:           tr.sponsoring.three_strike_msg,
+  report_dialog_unavailable:  tr.sponsoring.report_dialog_unavailable,
   paused_reason: {
     rate_limit:         tr.sponsoring.paused_reason_rate_limit,
     cred_invalid:       tr.sponsoring.paused_reason_cred_invalid,
@@ -401,6 +406,7 @@ const langJson = JSON.stringify(lang);
     listMyPools, createPool, setPoolStatus, updatePool, deletePool,
     listPoolBeneficiaries,
   } from '../lib/sponsorships';
+  import { showToast } from '../lib/toast';
 
   type I18nBag = {
     below_engagement_threshold: string;
@@ -438,6 +444,11 @@ const langJson = JSON.stringify(lang);
     personal_enabled_toast: string;
     personal_disabled_toast: string;
     personal_error: string;
+    error_prefix_tmpl: string;
+    creds_load_failed: string;
+    add_credential_first: string;
+    three_strike_msg: string;
+    report_dialog_unavailable: string;
     paused_reason: {
       rate_limit: string;
       cred_invalid: string;
@@ -798,7 +809,7 @@ const langJson = JSON.stringify(lang);
         errEl.textContent = `Error: ${msg}`;
         errEl.classList.remove('hidden');
       } else {
-        alert(`Error: ${msg}`);
+        showToast({ message: (tr.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', msg), variant: 'error' });
       }
     } finally {
       if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = originalSubmitText; }
@@ -818,7 +829,7 @@ const langJson = JSON.stringify(lang);
       (document.getElementById('rotate-secret-input') as HTMLInputElement).value = '';
       rotateDialog?.close();
       await refreshCreds();
-    } catch (err) { alert(`Error: ${(err as Error).message}`); }
+    } catch (err) { showToast({ message: (tr.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', (err as Error).message), variant: 'error' }); }
   });
 
   // ── M32 (#152): platform pool wiring ───────────────────────────────
@@ -826,7 +837,7 @@ const langJson = JSON.stringify(lang);
   document.getElementById('pool-add-btn')?.addEventListener('click', async () => {
     // Populate the credential dropdown with the sponsor's active creds.
     let creds: Awaited<ReturnType<typeof listCredentials>> = [];
-    try { creds = await listCredentials(); } catch { alert('Could not load credentials.'); return; }
+    try { creds = await listCredentials(); } catch { showToast({ message: tr.creds_load_failed ?? 'Could not load credentials.', variant: 'error' }); return; }
     creds = creds.filter(c => !c.revoked_at);
     const sel = document.getElementById('pool-cred-select') as HTMLSelectElement | null;
     if (!sel) return;
@@ -861,7 +872,7 @@ const langJson = JSON.stringify(lang);
       await createPool({ credential_id: credentialId, total_cap: totalCap, preferred_model: model, daily_user_cap: dailyCap, monthly_reset: monthlyReset });
       poolDialog?.close();
       await refreshPools();
-    } catch (err) { alert(`Error: ${(err as Error).message}`); }
+    } catch (err) { showToast({ message: (tr.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', (err as Error).message), variant: 'error' }); }
   });
 
   async function refreshPools() {
@@ -937,7 +948,7 @@ const langJson = JSON.stringify(lang);
       } else if (target.dataset.poolBens) {
         await openPoolBeneficiariesDialog(target.dataset.poolBens);
       }
-    } catch (err) { alert(`Error: ${(err as Error).message}`); }
+    } catch (err) { showToast({ message: (tr.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', (err as Error).message), variant: 'error' }); }
   });
 
   // ── #468: Edit pool dialog ────────────────────────────────────────
@@ -1115,7 +1126,7 @@ const langJson = JSON.stringify(lang);
     } catch (err) {
       checkbox.checked = previous;
       const detail = err instanceof Error ? err.message : String(err);
-      alert(`${tr.personal_error} (${detail})`);
+      showToast({ message: `${tr.personal_error} (${detail})`, variant: 'error' });
     } finally {
       checkbox.disabled = false;
     }
@@ -1211,8 +1222,8 @@ const langJson = JSON.stringify(lang);
   const addBenDialog = document.getElementById('add-ben-dialog') as HTMLDialogElement | null;
   document.getElementById('add-ben-btn')?.addEventListener('click', async () => {
     let creds: Awaited<ReturnType<typeof listCredentials>> = [];
-    try { creds = await listCredentials(); } catch { alert('Could not load credentials.'); return; }
-    if (creds.length === 0) { alert('Add a credential first.'); return; }
+    try { creds = await listCredentials(); } catch { showToast({ message: tr.creds_load_failed ?? 'Could not load credentials.', variant: 'error' }); return; }
+    if (creds.length === 0) { showToast({ message: tr.add_credential_first ?? 'Add a credential first.', variant: 'error' }); return; }
     const select = document.getElementById('ben-cred-select') as HTMLSelectElement | null;
     if (select) {
       select.innerHTML = creds.filter(c => !c.revoked_at).map(c =>
@@ -1235,14 +1246,14 @@ const langJson = JSON.stringify(lang);
       (document.getElementById('ben-username-input') as HTMLInputElement).value = '';
       addBenDialog?.close();
       await refreshBens();
-    } catch (err) { alert(`Error: ${(err as Error).message}`); }
+    } catch (err) { showToast({ message: (tr.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', (err as Error).message), variant: 'error' }); }
   });
 
   document.getElementById('bens-tbody')?.addEventListener('click', async (e) => {
     const target = e.target as HTMLElement;
     if (target.dataset.unpause) {
       const r = await unpauseSponsorship(target.dataset.unpause);
-      if (r.error === 'three_strike') alert('Three-strike: revoke and recreate.');
+      if (r.error === 'three_strike') showToast({ message: tr.three_strike_msg ?? 'Three-strike: revoke and recreate.', variant: 'error' });
       await refreshBens();
     } else if (target.dataset.revokeSpons) {
       if (await showConfirm('Revoke?')) {
@@ -1258,7 +1269,7 @@ const langJson = JSON.stringify(lang);
         dialog.classList.remove('hidden');
       } else {
         console.warn('[sponsoring] #rastrum-report-dialog not in DOM — report dialog unavailable');
-        alert('Report dialog unavailable — please reload the page.');
+        showToast({ message: tr.report_dialog_unavailable ?? 'Report dialog unavailable — please reload the page.', variant: 'error' });
       }
     }
   });
@@ -1410,15 +1421,15 @@ const langJson = JSON.stringify(lang);
     if (target.dataset.approve) {
       const { approveRequest, listCredentials } = await import('../lib/sponsorships');
       let creds: Awaited<ReturnType<typeof listCredentials>> = [];
-      try { creds = await listCredentials(); } catch { alert('Could not load credentials.'); return; }
+      try { creds = await listCredentials(); } catch { showToast({ message: tr.creds_load_failed ?? 'Could not load credentials.', variant: 'error' }); return; }
       const activeCreds = creds.filter(c => !c.revoked_at);
-      if (activeCreds.length === 0) { alert(tr.add_credential ?? 'Add a credential first.'); return; }
+      if (activeCreds.length === 0) { showToast({ message: tr.add_credential_first ?? tr.add_credential ?? 'Add a credential first.', variant: 'error' }); return; }
       try {
         await approveRequest(target.dataset.approve, { credential_id: activeCreds[0].id, monthly_call_cap: 200 });
         await refreshRequests();
         await refreshBens();
       } catch (err) {
-        alert(`Error: ${(err as Error).message}`);
+        showToast({ message: (tr.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', (err as Error).message), variant: 'error' });
       }
     } else if (target.dataset.reject) {
       const { rejectRequest } = await import('../lib/sponsorships');
@@ -1427,7 +1438,7 @@ const langJson = JSON.stringify(lang);
           await rejectRequest(target.dataset.reject);
           await refreshRequests();
         } catch (err) {
-          alert(`Error: ${(err as Error).message}`);
+          showToast({ message: (tr.error_prefix_tmpl ?? 'Error: {msg}').replace('{msg}', (err as Error).message), variant: 'error' });
         }
       }
     }

--- a/src/components/Toast.astro
+++ b/src/components/Toast.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * Toast — single global toast container. Mounted once in
+ * `BaseLayout.astro` and `ConsoleLayout.astro`, adjacent to
+ * `<ConfirmDialog>`. Surfaces fire toasts via `showToast({...})`
+ * from `src/lib/toast.ts` (fire-and-forget, non-blocking).
+ *
+ * The container owns the aria-live region; individual toasts get
+ * `pointer-events-auto` so their dismiss button is clickable while
+ * the container itself stays click-through.
+ */
+import { t } from '../i18n/utils';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+
+const { lang } = Astro.props;
+const tr = t(lang);
+---
+
+<div
+  id="rastrum-toast-container"
+  class="fixed left-1/2 -translate-x-1/2 bottom-[calc(5rem+env(safe-area-inset-bottom))] sm:bottom-4 z-50 flex flex-col items-center gap-2 pointer-events-none"
+  role="status"
+  aria-live="polite"
+  data-lang={lang}
+  data-dismiss-label={tr.toast.dismiss}
+>
+</div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3253,7 +3253,18 @@
         "perWebhookEmpty": "No deliveries for this webhook yet."
       },
       "empty": "No webhooks configured.",
-      "deliveriesEmpty": "No deliveries yet."
+      "deliveriesEmpty": "No deliveries yet.",
+      "slideOver": {
+        "enableTitle": "Enable webhook",
+        "disableTitle": "Disable webhook",
+        "deleteTitle": "Delete webhook",
+        "replayTitle": "Replay last delivery",
+        "reasonRoutineMaintenance": "Routine maintenance",
+        "reasonEndpointMigration": "Endpoint migration",
+        "reasonNoLongerNeeded": "No longer needed",
+        "reasonMisconfigured": "Misconfigured subscription",
+        "reasonRetryFailedDelivery": "Retry failed delivery"
+      }
     },
     "plantnetQuota": {
       "title": "PlantNet Quota",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1548,7 +1548,9 @@
       "button": "Block",
       "unblock": "Unblock",
       "blocked_users": "Blocked users",
-      "empty": "You haven't blocked anyone."
+      "empty": "You haven't blocked anyone.",
+      "blocked_toast": "User blocked.",
+      "block_error": "Could not block."
     },
     "list": {
       "followers": "Followers",
@@ -1574,6 +1576,11 @@
     "credentials_section": "My credentials",
     "credentials_empty": "No credentials yet. Add one to start sponsoring.",
     "add_credential": "Add credential",
+    "error_prefix_tmpl": "Error: {msg}",
+    "creds_load_failed": "Could not load credentials.",
+    "add_credential_first": "Add a credential first.",
+    "three_strike_msg": "Three-strike: revoke and recreate.",
+    "report_dialog_unavailable": "Report dialog unavailable — please reload the page.",
     "credential_label": "Label",
     "credential_label_help": "A friendly name to recognize this credential later.",
     "credential_secret": "API key or long-lived token",
@@ -2085,7 +2092,9 @@
     "revoke": "Revoke",
     "revoke_confirm_title": "Revoke token?",
     "revoke_confirm": "Revoke this token? This cannot be undone.",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "revoke_failed": "Failed to revoke token.",
+    "create_failed_tmpl": "Failed to create token: {msg}"
   },
   "explore_pages": {
     "recent": {
@@ -3237,6 +3246,8 @@
         "replayConfirmReason": "Reason for replaying this delivery?",
         "replayDone": "Replay sent (HTTP {status}).",
         "replayFailed": "Replay failed: {error}",
+        "testDeliveryDone": "Test delivery: HTTP {status}.",
+        "testDeliveryFailed": "Test delivery failed: {error}",
         "nonceCopied": "Nonce copied.",
         "loadFailed": "Could not load deliveries: {error}",
         "perWebhookEmpty": "No deliveries for this webhook yet."
@@ -3637,6 +3648,9 @@
     "default_confirm": "Confirm",
     "default_cancel": "Cancel",
     "aria_dialog_label": "Confirmation dialog"
+  },
+  "toast": {
+    "dismiss": "Dismiss"
   },
   "observe2": {
     "heading": "Log observation",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1464,6 +1464,7 @@
     "edited": "edited",
     "delete": "Delete",
     "delete_confirm": "Delete this comment? This can't be undone.",
+    "delete_confirm_title": "Delete comment?",
     "comment_deleted": "Comment deleted.",
     "empty_comments": "No comments yet — be the first to chime in.",
     "thread_locked_banner": "This thread was locked by a moderator.",
@@ -1558,6 +1559,7 @@
     "cards": {
       "more_actions": "More actions",
       "block_user_confirm": "Block @{{handle}}? They'll disappear from your feeds and you won't see each other's reactions. You can undo this in Settings → Privacy.",
+      "block_user_confirm_title": "Block this user?",
       "block_user_success": "User blocked.",
       "block_user_error": "Could not block. Try again.",
       "report_observation_aria": "Report this observation",
@@ -2079,7 +2081,11 @@
     "no_expiry": "Never expires",
     "days": "days",
     "year": "year",
-    "create": "Create token"
+    "create": "Create token",
+    "revoke": "Revoke",
+    "revoke_confirm_title": "Revoke token?",
+    "revoke_confirm": "Revoke this token? This cannot be undone.",
+    "cancel": "Cancel"
   },
   "explore_pages": {
     "recent": {
@@ -2940,6 +2946,7 @@
     "taxa_recompute_coming": "Recompute all taxon rarity scores",
     "taxa_actions_coming": "",
     "taxa_recompute_confirm": "Recompute rarity scores for all taxa? This may take a moment.",
+    "taxa_recompute_confirm_title": "Recompute rarity scores?",
     "taxa_recompute_success": "Rarity recompute triggered successfully.",
     "taxa_recompute_error": "Failed to recompute rarity: ",
     "taxa_flag_slide_heading": "Edit conservation flag",
@@ -3211,6 +3218,9 @@
         "deliveries": "Deliveries",
         "hideDeliveries": "Hide deliveries"
       },
+      "deleteConfirmTitle": "Delete webhook?",
+      "deleteConfirm": "Delete this webhook? This cannot be undone.",
+      "cancel": "Cancel",
       "deliveries": {
         "heading": "Recent deliveries (last 20)",
         "event": "Event",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1464,6 +1464,7 @@
     "edited": "editado",
     "delete": "Eliminar",
     "delete_confirm": "¿Eliminar este comentario? No se puede deshacer.",
+    "delete_confirm_title": "¿Eliminar comentario?",
     "comment_deleted": "Comentario eliminado.",
     "empty_comments": "Sin comentarios aún — sé la primera persona en opinar.",
     "thread_locked_banner": "Esta conversación fue cerrada por un moderador.",
@@ -1558,6 +1559,7 @@
     "cards": {
       "more_actions": "Más acciones",
       "block_user_confirm": "¿Bloquear a @{{handle}}? Desaparecerá de tus feeds y no verán sus reacciones mutuas. Puedes deshacerlo en Ajustes → Privacidad.",
+      "block_user_confirm_title": "¿Bloquear a este usuario?",
       "block_user_success": "Usuario bloqueado.",
       "block_user_error": "No se pudo bloquear. Intenta de nuevo.",
       "report_observation_aria": "Reportar esta observación",
@@ -2079,7 +2081,11 @@
     "no_expiry": "Sin expiración",
     "days": "días",
     "year": "año",
-    "create": "Crear token"
+    "create": "Crear token",
+    "revoke": "Revocar",
+    "revoke_confirm_title": "¿Revocar token?",
+    "revoke_confirm": "¿Revocar este token? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar"
   },
   "explore_pages": {
     "recent": {
@@ -2940,6 +2946,7 @@
     "taxa_recompute_coming": "Recomputar puntajes de rareza para todos los taxa",
     "taxa_actions_coming": "",
     "taxa_recompute_confirm": "¿Recomputar rareza para todos los taxa? Esto puede tardar un momento.",
+    "taxa_recompute_confirm_title": "¿Recomputar puntajes de rareza?",
     "taxa_recompute_success": "Recomputo de rareza iniciado correctamente.",
     "taxa_recompute_error": "Error al recomputar rareza: ",
     "taxa_flag_slide_heading": "Editar bandera de conservación",
@@ -3211,6 +3218,9 @@
         "deliveries": "Entregas",
         "hideDeliveries": "Ocultar entregas"
       },
+      "deleteConfirmTitle": "¿Eliminar webhook?",
+      "deleteConfirm": "¿Eliminar este webhook? Esta acción no se puede deshacer.",
+      "cancel": "Cancelar",
       "deliveries": {
         "heading": "Entregas recientes (últimas 20)",
         "event": "Evento",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -3253,7 +3253,18 @@
         "perWebhookEmpty": "Aún no hay entregas para este webhook."
       },
       "empty": "No hay webhooks configurados.",
-      "deliveriesEmpty": "Aún no hay entregas."
+      "deliveriesEmpty": "Aún no hay entregas.",
+      "slideOver": {
+        "enableTitle": "Activar webhook",
+        "disableTitle": "Desactivar webhook",
+        "deleteTitle": "Eliminar webhook",
+        "replayTitle": "Reenviar última entrega",
+        "reasonRoutineMaintenance": "Mantenimiento rutinario",
+        "reasonEndpointMigration": "Migración de endpoint",
+        "reasonNoLongerNeeded": "Ya no se necesita",
+        "reasonMisconfigured": "Suscripción mal configurada",
+        "reasonRetryFailedDelivery": "Reintentar entrega fallida"
+      }
     },
     "plantnetQuota": {
       "title": "Cuota PlantNet",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1548,7 +1548,9 @@
       "button": "Bloquear",
       "unblock": "Desbloquear",
       "blocked_users": "Usuarios bloqueados",
-      "empty": "No has bloqueado a nadie."
+      "empty": "No has bloqueado a nadie.",
+      "blocked_toast": "Usuario bloqueado.",
+      "block_error": "No se pudo bloquear."
     },
     "list": {
       "followers": "Seguidores",
@@ -1574,6 +1576,11 @@
     "credentials_section": "Mis credenciales",
     "credentials_empty": "Aún no tienes credenciales. Agrega una para empezar a patrocinar.",
     "add_credential": "Agregar credencial",
+    "error_prefix_tmpl": "Error: {msg}",
+    "creds_load_failed": "No se pudieron cargar las credenciales.",
+    "add_credential_first": "Agrega una credencial primero.",
+    "three_strike_msg": "Tres strikes: revoca y vuelve a crear.",
+    "report_dialog_unavailable": "Diálogo de reporte no disponible — recarga la página.",
     "credential_label": "Etiqueta",
     "credential_label_help": "Un nombre amigable para reconocer esta credencial.",
     "credential_secret": "API key o token de larga duración",
@@ -2085,7 +2092,9 @@
     "revoke": "Revocar",
     "revoke_confirm_title": "¿Revocar token?",
     "revoke_confirm": "¿Revocar este token? Esta acción no se puede deshacer.",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "revoke_failed": "No se pudo revocar el token.",
+    "create_failed_tmpl": "No se pudo crear el token: {msg}"
   },
   "explore_pages": {
     "recent": {
@@ -3237,6 +3246,8 @@
         "replayConfirmReason": "¿Razón para reenviar esta entrega?",
         "replayDone": "Reenvío realizado (HTTP {status}).",
         "replayFailed": "Reenvío falló: {error}",
+        "testDeliveryDone": "Entrega de prueba: HTTP {status}.",
+        "testDeliveryFailed": "Entrega de prueba falló: {error}",
         "nonceCopied": "Nonce copiado.",
         "loadFailed": "No se pudieron cargar las entregas: {error}",
         "perWebhookEmpty": "Aún no hay entregas para este webhook."
@@ -3637,6 +3648,9 @@
     "default_confirm": "Confirmar",
     "default_cancel": "Cancelar",
     "aria_dialog_label": "Diálogo de confirmación"
+  },
+  "toast": {
+    "dismiss": "Descartar"
   },
   "observe2": {
     "heading": "Registrar observación",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,7 @@ import SwUpdateToast from '../components/SwUpdateToast.astro';
 import OfflineBanner from '../components/OfflineBanner.astro';
 import ReportDialog from '../components/ReportDialog.astro';
 import ConfirmDialog from '../components/ConfirmDialog.astro';
+import Toast from '../components/Toast.astro';
 import PhotoCropModal from '../components/PhotoCropModal.astro';
 import WhyAmISeeingThisDialog from '../components/WhyAmISeeingThisDialog.astro';
 import SurpriseOverlay from '../components/SurpriseOverlay.astro';
@@ -379,6 +380,7 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
     <SwUpdateToast lang={lang} />
     <ReportDialog lang={installLang} />
     <ConfirmDialog lang={installLang} />
+    <Toast lang={installLang} />
     <PhotoCropModal lang={installLang} />
     <WhyAmISeeingThisDialog lang={installLang} />
     <SurpriseOverlay lang={installLang} />

--- a/src/lib/toast.test.ts
+++ b/src/lib/toast.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  showToast,
+  TOAST_CONTAINER_ID,
+  _resetToastContainer,
+} from './toast';
+
+function mountContainer(lang: 'en' | 'es' = 'en') {
+  const c = document.createElement('div');
+  c.id = TOAST_CONTAINER_ID;
+  c.setAttribute('role', 'status');
+  c.setAttribute('aria-live', 'polite');
+  c.dataset.lang = lang;
+  c.dataset.dismissLabel = lang === 'es' ? 'Descartar' : 'Dismiss';
+  document.body.appendChild(c);
+  return c;
+}
+
+describe('showToast', () => {
+  beforeEach(() => {
+    _resetToastContainer();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    _resetToastContainer();
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+  });
+
+  it('appends a toast into the mounted container', () => {
+    const c = mountContainer();
+    showToast({ message: 'Saved' });
+    expect(c.children.length).toBe(1);
+    expect(c.querySelector('span')?.textContent).toBe('Saved');
+  });
+
+  it('lazily creates the container if absent (safety net)', () => {
+    expect(document.getElementById(TOAST_CONTAINER_ID)).toBeNull();
+    showToast({ message: 'No container yet', variant: 'info' });
+    const c = document.getElementById(TOAST_CONTAINER_ID);
+    expect(c).not.toBeNull();
+    expect(c?.children.length).toBe(1);
+  });
+
+  it('maps variant → palette class', () => {
+    const c = mountContainer();
+    showToast({ message: 'ok', variant: 'success' });
+    showToast({ message: 'bad', variant: 'error' });
+    showToast({ message: 'fyi', variant: 'info' });
+    const els = Array.from(c.children) as HTMLElement[];
+    expect(els[0].className).toContain('bg-emerald-700');
+    expect(els[1].className).toContain('bg-red-700');
+    expect(els[2].className).toContain('bg-zinc-800');
+  });
+
+  it('defaults to the info variant', () => {
+    const c = mountContainer();
+    showToast({ message: 'default' });
+    expect((c.firstElementChild as HTMLElement).className).toContain('bg-zinc-800');
+  });
+
+  it('sets role=alert only on error toasts', () => {
+    const c = mountContainer();
+    showToast({ message: 'oops', variant: 'error' });
+    showToast({ message: 'fine', variant: 'success' });
+    const els = Array.from(c.children) as HTMLElement[];
+    expect(els[0].getAttribute('role')).toBe('alert');
+    expect(els[1].getAttribute('role')).toBeNull();
+  });
+
+  it('renders a dismiss button with the container aria-label (ES)', () => {
+    const c = mountContainer('es');
+    showToast({ message: 'hola' });
+    const btn = c.querySelector('button');
+    expect(btn).not.toBeNull();
+    expect(btn?.getAttribute('aria-label')).toBe('Descartar');
+  });
+
+  it('auto-dismisses after the default duration', () => {
+    vi.useFakeTimers();
+    const c = mountContainer();
+    showToast({ message: 'transient' });
+    expect(c.children.length).toBe(1);
+    vi.advanceTimersByTime(4000);
+    vi.advanceTimersByTime(300);
+    expect(c.children.length).toBe(0);
+  });
+
+  it('respects a custom durationMs', () => {
+    vi.useFakeTimers();
+    const c = mountContainer();
+    showToast({ message: 'quick', durationMs: 1000 });
+    vi.advanceTimersByTime(900);
+    expect(c.children.length).toBe(1);
+    vi.advanceTimersByTime(100 + 300);
+    expect(c.children.length).toBe(0);
+  });
+
+  it('durationMs:0 stays until manually dismissed', () => {
+    vi.useFakeTimers();
+    const c = mountContainer();
+    showToast({ message: 'sticky', durationMs: 0 });
+    vi.advanceTimersByTime(60_000);
+    expect(c.children.length).toBe(1);
+    const btn = c.querySelector('button')!;
+    btn.dispatchEvent(new Event('click'));
+    vi.advanceTimersByTime(300);
+    expect(c.children.length).toBe(0);
+  });
+
+  it('manual dismiss clears the auto-dismiss timer (no double-remove throw)', () => {
+    vi.useFakeTimers();
+    const c = mountContainer();
+    showToast({ message: 'click me' });
+    const btn = c.querySelector('button')!;
+    btn.dispatchEvent(new Event('click'));
+    vi.advanceTimersByTime(300);
+    expect(c.children.length).toBe(0);
+    // Original auto-dismiss timer must not fire / throw later.
+    expect(() => vi.advanceTimersByTime(10_000)).not.toThrow();
+    expect(c.children.length).toBe(0);
+  });
+
+  it('is a no-op when document is undefined (SSR)', () => {
+    const realDoc = globalThis.document;
+    // simulate SSR by removing the global document
+    delete (globalThis as { document?: unknown }).document;
+    expect(() => showToast({ message: 'ssr' })).not.toThrow();
+    (globalThis as { document?: unknown }).document = realDoc;
+  });
+
+  it('_resetToastContainer removes the existing container', () => {
+    mountContainer();
+    showToast({ message: 'x' });
+    expect(document.getElementById(TOAST_CONTAINER_ID)).not.toBeNull();
+    _resetToastContainer();
+    expect(document.getElementById(TOAST_CONTAINER_ID)).toBeNull();
+  });
+});

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,126 @@
+/**
+ * Canonical in-UI toast — fire-and-forget replacement for `window.alert()`.
+ * Drives the global `<Toast>` container mounted in `BaseLayout.astro` and
+ * `ConsoleLayout.astro`. Mirrors the `confirm-dialog` / `karma-toast`
+ * patterns so all global chrome shares one mental model.
+ *
+ * Non-blocking: callers MUST keep their existing control flow (the `return;`
+ * after a failed-path `alert()` stays). Do NOT await `showToast`.
+ *
+ * SSR-safe: a no-op when `document` is undefined.
+ */
+
+export type ToastVariant = 'success' | 'error' | 'info';
+
+export interface ToastOptions {
+  message: string;
+  variant?: ToastVariant;
+  /** 0 = sticky (manual dismiss only). Default 4000ms. */
+  durationMs?: number;
+}
+
+export const TOAST_CONTAINER_ID = 'rastrum-toast-container';
+
+const DEFAULT_DURATION_MS = 4000;
+
+function variantClass(variant: ToastVariant): string {
+  switch (variant) {
+    case 'success':
+      return 'bg-emerald-700 text-white';
+    case 'error':
+      return 'bg-red-700 text-white';
+    case 'info':
+      return 'bg-zinc-800 text-white';
+    default: {
+      const _exhaustive: never = variant;
+      return _exhaustive;
+    }
+  }
+}
+
+function resolveContainer(): HTMLElement {
+  let container = document.getElementById(TOAST_CONTAINER_ID);
+  if (!container) {
+    // Safety net (mirrors karma-toast.ts lazy-container guard): the
+    // component is mounted globally, but if a surface renders before it
+    // we still create a usable container rather than dropping the toast.
+    container = document.createElement('div');
+    container.id = TOAST_CONTAINER_ID;
+    container.className =
+      'fixed left-1/2 -translate-x-1/2 bottom-[calc(5rem+env(safe-area-inset-bottom))] sm:bottom-4 z-50 flex flex-col items-center gap-2 pointer-events-none';
+    container.setAttribute('role', 'status');
+    container.setAttribute('aria-live', 'polite');
+    document.body.appendChild(container);
+  }
+  return container;
+}
+
+export function showToast(opts: ToastOptions): void {
+  if (typeof document === 'undefined') return;
+
+  const variant: ToastVariant = opts.variant ?? 'info';
+  const durationMs = opts.durationMs ?? DEFAULT_DURATION_MS;
+  const container = resolveContainer();
+
+  const dismissLabel =
+    container.dataset.dismissLabel ??
+    (container.dataset.lang === 'es' ? 'Descartar' : 'Dismiss');
+
+  const el = document.createElement('div');
+  el.className =
+    `pointer-events-auto flex items-start gap-3 max-w-sm px-4 py-2 rounded-lg shadow-lg text-sm font-medium transition-all duration-300 ${variantClass(variant)}`;
+  if (variant === 'error') el.setAttribute('role', 'alert');
+
+  const text = document.createElement('span');
+  text.className = 'flex-1';
+  text.textContent = opts.message;
+  el.appendChild(text);
+
+  const dismissBtn = document.createElement('button');
+  dismissBtn.type = 'button';
+  dismissBtn.textContent = '×';
+  dismissBtn.setAttribute('aria-label', dismissLabel);
+  dismissBtn.className =
+    'shrink-0 -mr-1 px-1 leading-none text-lg opacity-80 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-white/60 rounded';
+  el.appendChild(dismissBtn);
+
+  el.style.opacity = '0';
+  el.style.transform = 'translateY(10px)';
+  container.appendChild(el);
+
+  requestAnimationFrame(() => {
+    el.style.opacity = '1';
+    el.style.transform = 'translateY(0)';
+  });
+
+  let removeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function dismiss() {
+    if (removeTimer) {
+      clearTimeout(removeTimer);
+      removeTimer = null;
+    }
+    el.style.opacity = '0';
+    el.style.transform = 'translateY(-10px)';
+    setTimeout(() => el.remove(), 300);
+  }
+
+  dismissBtn.addEventListener('click', dismiss);
+
+  if (durationMs > 0) {
+    removeTimer = setTimeout(() => {
+      el.style.opacity = '0';
+      el.style.transform = 'translateY(-10px)';
+      setTimeout(() => el.remove(), 300);
+    }, durationMs);
+  }
+}
+
+/** Test-only: drop any reference so the next showToast re-resolves. */
+export function _resetToastContainer(): void {
+  const existing =
+    typeof document !== 'undefined'
+      ? document.getElementById(TOAST_CONTAINER_ID)
+      : null;
+  existing?.remove();
+}

--- a/src/pages/en/profile/tokens.astro
+++ b/src/pages/en/profile/tokens.astro
@@ -17,6 +17,8 @@ const tr = t(lang) as any;
     data-label-revoke-confirm-title={tr.tokens.revoke_confirm_title}
     data-label-revoke-confirm={tr.tokens.revoke_confirm}
     data-label-cancel={tr.tokens.cancel}
+    data-label-revoke-failed={tr.tokens.revoke_failed}
+    data-label-create-failed-tmpl={tr.tokens.create_failed_tmpl}
   >
     <h1 class="text-2xl font-bold mb-1">{tr.tokens.title}</h1>
     <p class="text-sm text-gray-500 mb-8">{tr.tokens.desc}</p>
@@ -74,6 +76,7 @@ const tr = t(lang) as any;
 <script>
   import {getCachedSession, getSupabase} from '../../../lib/supabase';
   import { openConfirmDialog } from '../../../lib/confirm-dialog';
+  import { showToast } from '../../../lib/toast';
   const supabase = getSupabase();
   const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
   const mainEl = document.querySelector<HTMLElement>('main');
@@ -82,6 +85,8 @@ const tr = t(lang) as any;
     revokeConfirmTitle: mainEl?.dataset.labelRevokeConfirmTitle ?? 'Revoke token?',
     revokeConfirm: mainEl?.dataset.labelRevokeConfirm ?? 'Revoke this token? This cannot be undone.',
     cancel: mainEl?.dataset.labelCancel ?? 'Cancel',
+    revokeFailed: mainEl?.dataset.labelRevokeFailed ?? 'Failed to revoke token.',
+    createFailedTmpl: mainEl?.dataset.labelCreateFailedTmpl ?? 'Failed to create token: {msg}',
   };
 
   async function getAuthHeader() {
@@ -122,7 +127,7 @@ const tr = t(lang) as any;
         cancelLabel: L.cancel,
       }))) return;
       const r = await fetch(`${TOKENS_URL}/${t.id}`, { method: 'DELETE', headers: { Authorization: await getAuthHeader() } });
-      if (!r.ok) { alert('Failed to revoke token.'); return; }
+      if (!r.ok) { showToast({ message: L.revokeFailed, variant: 'error' }); return; }
       loadTokens();
     });
     row.append(content, btn);
@@ -177,7 +182,7 @@ const tr = t(lang) as any;
       (document.getElementById('token-name') as HTMLInputElement).value = '';
       loadTokens();
     } catch (err) {
-      alert(`Failed to create token: ${err instanceof Error ? err.message : err}`);
+      showToast({ message: L.createFailedTmpl.replace('{msg}', String(err instanceof Error ? err.message : err)), variant: 'error' });
     } finally {
       if (btn) { btn.disabled = false; btn.textContent = 'Create token'; }
     }

--- a/src/pages/en/profile/tokens.astro
+++ b/src/pages/en/profile/tokens.astro
@@ -11,7 +11,13 @@ const tr = t(lang) as any;
 ---
 
 <BaseLayout title={tr.tokens.title} description="Personal API tokens for the Rastrum REST API and MCP server. Use these to integrate Rastrum into agents, scripts, and external tooling." lang={lang}>
-  <main class="mx-auto max-w-2xl px-4 py-10">
+  <main
+    class="mx-auto max-w-2xl px-4 py-10"
+    data-label-revoke={tr.tokens.revoke}
+    data-label-revoke-confirm-title={tr.tokens.revoke_confirm_title}
+    data-label-revoke-confirm={tr.tokens.revoke_confirm}
+    data-label-cancel={tr.tokens.cancel}
+  >
     <h1 class="text-2xl font-bold mb-1">{tr.tokens.title}</h1>
     <p class="text-sm text-gray-500 mb-8">{tr.tokens.desc}</p>
 
@@ -67,8 +73,16 @@ const tr = t(lang) as any;
 
 <script>
   import {getCachedSession, getSupabase} from '../../../lib/supabase';
+  import { openConfirmDialog } from '../../../lib/confirm-dialog';
   const supabase = getSupabase();
   const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
+  const mainEl = document.querySelector<HTMLElement>('main');
+  const L = {
+    revoke: mainEl?.dataset.labelRevoke ?? 'Revoke',
+    revokeConfirmTitle: mainEl?.dataset.labelRevokeConfirmTitle ?? 'Revoke token?',
+    revokeConfirm: mainEl?.dataset.labelRevokeConfirm ?? 'Revoke this token? This cannot be undone.',
+    cancel: mainEl?.dataset.labelCancel ?? 'Cancel',
+  };
 
   async function getAuthHeader() {
     const session = await getCachedSession();
@@ -98,9 +112,15 @@ const tr = t(lang) as any;
     const btn = document.createElement('button');
     btn.dataset.id = t.id ?? '';
     btn.className = 'revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50';
-    btn.textContent = 'Revoke';
+    btn.textContent = L.revoke;
     btn.addEventListener('click', async () => {
-      if (!confirm('Revoke this token? This cannot be undone.')) return;
+      if (!(await openConfirmDialog({
+        title: L.revokeConfirmTitle,
+        message: L.revokeConfirm,
+        variant: 'danger',
+        confirmLabel: L.revoke,
+        cancelLabel: L.cancel,
+      }))) return;
       const r = await fetch(`${TOKENS_URL}/${t.id}`, { method: 'DELETE', headers: { Authorization: await getAuthHeader() } });
       if (!r.ok) { alert('Failed to revoke token.'); return; }
       loadTokens();

--- a/src/pages/es/perfil/tokens.astro
+++ b/src/pages/es/perfil/tokens.astro
@@ -17,6 +17,8 @@ const tr = t(lang) as any;
     data-label-revoke-confirm-title={tr.tokens.revoke_confirm_title}
     data-label-revoke-confirm={tr.tokens.revoke_confirm}
     data-label-cancel={tr.tokens.cancel}
+    data-label-revoke-failed={tr.tokens.revoke_failed}
+    data-label-create-failed-tmpl={tr.tokens.create_failed_tmpl}
   >
     <h1 class="text-2xl font-bold mb-1">{tr.tokens.title}</h1>
     <p class="text-sm text-gray-500 mb-8">{tr.tokens.desc}</p>
@@ -99,6 +101,7 @@ const tr = t(lang) as any;
 <script>
   import {getCachedSession, getSupabase} from '../../../lib/supabase';
   import { openConfirmDialog } from '../../../lib/confirm-dialog';
+  import { showToast } from '../../../lib/toast';
   const supabase = getSupabase();
 
   const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
@@ -108,6 +111,8 @@ const tr = t(lang) as any;
     revokeConfirmTitle: mainEl?.dataset.labelRevokeConfirmTitle ?? '¿Revocar token?',
     revokeConfirm: mainEl?.dataset.labelRevokeConfirm ?? '¿Revocar este token? Esta acción no se puede deshacer.',
     cancel: mainEl?.dataset.labelCancel ?? 'Cancelar',
+    revokeFailed: mainEl?.dataset.labelRevokeFailed ?? 'No se pudo revocar el token.',
+    createFailedTmpl: mainEl?.dataset.labelCreateFailedTmpl ?? 'No se pudo crear el token: {msg}',
   };
 
   async function getAuthHeader() {
@@ -159,7 +164,7 @@ const tr = t(lang) as any;
         method: 'DELETE',
         headers: { Authorization: await getAuthHeader() },
       });
-      if (!r.ok) { alert('Error al revocar el token.'); return; }
+      if (!r.ok) { showToast({ message: L.revokeFailed, variant: 'error' }); return; }
       loadTokens();
     });
 
@@ -224,7 +229,7 @@ const tr = t(lang) as any;
       (document.getElementById('token-name') as HTMLInputElement).value = '';
       loadTokens();
     } catch (err) {
-      alert(`Error al crear el token: ${err instanceof Error ? err.message : err}`);
+      showToast({ message: L.createFailedTmpl.replace('{msg}', String(err instanceof Error ? err.message : err)), variant: 'error' });
     } finally {
       if (btn) { btn.disabled = false; btn.textContent = 'Crear token'; }
     }

--- a/src/pages/es/perfil/tokens.astro
+++ b/src/pages/es/perfil/tokens.astro
@@ -11,7 +11,13 @@ const tr = t(lang) as any;
 ---
 
 <BaseLayout title={tr.tokens.title} description="Tokens personales para la API REST y servidor MCP de Rastrum. Úsalos para integrar Rastrum con agentes, scripts y herramientas externas." lang={lang}>
-  <main class="mx-auto max-w-2xl px-4 py-10">
+  <main
+    class="mx-auto max-w-2xl px-4 py-10"
+    data-label-revoke={tr.tokens.revoke}
+    data-label-revoke-confirm-title={tr.tokens.revoke_confirm_title}
+    data-label-revoke-confirm={tr.tokens.revoke_confirm}
+    data-label-cancel={tr.tokens.cancel}
+  >
     <h1 class="text-2xl font-bold mb-1">{tr.tokens.title}</h1>
     <p class="text-sm text-gray-500 mb-8">{tr.tokens.desc}</p>
 
@@ -92,9 +98,17 @@ const tr = t(lang) as any;
 
 <script>
   import {getCachedSession, getSupabase} from '../../../lib/supabase';
+  import { openConfirmDialog } from '../../../lib/confirm-dialog';
   const supabase = getSupabase();
 
   const TOKENS_URL = `${import.meta.env.PUBLIC_SUPABASE_URL}/functions/v1/tokens`;
+  const mainEl = document.querySelector<HTMLElement>('main');
+  const L = {
+    revoke: mainEl?.dataset.labelRevoke ?? 'Revocar',
+    revokeConfirmTitle: mainEl?.dataset.labelRevokeConfirmTitle ?? '¿Revocar token?',
+    revokeConfirm: mainEl?.dataset.labelRevokeConfirm ?? '¿Revocar este token? Esta acción no se puede deshacer.',
+    cancel: mainEl?.dataset.labelCancel ?? 'Cancelar',
+  };
 
   async function getAuthHeader() {
     const session = await getCachedSession();
@@ -132,9 +146,15 @@ const tr = t(lang) as any;
     const btn = document.createElement('button');
     btn.dataset.id = t.id ?? '';
     btn.className = 'revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50';
-    btn.textContent = 'Revocar';
+    btn.textContent = L.revoke;
     btn.addEventListener('click', async () => {
-      if (!confirm('¿Revocar este token? Esta acción no se puede deshacer.')) return;
+      if (!(await openConfirmDialog({
+        title: L.revokeConfirmTitle,
+        message: L.revokeConfirm,
+        variant: 'danger',
+        confirmLabel: L.revoke,
+        cancelLabel: L.cancel,
+      }))) return;
       const r = await fetch(`${TOKENS_URL}/${t.id}`, {
         method: 'DELETE',
         headers: { Authorization: await getAuthHeader() },


### PR DESCRIPTION
Full sweep: **zero native `confirm()`/`alert()`/`prompt()` remain in `src/`**. 22 atomic commits, one thematic PR (per the repo's CI-coupling lesson).

**Pass A — 13 `confirm()` → `openConfirmDialog()`** (existing infra) across 11 files (Comments, Profile{Edit,Security}, SpeciesLists, ProjectDetail, ExploreRecent, LocalObservation, ObservationForm, tokens en/es, ConsoleTaxa, ConsoleWebhooks). Also mounts the global `ConfirmDialog` in **ConsoleLayout** (was BaseLayout-only — console confirms previously silently no-op'd).

**Pass B — new canonical toast infra + 32 `alert()` → `showToast()`.** New `src/lib/toast.ts` (SSR-safe, variants success/error/info, sticky/auto-dismiss, exhaustive `never` switch, `_resetToastContainer` test hook) + `src/components/Toast.astro` (`role=status`/`aria-live`, per-toast dismiss, i18n `toast.dismiss`) mounted in **BaseLayout AND ConsoleLayout**. 13 toast unit tests. Control flow preserved (non-blocking; `return;` kept). Inline lang ternaries / English literals extracted to EN+ES i18n.

**Pass C — 3 `prompt()` → `ConsoleSlideOver`** reason pattern (ConsoleWebhooksView toggle/delete/replay); the webhook-delete confirm folds into an `irreversible` slide-over (subsumes confirm+reason, consistent with every other console privileged write).

Verified at final tree: **typecheck clean · 2407 tests (212 files) · build 255 pages**, EN/ES paired.

_Process note: during Pass B a subagent's tool-path briefly resolved to the main repo; detected, fully remediated, and **independently verified by the controller** (main working dir confirmed clean; all changes isolated to the worktree; Pass A/B/C commits intact). No infra files (confirm-dialog, manage-panel) or PWA `beforeinstallprompt` touched._

🤖 Generated with [Claude Code](https://claude.com/claude-code)