### PR TITLE
fix(console): disambiguate observations↔taxa embed (closes #1112)

### DIFF
--- a/src/components/ConsoleObservationsView.astro
+++ b/src/components/ConsoleObservationsView.astro
@@ -237,7 +237,7 @@ const tr = t(lang);
 
     let query = supabase
       .from('observations')
-      .select('id, observer_id, observed_at, primary_taxon_id, obscure_level, location_obscured, hidden, hidden_reason, hidden_at, hidden_by, sync_status, created_at, taxa(scientific_name), users!observer_id(username, display_name, observer_license)')
+      .select('id, observer_id, observed_at, primary_taxon_id, obscure_level, location_obscured, hidden, hidden_reason, hidden_at, hidden_by, sync_status, created_at, taxa!primary_taxon_id(scientific_name), users!observer_id(username, display_name, observer_license)')
       .order('created_at', { ascending: false })
       .limit(50);
 


### PR DESCRIPTION
## Bug (found in the 2026-05-16 Chrome production sweep)

Admin console **Observaciones** browser (`/{en,es}/{console,consola}/observaciones/`) never loaded its list. PostgREST returned, rendered as in-page text (no JS console error — so e2e specs missed it):

> Could not embed because more than one relationship was found for 'observations' and 'taxa'

## Root cause

Two FK relationships between `observations` and `taxa`:
- `observations.primary_taxon_id → taxa(id)` (schema:243)
- `taxa.hero_observation_id → observations(id)` (schema:7235 — species-hero feature, added later)

so `ConsoleObservationsView.astro`'s bare embed `taxa(scientific_name)` is ambiguous and PostgREST refuses the whole query → empty list, admin tab non-functional.

## Fix

One-token change: `taxa(scientific_name)` → `taxa!primary_taxon_id(scientific_name)` — pins the embed to the forward primary-taxon FK. Column-hint form, identical to the `users!observer_id` hint already on the same select line and consistent with every FK disambiguation in the codebase (always column form, never constraint-name). Page intent unchanged (already selects `primary_taxon_id`, renders `taxa.scientific_name` as species).

Frontend-only — no schema/RLS/deps.

## Verification

tsc clean · 2422/2422 vitest · 255-page astro build.

Surfaced by the journey audit (`docs/journey-audit-2026-05-15.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)