### PR TITLE
fix(auth): collapse 7 gotrue subscriptions onto one shared listener (#1076 root cause)

### DIFF
--- a/src/components/BanBanner.astro
+++ b/src/components/BanBanner.astro
@@ -41,7 +41,7 @@ const appealPath = getLocalizedPath(
 </div>
 
 <script>
-  import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase, onAuthChange } from '../lib/supabase';
   import { getActiveBanForUser } from '../lib/check-ban-status';
 
   async function paintBanBanner() {
@@ -82,8 +82,7 @@ const appealPath = getLocalizedPath(
   // Run on page load and on auth state changes.
   paintBanBanner().catch(() => { /* env not configured */ });
   try {
-    const supabase = getSupabase();
-    supabase.auth.onAuthStateChange(() => {
+    onAuthChange(() => {
       paintBanBanner().catch(() => { /* noop */ });
     });
   } catch { /* env not configured */ }

--- a/src/components/BellIcon.astro
+++ b/src/components/BellIcon.astro
@@ -38,7 +38,7 @@ const ariaLabel = lang === 'es' ? 'Bandeja' : 'Inbox';
 </a>
 
 <script>
-  import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase, onAuthChange } from '../lib/supabase';
 
   const POLL_MS = 60_000;
 
@@ -93,7 +93,7 @@ const ariaLabel = lang === 'es' ? 'Bandeja' : 'Inbox';
     if (document.visibilityState === 'visible') start();
 
     try {
-      getSupabase().auth.onAuthStateChange(() => { tick().catch(() => {}); });
+      onAuthChange(() => { tick().catch(() => {}); });
     } catch { /* env not set */ }
   }
 </script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -319,7 +319,7 @@ const docColumns = [
 
 <!-- Auth status: keeps the existing avatar-swap behavior -->
 <script>
-  import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { getCachedUser, getSupabase, onAuthChange } from '../lib/supabase';
   import { signOut, SUPABASE_AUTH_STORAGE_KEY, HEADER_AVATAR_CACHE_KEY, HEADER_AVATAR_NAME_KEY } from '../lib/auth';
   import { getUserRoles } from '../lib/user-roles';
   import type { UserProfile } from '../lib/types';
@@ -417,7 +417,7 @@ const docColumns = [
       const user = await getCachedUser();
       await paint(!!user, user as Parameters<typeof paint>[1]);
       if (user) await maybeShowConsolePill(user.id);
-      getSupabase().auth.onAuthStateChange(async (_evt, s) => {
+      onAuthChange(async (_evt, s) => {
         paint(!!s, s?.user as Parameters<typeof paint>[1]);
         if (s?.user) await maybeShowConsolePill(s.user.id);
       });

--- a/src/components/MobileBottomBar.astro
+++ b/src/components/MobileBottomBar.astro
@@ -205,7 +205,7 @@ const discoverActive  = isActiveSection(currentPath, 'discover',     lang);
   another tab, etc.) so the bar stays in sync.
 -->
 <script>
-  import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { getCachedUser, onAuthChange } from '../lib/supabase';
 
   const authed = document.getElementById('mbb-authed');
   const anon   = document.getElementById('mbb-anon');
@@ -220,7 +220,7 @@ const discoverActive  = isActiveSection(currentPath, 'discover',     lang);
     try {
       const user = await getCachedUser();
       paint(!!user);
-      getSupabase().auth.onAuthStateChange((_e, s) => paint(!!s));
+      onAuthChange((_e, s) => paint(!!s));
     } catch { /* env not set; leave anon visible */ }
   })();
 </script>

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -194,7 +194,7 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
 </aside>
 
 <script>
-  import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { getCachedUser, onAuthChange } from '../lib/supabase';
   import { signOut, SUPABASE_AUTH_STORAGE_KEY, HEADER_AVATAR_CACHE_KEY, HEADER_AVATAR_NAME_KEY } from '../lib/auth';
   import { getUserRoles } from '../lib/user-roles';
 
@@ -244,7 +244,7 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
       const user = await getCachedUser();
       paintAuth(!!user);
       if (user) await maybeShowConsoleLink(user.id);
-      getSupabase().auth.onAuthStateChange(async (_e, s) => {
+      onAuthChange(async (_e, s) => {
         paintAuth(!!s);
         if (s?.user) await maybeShowConsoleLink(s.user.id);
       });

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -96,7 +96,18 @@ function ensureAuthListener() {
  * callback fires once with `('INITIAL_SESSION', <current session>)` on
  * subscribe (via the dedup'd cached session — no extra lock) so callers
  * that paint from the initial session still do, then on every change.
- * Returns an unsubscribe function.
+ *
+ * Returns an unsubscribe function. Today's callers are chrome islands
+ * that live for the whole session, so none call it. But any caller in a
+ * dynamic context (SPA navigation, a conditionally-mounted island, a
+ * component teardown) MUST call it on unmount — otherwise the callback
+ * stays in `_authListeners` and leaks (and keeps firing against dead
+ * DOM):
+ *
+ * ```ts
+ * const off = onAuthChange((event, session) => paint(!!session));
+ * onCleanup(off); // or: element.addEventListener('rastrum:unmount', off)
+ * ```
  */
 export function onAuthChange(cb: AuthChangeCb): () => void {
   ensureAuthListener();

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -56,18 +56,55 @@ if (typeof document !== 'undefined') {
   });
 }
 
-// Invalidate cache on sign-out so components reflect signed-out state immediately.
-// We attach this lazily (first getCachedUser() call) to avoid circular initialization.
+// Single shared gotrue subscription, fanned out to in-process listeners.
+// Each direct `supabase.auth.onAuthStateChange()` registers a gotrue
+// subscription whose INITIAL_SESSION replay + internal `_useSession`
+// path acquires the single navigator lock (`lock:rastrum-auth-v1`).
+// Five chrome islands (Header/MobileBottomBar/MobileDrawer/BellIcon/
+// BanBanner) each subscribing → lock contention → "Lock not released
+// within 5000ms" → an in-flight destructive call's auth gets stolen
+// (`AbortError: Lock broken … 'steal'`), which is the delete-hang in
+// #1098. Collapsing every subscriber onto ONE shared gotrue listener +
+// a lightweight callback registry leaves a single lock acquirer. The
+// SIGNED_OUT cache-invalidation semantics (#1064) are unchanged.
+type AuthChangeCb = (
+  event: string,
+  session: import('@supabase/supabase-js').Session | null,
+) => void;
+const _authListeners = new Set<AuthChangeCb>();
+
 let _authListenerAttached = false;
 function ensureAuthListener() {
   if (_authListenerAttached) return;
   _authListenerAttached = true;
-  getSupabase().auth.onAuthStateChange((event) => {
+  getSupabase().auth.onAuthStateChange((event, session) => {
     if (event === 'SIGNED_OUT') {
       _userCache = null;
       _sessionCache = null;
     }
+    for (const cb of _authListeners) {
+      try { cb(event, session); } catch { /* one listener must not break the rest */ }
+    }
   });
+}
+
+/**
+ * Subscribe to auth-state changes through the single shared gotrue
+ * listener instead of calling `getSupabase().auth.onAuthStateChange()`
+ * directly (each direct call adds a navigator-lock acquirer — the
+ * lock-steal root cause of #1076/#1098). Mirrors gotrue's contract: the
+ * callback fires once with `('INITIAL_SESSION', <current session>)` on
+ * subscribe (via the dedup'd cached session — no extra lock) so callers
+ * that paint from the initial session still do, then on every change.
+ * Returns an unsubscribe function.
+ */
+export function onAuthChange(cb: AuthChangeCb): () => void {
+  ensureAuthListener();
+  _authListeners.add(cb);
+  getCachedSession()
+    .then((session) => { if (_authListeners.has(cb)) cb('INITIAL_SESSION', session); })
+    .catch(() => { /* offline / no session — skip the initial fire */ });
+  return () => { _authListeners.delete(cb); };
 }
 
 /**

--- a/src/lib/user-roles.ts
+++ b/src/lib/user-roles.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from './supabase';
+import { getSupabase, onAuthChange } from './supabase';
 import type { UserRole } from './types';
 
 const ROLES_CACHE_TTL_MS = 30_000;
@@ -10,7 +10,7 @@ function ensureRolesAuthListener() {
   if (_rolesListenerAttached) return;
   _rolesListenerAttached = true;
   try {
-    getSupabase().auth.onAuthStateChange((event) => {
+    onAuthChange((event) => {
       if (event === 'SIGNED_OUT') {
         _rolesCache = null;
         _rolesFlight = null;


### PR DESCRIPTION
## Why

Root cause of the navigator-lock-steal `AbortError` (#1076) and the `delete-observation` hang it triggered (#1098). PR #1099 added the defensive timeouts (R2 `AbortController` + client `Promise.race`) that stop the hang from being *unbounded*; **this PR removes the cause**.

## Root cause

Seven code paths each called `supabase.auth.onAuthStateChange()` directly:

| Site | Purpose |
|---|---|
| `Header.astro` | auth pill + console pill |
| `MobileBottomBar.astro` | authed/anon paint |
| `MobileDrawer.astro` | authed/anon + console link |
| `BellIcon.astro` | notification poll gate |
| `BanBanner.astro` | ban banner repaint |
| `supabase.ts` | `_userCache`/`_sessionCache` invalidation |
| `user-roles.ts` | `_rolesCache` invalidation |

Every direct subscription registers a gotrue listener whose `INITIAL_SESSION` replay + internal `_useSession` path acquires the single `lock:rastrum-auth-v1` navigator lock. Seven near-simultaneous acquirers on first paint → *"Lock not released within 5000ms"* → an in-flight destructive call's auth gets stolen (`AbortError: Lock broken by another request with the 'steal' option`).

## Fix

`supabase.ts` now owns **one** shared gotrue subscription, fanned out to an in-process `Set` of callbacks via a new exported `onAuthChange(cb)`. It mirrors gotrue's contract: the callback fires once with `('INITIAL_SESSION', <cached session>)` on subscribe — via the already-dedup'd `getCachedSession()`, so **no extra lock acquirer** — then on every change. All 6 external callers migrated. **7 lock acquirers → 1.**

`SIGNED_OUT` cache-invalidation semantics (#1064 / #1065) are unchanged: the shared listener still clears `_userCache`/`_sessionCache` on `SIGNED_OUT` *before* fanning out.

## Verification

- `tsc --noEmit` clean
- 2407/2407 vitest pass (incl. `user-roles.test.ts`)
- 255-page astro build clean

## Review note (no auto-merge)

This touches the auth path of all 5 chrome islands. **This PR's own `e2e.yml` (Playwright chromium + mobile-chrome) is the #1064/#1065 regression gate** — auth-pill paint, mobile bar, console pill, bell, ban banner all exercise `onAuthChange`'s INITIAL_SESSION-on-subscribe contract. Left for human review rather than auto-merge by design.

Refs #1076 #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)