### PR TITLE
fix(observe): self-heal stale dynamic-import failures after deploy

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -424,6 +424,27 @@ import { saveObservationToOutbox, resolveObserverRef } from '../lib/observe';
 import { syncOutbox } from '../lib/sync';
 import { SYNC_EVENTS, type SyncRowDetail } from '../lib/sync-events';
 import { getObservationDefaults, setObservationDefaults } from '../lib/observation-defaults';
+import { recoverFromChunkLoadError } from '../lib/chunk-reload';
+
+// A stale dynamic-import after a deploy ("Failed to fetch dynamically
+// imported module") would otherwise degrade the pipeline silently to an
+// empty stepper. Self-heal with a single guarded reload that pulls a
+// fresh SW + shell; returns true when it took over (caller must `return`
+// and NOT mark the pipeline failed, so the post-reload resume retries
+// with the fresh chunk graph). Second occurrence falls through to the
+// normal degraded fallback so a real build inconsistency can't loop.
+function maybeSelfHealChunk(err: unknown): boolean {
+  return recoverFromChunkLoadError(err, {
+    storage: sessionStorage,
+    reload: () => {
+      navigator.serviceWorker
+        ?.getRegistration()
+        .then((r) => r?.update())
+        .catch(() => {})
+        .finally(() => location.reload());
+    },
+  });
+}
 
 // ── State ──────────────────────────────────────────────────────────────────
 const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
@@ -732,6 +753,7 @@ document.addEventListener('rastrum:photo-edited', (e: Event) => {
     pipelineSection?.classList.remove('hidden');
     updatePipelineUI();
     runPipeline(pipelineState).catch(err => {
+      if (maybeSelfHealChunk(err)) return;
       console.error('[rastrum] re-run after edit failed', err);
       showPostForm();
     });
@@ -790,6 +812,7 @@ document.addEventListener('rastrum:files-dropped', async (e: Event) => {
   try {
     await runPipeline(pipelineState);
   } catch (err) {
+    if (maybeSelfHealChunk(err)) return;
     console.error('[rastrum] pipeline error — showing post-form as fallback', err);
     pipelineState.status = 'failed';
     await savePipelineState(pipelineState).catch(() => {});
@@ -1419,6 +1442,7 @@ async function resumePipeline(state: PipelineState) {
     try {
       await runPipeline(state);
     } catch (err) {
+      if (maybeSelfHealChunk(err)) return;
       console.error('[rastrum] resume pipeline error — showing post-form as fallback', err);
       state.status = 'failed';
       await savePipelineState(state).catch(() => {});

--- a/src/lib/chunk-reload.test.ts
+++ b/src/lib/chunk-reload.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { isChunkLoadError, recoverFromChunkLoadError } from './chunk-reload';
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const m = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => (m.has(k) ? (m.get(k) as string) : null),
+    setItem: (k: string, v: string) => void m.set(k, v),
+  };
+}
+
+describe('isChunkLoadError', () => {
+  it('is true for the Vite/Chrome dynamic-import failure', () => {
+    expect(
+      isChunkLoadError(
+        new TypeError(
+          'Failed to fetch dynamically imported module: https://rastrum.org/_astro/claude-availability.DmTXbHnd.js',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('is true for the Safari "Importing a module script failed" message', () => {
+    expect(isChunkLoadError(new Error('Importing a module script failed.'))).toBe(true);
+  });
+
+  it('is true for a named ChunkLoadError', () => {
+    const e = new Error('loading chunk 42 failed');
+    e.name = 'ChunkLoadError';
+    expect(isChunkLoadError(e)).toBe(true);
+  });
+
+  it('is false for an unrelated runtime error', () => {
+    expect(isChunkLoadError(new TypeError("Cannot read properties of null (reading 'x')"))).toBe(
+      false,
+    );
+  });
+
+  it('is false for non-error values', () => {
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError('nope')).toBe(false);
+  });
+});
+
+describe('recoverFromChunkLoadError', () => {
+  const chunkErr = new TypeError('Failed to fetch dynamically imported module: /x.js');
+
+  it('reloads once and records a one-shot guard on first chunk failure', () => {
+    const storage = fakeStorage();
+    const reload = vi.fn();
+    const recovered = recoverFromChunkLoadError(chunkErr, { storage, reload });
+    expect(recovered).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.getItem('rastrum.chunkReload')).toBeTruthy();
+  });
+
+  it('does not reload again if the guard is already set (no reload loop)', () => {
+    const storage = fakeStorage({ 'rastrum.chunkReload': '1' });
+    const reload = vi.fn();
+    const recovered = recoverFromChunkLoadError(chunkErr, { storage, reload });
+    expect(recovered).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-chunk errors (caller handles them normally)', () => {
+    const storage = fakeStorage();
+    const reload = vi.fn();
+    const recovered = recoverFromChunkLoadError(new Error('boom'), { storage, reload });
+    expect(recovered).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+    expect(storage.getItem('rastrum.chunkReload')).toBeNull();
+  });
+});

--- a/src/lib/chunk-reload.ts
+++ b/src/lib/chunk-reload.ts
@@ -1,0 +1,53 @@
+/**
+ * Self-heal stale dynamic-import ("chunk") failures after a deploy.
+ *
+ * When the static site is redeployed, `_astro/*.[hash].js` filenames
+ * change. A tab/SW that still runs an old parent chunk will `import()` a
+ * child hash that no longer exists on the origin → the pipeline (and any
+ * other dynamic-import site) dies with a `TypeError: Failed to fetch
+ * dynamically imported module`. Reloading normally is not enough because
+ * the service worker keeps serving the stale shell cache-first.
+ *
+ * `recoverFromChunkLoadError` detects that specific failure and forces a
+ * single full reload (one-shot guarded via sessionStorage so we never
+ * loop). The reload re-fetches the fresh document; the new SW (which
+ * already `skipWaiting()`s + `clients.claim()`s) then serves the current
+ * asset graph. For non-chunk errors it returns `false` so the caller's
+ * normal degraded fallback still runs.
+ */
+
+const GUARD_KEY = 'rastrum.chunkReload';
+
+const CHUNK_ERROR_PATTERNS = [
+  'failed to fetch dynamically imported module',
+  'error loading dynamically imported module',
+  'importing a module script failed',
+];
+
+export function isChunkLoadError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { name?: unknown; message?: unknown };
+  if (e.name === 'ChunkLoadError') return true;
+  const msg = typeof e.message === 'string' ? e.message.toLowerCase() : '';
+  if (!msg) return false;
+  return CHUNK_ERROR_PATTERNS.some((p) => msg.includes(p));
+}
+
+export interface ChunkReloadDeps {
+  storage: Pick<Storage, 'getItem' | 'setItem'>;
+  reload: () => void;
+}
+
+/**
+ * Returns `true` if it handled the error by triggering a one-shot reload.
+ * Returns `false` if the caller should fall back to its normal handling
+ * (error is not a chunk-load failure, or we've already reloaded once this
+ * session and must not loop).
+ */
+export function recoverFromChunkLoadError(err: unknown, deps: ChunkReloadDeps): boolean {
+  if (!isChunkLoadError(err)) return false;
+  if (deps.storage.getItem(GUARD_KEY)) return false;
+  deps.storage.setItem(GUARD_KEY, String(Date.now()));
+  deps.reload();
+  return true;
+}


### PR DESCRIPTION
## Problem (prod, 2026-05-16)

After a static-site redeploy, `_astro/*.[hash].js` filenames change. A
tab — or a stale service-worker shell — still running an old parent
chunk `import()`s a child hash that no longer exists on the origin →
`TypeError: Failed to fetch dynamically imported module`. The observe
pipeline caught it and degraded **silently to an empty stepper** ("cards
vacíos"). A plain reload didn't fix it because the old SW kept serving
the stale shell cache-first; the user was stuck until caches were purged
by hand.

This is independent of the Edge Function serving-layer incident (PR
#1102) — it's the classic PWA stale-chunk-after-deploy class, made
visible by today's rapid deploys.

## Fix

`src/lib/chunk-reload.ts`:
- `isChunkLoadError(err)` — classifies the Vite/Chrome
  ("Failed to fetch dynamically imported module"), Safari
  ("Importing a module script failed"), and named `ChunkLoadError`
  signatures.
- `recoverFromChunkLoadError(err, deps)` — one-shot,
  `sessionStorage`-guarded full reload (never loops); the prod reload
  first calls `serviceWorker.getRegistration().update()` so the fresh
  SW + asset graph win.

Wired into ObserveView2's three pipeline-error catches **before** the
degraded fallback and **before** marking the pipeline `failed`, so the
post-reload resume retries with the fresh chunks. A second occurrence
falls through to the existing degraded fallback, so a genuine build
inconsistency can't loop.

The helper is a **static import** (bundled into the parent chunk) — the
self-heal path itself can never be the failing dynamic import.

## Tests

TDD: `src/lib/chunk-reload.test.ts` (8 cases — signature classification,
one-shot reload, loop guard, non-chunk passthrough). Watched RED (module
missing) → GREEN. Full suite 2415/2415, typecheck clean, build 255 pages.

## Follow-ups (not here)

- `ObservationForm.astro` / `QuickObserveSheet.astro` also dynamic-import
  `claude-availability`; same wrapper could be applied if those surfaces
  matter.
- Root prevention discussed separately: external EF heartbeat;
  on-device-AI fallback (resilience #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)