### PR TITLE
fix(obs): positive post-delete UX — success toast + friendly not-found (#1098)

### DIFF
--- a/src/components/MyObservationsView.astro
+++ b/src/components/MyObservationsView.astro
@@ -256,6 +256,21 @@ const tabs = [
   const lang: Lang = root?.dataset.lang === 'es' ? 'es' : 'en';
   const shareBase = root?.dataset.shareObsBase ?? '/share/obs/';
 
+  // Positive confirmation after a delete: ObsManagePanel redirects here
+  // with ?deleted=1 so the user gets explicit feedback instead of
+  // silently landing on the list unsure whether it worked, or — if the
+  // success redirect raced a hang — ever on the bare not-found page
+  // (#1098 follow-up). Strip the param so reload/back doesn't re-toast.
+  try {
+    const sp = new URLSearchParams(window.location.search);
+    if (sp.get('deleted') === '1') {
+      showToast(lang === 'es' ? 'Observación eliminada.' : 'Observation deleted.', 'ok');
+      sp.delete('deleted');
+      const qs = sp.toString();
+      window.history.replaceState({}, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash);
+    }
+  } catch { /* URL/history unavailable — non-fatal */ }
+
   let currentTab: SyncFilter = 'all';
   let offset = 0;
   let exhausted = false;

--- a/src/lib/manage-panel.ts
+++ b/src/lib/manage-panel.ts
@@ -348,7 +348,7 @@ export async function wireManagePanelDetails(
       const { data, error: invokeErr } = result;
       if (invokeErr) throw invokeErr;
       if (data && !data.ok) throw new Error(data.error ?? 'Delete failed');
-      window.location.href = `/${lang}/${lang === 'es' ? 'perfil/observaciones' : 'profile/observations'}/`;
+      window.location.href = `/${lang}/${lang === 'es' ? 'perfil/observaciones' : 'profile/observations'}/?deleted=1`;
     } catch (err) {
       if (errEl) {
         const msg = err instanceof Error

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -119,7 +119,30 @@ const lang: 'en' | 'es' = 'en';
         .maybeSingle();
 
       if (error) throw error;
-      if (!obs) throw new Error('Observation not found.');
+      if (!obs) {
+        // Friendly, localized terminal state — this is most often hit
+        // right after the owner deleted the observation (or revisits an
+        // old link), where a bare "Observation not found." reads like a
+        // failure. Soften the copy + offer a clear way forward.
+        document.getElementById('loading')?.classList.add('hidden');
+        const errEl = document.getElementById('err');
+        if (errEl) {
+          const es = document.documentElement.lang === 'es';
+          const recent = es ? '/es/explorar/recientes/' : '/en/explore/recent/';
+          const home   = es ? '/es/' : '/en/';
+          errEl.innerHTML =
+            `<span class="block">${es
+              ? 'Esta observación no está disponible — puede que haya sido eliminada.'
+              : "This observation isn't available — it may have been deleted."}</span>` +
+            `<span class="mt-3 flex gap-4 justify-center text-sm not-italic">` +
+            `<a class="text-emerald-700 dark:text-emerald-400 underline" href="${recent}">${es
+              ? 'Ver observaciones recientes →' : 'Browse recent observations →'}</a>` +
+            `<a class="text-zinc-500 underline" href="${home}">${es ? 'Inicio' : 'Home'}</a>` +
+            `</span>`;
+          errEl.classList.remove('hidden');
+        }
+        return;
+      }
 
       const idArr = Array.isArray(obs.identifications) ? obs.identifications : (obs.identifications ? [obs.identifications] : []);
       const ident = idArr.find((x: { is_primary?: boolean }) => x?.is_primary) ?? idArr[0];


### PR DESCRIPTION
Closes the post-delete UX gap raised after #1099: a successful delete gave no confirmation (and any degraded path showed a cold hardcoded-English 'Observation not found.'). Now: success → `?deleted=1` → 'Observation deleted.' toast (param stripped); share/obs not-found → localized 'may have been deleted' + recent/home CTAs (also fixes an EN/ES-parity miss). Pure additive UX — the delete logic itself is unchanged. typecheck · 2407 tests · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)