### PR TITLE
fix(obs): observation delete actually persists + no silent hang (#1098)

### DIFF
--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -323,12 +323,29 @@ export async function wireManagePanelDetails(
   async function runDelete(): Promise<void> {
     if (confirmYesBtn) confirmYesBtn.disabled = true;
     errEl?.classList.add('hidden');
+    // The invoke can hang indefinitely (e.g. the gotrue auth-lock steal —
+    // #1076/#1098): without a bound the try never settles, the catch never
+    // fires and the confirm button stays disabled forever with no feedback.
+    // Race it against a timeout and always re-enable in finally so a hang
+    // becomes a visible, retryable error (the confirm row stays open so the
+    // user can just click Delete again; the EF soft-delete is idempotent).
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const { data, error: invokeErr } = await supabase.functions.invoke<{
-        ok: boolean; r2_deleted?: number; r2_errors?: unknown[]; error?: string;
-      }>('delete-observation', {
-        body: { observation_id: obsId },
-      });
+      const result = await Promise.race([
+        supabase.functions.invoke<{
+          ok: boolean; r2_deleted?: number; r2_errors?: unknown[]; error?: string;
+        }>('delete-observation', {
+          body: { observation_id: obsId },
+        }),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(
+            lang === 'es'
+              ? 'La eliminación tardó demasiado. Revisa tu conexión e inténtalo de nuevo.'
+              : 'Delete timed out. Check your connection and try again.',
+          )), 15000);
+        }),
+      ]);
+      const { data, error: invokeErr } = result;
       if (invokeErr) throw invokeErr;
       if (data && !data.ok) throw new Error(data.error ?? 'Delete failed');
       window.location.href = `/${lang}/${lang === 'es' ? 'perfil/observaciones' : 'profile/observations'}/`;
@@ -342,6 +359,11 @@ export async function wireManagePanelDetails(
         errEl.textContent = msg;
         errEl.classList.remove('hidden');
       }
+    } finally {
+      if (timer) clearTimeout(timer);
+      // Always re-enable — harmless on the success path (page is navigating
+      // away); critical on every failure/timeout path so the button is
+      // never left silently stuck disabled.
       if (confirmYesBtn) confirmYesBtn.disabled = false;
     }
   }

--- a/supabase/functions/delete-observation/index.ts
+++ b/supabase/functions/delete-observation/index.ts
@@ -131,22 +131,36 @@ export async function handler(req: Request): Promise<Response> {
   });
   let r2Deleted = 0;
   let r2Errors: Array<{ Key?: string; Code?: string; Message?: string }> = [];
+  let r2Deferred = false;
   if (r2Keys.length > 0) {
+    // The esm.sh @aws-sdk/client-s3 client can *hang* (not throw) inside
+    // the Deno edge runtime if R2 is slow/unreachable. A bare try/catch
+    // does not catch a hang, so an unbounded `r2.send` stalls the whole
+    // function and the DB soft-delete below never runs (observed in prod
+    // — issue #1098). Bound it with an AbortController so a hang aborts
+    // and we still proceed: leaving orphan blobs is acceptable here
+    // (gc-orphan-media is the v1.1 sweep, per the obs-detail runbook),
+    // whereas leaving the metadata row is worse.
+    const r2Ac = new AbortController();
+    const r2Timer = setTimeout(() => r2Ac.abort(), 8000);
     try {
       const out = await r2.send(new DeleteObjectsCommand({
         Bucket: env('R2_BUCKET_NAME')!,
         Delete: { Objects: r2Keys.map(Key => ({ Key })), Quiet: false },
-      }));
+      }), { abortSignal: r2Ac.signal });
       r2Deleted = (out.Deleted ?? []).length;
       r2Errors  = (out.Errors  ?? []) as typeof r2Errors;
     } catch (err) {
-      // R2 deletion failure is non-fatal for the DB delete — we
+      // R2 deletion failure/timeout is non-fatal for the DB delete — we
       // surface the error in the response body so the caller knows
       // the orphan situation, but we still proceed with the DB
       // delete because leaving the metadata row + R2 blobs is worse
       // than just leaving the R2 blobs.
-      console.warn('[delete-observation] R2 delete failed', err);
+      console.warn('[delete-observation] R2 delete failed or timed out', err);
+      r2Deferred = true;
       r2Errors = [{ Code: 'r2_request_failed', Message: err instanceof Error ? err.message : String(err) }];
+    } finally {
+      clearTimeout(r2Timer);
     }
   }
 
@@ -175,6 +189,7 @@ export async function handler(req: Request): Promise<Response> {
     observation_id: obsId,
     r2_deleted: r2Deleted,
     r2_errors: r2Errors,
+    r2_cleanup: r2Deferred ? 'deferred' : 'done',
   });
 }
 


### PR DESCRIPTION
Fixes the user-facing #1098 (observation delete never completes / button hangs forever). Two atomic commits — the **complete user-facing fix**, verified:

**P1a — EF (`delete-observation/index.ts`):** prod edge logs proved the EF clears `auth → ownership(200) → media_files(200)` then never performs the DB soft-delete: the esm.sh `@aws-sdk/client-s3` `r2.send()` **hangs (does not throw)** in the Deno edge runtime when R2 is slow/unreachable, and a bare try/catch can't catch a hang. Bounded it with an `AbortController` (8s) → a hang aborts and execution continues to the DB soft-delete + cascade. Orphan blobs are acceptable (gc-orphan-media is the v1.1 sweep per the obs-detail runbook). Response now reports `r2_cleanup: 'deferred'|'done'`.

**P1b — client (`manage-panel.ts`):** `runDelete()` awaited the invoke unbounded → under the gotrue auth-lock steal it hangs, the catch never fires, the confirm button stays disabled forever with no feedback. Race against a 15s timeout + re-enable in `finally` → every failure/timeout becomes a visible, retryable error (in-panel confirm row stays open; EF soft-delete is idempotent).

Verified: typecheck clean · **2407 tests (212 files) pass** · build OK. EF tests run via CI's Deno harness (vitest scope is src/tests only — consistent with #1082's handling); P1a is a surgical type-checked timeout guard whose real validation is the CI redeploy + a live delete.

### Why #1076 (the gotrue lock-steal root cause) is NOT in this PR
P1a+P1b fully fix the user-facing symptom (delete persists server-side; client shows timeout+retry instead of an infinite silent hang). #1076 — consolidating the chrome islands' `onAuthStateChange` so the auth lock isn't stolen mid-flight — is the deeper reliability fix, but it touches the chrome contract and #1064/#1065 auth-fan-out territory. The #1076 spike already designed it; per this repo's own documented lesson (rushed multi-concern merges ship silent regressions) it warrants its own focused PR with full e2e #1064-regression verification, not a tail-end commit. Tracked in #1098/#1076.

**For maintainer review — not auto-merged** (destructive EF). On merge, CI auto-redeploys `delete-observation`; recommend verifying with a real delete + the OPTIONS curl from #1093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)