### PR TITLE
fix(map): sprite fallback handler silences styleimagemissing (closes #1113)

### DIFF
--- a/src/components/ExploreMap.astro
+++ b/src/components/ExploreMap.astro
@@ -50,7 +50,7 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
     getPmtilesCacheStatus,
     getPmtilesMxUrl,
   } from '../lib/offline-map';
-  import { basemapStyleUrl } from '../lib/map-style';
+  import { basemapStyleUrl, installSpriteFallback } from '../lib/map-style';
 
   const isEs = document.documentElement.lang === 'es';
   const isDark = document.documentElement.classList.contains('dark');
@@ -197,6 +197,12 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
     zoom: 6,
     attributionControl: { compact: true },
   });
+
+  // #1113 — the hosted OpenFreeMap style references Maki POI icons
+  // (`circle-11`, …) via a sprite we don't control; register a transparent
+  // fallback so a slow/failed sprite load doesn't spam the console. Our
+  // observation layers are circle-paint and never hit this path.
+  installSpriteFallback(map);
 
   map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
 

--- a/src/lib/map-style.ts
+++ b/src/lib/map-style.ts
@@ -28,3 +28,38 @@ export function isDarkTheme(): boolean {
 export function basemapStyleUrl(dark: boolean = isDarkTheme()): string {
   return dark ? STREET_DARK : STREET_LIGHT;
 }
+
+/**
+ * Minimal shape of the MapLibre `Map` methods this module touches.
+ * Avoids importing maplibre-gl's types into a unit-testable module.
+ */
+interface SpriteFallbackMap {
+  on(type: 'styleimagemissing', listener: (e: { id: string }) => void): unknown;
+  hasImage(id: string): boolean;
+  addImage(
+    id: string,
+    image: { width: number; height: number; data: Uint8Array | Uint8ClampedArray },
+  ): void;
+}
+
+/**
+ * #1113 — the hosted OpenFreeMap `liberty` / `dark` styles ship a `sprite`
+ * URL and POI symbol layers that reference Maki icons (`circle-11`, …).
+ * When that external sprite is slow or fails to load (first paint can take
+ * ~10 s) MapLibre raises a `styleimagemissing` event and logs a noisy
+ * console warning for every missing icon. We don't control that sprite, so
+ * the idiomatic fix is to register a 1×1 transparent fallback for any icon
+ * the style asks for that isn't present. Our own observation layers are
+ * `circle`-type paint layers and never hit this path — this only silences
+ * the basemap's POI-icon warnings while keeping markers rendering.
+ *
+ * Idempotent: skips ids already registered (e.g. once the real sprite
+ * eventually loads, MapLibre won't ask again, but a re-fire is harmless).
+ */
+export function installSpriteFallback(map: SpriteFallbackMap): void {
+  map.on('styleimagemissing', (e) => {
+    const id = e?.id;
+    if (!id || map.hasImage(id)) return;
+    map.addImage(id, { width: 1, height: 1, data: new Uint8ClampedArray(4) });
+  });
+}

--- a/tests/unit/map-style.test.ts
+++ b/tests/unit/map-style.test.ts
@@ -5,8 +5,8 @@
  * community / share maps. `basemapStyleUrl` is the shared, theme-aware
  * source of truth all three now consume.
  */
-import { describe, it, expect } from 'vitest';
-import { basemapStyleUrl } from '../../src/lib/map-style';
+import { describe, it, expect, vi } from 'vitest';
+import { basemapStyleUrl, installSpriteFallback } from '../../src/lib/map-style';
 
 describe('basemapStyleUrl (#1081)', () => {
   it('returns the dark OpenFreeMap style in dark mode', () => {
@@ -19,5 +19,52 @@ describe('basemapStyleUrl (#1081)', () => {
 
   it('is a single source of truth — light and dark differ', () => {
     expect(basemapStyleUrl(true)).not.toBe(basemapStyleUrl(false));
+  });
+});
+
+describe('installSpriteFallback (#1113)', () => {
+  function fakeMap() {
+    let handler: ((e: { id: string }) => void) | null = null;
+    const images = new Set<string>();
+    return {
+      on: vi.fn((_type: string, fn: (e: { id: string }) => void) => { handler = fn; }),
+      hasImage: (id: string) => images.has(id),
+      addImage: vi.fn((id: string) => { images.add(id); }),
+      fire: (id: string) => handler?.({ id }),
+      images,
+    };
+  }
+
+  it('subscribes to styleimagemissing', () => {
+    const m = fakeMap();
+    installSpriteFallback(m);
+    expect(m.on).toHaveBeenCalledWith('styleimagemissing', expect.any(Function));
+  });
+
+  it('registers a 1x1 transparent fallback for a missing basemap icon', () => {
+    const m = fakeMap();
+    installSpriteFallback(m);
+    m.fire('circle-11');
+    expect(m.addImage).toHaveBeenCalledWith('circle-11', {
+      width: 1,
+      height: 1,
+      data: new Uint8ClampedArray(4),
+    });
+    expect(m.images.has('circle-11')).toBe(true);
+  });
+
+  it('is idempotent — does not re-register an already-present image', () => {
+    const m = fakeMap();
+    installSpriteFallback(m);
+    m.fire('circle-11');
+    m.fire('circle-11');
+    expect(m.addImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a missing event with no id', () => {
+    const m = fakeMap();
+    installSpriteFallback(m);
+    m.fire(undefined as unknown as string);
+    expect(m.addImage).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Bug + premise correction

Found in the 2026-05-16 Chrome sweep: explore map logs `Image "circle-11" could not be loaded`.

**Correction to #1113's premise (faithful reporting):** investigation showed the obs layers (`clusters`/`pin`) are `circle`-**paint** layers — **markers were never actually missing**. `circle-11` is a Maki POI icon from the *hosted OpenFreeMap basemap style* (`map-style.ts:28` `basemapStyleUrl` → liberty/dark), whose sprite is slow/absent on first paint. So this is real console noise from an external style we don't own — not a data-visibility bug. #1113's "markers likely missing" was an over-inference; corrected here and on the issue.

## Fix

`installSpriteFallback(map)` added to the shared `src/lib/map-style.ts`: a `styleimagemissing` handler registering a 1×1 transparent image for any icon the external style requests but its sprite lacks. Idempotent (`hasImage` guard), null-safe, typed via a minimal local interface (unit-testable without maplibre-gl types). Wired into `ExploreMap.astro` immediately after map construction. Robust to the slow/failed external sprite. +4 unit tests in the existing `tests/unit/map-style.test.ts` pattern.

Frontend-only — no deps/schema/RLS.

## Verification

tsc clean · 2426/2426 vitest (incl. 4 new) · 255-page build.

Surfaced by the journey audit. Reusable by `MapPicker`/`CommunityMapView` later if they hit the same warning (only the explore-map surface wired now, per issue scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)