### PR TITLE
feat(console): inline target preview in the flag-queue triage panel

### DIFF
--- a/src/components/ConsoleFlagQueueView.astro
+++ b/src/components/ConsoleFlagQueueView.astro
@@ -83,6 +83,19 @@ const tr = t(lang);
           <dd id="flagq-detail-target" class="font-medium text-zinc-800 dark:text-zinc-200"></dd>
         </dl>
 
+        <p id="flagq-preview-loading" class="hidden text-xs text-zinc-400 italic">{tr.console.flagq_preview_loading}</p>
+        <div id="flagq-detail-preview" class="hidden rounded-lg border border-zinc-200 dark:border-zinc-800 overflow-hidden">
+          <a id="flagq-preview-link" href="#" target="_blank" rel="noopener" class="flex gap-3 p-3 hover:bg-zinc-50 dark:hover:bg-zinc-800/40">
+            <img id="flagq-preview-thumb" class="hidden h-20 w-20 rounded object-cover bg-zinc-100 dark:bg-zinc-800 shrink-0" loading="lazy" alt="" />
+            <span class="min-w-0 flex-1">
+              <span id="flagq-preview-title" class="block text-sm font-medium text-zinc-800 dark:text-zinc-200 break-words"></span>
+              <span id="flagq-preview-sub" class="block text-xs text-zinc-500 dark:text-zinc-400 mt-0.5"></span>
+              <span id="flagq-preview-snippet" class="hidden text-xs text-zinc-600 dark:text-zinc-300 mt-1 italic break-words"></span>
+            </span>
+          </a>
+        </div>
+        <p id="flagq-preview-unavailable" class="hidden text-xs text-zinc-400 dark:text-zinc-600 italic">{tr.console.flagq_preview_unavailable}</p>
+
         <div id="flagq-detail-note-row" class="hidden text-sm">
           <span class="text-zinc-500">{tr.console.flagq_note_label}: </span>
           <span id="flagq-detail-note" class="text-zinc-700 dark:text-zinc-300 italic"></span>
@@ -278,13 +291,7 @@ const tr = t(lang);
       noteRow.classList.add('hidden');
     }
 
-    const viewLink = document.getElementById('flagq-view-target') as HTMLAnchorElement | null;
-    if (viewLink && r.target_type === 'observation') {
-      viewLink.href = `/share/obs/?id=${r.target_id}`;
-      viewLink.classList.remove('hidden');
-    } else if (viewLink) {
-      viewLink.classList.add('hidden');
-    }
+    void renderTargetPreview(r);
 
     // Show/hide action chips based on current status
     const triageBtn = document.getElementById('flagq-action-triage')!;
@@ -294,6 +301,132 @@ const tr = t(lang);
     triageBtn.classList.toggle('hidden', r.status !== 'open');
     resolveBtn.classList.toggle('hidden', r.status === 'resolved' || r.status === 'dismissed');
     dismissBtn.classList.toggle('hidden', r.status === 'resolved' || r.status === 'dismissed');
+  }
+
+  function setTargetLinks(href: string) {
+    const a = document.getElementById('flagq-view-target') as HTMLAnchorElement | null;
+    const cardA = document.getElementById('flagq-preview-link') as HTMLAnchorElement | null;
+    if (href) {
+      if (a) { a.href = href; a.classList.remove('hidden'); }
+      if (cardA) cardA.href = href;
+    } else {
+      if (a) a.classList.add('hidden');
+      if (cardA) cardA.removeAttribute('href');
+    }
+  }
+
+  async function renderTargetPreview(r: ReportRow) {
+    const thumb = document.getElementById('flagq-preview-thumb') as HTMLImageElement;
+    const snippetEl = document.getElementById('flagq-preview-snippet')!;
+    hide('flagq-detail-preview');
+    hide('flagq-preview-unavailable');
+    thumb.classList.add('hidden');
+    thumb.removeAttribute('src');
+    snippetEl.classList.add('hidden');
+    snippetEl.textContent = '';
+    document.getElementById('flagq-preview-title')!.textContent = '';
+    document.getElementById('flagq-preview-sub')!.textContent = '';
+    setTargetLinks('');
+    show('flagq-preview-loading');
+
+    let title = '';
+    let sub = '';
+    let snip = '';
+    let img = '';
+    let href = '';
+
+    try {
+      if (r.target_type === 'observation') {
+        const { data } = await supabase
+          .from('observations')
+          .select('id, observed_at, state_province, users:observer_id(username, display_name), identifications(scientific_name, is_primary)')
+          .eq('id', r.target_id)
+          .maybeSingle();
+        const obs = data as unknown as {
+          id: string; observed_at: string | null; state_province: string | null;
+          users: { username: string | null; display_name: string | null } | null;
+          identifications: { scientific_name: string | null; is_primary: boolean }[] | null;
+        } | null;
+        if (obs) {
+          const prim = obs.identifications?.find(i => i.is_primary) ?? obs.identifications?.[0];
+          title = prim?.scientific_name ?? '—';
+          const who = obs.users?.username ? `@${obs.users.username}` : '';
+          const when = obs.observed_at ? fmtDate(obs.observed_at) : '';
+          sub = [who, when, obs.state_province ?? ''].filter(Boolean).join(' · ');
+          href = `/share/obs/?id=${obs.id}`;
+          const { data: m } = await supabase
+            .from('media_files')
+            .select('url, thumbnail_url, is_primary, sort_order, media_type, deleted_at')
+            .eq('observation_id', r.target_id)
+            .is('deleted_at', null)
+            .order('is_primary', { ascending: false })
+            .order('sort_order', { ascending: true })
+            .limit(1);
+          const mf = (m as unknown as { url: string | null; thumbnail_url: string | null; media_type: string | null }[] | null)?.[0];
+          if (mf && mf.media_type === 'photo') img = mf.thumbnail_url ?? mf.url ?? '';
+        }
+      } else if (r.target_type === 'photo') {
+        const { data } = await supabase
+          .from('media_files')
+          .select('url, thumbnail_url, observation_id, media_type')
+          .eq('id', r.target_id)
+          .maybeSingle();
+        const mf = data as unknown as { url: string | null; thumbnail_url: string | null; observation_id: string | null; media_type: string | null } | null;
+        if (mf) {
+          title = r.target_type;
+          if (mf.media_type === 'photo') img = mf.thumbnail_url ?? mf.url ?? '';
+          if (mf.observation_id) href = `/share/obs/?id=${mf.observation_id}`;
+        }
+      } else if (r.target_type === 'identification') {
+        const { data } = await supabase
+          .from('identifications')
+          .select('scientific_name, observation_id')
+          .eq('id', r.target_id)
+          .maybeSingle();
+        const idn = data as unknown as { scientific_name: string | null; observation_id: string | null } | null;
+        if (idn) {
+          title = idn.scientific_name ?? '—';
+          if (idn.observation_id) href = `/share/obs/?id=${idn.observation_id}`;
+        }
+      } else if (r.target_type === 'comment') {
+        const { data } = await supabase
+          .from('observation_comments')
+          .select('body, observation_id, deleted_at')
+          .eq('id', r.target_id)
+          .maybeSingle();
+        const c = data as unknown as { body: string | null; observation_id: string | null; deleted_at: string | null } | null;
+        if (c) {
+          title = r.target_type;
+          snip = (c.body ?? '').slice(0, 280);
+          if (c.observation_id) href = `/share/obs/?id=${c.observation_id}`;
+        }
+      } else if (r.target_type === 'user') {
+        const { data } = await supabase
+          .from('users')
+          .select('username, display_name, avatar_url')
+          .eq('id', r.target_id)
+          .maybeSingle();
+        const u = data as unknown as { username: string | null; display_name: string | null; avatar_url: string | null } | null;
+        if (u) {
+          title = u.display_name ?? (u.username ? `@${u.username}` : '—');
+          sub = u.username ? `@${u.username}` : '';
+          img = u.avatar_url ?? '';
+          if (u.username) href = `/u/?username=${encodeURIComponent(u.username)}`;
+        }
+      }
+    } catch { /* RLS / network — fall through to the unavailable state */ }
+
+    if (selectedId !== r.id) return;
+    hide('flagq-preview-loading');
+    setTargetLinks(href);
+
+    if (!title && !snip && !img) { show('flagq-preview-unavailable'); return; }
+
+    document.getElementById('flagq-preview-title')!.textContent = title || r.target_type;
+    document.getElementById('flagq-preview-sub')!.textContent = sub;
+    if (snip) { snippetEl.textContent = snip; snippetEl.classList.remove('hidden'); }
+    if (img) { thumb.src = img; thumb.classList.remove('hidden'); }
+    show('flagq-detail-preview');
   }
 
   async function refreshSelected() {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2796,6 +2796,8 @@
     "flagq_action_resolve": "Resolve report",
     "flagq_action_dismiss": "Dismiss report",
     "flagq_view_target": "View target →",
+    "flagq_preview_loading": "Loading preview…",
+    "flagq_preview_unavailable": "Preview unavailable — the target may be private, obscured, or already removed. Use “View target →” to open it directly.",
     "modcom_heading": "Comments",
     "modcom_intro": "Moderate observation comments. Hide, unhide, lock, or unlock. All actions are logged.",
     "modcom_filter_status": "Status",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2796,6 +2796,8 @@
     "flagq_action_resolve": "Resolver reporte",
     "flagq_action_dismiss": "Descartar reporte",
     "flagq_view_target": "Ver objetivo →",
+    "flagq_preview_loading": "Cargando vista previa…",
+    "flagq_preview_unavailable": "Vista previa no disponible — el objetivo puede ser privado, ofuscado o ya estar eliminado. Usa «Ver objetivo →» para abrirlo directamente.",
     "modcom_heading": "Comentarios",
     "modcom_intro": "Modera comentarios de observaciones. Ocultar, mostrar, bloquear o desbloquear. Todas las acciones se registran.",
     "modcom_filter_status": "Estado",


### PR DESCRIPTION
## Why

While clearing the 2 stale test reports during the 2026-05-16 residue sweep (see `docs/journey-audit-2026-05-15.md` §6), the moderation triage UX gap was obvious: the report detail panel showed only `Tipo / Razón / Estado / Creado / Reportador / Objetivo: observation:<uuid>` and an **observation-only** "Ver objetivo →" link. To judge *any* report a moderator had to leave the queue and open the target elsewhere — no image, species, observer, or date inline. User-reported: *"en esa página de triage no se muestra la imagen ni detalles de la observación, por lo que para un admin no es fácil."*

## What

An inline **target preview card** in the detail panel, resolved per `target_type`:

| Target | Preview |
|---|---|
| `observation` | primary scientific name · `@observer · date · region` · primary photo thumbnail |
| `photo` | thumbnail + parent-observation link |
| `identification` | scientific name + parent-observation link |
| `comment` | body snippet (≤280 chars) + parent-observation link |
| `user` | display name · `@handle` · avatar · public-profile link |

The whole card is clickable, and **"Ver objetivo →" now resolves for all target types** (was observation-only): obs/photo/id/comment → `/share/obs/?id=…`, user → `/u/?username=…`.

## Engineering notes

- **RLS-honest, no scope creep.** Best-effort fetch under the moderator's own RLS — reported content is almost always public/synced (the reporter could see it to report it). When the target is private/obscured/removed it degrades to an explicit *"Preview unavailable — use View target →"* rather than a dead id. **No new Edge Function, no RLS change, no schema change** — frontend-only additive read. (A full RLS-bypassing admin-EF preview is a possible later follow-up if the obscured-target case proves material; deliberately not done here to avoid audit-log spam and EF-deploy scope.)
- `selectedId` race-guard: a slow target fetch won't paint onto a report the moderator already clicked away from.
- EN/ES parity kept (2 new `console.flagq_preview_*` keys, both files).

## Verification

- `tsc --noEmit` clean
- 2415/2415 vitest (incl. i18n parity test)
- 255-page astro build clean

Surfaced by the journey audit (`docs/journey-audit-2026-05-15.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)