### PR TITLE
fix(observe): extend chunk self-heal to ObservationForm + QuickObserveSheet

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -679,6 +679,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
 
 <script>
   import { parse as parseExif } from 'exifr';
+  import { selfHealChunk } from '../lib/chunk-reload';
   import { syncOutbox, registerSyncTriggers } from '../lib/sync';
   import { resolveObserverRef, saveObservationToOutbox } from '../lib/observe';
   import { checkOutlier, formatDistanceKm } from '../lib/outlier-alert';
@@ -1293,6 +1294,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
         status.classList.add('hidden');
       }
     } catch (err) {
+      if (selfHealChunk(err)) return;
       if (status) status.textContent = err instanceof Error ? err.message : String(err);
     } finally {
       btn.disabled = false;
@@ -1559,6 +1561,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
         }
       }
     } catch (err) {
+      if (selfHealChunk(err)) return;
       phiProgress?.classList.add('hidden');
       if (idAllFailed) {
         idAllFailed.textContent = err instanceof Error ? err.message : String(err);
@@ -1626,6 +1629,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
         }
       }
     } catch (err) {
+      if (selfHealChunk(err)) return;
       gemmaProgress?.classList.add('hidden');
       if (idAllFailed) {
         idAllFailed.textContent = err instanceof Error ? err.message : String(err);

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -424,27 +424,7 @@ import { saveObservationToOutbox, resolveObserverRef } from '../lib/observe';
 import { syncOutbox } from '../lib/sync';
 import { SYNC_EVENTS, type SyncRowDetail } from '../lib/sync-events';
 import { getObservationDefaults, setObservationDefaults } from '../lib/observation-defaults';
-import { recoverFromChunkLoadError } from '../lib/chunk-reload';
-
-// A stale dynamic-import after a deploy ("Failed to fetch dynamically
-// imported module") would otherwise degrade the pipeline silently to an
-// empty stepper. Self-heal with a single guarded reload that pulls a
-// fresh SW + shell; returns true when it took over (caller must `return`
-// and NOT mark the pipeline failed, so the post-reload resume retries
-// with the fresh chunk graph). Second occurrence falls through to the
-// normal degraded fallback so a real build inconsistency can't loop.
-function maybeSelfHealChunk(err: unknown): boolean {
-  return recoverFromChunkLoadError(err, {
-    storage: sessionStorage,
-    reload: () => {
-      navigator.serviceWorker
-        ?.getRegistration()
-        .then((r) => r?.update())
-        .catch(() => {})
-        .finally(() => location.reload());
-    },
-  });
-}
+import { selfHealChunk } from '../lib/chunk-reload';
 
 // ── State ──────────────────────────────────────────────────────────────────
 const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
@@ -753,7 +733,7 @@ document.addEventListener('rastrum:photo-edited', (e: Event) => {
     pipelineSection?.classList.remove('hidden');
     updatePipelineUI();
     runPipeline(pipelineState).catch(err => {
-      if (maybeSelfHealChunk(err)) return;
+      if (selfHealChunk(err)) return;
       console.error('[rastrum] re-run after edit failed', err);
       showPostForm();
     });
@@ -812,7 +792,7 @@ document.addEventListener('rastrum:files-dropped', async (e: Event) => {
   try {
     await runPipeline(pipelineState);
   } catch (err) {
-    if (maybeSelfHealChunk(err)) return;
+    if (selfHealChunk(err)) return;
     console.error('[rastrum] pipeline error — showing post-form as fallback', err);
     pipelineState.status = 'failed';
     await savePipelineState(pipelineState).catch(() => {});
@@ -1442,7 +1422,7 @@ async function resumePipeline(state: PipelineState) {
     try {
       await runPipeline(state);
     } catch (err) {
-      if (maybeSelfHealChunk(err)) return;
+      if (selfHealChunk(err)) return;
       console.error('[rastrum] resume pipeline error — showing post-form as fallback', err);
       state.status = 'failed';
       await savePipelineState(state).catch(() => {});

--- a/src/components/QuickObserveSheet.astro
+++ b/src/components/QuickObserveSheet.astro
@@ -128,6 +128,7 @@ const isEs = lang === "es";
 import { triageFile, buildGraph, savePipelineState } from '../lib/pipeline-engine';
 import type { PipelineFile, PipelineState } from '../lib/pipeline-engine';
 import { saveObservationToOutbox, resolveObserverRef } from '../lib/observe';
+import { selfHealChunk } from '../lib/chunk-reload';
 import { syncOutbox } from '../lib/sync';
 import { PENDING_OBSERVATION_KEY } from '../lib/chat-attachment-helpers';
 import { showToast } from '../lib/toast';
@@ -326,6 +327,7 @@ saveBtn?.addEventListener('click', async () => {
     document.dispatchEvent(new CustomEvent('rastrum:quick-saved'));
     setTimeout(closeSheet, 1800);
   } catch (err) {
+    if (selfHealChunk(err)) return;
     if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = isEs ? 'Confirmar y guardar' : 'Confirm & save'; }
     showToast({ message: (err as Error).message, variant: 'error' });
   }

--- a/src/lib/chunk-reload.ts
+++ b/src/lib/chunk-reload.ts
@@ -51,3 +51,23 @@ export function recoverFromChunkLoadError(err: unknown, deps: ChunkReloadDeps): 
   deps.reload();
   return true;
 }
+
+/**
+ * Browser-bound convenience wrapper around {@link recoverFromChunkLoadError}.
+ * Thin glue (the decision logic is unit-tested via the injected-deps form):
+ * uses `sessionStorage` for the one-shot guard and, before reloading, nudges
+ * the service worker to update so the fresh asset graph wins the reload.
+ * Call it first in any dynamic-import catch: `if (selfHealChunk(err)) return;`
+ */
+export function selfHealChunk(err: unknown): boolean {
+  return recoverFromChunkLoadError(err, {
+    storage: sessionStorage,
+    reload: () => {
+      navigator.serviceWorker
+        ?.getRegistration()
+        .then((r) => r?.update())
+        .catch(() => {})
+        .finally(() => location.reload());
+    },
+  });
+}


### PR DESCRIPTION
Follow-up to #1104. Exports `selfHealChunk()` (prod-bound wrapper around
the unit-tested `recoverFromChunkLoadError`) from `chunk-reload.ts`,
refactors `ObserveView2` to use it instead of an inline copy, and wires
it into the dynamic-import catch sites in `ObservationForm` (client
identify, Phi, Gemma) and `QuickObserveSheet` (confirm + save) so a
stale post-deploy chunk self-heals on every observe surface, not just
the default one.

No new logic — the decision/guard is the same already-tested code (8
unit tests in `chunk-reload.test.ts`). Typecheck clean, build 255 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)