### PR TITLE
feat(observe): on-device-first photo identification (foundation)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -509,18 +509,27 @@ function showModeToast(msg: string): void {
   try {
     const { hasKeysForPlugin } = await import('../lib/byo-keys');
     const { getBirdNETCacheStatus, getBirdNETWeightsBaseUrl } = await import('../lib/identifiers/birdnet-cache');
+    const { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } = await import('../lib/identifiers/onnx-base-cache');
     const hasByo = hasKeysForPlugin('claude_haiku') || hasKeysForPlugin('plantnet');
     const hasBirdnet = getBirdNETWeightsBaseUrl() ? await getBirdNETCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false) : false;
+    const hasEfficientNet = getOnnxBaseWeightsBaseUrl()
+      ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
+      : false;
+    const hasPhi = await pluginReady('webllm_phi35_vision').catch(() => false);
+    const hasGemma = await pluginReady('onnx_gemma4_vision').catch(() => false);
+    // Local mode is usable if ANY on-device runner is available — BirdNET
+    // for audio OR an on-device photo model (EfficientNet/Phi/Gemma).
+    const hasLocal = hasBirdnet || hasEfficientNet || hasPhi || hasGemma;
     const ownBtn = document.getElementById('obs2-mode-own-key') as HTMLButtonElement | null;
     const locBtn = document.getElementById('obs2-mode-local') as HTMLButtonElement | null;
     if (ownBtn && !hasByo) ownBtn.disabled = true;
-    if (locBtn && !hasBirdnet) locBtn.disabled = true;
+    if (locBtn && !hasLocal) locBtn.disabled = true;
     applyModeStyles(readAiMode());
     // Only reveal the selector when ≥2 modes are usable (#942 PR5 redo).
     // Sponsored is always available; count it plus any of own-key/local
     // that are not disabled. With ≤1 usable mode the selector reads as
     // broken UI ("disabled buttons next to one live button").
-    const usableModes = 1 /* sponsored */ + (hasByo ? 1 : 0) + (hasBirdnet ? 1 : 0);
+    const usableModes = 1 /* sponsored */ + (hasByo ? 1 : 0) + (hasLocal ? 1 : 0);
     if (usableModes >= 2) {
       document.getElementById('obs2-ai-mode-selector')?.classList.remove('hidden');
     }
@@ -908,7 +917,7 @@ async function runPipeline(state: PipelineState) {
         if (aiMode === 'local' && chosen.length === 0) {
           // Nothing on-device for photos — honest fallback to sponsored.
           aiMode = 'sponsored'; writeAiMode('sponsored'); applyModeStyles('sponsored');
-          showModeToast(isEs ? 'Sin modelo on-device para fotos — usando patrocinado.' : 'No on-device photo model — using sponsored.');
+          showModeToast(tr.observe.local_fallback_sponsored);
           chosen = resolveRunnerSet({ aiMode, mediaKind: 'photo', available: avail });
         }
         const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -425,6 +425,7 @@ import { syncOutbox } from '../lib/sync';
 import { SYNC_EVENTS, type SyncRowDetail } from '../lib/sync-events';
 import { getObservationDefaults, setObservationDefaults } from '../lib/observation-defaults';
 import { selfHealChunk } from '../lib/chunk-reload';
+import { resolveRunnerSet, type RunnerAvailability } from '../lib/observe-runner-set';
 
 // ── State ──────────────────────────────────────────────────────────────────
 const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
@@ -875,10 +876,6 @@ async function runPipeline(state: PipelineState) {
       aiMode = 'sponsored'; writeAiMode('sponsored'); applyModeStyles('sponsored');
       showModeToast(isEs ? 'Modo de IA no disponible — usando patrocinado.' : 'Selected AI mode unavailable — using sponsored.');
     }
-  } else if (aiMode === 'local') {
-    const { getBirdNETCacheStatus, getBirdNETWeightsBaseUrl } = await import('../lib/identifiers/birdnet-cache');
-    const ok = getBirdNETWeightsBaseUrl() ? await getBirdNETCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false) : false;
-    if (!ok) { aiMode = 'sponsored'; writeAiMode('sponsored'); applyModeStyles('sponsored'); showModeToast(isEs ? 'Modo de IA no disponible — usando patrocinado.' : 'Selected AI mode unavailable — using sponsored.'); }
   }
 
   for (const node of state.nodes) {
@@ -888,43 +885,46 @@ async function runPipeline(state: PipelineState) {
     setNodeState(state, node.id, 'running');
     try {
       if (pf.kind === 'photo') {
-        if (aiMode === 'local') { setNodeState(state, node.id, 'skipped', undefined, 'Local-only mode'); continue; }
-        const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
-        // PlantNet always works via the Edge Function (operator key server-side);
-        // include it unconditionally. A BYO key (if present) is forwarded to the
-        // EF as client_keys.plantnet for user's own quota, but is not required.
-        runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
-        if (aiMode === 'own-key') {
-          const { hasKeysForPlugin } = await import('../lib/byo-keys');
-          if (hasKeysForPlugin('claude_haiku') && await hasAnthropicKey()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
-        } else {
-          // Sponsored mode: BYO key OR server-side sponsor/pool unlocks Claude.
-          if (await claudeAvailable()) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+        const { hasKeysForPlugin } = await import('../lib/byo-keys');
+        const { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } = await import('../lib/identifiers/onnx-base-cache');
+        const efficientNetCached = getOnnxBaseWeightsBaseUrl()
+          ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
+          : false;
+        const avail: RunnerAvailability = {
+          // PlantNet is always reachable via the EF operator key when online.
+          plantnet: true,
+          claude: aiMode === 'own-key'
+            ? (hasKeysForPlugin('claude_haiku') && await hasAnthropicKey())
+            : await claudeAvailable(),
+          phi: await pluginReady('webllm_phi35_vision').catch(() => false),
+          gemma: await pluginReady('onnx_gemma4_vision').catch(() => false),
+          efficientNet: efficientNetCached,
+          // MegaDetector pre-filter wiring is a later card-spec task.
+          megaDetector: false,
+          // Audio (BirdNET) is handled by the non-photo branch.
+          birdnet: false,
+        };
+        let chosen = resolveRunnerSet({ aiMode, mediaKind: 'photo', available: avail });
+        if (aiMode === 'local' && chosen.length === 0) {
+          // Nothing on-device for photos — honest fallback to sponsored.
+          aiMode = 'sponsored'; writeAiMode('sponsored'); applyModeStyles('sponsored');
+          showModeToast(isEs ? 'Sin modelo on-device para fotos — usando patrocinado.' : 'No on-device photo model — using sponsored.');
+          chosen = resolveRunnerSet({ aiMode, mediaKind: 'photo', available: avail });
         }
-
-        // Phi vision (opt-in): runs in parallel as an additional on-device runner.
-        try {
-          if (await pluginReady('webllm_phi35_vision')) {
-            runners.webllm_phi35_vision = makePhiRunner(lang as 'en' | 'es');
-          }
-        } catch { /* WebLLM unavailable, skip */ }
-
-        // Gemma 4 vision (opt-in, parallel runtime to Phi).
-        try {
-          if (await pluginReady('onnx_gemma4_vision')) {
+        const runners: Record<string, import('../lib/identify-cascade-client').IdentifierRunner> = {};
+        if (chosen.includes('plantnet')) runners.plantnet = makePlantNetRunner(lang as 'en' | 'es');
+        if (chosen.includes('claude')) runners.claude_haiku = makeClaudeRunner(lang as 'en' | 'es');
+        if (chosen.includes('phi')) {
+          try { runners.webllm_phi35_vision = makePhiRunner(lang as 'en' | 'es'); } catch { /* WebLLM unavailable, skip */ }
+        }
+        if (chosen.includes('gemma')) {
+          try {
             const { makeGemmaRunner } = await import('../lib/identify-runners');
             runners.onnx_gemma4_vision = makeGemmaRunner(lang as 'en' | 'es');
-          }
-        } catch { /* transformers.js unavailable, skip */ }
-
-        // EfficientNet-Lite0: always add as fallback if downloaded (~2.8 MB, no key needed).
-        // It runs in-parallel as a zero-cost fallback alongside cloud runners.
-        try {
-          const { getOnnxBaseCacheStatus, getOnnxBaseWeightsBaseUrl } = await import('../lib/identifiers/onnx-base-cache');
-          const enCached = getOnnxBaseWeightsBaseUrl()
-            ? await getOnnxBaseCacheStatus().then(s => s.modelCached && s.labelsCached).catch(() => false)
-            : false;
-          if (enCached) {
+          } catch { /* transformers.js unavailable, skip */ }
+        }
+        if (chosen.includes('efficientNet')) {
+          try {
             const { onnxBaseIdentifier } = await import('../lib/identifiers/onnx-base');
             runners.onnx_efficientnet_lite0 = async (file: File) => {
               const result = await onnxBaseIdentifier.identify({
@@ -934,8 +934,8 @@ async function runPipeline(state: PipelineState) {
               });
               return result;
             };
-          }
-        } catch { /* EfficientNet unavailable, skip */ }
+          } catch { /* EfficientNet unavailable, skip */ }
+        }
 
         if (Object.keys(runners).length === 0) {
           setNodeState(state, node.id, 'skipped', undefined, 'No runner available');

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -752,6 +752,7 @@
     }
   },
   "observe": {
+    "local_fallback_sponsored": "No on-device photo model — using sponsored.",
     "active_banner": {
       "today_n": "Today {count} people are observing in {region} · join in",
       "today_one": "Today 1 person is observing in {region} · join in",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -752,6 +752,7 @@
     }
   },
   "observe": {
+    "local_fallback_sponsored": "Sin modelo on-device para fotos — usando patrocinado.",
     "active_banner": {
       "today_n": "Hoy {count} personas observan en {region} · únete",
       "today_one": "Hoy 1 persona observa en {region} · únete",

--- a/src/lib/observe-runner-set.test.ts
+++ b/src/lib/observe-runner-set.test.ts
@@ -56,4 +56,14 @@ describe('resolveRunnerSet — local-first invariants', () => {
   it('unknown / unsupported media returns []', () => {
     expect(resolveRunnerSet({ aiMode: 'local', mediaKind: 'unknown', available: { ...none, efficientNet: true } })).toEqual([]);
   });
+
+  it('REGRESSION: local + photo with a cached on-device model never returns [] (no skip)', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'local', mediaKind: 'photo',
+      available: { plantnet: true, claude: true, phi: false, gemma: false,
+        efficientNet: true, megaDetector: false, birdnet: false },
+    });
+    expect(r.length).toBeGreaterThan(0);
+    expect(r).not.toContain('plantnet');
+  });
 });

--- a/src/lib/observe-runner-set.test.ts
+++ b/src/lib/observe-runner-set.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRunnerSet, type RunnerAvailability } from './observe-runner-set';
+
+const none: RunnerAvailability = {
+  plantnet: false, claude: false, phi: false, gemma: false,
+  efficientNet: false, megaDetector: false, birdnet: false,
+};
+
+describe('resolveRunnerSet — local-first invariants', () => {
+  it('local mode + photo runs available on-device photo runners, NO cloud', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'local', mediaKind: 'photo',
+      available: { ...none, efficientNet: true, megaDetector: true, phi: true, plantnet: true, claude: true },
+    });
+    expect(r).toContain('efficientNet');
+    expect(r).toContain('phi');
+    expect(r).toContain('megaDetector');
+    expect(r).not.toContain('plantnet');
+    expect(r).not.toContain('claude');
+  });
+
+  it('local mode + photo with nothing on-device returns [] (caller falls back)', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'local', mediaKind: 'photo',
+      available: { ...none, plantnet: true, claude: true },
+    });
+    expect(r).toEqual([]);
+  });
+
+  it('sponsored mode + photo runs cloud AND on-device in parallel', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'sponsored', mediaKind: 'photo',
+      available: { ...none, plantnet: true, claude: true, efficientNet: true },
+    });
+    expect(r).toEqual(expect.arrayContaining(['plantnet', 'claude', 'efficientNet']));
+  });
+
+  it('audio runs birdnet only, in any mode', () => {
+    for (const aiMode of ['local', 'sponsored', 'own-key'] as const) {
+      expect(
+        resolveRunnerSet({ aiMode, mediaKind: 'audio', available: { ...none, birdnet: true, claude: true } }),
+      ).toEqual(['birdnet']);
+    }
+  });
+
+  it('own-key mode + photo excludes cloud claude when claude unavailable', () => {
+    const r = resolveRunnerSet({
+      aiMode: 'own-key', mediaKind: 'photo',
+      available: { ...none, plantnet: true, claude: false, efficientNet: true },
+    });
+    expect(r).toContain('plantnet');
+    expect(r).toContain('efficientNet');
+    expect(r).not.toContain('claude');
+  });
+
+  it('unknown / unsupported media returns []', () => {
+    expect(resolveRunnerSet({ aiMode: 'local', mediaKind: 'unknown', available: { ...none, efficientNet: true } })).toEqual([]);
+  });
+});

--- a/src/lib/observe-runner-set.ts
+++ b/src/lib/observe-runner-set.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure decision: which identifier runners run for one pipeline node.
+ *
+ * Local-first invariants:
+ *  - `local` mode never returns a cloud runner.
+ *  - `local` + photo is NOT skipped — it returns the available on-device
+ *    photo runners (efficientNet / phi / gemma) plus the megaDetector
+ *    pre-filter. Returns [] only when nothing on-device is available, so
+ *    the caller can fall back to `sponsored`.
+ *  - `sponsored` / `own-key` run cloud runners AND on-device in parallel.
+ *  - audio is birdnet-only in every mode.
+ *
+ * Returns abstract runner names; the caller maps them to concrete
+ * runner-map keys.
+ */
+export type AiMode = 'sponsored' | 'own-key' | 'local';
+export type MediaKind = 'photo' | 'audio' | 'video' | 'unknown';
+
+export interface RunnerAvailability {
+  plantnet: boolean;
+  claude: boolean;
+  phi: boolean;
+  gemma: boolean;
+  efficientNet: boolean;
+  megaDetector: boolean;
+  birdnet: boolean;
+}
+
+export interface ResolveInput {
+  aiMode: AiMode;
+  mediaKind: MediaKind;
+  available: RunnerAvailability;
+}
+
+const ONDEVICE_PHOTO: Array<keyof RunnerAvailability> = [
+  'megaDetector', 'efficientNet', 'phi', 'gemma',
+];
+const CLOUD_PHOTO: Array<keyof RunnerAvailability> = ['plantnet', 'claude'];
+
+export function resolveRunnerSet(input: ResolveInput): string[] {
+  const { aiMode, mediaKind, available } = input;
+
+  if (mediaKind === 'audio') {
+    return available.birdnet ? ['birdnet'] : [];
+  }
+  if (mediaKind !== 'photo') {
+    return [];
+  }
+
+  const onDevice = ONDEVICE_PHOTO.filter((k) => available[k]);
+
+  if (aiMode === 'local') {
+    return onDevice; // [] → caller falls back to sponsored
+  }
+
+  const cloud = CLOUD_PHOTO.filter((k) => available[k]);
+  return [...cloud, ...onDevice];
+}


### PR DESCRIPTION
First build slice of the observe AI UX redesign (spec: PR #1107 / `docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md`).

## Summary
- New pure `src/lib/observe-runner-set.ts` — `resolveRunnerSet()` decides which identifier runners run per node with **local-first invariants**: `local` mode never returns cloud and **no longer skips photos**; sponsored/own-key run cloud + on-device in parallel; audio is BirdNET-only.
- `ObserveView2.astro`: wired the resolver into the photo branch; **deleted the `local`-mode photo hard-skip ("Local-only mode")** and the dead BirdNET-only `local` pre-empt arm; honest fallback to sponsored only when nothing on-device.
- Mode-selector "Local" button + `usableModes` now gate on **any** on-device runner (BirdNET OR EfficientNet/Phi/Gemma), so a photo-only on-device user can reach local mode.
- New fallback toast moved to i18n (`observe.local_fallback_sponsored`, EN+ES) per the hard parity rule.

Root-cause note: the original spec premise ("split `localAISupported()`") was verified wrong during planning — the gate never blocked the lightweight WASM path; the `:891` photo-skip did. Spec amended accordingly (PR #1107).

## Test Plan
- [x] `npx vitest run` — 2422/2422 (7 new resolver tests incl. regression guard for the photo-skip)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — 255 pages, no error
- [ ] Manual: in `local` mode with only EfficientNet cached, add a photo → on-device ID runs (no "Local-only mode" skip), no cloud call
- [ ] Manual: `local` mode, nothing on-device → honest toast + sponsored fallback

Out of scope (separate child specs): progressive result card, downloads UX, consensus R1–R3, review-request queue, MegaDetector pre-filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)