### PR TITLE
docs(spec): observe AI progressive result card design

### DIFF
--- a/docs/superpowers/plans/2026-05-16-observe-ondevice-first-runner-set.md
+++ b/docs/superpowers/plans/2026-05-16-observe-ondevice-first-runner-set.md
@@ -1,0 +1,327 @@
+# On-device-first photo runners — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make on-device photo identification run **without the cloud and first** in `local` mode, by extracting a pure runner-set resolver and removing the `ObserveView2.astro` photo hard-skip — the structural foundation of the local-first progressive card.
+
+**Architecture:** A new pure module `src/lib/observe-runner-set.ts` decides *which* identifier runners run, given AI mode + media kind + availability, with local-first invariants. `ObserveView2.astro`'s pipeline loop calls it instead of the inline ad-hoc logic, and the `'local'`-mode photo `continue` skip is deleted. The resolver is unit-tested in isolation; the wiring is a mechanical substitution.
+
+**Tech Stack:** TypeScript (strict), Vitest (happy-dom), Astro inline module script.
+
+**Scope note:** R1 (`sync.ts` `?? 'human'`) and R2 (confidence-cap preservation) are separable invariants — they get their own short follow-up plan, because R1's correct fix depends on the manual-entry source path and must not be guessed here. This plan delivers the on-device-first runner foundation only.
+
+---
+
+### Task 1: Pure runner-set resolver
+
+**Files:**
+- Create: `src/lib/observe-runner-set.ts`
+- Test: `src/lib/observe-runner-set.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/observe-runner-set.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolveRunnerSet, type RunnerAvailability } from './observe-runner-set';
+
+const none: RunnerAvailability = {
+  plantnet: false, claude: false, phi: false, gemma: false,
+  efficientNet: false, megaDetector: false, birdnet: false,
+};
+
+describe('resolveRunnerSet — local-first invariants', () => {
+  it('local mode + photo runs available on-device photo runners, NO cloud', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'local', mediaKind: 'photo',
+      available: { ...none, efficientNet: true, megaDetector: true, phi: true, plantnet: true, claude: true },
+    });
+    expect(r).toContain('efficientNet');
+    expect(r).toContain('phi');
+    expect(r).toContain('megaDetector');
+    expect(r).not.toContain('plantnet');
+    expect(r).not.toContain('claude');
+  });
+
+  it('local mode + photo with nothing on-device returns [] (caller falls back)', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'local', mediaKind: 'photo',
+      available: { ...none, plantnet: true, claude: true },
+    });
+    expect(r).toEqual([]);
+  });
+
+  it('sponsored mode + photo runs cloud AND on-device in parallel', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'sponsored', mediaKind: 'photo',
+      available: { ...none, plantnet: true, claude: true, efficientNet: true },
+    });
+    expect(r).toEqual(expect.arrayContaining(['plantnet', 'claude', 'efficientNet']));
+  });
+
+  it('audio runs birdnet only, in any mode', () => {
+    for (const aiMode of ['local', 'sponsored', 'own-key'] as const) {
+      expect(
+        resolveRunnerSet({ aiMode, mediaKind: 'audio', available: { ...none, birdnet: true, claude: true } }),
+      ).toEqual(['birdnet']);
+    }
+  });
+
+  it('own-key mode + photo excludes cloud claude when claude unavailable', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'own-key', mediaKind: 'photo',
+      available: { ...none, plantnet: true, claude: false, efficientNet: true },
+    });
+    expect(r).toContain('plantnet');
+    expect(r).toContain('efficientNet');
+    expect(r).not.toContain('claude');
+  });
+
+  it('unknown / unsupported media returns []', () => {
+    expect(resolveRunnerSet({ aiMode: 'local', mediaKind: 'unknown', available: { ...none, efficientNet: true } })).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/observe-runner-set.test.ts`
+Expected: FAIL — `Failed to resolve import "./observe-runner-set"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/lib/observe-runner-set.ts
+/**
+ * Pure decision: which identifier runners run for one pipeline node.
+ *
+ * Local-first invariants:
+ *  - `local` mode never returns a cloud runner.
+ *  - `local` + photo is NOT skipped — it returns the available on-device
+ *    photo runners (efficientNet / phi / gemma) plus the megaDetector
+ *    pre-filter. Returns [] only when nothing on-device is available, so
+ *    the caller can fall back to `sponsored`.
+ *  - `sponsored` / `own-key` run cloud runners AND on-device in parallel.
+ *  - audio is birdnet-only in every mode.
+ *
+ * Returns abstract runner names; the caller maps them to concrete
+ * runner-map keys.
+ */
+export type AiMode = 'sponsored' | 'own-key' | 'local';
+export type MediaKind = 'photo' | 'audio' | 'video' | 'unknown';
+
+export interface RunnerAvailability {
+  plantnet: boolean;
+  claude: boolean;
+  phi: boolean;
+  gemma: boolean;
+  efficientNet: boolean;
+  megaDetector: boolean;
+  birdnet: boolean;
+}
+
+export interface ResolveInput {
+  aiMode: AiMode;
+  mediaKind: MediaKind;
+  available: RunnerAvailability;
+}
+
+const ONDEVICE_PHOTO: Array<keyof RunnerAvailability> = [
+  'megaDetector', 'efficientNet', 'phi', 'gemma',
+];
+const CLOUD_PHOTO: Array<keyof RunnerAvailability> = ['plantnet', 'claude'];
+
+export function resolveRunnerSet(input: ResolveInput): string[] {
+  const { aiMode, mediaKind, available } = input;
+
+  if (mediaKind === 'audio') {
+    return available.birdnet ? ['birdnet'] : [];
+  }
+  if (mediaKind !== 'photo') {
+    return [];
+  }
+
+  const onDevice = ONDEVICE_PHOTO.filter((k) => available[k]);
+
+  if (aiMode === 'local') {
+    return onDevice; // [] → caller falls back to sponsored
+  }
+
+  const cloud = CLOUD_PHOTO.filter((k) => available[k]);
+  return [...cloud, ...onDevice];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/observe-runner-set.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npx tsc --noEmit
+git add src/lib/observe-runner-set.ts src/lib/observe-runner-set.test.ts
+git commit -m "feat(observe): pure on-device-first runner-set resolver"
+```
+
+---
+
+### Task 2: Wire resolver into ObserveView2 + delete the photo skip
+
+**Files:**
+- Modify: `src/components/ObserveView2.astro` (the `runPipeline` photo branch, currently lines ~890–925; the `'local'`-mode skip is the line `if (aiMode === 'local') { setNodeState(state, node.id, 'skipped', undefined, 'Local-only mode'); continue; }`)
+
+**Context (current code, for orientation — do not assume line numbers, match on text):**
+
+```ts
+      if (pf.kind === 'photo') {
+        if (aiMode === 'local') { setNodeState(state, node.id, 'skipped', undefined, 'Local-only mode'); continue; }
+        const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
+        runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
+        if (aiMode === 'own-key') {
+          const { hasKeysForPlugin } = await import('../lib/byo-keys');
+          if (hasKeysForPlugin('claude_haiku') && await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+        } else {
+          if (await claudeAvailable()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+        }
+        try {
+          if (await pluginReady('webllm_phi35_vision')) {
+            runners.webllm_phi35_vision = makePhiRunner(lang as 'en' | 'es');
+          }
+        } catch { /* WebLLM unavailable, skip */ }
+        try {
+          if (await pluginReady('onnx_gemma4_vision')) {
+            const { makeGemmaRunner } = await import('../lib/identify-runners');
+            runners.onnx_gemma4_vision = makeGemmaRunner(lang as 'en' | 'es');
+          }
+        } catch { /* transformers.js unavailable, skip */ }
+        // EfficientNet block follows (getOnnxBaseCacheStatus → runners.onnx_efficientnet_lite0)
+```
+
+- [ ] **Step 1: Add the resolver import**
+
+At the top of the `<script>` module in `ObserveView2.astro` (with the other `../lib/...` imports, next to `import { selfHealChunk } from '../lib/chunk-reload';`), add:
+
+```ts
+import { resolveRunnerSet, type RunnerAvailability } from '../lib/observe-runner-set';
+```
+
+- [ ] **Step 2: Replace the photo branch's runner assembly**
+
+Replace the block from `if (aiMode === 'local') { setNodeState(...'Local-only mode'); continue; }` through the end of the EfficientNet block with the following. Compute availability first, resolve, then build only the resolved runners. (Keep the existing `makePlantNetRunner`/`makeClaudeRunner`/`makePhiRunner`/`makeGemmaRunner`/EfficientNet runner factories — only the *selection* changes.)
+
+```ts
+      if (pf.kind === 'photo') {
+        const { hasKeysForPlugin } = await import('../lib/byo-keys');
+        const { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } = await import('../lib/identifiers/onnx-base-cache');
+        const efficientNetCached = getOnnxBaseWeightsBaseUrl()
+          ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
+          : false;
+        const avail: RunnerAvailability = {
+          plantnet: true, // EF operator key — always reachable when online
+          claude: aiMode === 'own-key'
+            ? (hasKeysForPlugin('claude_haiku') && await hasAnthropicKey())
+            : await claudeAvailable(),
+          phi: await pluginReady('webllm_phi35_vision').catch(() => false),
+          gemma: await pluginReady('onnx_gemma4_vision').catch(() => false),
+          efficientNet: efficientNetCached,
+          megaDetector: false, // pre-filter wiring is a later card-spec task; not in this slice
+          birdnet: false,
+        };
+        let chosen = resolveRunnerSet({ aiMode, mediaKind: 'photo', available: avail });
+        if (aiMode === 'local' && chosen.length === 0) {
+          // Nothing on-device for photos — honest fallback to sponsored.
+          aiMode = 'sponsored'; writeAiMode('sponsored'); applyModeStyles('sponsored');
+          showModeToast(isEs ? 'Sin modelo on-device para fotos — usando patrocinado.' : 'No on-device photo model — using sponsored.');
+          chosen = resolveRunnerSet({ aiMode, mediaKind: 'photo', available: avail });
+        }
+        const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
+        if (chosen.includes('plantnet')) runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
+        if (chosen.includes('claude')) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+        if (chosen.includes('phi')) runners.webllm_phi35_vision = makePhiRunner(lang as 'en' | 'es');
+        if (chosen.includes('gemma')) {
+          const { makeGemmaRunner } = await import('../lib/identify-runners');
+          runners.onnx_gemma4_vision = makeGemmaRunner(lang as 'en' | 'es');
+        }
+        if (chosen.includes('efficientNet')) {
+          const { makeEfficientNetRunner } = await import('../lib/identify-runners');
+          runners.onnx_efficientnet_lite0 = makeEfficientNetRunner(lang as 'en' | 'es');
+        }
+```
+
+> Note for the implementer: confirm the exact EfficientNet runner factory name and plugin key by reading the *existing* EfficientNet block you are replacing (search `onnx_efficientnet` / `getOnnxBaseCacheStatus` in `ObserveView2.astro` and `src/lib/identify-runners.ts`). Use the names found there verbatim — do not invent. If the existing code uses a different factory name than `makeEfficientNetRunner`, use the existing one.
+
+- [ ] **Step 3: Remove the now-dead BirdNET-only `local` gate (lines ~878–882)**
+
+The earlier block `} else if (aiMode === 'local') { const { getBirdNETCacheStatus ... } ... if (!ok) { aiMode = 'sponsored'; ... } }` pre-empted `local` mode to sponsored whenever BirdNET wasn't cached — that defeats on-device photo. Delete that `else if (aiMode === 'local') { ... }` arm entirely; per-node resolution (Step 2 for photo, the existing audio branch for BirdNET) now handles availability correctly.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: zero errors.
+
+- [ ] **Step 5: Full unit suite + build**
+
+Run: `npx vitest run` then `npm run build`
+Expected: all tests pass; build completes (no Astro/JSX error).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/ObserveView2.astro
+git commit -m "feat(observe): on-device-first photo ID — resolver-driven runners, delete :891 skip"
+```
+
+---
+
+### Task 3: Regression guard — local mode no longer skips photos
+
+**Files:**
+- Test: `src/lib/observe-runner-set.test.ts` (extend)
+
+- [ ] **Step 1: Add the regression test**
+
+```typescript
+it('REGRESSION: local + photo with a cached on-device model never returns [] (no skip)', () => {
+  const r = resolveRunnerSet({
+    aiMode: 'local', mediaKind: 'photo',
+    available: { plantnet: true, claude: true, phi: false, gemma: false,
+      efficientNet: true, megaDetector: false, birdnet: false },
+  });
+  expect(r.length).toBeGreaterThan(0);
+  expect(r).not.toContain('plantnet');
+});
+```
+
+- [ ] **Step 2: Run + verify pass**
+
+Run: `npx vitest run src/lib/observe-runner-set.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/observe-runner-set.test.ts
+git commit -m "test(observe): regression guard — local mode runs on-device photo runners"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Implements the amended foundation ("remove `:891`
+  skip + runner-set resolver, on-device photo without/before cloud").
+  R1/R2 explicitly scoped out to a follow-up plan (stated in header) —
+  not a gap, a decomposition. MegaDetector pre-filter availability is
+  wired as `false` here with an inline note that it's a later card-spec
+  task — consistent with the spec's "orchestration" being a separate
+  concern.
+- **Placeholder scan:** No TBD/TODO. The one implementer note (EfficientNet
+  factory name) instructs reading existing code and using it verbatim —
+  this is correct guidance, not a placeholder, because inventing the name
+  would be the error.
+- **Type consistency:** `RunnerAvailability` / `ResolveInput` /
+  `resolveRunnerSet` names match across Task 1 and Task 2. Abstract names
+  (`plantnet`,`claude`,`phi`,`gemma`,`efficientNet`,`megaDetector`,
+  `birdnet`) are consistent between resolver and wiring.

--- a/docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md
+++ b/docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md
@@ -1,0 +1,153 @@
+# Observe AI — progressive result card (design)
+
+> Status: design approved via brainstorming 2026-05-16. Spine of the
+> observe AI UX redesign. Child specs (gate split, downloads UX, consensus
+> hardening R1–R3, review-request queue) are referenced, not specified here.
+
+## Problem
+
+The observe AI experience exposes a heterogeneous identifier roster
+(PlantNet, Claude, MegaDetector, EfficientNet, Phi, Gemma, BirdNET) to the
+user as a 9-card power panel plus a 3-way `sponsored/own-key/local` mode
+toggle. The interactive pipeline depends on the `identify` Edge Function
+for cloud runners; an EF outage (incident 2026-05-16) dead-ended identify
+with an empty stepper. The product is local-first for capture + storage
+but **not** for identification: high-accuracy identifiers are inherently
+cloud, on-device options are narrower/weaker and capped, and the
+`localAISupported()` gate blocks the lightweight WASM path on phones.
+
+The user must currently never think about *which* model. The roster is a
+capability graph the app orchestrates, not a menu the user navigates.
+"Local-first" here means: an instant on-device answer that **never blocks
+capture**; the cloud is a parallel enhancement that upgrades, not a
+prerequisite.
+
+## Decided behavior (brainstorming Q1–Q4)
+
+- **Q1 — Spine:** the progressive result card. Downloads/orchestration/
+  consensus feed it; they are child specs with interface contracts to it.
+- **Q2 — Role:** confidence-adaptive hybrid. High AI confidence behaves as
+  "one-tap, saved"; weak/capped/offline becomes an honest "affirm or ask
+  for help" surface.
+- **Q3 — Upgrade conflict:** the observer's explicit affirmation is
+  sovereign. If the observer did not act, the cloud upgrade fills/improves
+  freely. If the observer affirmed, the cloud result is a **parallel
+  suggestion** (adopt/dismiss) and never overwrites. The machine never
+  overrides the human.
+- **Q4 — Audit:** progressive disclosure. An inline source label is always
+  shown; "ver traza / view trace" expands a full per-model trail that maps
+  1:1 to existing `identifications` rows.
+
+## Card structure
+
+One card that morphs through states. **C-base** (question-framed: the AI
+asks the human) + **A's adaptive collapse** (high confidence → compact
+"✓ saved" row, zero friction) + **B's provenance strip** (device → cloud →
+community) shown while the ID is unconfirmed.
+
+### State machine
+
+| State | Trigger | Card |
+|---|---|---|
+| **S0 Analyzing** | media added | "Identifying on your device…", cloud in parallel if online; **never blocks** |
+| **S1a High confidence** | strong AI result | Collapsed: "✓ saved · PlantNet 94% · view trace". No question. |
+| **S1b Weak/uncertain** | capped/low-confidence provisional | Question: *Yes / No, other… / I don't know — ask for review*; provenance strip |
+| **S2 Upgrade, no observer action** | cloud result, `observer_affirmed = false` | Primary re-stamped to cloud result ("↑ improved by cloud") |
+| **S2′ Upgrade, observer affirmed** | cloud result, `observer_affirmed = true` | Observer's ID stays primary; cloud shown as parallel suggestion (adopt/dismiss) |
+| **S3 No model + no network** | worst field case | "Unidentified — will identify on sync"; name-it / ask-review / save-anyway. **Never blocks save.** |
+
+`view trace` is available in every state (audit layer below).
+
+**S1a vs S1b boundary (explicit, no new constants):** S1a (collapse /
+auto-save) only when the winning result comes from a **non-capped** source
+**and** its confidence ≥ the cascade accept threshold (0.7, the existing
+`ACCEPT_THRESHOLD`). Every capped-source result (EfficientNet/Phi/Gemma —
+`confidence_ceiling` ≤ 0.40) is **always S1b** by definition (it can never
+be authoritative). Anything below 0.7, or any unresolved/offline state, is
+S1b. No new tunables — reuses the constants the cascade already defines.
+
+## Two-stage flow + sovereignty (data integration)
+
+```
+media → on-device pass (instant, NO Edge Function)
+         └─ writes provisional identifications row:
+            is_primary, source=<on-device model id>, confidence CAPPED
+   ‖ parallel if online, else on sync via existing triggerIdentify()
+cloud → authoritative identifications row
+```
+
+**Sovereignty resolver.** A boolean `observer_affirmed` is set by any
+explicit observer action (Yes / No-other / name-it).
+- `observer_affirmed = false` when cloud result arrives → re-stamp the
+  primary row (source/confidence) → UI S2.
+- `observer_affirmed = true` → store the cloud result as a **non-primary**
+  suggestion row; the observer's row stays `is_primary` → UI S2′.
+
+**Consensus integrity (R1–R3, preserved, not implemented here):**
+- "Yes, it's that" → observer identification, `source='human'`,
+  `validated_by = NULL` (existing self-validation trigger) → seeds primary
+  but `recompute_consensus` still requires other human validators.
+  Unchanged.
+- On-device guesses keep their machine `source` (**R1**: remove the
+  `?? 'human'` default in `sync.ts`) and **capped** confidence (**R2**:
+  preserve cap end-to-end) so the ≥0.4 research-grade floor keeps them
+  out. Unchanged consensus weighting.
+- "I don't know — ask for review" → sets observer-set `review_requested`
+  flag → routes into the validate/expert queue by kingdom (**R3**). Pure
+  routing/visibility; does not touch consensus weight.
+
+**S3 / offline:** save with no primary (or a human-named ID if the
+observer names it); `triggerIdentify()` runs the server cascade on sync
+(existing plumbing). Save is always available in every state.
+
+## Audit trace layer
+
+Progressive disclosure. Collapsed: inline source label (model +
+confidence). Expanded ("view trace"): one row per real attempt — model ·
+where (device/cloud) · prediction · confidence · typed outcome
+(`pre-filter · provisional · primary · non-primary · replaced · filtered ·
+human-affirmed · cloud-suggested`) · timestamp. Capped-confidence rows are
+explicitly flagged (why a 0.31 cannot reach research-grade). Consensus
+status at the foot. JSON export. **No new data model** — this is UI over
+`identifications` rows + cascade filter outcomes the schema already
+persists.
+
+## Scope
+
+**In scope (this spec):** the card component + state machine (S0–S3, S2′);
+confidence-adaptive collapse; sovereignty resolver; audit-trace UI over
+existing `identifications` data; wiring to save/sync. EN/ES parity.
+
+**Consumed, not owned (child specs, interface contracts only):**
+- Split `localAISupported()` so the lightweight WASM path
+  (EfficientNet/SpeciesNet/BirdNET/MegaDetector) is not gated by
+  WebGPU/≥6 GB — structural foundation; first build slice.
+- User-controlled downloads (capability chooser) — card degrades per the
+  capability graph.
+- R1 (kill `?? 'human'`), R2 (preserve confidence cap end-to-end),
+  R3 (source/confidence-aware validate/expert queue).
+- `review_requested` flag + queue/expert routing.
+
+**Non-goals (YAGNI):** no new ML models; no new identification data model
+(reuse `identifications`); no redesign of the validate/expert pages (only
+the flag they consume); no offline-map/Llama changes; heavy WebLLM
+(Phi/Gemma) stays in "Advanced", out of the card's default path.
+
+## Testing (TDD)
+
+Unit-test the pure logic, isolated from the DOM:
+1. **State selector** — confidence + availability → card state.
+2. **Sovereignty resolver** — (`observer_affirmed`, cloud result) →
+   action (`upgrade-primary` | `parallel-suggestion`).
+3. **Trace builder** — `identifications` rows + cascade outcomes →
+   ordered, typed trace.
+
+Plus an EN/ES string-parity test. Card DOM behavior covered sparingly by
+existing e2e smoke patterns per `docs/qa-policy.md`.
+
+## Recommended build order
+
+1. Child spec **gate split + R1 + R2** (foundation, low risk, TDD).
+2. **This card spec** (state machine + sovereignty + audit UI).
+3. Downloads UX (capability chooser).
+4. R3 + review-request queue routing.

--- a/docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md
+++ b/docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md
@@ -1,8 +1,9 @@
 # Observe AI — progressive result card (design)
 
 > Status: design approved via brainstorming 2026-05-16. Spine of the
-> observe AI UX redesign. Child specs (gate split, downloads UX, consensus
-> hardening R1–R3, review-request queue) are referenced, not specified here.
+> observe AI UX redesign. Child specs (on-device-first photo runners,
+> downloads UX, consensus hardening R1–R3, review-request queue) are
+> referenced, not specified here.
 
 ## Problem
 
@@ -13,8 +14,15 @@ toggle. The interactive pipeline depends on the `identify` Edge Function
 for cloud runners; an EF outage (incident 2026-05-16) dead-ended identify
 with an empty stepper. The product is local-first for capture + storage
 but **not** for identification: high-accuracy identifiers are inherently
-cloud, on-device options are narrower/weaker and capped, and the
-`localAISupported()` gate blocks the lightweight WASM path on phones.
+cloud, on-device options are narrower/weaker and capped, and **there is
+no path where on-device photo identification runs without the cloud and
+first**: `ObserveView2.astro:891` hard-skips photo ID in `local` mode
+("Local-only mode" → only BirdNET audio runs), and the other modes add
+on-device photo runners only *in parallel with* the cloud (cloud-primary,
+on-device as a co-runner). (`localAISupported()` is a separate WebGPU/≥6 GB
+gate used only by the heavy WebLLM models — Phi/Gemma/Llama — and does
+**not** gate the lightweight ONNX/WASM identifiers, which self-gate on
+cache status.)
 
 The user must currently never think about *which* model. The roster is a
 capability graph the app orchestrates, not a menu the user navigates.
@@ -119,9 +127,12 @@ confidence-adaptive collapse; sovereignty resolver; audit-trace UI over
 existing `identifications` data; wiring to save/sync. EN/ES parity.
 
 **Consumed, not owned (child specs, interface contracts only):**
-- Split `localAISupported()` so the lightweight WASM path
-  (EfficientNet/SpeciesNet/BirdNET/MegaDetector) is not gated by
-  WebGPU/≥6 GB — structural foundation; first build slice.
+- On-device-first photo identification: remove the `local`-mode photo
+  hard-skip (`ObserveView2.astro:891`) and introduce a runner-set
+  resolver so on-device photo runners run without (and before) the cloud
+  — structural foundation; first build slice. (NOT a `localAISupported()`
+  gate split — verified 2026-05-16 that the gate does not block the
+  lightweight path; the photo-skip + cloud-primary runner wiring does.)
 - User-controlled downloads (capability chooser) — card degrades per the
   capability graph.
 - R1 (kill `?? 'human'`), R2 (preserve confidence cap end-to-end),
@@ -147,7 +158,8 @@ existing e2e smoke patterns per `docs/qa-policy.md`.
 
 ## Recommended build order
 
-1. Child spec **gate split + R1 + R2** (foundation, low risk, TDD).
+1. Child spec **on-device-first photo runners (remove `:891` skip +
+   runner-set resolver) + R1 + R2** (foundation, low risk, TDD).
 2. **This card spec** (state machine + sovereignty + audit UI).
 3. Downloads UX (capability chooser).
 4. R3 + review-request queue routing.


### PR DESCRIPTION
Design doc from the 2026-05-16 brainstorming session (visual companion). Spine spec for the observe AI UX redesign; child specs referenced with interface contracts. No code changes — design only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)