### PR TITLE
feat(observe): progressive card pure logic (state/sovereignty/audit)

### DIFF
--- a/src/lib/observe-audit-trace.test.ts
+++ b/src/lib/observe-audit-trace.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { buildAuditTrace, type IdAttempt } from './observe-audit-trace';
+
+const attempts: IdAttempt[] = [
+  { source: 'plantnet', where: 'cloud', scientificName: 'Quercus rugosa', confidence: 0.94, isPrimary: true, createdAt: '2026-05-16T10:02:09Z' },
+  { source: 'onnx_efficientnet_lite0', where: 'device', scientificName: 'Quercus sp.', confidence: 0.31, isPrimary: false, createdAt: '2026-05-16T10:02:02Z' },
+  { source: 'camera_trap_megadetector', where: 'device', scientificName: null, confidence: 0.71, isPrimary: false, createdAt: '2026-05-16T10:02:01Z', filteredLabel: 'animal' },
+];
+
+describe('buildAuditTrace', () => {
+  it('sorts by createdAt ascending', () => {
+    expect(buildAuditTrace(attempts).map(e => e.source)).toEqual(['camera_trap_megadetector', 'onnx_efficientnet_lite0', 'plantnet']);
+  });
+  it('types the outcome per attempt', () => {
+    const bySrc = Object.fromEntries(buildAuditTrace(attempts).map(e => [e.source, e.outcome]));
+    expect(bySrc['plantnet']).toBe('primary');
+    expect(bySrc['onnx_efficientnet_lite0']).toBe('non-primary');
+    expect(bySrc['camera_trap_megadetector']).toBe('pre-filter');
+  });
+  it('flags capped-source rows so the UI can explain the research-grade floor', () => {
+    const t = buildAuditTrace(attempts);
+    expect(t.find(e => e.source === 'onnx_efficientnet_lite0')?.capped).toBe(true);
+    expect(t.find(e => e.source === 'plantnet')?.capped).toBe(false);
+  });
+  it('returns [] for no attempts', () => {
+    expect(buildAuditTrace([])).toEqual([]);
+  });
+});

--- a/src/lib/observe-audit-trace.ts
+++ b/src/lib/observe-audit-trace.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure builder for the audit "view trace" panel. One row per real
+ * identification attempt (maps to identifications rows + cascade filter
+ * outcomes), sorted oldest-first, with a typed outcome and a capped flag
+ * for honest research-grade-floor messaging. See spec
+ * docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md.
+ */
+
+// Sources whose registry confidence_ceiling is below the cascade
+// ACCEPT_THRESHOLD (0.7) — they can never be authoritative / research-grade.
+// EfficientNet 0.4, MegaDetector 0.4, Phi 0.35, Gemma 0.35. SpeciesNet
+// (0.85) and cloud sources are NOT capped.
+const CAPPED_SOURCES = new Set<string>([
+  'onnx_efficientnet_lite0',
+  'camera_trap_megadetector',
+  'phi_vision',
+  'onnx_gemma4_vision',
+]);
+
+export interface IdAttempt {
+  source: string;
+  where: 'device' | 'cloud';
+  scientificName: string | null;
+  confidence: number;
+  isPrimary: boolean;
+  createdAt: string;
+  filteredLabel?: string;
+}
+
+export type TraceOutcome = 'pre-filter' | 'primary' | 'non-primary';
+
+export interface TraceEntry {
+  source: string;
+  where: 'device' | 'cloud';
+  scientificName: string | null;
+  confidence: number;
+  outcome: TraceOutcome;
+  capped: boolean;
+  createdAt: string;
+}
+
+export function buildAuditTrace(attempts: IdAttempt[]): TraceEntry[] {
+  return [...attempts]
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .map((a) => ({
+      source: a.source,
+      where: a.where,
+      scientificName: a.scientificName,
+      confidence: a.confidence,
+      outcome: a.filteredLabel ? 'pre-filter' : a.isPrimary ? 'primary' : 'non-primary',
+      capped: CAPPED_SOURCES.has(a.source),
+      createdAt: a.createdAt,
+    }));
+}

--- a/src/lib/observe-card-state.test.ts
+++ b/src/lib/observe-card-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCardState, type CardStateInput } from './observe-card-state';
+import { ACCEPT_THRESHOLD } from './identifiers/cascade';
+
+const base: CardStateInput = {
+  provisional: null, cloud: null, observerAffirmed: false,
+  online: true, hasOnDeviceModel: true,
+};
+
+describe('resolveCardState', () => {
+  it('S0 when nothing has resolved yet', () => {
+    expect(resolveCardState(base)).toBe('S0');
+  });
+  it('S1a when a non-capped result clears ACCEPT_THRESHOLD', () => {
+    expect(resolveCardState({ ...base, cloud: { scientificName: 'Quercus rugosa', confidence: 0.94, source: 'plantnet', confidenceCeiling: 1 } })).toBe('S1a');
+  });
+  it('S1b when a capped-source result cannot be authoritative even at high confidence', () => {
+    expect(resolveCardState({ ...base, provisional: { scientificName: 'Quercus sp.', confidence: 0.4, source: 'onnx_efficientnet_lite0', confidenceCeiling: 0.4 } })).toBe('S1b');
+  });
+  it('S1b when a non-capped result is below ACCEPT_THRESHOLD', () => {
+    expect(resolveCardState({ ...base, cloud: { scientificName: 'Quercus sp.', confidence: 0.55, source: 'claude_haiku', confidenceCeiling: 1 } })).toBe('S1b');
+  });
+  it('S2 when cloud upgrades and the observer did not act', () => {
+    expect(resolveCardState({ ...base, provisional: { scientificName: 'Quercus sp.', confidence: 0.3, source: 'onnx_efficientnet_lite0', confidenceCeiling: 0.4 }, cloud: { scientificName: 'Quercus rugosa', confidence: 0.94, source: 'plantnet', confidenceCeiling: 1 }, observerAffirmed: false })).toBe('S2');
+  });
+  it('stays S1a when an already-authoritative provisional is followed by a cloud result (no un-collapse)', () => {
+    expect(resolveCardState({ ...base, provisional: { scientificName: 'Puma concolor', confidence: 0.88, source: 'speciesnet', confidenceCeiling: 0.85 }, cloud: { scientificName: 'Puma concolor', confidence: 0.91, source: 'claude_haiku', confidenceCeiling: 1 }, observerAffirmed: false })).toBe('S1a');
+  });
+  it('S2prime when cloud arrives but the observer already affirmed', () => {
+    expect(resolveCardState({ ...base, provisional: { scientificName: 'Quercus crassifolia', confidence: 1, source: 'human', confidenceCeiling: 1 }, cloud: { scientificName: 'Quercus rugosa', confidence: 0.94, source: 'plantnet', confidenceCeiling: 1 }, observerAffirmed: true })).toBe('S2prime');
+  });
+  it('S3 worst case: no on-device model and offline, nothing resolved', () => {
+    expect(resolveCardState({ ...base, online: false, hasOnDeviceModel: false })).toBe('S3');
+  });
+  it('LOCAL ACCEPT_THRESHOLD constant matches the canonical cascade value', () => {
+    expect(ACCEPT_THRESHOLD).toBe(0.7);
+  });
+});

--- a/src/lib/observe-card-state.ts
+++ b/src/lib/observe-card-state.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure card-state selector for the observe progressive result card.
+ * No DOM / network. See
+ * docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md.
+ */
+
+// Must match ACCEPT_THRESHOLD in src/lib/identifiers/cascade.ts. The
+// canonical value is asserted equal by the test (parity guard); declared
+// locally so this module stays dependency-free.
+const ACCEPT_THRESHOLD = 0.7;
+
+export interface IdResult {
+  scientificName: string;
+  confidence: number;
+  source: string;
+  /** The source's confidence ceiling from the identifier registry. */
+  confidenceCeiling: number;
+}
+
+export interface CardStateInput {
+  provisional: IdResult | null;
+  cloud: IdResult | null;
+  observerAffirmed: boolean;
+  online: boolean;
+  hasOnDeviceModel: boolean;
+}
+
+export type CardState = 'S0' | 'S1a' | 'S1b' | 'S2' | 'S2prime' | 'S3';
+
+function isAuthoritative(r: IdResult): boolean {
+  return r.confidenceCeiling >= ACCEPT_THRESHOLD && r.confidence >= ACCEPT_THRESHOLD;
+}
+
+export function resolveCardState(input: CardStateInput): CardState {
+  const { provisional, cloud, observerAffirmed, online, hasOnDeviceModel } = input;
+  if (cloud) {
+    if (observerAffirmed) return 'S2prime';
+    // S2 only when the cloud upgrades a provisional that was NOT already
+    // authoritative. An already-authoritative provisional (e.g. SpeciesNet
+    // 0.85) stays collapsed — a later cloud result must not un-collapse it.
+    if (provisional && !isAuthoritative(provisional)) return 'S2';
+    return isAuthoritative(cloud) ? 'S1a' : 'S1b';
+  }
+  if (provisional) {
+    return isAuthoritative(provisional) ? 'S1a' : 'S1b';
+  }
+  if (!online && !hasOnDeviceModel) {
+    return 'S3';
+  }
+  return 'S0';
+}

--- a/src/lib/observe-sovereignty.test.ts
+++ b/src/lib/observe-sovereignty.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSovereignty } from './observe-sovereignty';
+
+describe('resolveSovereignty', () => {
+  it('upgrade-primary when cloud arrives and observer did not act', () => {
+    expect(resolveSovereignty({ observerAffirmed: false, cloudArrived: true })).toBe('upgrade-primary');
+  });
+  it('parallel-suggestion when cloud arrives but observer already affirmed', () => {
+    expect(resolveSovereignty({ observerAffirmed: true, cloudArrived: true })).toBe('parallel-suggestion');
+  });
+  it('none when no cloud result has arrived (regardless of affirmation)', () => {
+    expect(resolveSovereignty({ observerAffirmed: false, cloudArrived: false })).toBe('none');
+    expect(resolveSovereignty({ observerAffirmed: true, cloudArrived: false })).toBe('none');
+  });
+});

--- a/src/lib/observe-sovereignty.ts
+++ b/src/lib/observe-sovereignty.ts
@@ -1,0 +1,16 @@
+/**
+ * Pure resolver for the "observer affirmation is sovereign" rule. The
+ * machine never overrides an explicit human identification. See spec
+ * docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md.
+ */
+export interface SovereigntyInput {
+  observerAffirmed: boolean;
+  cloudArrived: boolean;
+}
+
+export type SovereigntyAction = 'upgrade-primary' | 'parallel-suggestion' | 'none';
+
+export function resolveSovereignty(input: SovereigntyInput): SovereigntyAction {
+  if (!input.cloudArrived) return 'none';
+  return input.observerAffirmed ? 'parallel-suggestion' : 'upgrade-primary';
+}


### PR DESCRIPTION
Child #2 of the observe AI redesign — the **pure decision modules** the progressive result card needs. Plan: \`docs/superpowers/plans/2026-05-16-observe-progressive-card-pure-logic.md\` (PR #1111). Spec: PR #1107.

## Summary
- \`src/lib/observe-card-state.ts\` — `resolveCardState` → S0/S1a/S1b/S2/S2′/S3. S1a only for non-capped sources ≥ \`ACCEPT_THRESHOLD\` (0.7, parity-tested vs cascade). **Review caught a logic bug in the plan's verbatim impl** (an already-authoritative provisional was un-collapsed to S2 by a later cloud result) — fixed and pinned with a regression test.
- \`src/lib/observe-sovereignty.ts\` — `resolveSovereignty`: cloud+not-affirmed→upgrade-primary, cloud+affirmed→parallel-suggestion, no-cloud→none. Machine never overrides human.
- \`src/lib/observe-audit-trace.ts\` — `buildAuditTrace`: typed, oldest-first trace over identification attempts + capped flag for honest research-grade-floor messaging.

All pure (no DOM/network), same proven pattern as \`observe-runner-set.ts\`.

## Test Plan
- [x] 16 unit tests across 3 modules (incl. ACCEPT_THRESHOLD parity guard + the un-collapse regression)
- [x] \`npx vitest run\` — 2438/2438
- [x] \`npx tsc --noEmit\` — clean

Out of scope (separate later plans): the card render + ObserveView2 wiring, downloads UX, R1–R3, \`review_requested\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)