### PR TITLE
fix(deploy): recover Supabase Edge serving-layer drop + post-deploy runtime gate

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -257,6 +257,48 @@ jobs:
             supabase functions deploy "$fn" --project-ref "$PROJECT_REF" $EXTRA_FLAGS
           done
 
+      - name: Verify runtime serves every deployed function
+        if: ${{ steps.targets.outputs.fns != '' }}
+        run: |
+          set -euo pipefail
+          # The Supabase CLI prints "Deployed Functions on project ...: X" even
+          # when it SKIPPED the upload ("No change found in Function: X"). If the
+          # Edge serving layer has dropped a function (ACTIVE in the control
+          # plane but 404 at the gateway — incident 2026-05-16, see
+          # docs/runbooks/ef-serving-layer-recovery.md), a plain redeploy is a
+          # silent no-op and this workflow stays green while production is down.
+          # This gate makes that class fail loudly: every just-deployed function
+          # MUST answer its OPTIONS preflight with a non-404 status. A CORS
+          # preflight is auth-exempt (no apikey/JWT needed), so HTTP 404 with
+          # `sb-error-code: NOT_FOUND` unambiguously means "runtime not serving".
+          base="https://${PROJECT_REF}.supabase.co/functions/v1"
+          failed=""
+          for fn in ${{ steps.targets.outputs.fns }}; do
+            code=""
+            for attempt in 1 2 3 4 5 6; do
+              code=$(curl -s -o /dev/null -w "%{http_code}" -X OPTIONS \
+                "$base/$fn" \
+                -H "Origin: https://rastrum.org" \
+                -H "Access-Control-Request-Method: POST" \
+                -H "Access-Control-Request-Headers: authorization,apikey,content-type" \
+                --max-time 15 || echo 000)
+              if [ "$code" != "404" ] && [ "$code" != "000" ]; then break; fi
+              echo "  $fn -> $code (attempt $attempt/6), waiting for propagation..."
+              sleep 10
+            done
+            if [ "$code" = "404" ] || [ "$code" = "000" ]; then
+              echo "  MISSING $fn -> $code (runtime does NOT serve this function)"
+              failed="$failed $fn"
+            else
+              echo "  ok      $fn -> $code"
+            fi
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::Edge runtime does not serve:$failed -- the CLI reported success but these functions are 404 at the gateway (a 'No change found' silent no-op over a Supabase serving-layer drop). Bust the bundle hash to force a real re-upload; see docs/runbooks/ef-serving-layer-recovery.md"
+            exit 1
+          fi
+          echo "All deployed functions are served by the runtime."
+
       - name: Audit CORS on every browser-facing function
         if: ${{ steps.targets.outputs.fns != '' }}
         run: |

--- a/docs/runbooks/00-index.md
+++ b/docs/runbooks/00-index.md
@@ -79,6 +79,7 @@ high-level system view.
 | [`posthog.md`](posthog.md) | PostHog snippet wiring, captured events, reverse-proxy verification, token rotation. |
 | [`themes.md`](themes.md) | Seasonal + regional theme variants (`monarca` / `lluvias` / `secas` / `default`) — auto-resolution, manual override, and how to add a new season. |
 | [`ci-smoke-checks.md`](ci-smoke-checks.md) | `infra/smoke-model-assets.sh` post-deploy + nightly probe. |
+| [`ef-serving-layer-recovery.md`](ef-serving-layer-recovery.md) | Edge Function 404 despite ACTIVE — Supabase serving-layer drop, the CLI `No change found` no-op trap, bundle-hash-bust recovery + post-deploy runtime gate. |
 | [`sw-cache.md`](sw-cache.md) | Service-worker cache layout, invalidation, debugging stale assets. |
 | [`resend-smtp.md`](resend-smtp.md) | Custom SMTP setup (Resend) for magic-link + sponsor threshold emails. |
 | [`rotate-secret.md`](rotate-secret.md) | Secret rotation playbook — Supabase, R2, sponsor pool credentials. |

--- a/docs/runbooks/ef-serving-layer-recovery.md
+++ b/docs/runbooks/ef-serving-layer-recovery.md
@@ -1,0 +1,105 @@
+# Edge Function serving-layer recovery
+
+> Incident class first hit **2026-05-16**: the create-observation flow's
+> *Identify* step failed with `Failed to send a request to the Edge
+> Function`. Root cause was **not** in the app — it was a Supabase
+> platform-side serving-layer drop, masked by a deploy workflow that
+> reported success without serving anything.
+
+## Symptom
+
+- A browser call to an Edge Function fails with `FunctionsFetchError:
+  Failed to send a request to the Edge Function` (the browser reports it
+  as "Failed to fetch" / a CORS error because the **OPTIONS preflight
+  itself returns 404**, and a CORS preflight must be 2xx).
+- `curl` to the function (with the `apikey` header) returns:
+  `HTTP 404` + body `{"code":"NOT_FOUND","message":"Requested function
+  was not found"}` + header `sb-error-code: NOT_FOUND`, served by
+  `x-served-by: supabase-edge-runtime`.
+- The Supabase **control plane disagrees with the data plane**: the
+  Management API (`GET /v1/projects/{ref}/functions`) lists the function
+  as `status=ACTIVE`, the project is `ACTIVE_HEALTHY`, and DB / REST /
+  Auth / Storage / Realtime are all healthy. Only the Functions runtime
+  is 404ing.
+
+## Root cause
+
+A Supabase platform event dropped a subset of functions from the Edge
+**serving layer** while leaving them registered `ACTIVE` in the control
+plane. The reason this is sticky:
+
+> `supabase functions deploy` **content-hash dedups**. When a function's
+> bundle is unchanged it prints `No change found in Function: <fn>` and
+> **skips the upload**, then *still* prints `Deployed Functions on
+> project <ref>: <fn>` and exits 0. The deploy workflow goes green.
+
+So the natural remediation (redeploy / restart the project) is a **silent
+no-op** for any function whose source has not changed — the bundle is
+never re-uploaded, so the serving layer never re-registers it. The only
+functions that recover on their own are the ones that happened to get a
+real code change (their bundle hash changed → genuine re-upload).
+
+Project pause/resume and restart do **not** re-push bundles either.
+
+## Recovery
+
+Force a real re-upload by busting each affected function's bundle hash:
+
+1. Enumerate which functions the runtime is not serving (no secret
+   needed — OPTIONS preflight is auth-exempt):
+
+   ```bash
+   for d in supabase/functions/*/; do
+     fn=$(basename "$d"); [ "${fn#_}" != "$fn" ] && continue
+     code=$(curl -s -o /dev/null -w "%{http_code}" -X OPTIONS \
+       "https://<PROJECT_REF>.supabase.co/functions/v1/$fn" \
+       -H "Origin: https://rastrum.org" \
+       -H "Access-Control-Request-Method: POST" \
+       -H "Access-Control-Request-Headers: authorization,apikey,content-type")
+     [ "$code" = "404" ] && echo "DOWN  $fn" || echo "ok    $fn ($code)"
+   done
+   ```
+
+2. Append a behavior-neutral bundle-hash buster to each affected
+   function's `index.ts` (a top-level side-effecting global assignment —
+   survives any bundler, changes the eszip, never affects behavior):
+
+   ```ts
+   ;(globalThis as Record<string, unknown>).__rastrumRedeploy = "<date>-serving-layer-recovery";
+   ```
+
+3. Commit + push to `main`. `deploy-functions.yml` fires on
+   `supabase/functions/**`; because the workflow file or `_shared` may be
+   touched it deploys all, and the changed bundles are genuinely
+   re-uploaded.
+
+4. The **`Verify runtime serves every deployed function`** step in
+   `deploy-functions.yml` (added in the same incident) re-checks every
+   deployed function's OPTIONS endpoint and **fails the workflow loudly**
+   if any is still 404 — so a silent no-op can never ship green again.
+
+5. Once the runtime serves everything, the markers are cruft. They are
+   safe to remove in a follow-up PR (removal is itself a real bundle
+   change, so it re-deploys cleanly).
+
+## Escalation
+
+Per Supabase's own troubleshooting doc
+(`troubleshooting/edge-function-404-error-response`), a function that is
+ACTIVE but 404 at the runtime after a redeploy is a **suspected internal
+platform bug** — open a Supabase support ticket with: project ref, the
+`sb-request-id` from a failing `curl -i`, the Management API output
+showing `status=ACTIVE`, and the timestamp the serving layer dropped.
+
+## Prevention
+
+- **Post-deploy runtime gate** (`deploy-functions.yml`) — described
+  above; this is the durable guard. "Workflow green" now means "the
+  runtime actually serves it", not "the CLI exited 0".
+- The same anti-pattern bit `db-apply.yml` historically (PR #42 silent
+  skip) → fixed with the `db-validate` gate. Functions now have the
+  symmetric guard.
+- A continuous external heartbeat (Cloudflare Worker cron / uptime
+  monitor) on `OPTIONS /functions/v1/identify` is the only thing that
+  catches a serving-layer drop that happens *after* a successful deploy
+  (this incident broke ~1.5 h post-deploy). Tracked as a follow-up.

--- a/supabase/functions/api/index.ts
+++ b/supabase/functions/api/index.ts
@@ -325,3 +325,10 @@ function json(body: unknown, status = 200): Response {
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   });
 }
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/award-badges/index.ts
+++ b/supabase/functions/award-badges/index.ts
@@ -134,3 +134,10 @@ serve(async (req) => {
     headers: { 'content-type': 'application/json' },
   });
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/delete-photo/index.ts
+++ b/supabase/functions/delete-photo/index.ts
@@ -134,3 +134,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/email-unsubscribe/index.ts
+++ b/supabase/functions/email-unsubscribe/index.ts
@@ -155,3 +155,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/enrich-environment/index.ts
+++ b/supabase/functions/enrich-environment/index.ts
@@ -120,3 +120,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/enrich-taxon/index.ts
+++ b/supabase/functions/enrich-taxon/index.ts
@@ -180,3 +180,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/export-dwca/index.ts
+++ b/supabase/functions/export-dwca/index.ts
@@ -517,3 +517,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/export-trail-pdf/index.ts
+++ b/supabase/functions/export-trail-pdf/index.ts
@@ -319,3 +319,10 @@ function buildFieldGuideHtml(
 </body>
 </html>`;
 }
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/follow/index.ts
+++ b/supabase/functions/follow/index.ts
@@ -123,3 +123,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 Deno.serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/generate-wrapped/index.ts
+++ b/supabase/functions/generate-wrapped/index.ts
@@ -248,3 +248,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/get-upload-url/index.ts
+++ b/supabase/functions/get-upload-url/index.ts
@@ -153,3 +153,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/identify/index.ts
+++ b/supabase/functions/identify/index.ts
@@ -1034,3 +1034,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/kairos-fire/index.ts
+++ b/supabase/functions/kairos-fire/index.ts
@@ -433,3 +433,10 @@ if (anyOk) {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -515,3 +515,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 Deno.serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/plantnet-monitor/index.ts
+++ b/supabase/functions/plantnet-monitor/index.ts
@@ -108,3 +108,10 @@ serve(async (req) => {
     { headers: { 'content-type': 'application/json' } },
   );
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/react/index.ts
+++ b/supabase/functions/react/index.ts
@@ -91,3 +91,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 Deno.serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/recompute-streaks/index.ts
+++ b/supabase/functions/recompute-streaks/index.ts
@@ -38,3 +38,10 @@ serve(async (req) => {
     headers: { 'content-type': 'application/json' },
   });
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/recompute-taxa-cache/index.ts
+++ b/supabase/functions/recompute-taxa-cache/index.ts
@@ -41,3 +41,10 @@ serve(async (req) => {
     headers: { 'content-type': 'application/json' },
   });
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/recompute-user-stats/index.ts
+++ b/supabase/functions/recompute-user-stats/index.ts
@@ -65,3 +65,10 @@ serve(async (req) => {
     headers: { 'content-type': 'application/json' },
   });
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/refresh-conservation-status/index.ts
+++ b/supabase/functions/refresh-conservation-status/index.ts
@@ -264,3 +264,10 @@ serve(async (req) => {
     headers: { 'Content-Type': 'application/json' },
   });
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/refresh-taxon-ranges/index.ts
+++ b/supabase/functions/refresh-taxon-ranges/index.ts
@@ -53,3 +53,10 @@ serve(async (req) => {
     headers: { 'content-type': 'application/json' },
   });
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/report/index.ts
+++ b/supabase/functions/report/index.ts
@@ -93,3 +93,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 Deno.serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/share-card/index.ts
+++ b/supabase/functions/share-card/index.ts
@@ -184,3 +184,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/sponsorships/index.ts
+++ b/supabase/functions/sponsorships/index.ts
@@ -919,3 +919,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -94,3 +94,10 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/sync-error/index.ts
+++ b/supabase/functions/sync-error/index.ts
@@ -95,3 +95,10 @@ serve(async (req) => {
 
   return jsonResponse({ ok: true });
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/sync-gbif-regional-baseline/index.ts
+++ b/supabase/functions/sync-gbif-regional-baseline/index.ts
@@ -99,3 +99,10 @@ serve(async (req) => {
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/tokens/index.ts
+++ b/supabase/functions/tokens/index.ts
@@ -129,3 +129,10 @@ function json(body: unknown, status = 200): Response {
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   });
 }
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/weekly-digest/index.ts
+++ b/supabase/functions/weekly-digest/index.ts
@@ -278,3 +278,10 @@ serve(async (req) => {
     { headers: { 'content-type': 'application/json' } }
   );
 });
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";

--- a/supabase/functions/weekly-expert-lottery/index.ts
+++ b/supabase/functions/weekly-expert-lottery/index.ts
@@ -121,3 +121,10 @@ function getIsoWeek(): string {
   const week = Math.ceil(((thursday.getTime() - jan4.getTime()) / 86_400_000 + 1) / 7);
   return `${thursday.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
 }
+
+// rastrum incident 2026-05-16: forced re-upload to recover from a
+// Supabase Edge serving-layer drop (function ACTIVE in the control plane
+// but 404 at the runtime; `supabase functions deploy` skipped unchanged
+// bundles as a silent no-op). Behavior-neutral bundle-hash buster; safe to
+// remove once Supabase confirms the platform root cause (support ticket).
+;(globalThis as Record<string, unknown>).__rastrumRedeploy = "2026-05-16-serving-layer-recovery";


### PR DESCRIPTION
## Incident

The create-observation flow's *Identify* step failed in production with
`Failed to send a request to the Edge Function`. Root cause was a
**Supabase platform serving-layer drop**: 30 of 35 Edge Functions were
`status=ACTIVE` in the control plane (and DB/REST/Auth/Storage/Realtime
all healthy) but returned `HTTP 404 NOT_FOUND` at the runtime gateway.

Redeploy and project restart did **not** fix it: the Supabase CLI
content-hash dedups (`No change found in Function: X` → skips upload →
still prints `Deployed Functions ...: X` → exits 0 → workflow green).
The only functions still serving were the ones with a real recent code
change (#1086 / #1087 / #1094) whose bundle hash had changed.

Full evidence + RCA: `docs/runbooks/ef-serving-layer-recovery.md`.

## Fix

1. **Force re-upload** — append a behavior-neutral top-level global
   assignment to each of the 30 affected functions' `index.ts` to bust
   the bundle hash so `functions deploy` genuinely re-uploads them and
   the runtime re-registers them. Safe to remove once Supabase confirms
   the platform RCA (follow-up issue).
2. **Post-deploy runtime gate** — `deploy-functions.yml` now curls every
   just-deployed function's OPTIONS preflight (auth-exempt, no secret)
   and **fails the job** if any returns 404 / connection error. Symmetric
   to the `db-validate` gate that fixed the analogous `db-apply` silent
   skip (PR #42). "Workflow green" now means "the runtime serves it".
3. **Runbook** documenting the incident class, recovery, escalation.

## Verification

On merge, `deploy-functions.yml` fires on `supabase/functions/**`,
genuinely re-uploads the changed bundles, and the new gate asserts all
deployed functions return non-404. Self-verifying.

## Follow-ups (not in this PR)

- Remove the markers once Supabase confirms platform RCA.
- External heartbeat (Cloudflare Worker cron) on `OPTIONS
  /functions/v1/identify` — catches a serving-layer drop that happens
  *after* a successful deploy (this incident broke ~1.5 h post-deploy).
- Open Supabase support ticket (their 404 troubleshooting doc says a
  function ACTIVE-but-404 after redeploy is a suspected internal bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)