### PR TITLE
feat(observe): pure card view-model composer

### DIFF
--- a/src/lib/observe-card-vm.test.ts
+++ b/src/lib/observe-card-vm.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { buildCardViewModel, type CardVmInput } from './observe-card-vm';
+import type { IdAttempt } from './observe-audit-trace';
+
+const base: CardVmInput = {
+  provisional: null,
+  cloud: null,
+  observerAffirmed: false,
+  online: true,
+  hasOnDeviceModel: true,
+  attempts: [],
+};
+
+describe('buildCardViewModel', () => {
+  it('S0 with no headline/sourceLabel when nothing resolved', () => {
+    const vm = buildCardViewModel(base);
+    expect(vm.state).toBe('S0');
+    expect(vm.sovereignty).toBe('none');
+    expect(vm.headline).toBeNull();
+    expect(vm.sourceLabel).toBeNull();
+    expect(vm.trace).toEqual([]);
+  });
+
+  it('S1a with cloud headline + source label when an authoritative cloud result exists', () => {
+    const vm = buildCardViewModel({
+      ...base,
+      cloud: { scientificName: 'Quercus rugosa', confidence: 0.94, source: 'plantnet', confidenceCeiling: 1 },
+    });
+    expect(vm.state).toBe('S1a');
+    expect(vm.sovereignty).toBe('upgrade-primary');
+    expect(vm.headline).toBe('Quercus rugosa');
+    expect(vm.sourceLabel).toBe('plantnet · 94%');
+  });
+
+  it('S1b headline/source come from the provisional when there is no cloud', () => {
+    const vm = buildCardViewModel({
+      ...base,
+      provisional: { scientificName: 'Quercus sp.', confidence: 0.31, source: 'onnx_efficientnet_lite0', confidenceCeiling: 0.4 },
+    });
+    expect(vm.state).toBe('S1b');
+    expect(vm.sovereignty).toBe('none');
+    expect(vm.headline).toBe('Quercus sp.');
+    expect(vm.sourceLabel).toBe('onnx_efficientnet_lite0 · 31%');
+  });
+
+  it('S2prime keeps the observer headline; sovereignty is parallel-suggestion', () => {
+    const vm = buildCardViewModel({
+      ...base,
+      provisional: { scientificName: 'Quercus crassifolia', confidence: 1, source: 'human', confidenceCeiling: 1 },
+      cloud: { scientificName: 'Quercus rugosa', confidence: 0.94, source: 'plantnet', confidenceCeiling: 1 },
+      observerAffirmed: true,
+    });
+    expect(vm.state).toBe('S2prime');
+    expect(vm.sovereignty).toBe('parallel-suggestion');
+    expect(vm.headline).toBe('Quercus crassifolia');
+  });
+
+  it('passes the audit trace through, oldest-first', () => {
+    const attempts: IdAttempt[] = [
+      { source: 'plantnet', where: 'cloud', scientificName: 'Quercus rugosa', confidence: 0.94, isPrimary: true, createdAt: '2026-05-16T10:02:09Z' },
+      { source: 'onnx_efficientnet_lite0', where: 'device', scientificName: 'Quercus sp.', confidence: 0.31, isPrimary: false, createdAt: '2026-05-16T10:02:02Z' },
+    ];
+    const vm = buildCardViewModel({ ...base, cloud: { scientificName: 'Quercus rugosa', confidence: 0.94, source: 'plantnet', confidenceCeiling: 1 }, attempts });
+    expect(vm.trace.map(e => e.source)).toEqual(['onnx_efficientnet_lite0', 'plantnet']);
+  });
+
+  it('sourceLabel rounds confidence to whole percent', () => {
+    const vm = buildCardViewModel({
+      ...base,
+      cloud: { scientificName: 'X', confidence: 0.666, source: 'claude_haiku', confidenceCeiling: 1 },
+    });
+    expect(vm.sourceLabel).toBe('claude_haiku · 67%');
+  });
+});

--- a/src/lib/observe-card-vm.ts
+++ b/src/lib/observe-card-vm.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure composer: ties the three card resolvers into one view model the
+ * DOM render layer consumes. No DOM / network / i18n (the render layer
+ * localizes static chrome; sourceLabel is data). See spec
+ * docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md.
+ */
+import { resolveCardState, type IdResult, type CardState } from './observe-card-state';
+import { resolveSovereignty, type SovereigntyAction } from './observe-sovereignty';
+import { buildAuditTrace, type IdAttempt, type TraceEntry } from './observe-audit-trace';
+
+export interface CardVmInput {
+  provisional: IdResult | null;
+  cloud: IdResult | null;
+  observerAffirmed: boolean;
+  online: boolean;
+  hasOnDeviceModel: boolean;
+  attempts: IdAttempt[];
+}
+
+export interface CardViewModel {
+  state: CardState;
+  sovereignty: SovereigntyAction;
+  trace: TraceEntry[];
+  /** Scientific name the card displays, or null when nothing resolved. */
+  headline: string | null;
+  /** Data label "source · NN%", or null when nothing resolved. */
+  sourceLabel: string | null;
+}
+
+function labelFor(r: IdResult): string {
+  return `${r.source} · ${Math.round(r.confidence * 100)}%`;
+}
+
+export function buildCardViewModel(input: CardVmInput): CardViewModel {
+  const state = resolveCardState({
+    provisional: input.provisional,
+    cloud: input.cloud,
+    observerAffirmed: input.observerAffirmed,
+    online: input.online,
+    hasOnDeviceModel: input.hasOnDeviceModel,
+  });
+  const sovereignty = resolveSovereignty({
+    observerAffirmed: input.observerAffirmed,
+    cloudArrived: input.cloud !== null,
+  });
+  const trace = buildAuditTrace(input.attempts);
+
+  const primary: IdResult | null =
+    input.observerAffirmed && input.provisional
+      ? input.provisional
+      : input.cloud ?? input.provisional;
+
+  return {
+    state,
+    sovereignty,
+    trace,
+    headline: primary ? primary.scientificName : null,
+    sourceLabel: primary ? labelFor(primary) : null,
+  };
+}


### PR DESCRIPTION
Next decomposed slice of the progressive card (spec PR #1107; plan PR #1117). Composes the 3 shipped pure resolvers (#1115) into one view model the DOM render layer will bind to.

## Summary
- `src/lib/observe-card-vm.ts` — `buildCardViewModel` → `{ state, sovereignty, trace, headline, sourceLabel }`. Headline priority honors sovereignty (affirmed observer ID wins, else cloud, else provisional). Pure, no DOM/network/i18n.

## Test Plan
- [x] 6 unit tests (states, sovereignty, trace passthrough, source-label rounding)
- [x] `npx vitest run` — 2444/2444
- [x] `npx tsc --noEmit` — clean

Out of scope (next plans): DOM render + ObserveView2 wiring, action handlers (Sí/No/No-sé) + `review_requested`, downloads UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)