### PR TITLE
feat(observe): expose runner attempts from runParallelIdentify

### DIFF
--- a/src/lib/identify-cascade-client.test.ts
+++ b/src/lib/identify-cascade-client.test.ts
@@ -6,6 +6,7 @@ import {
   filterRunnersByHint,
   type IdentifierRunner,
   type UnifiedIdResult,
+  type IdentifyAttempt,
 } from './identify-cascade-client';
 
 const fakeFile = new File([new Uint8Array([0])], 'test.jpg', { type: 'image/jpeg' });
@@ -203,6 +204,60 @@ describe('extractJsonObject', () => {
   it('returns null on empty/garbage', () => {
     expect(extractJsonObject('')).toBeNull();
     expect(extractJsonObject('no json here')).toBeNull();
+  });
+});
+
+describe('runParallelIdentify attempts', () => {
+  it('winner case: attempts contains both winner and loser sources', async () => {
+    const plantnet: IdentifierRunner = vi.fn(async () =>
+      makeResult({ source: 'plantnet', scientific_name: 'Quercus ilex', confidence: 0.9 }),
+    );
+    const claude: IdentifierRunner = vi.fn(async () =>
+      makeResult({ source: 'claude_haiku', scientific_name: 'Quercus robur', confidence: 0.4 }),
+    );
+    const out = await runParallelIdentify(fakeFile, { runners: { plantnet, claude_haiku: claude } });
+    expect(out.kind).toBe('winner');
+    expect(out.attempts).toBeDefined();
+    expect(out.attempts).toHaveLength(2);
+    const sources = out.attempts.map((a) => a.source);
+    expect(sources).toContain('plantnet');
+    expect(sources).toContain('claude_haiku');
+    const winner = out.attempts.find((a) => a.source === 'plantnet');
+    expect(winner?.scientific_name).toBe('Quercus ilex');
+    expect(winner?.confidence).toBe(0.9);
+    const loser = out.attempts.find((a) => a.source === 'claude_haiku');
+    expect(loser?.scientific_name).toBe('Quercus robur');
+    expect(loser?.confidence).toBe(0.4);
+  });
+
+  it('uncertain case: attempts length is 2 with both sources', async () => {
+    const plantnet: IdentifierRunner = vi.fn(async () =>
+      makeResult({ source: 'plantnet', scientific_name: 'Quercus ilex', confidence: 0.4 }),
+    );
+    const claude: IdentifierRunner = vi.fn(async () =>
+      makeResult({ source: 'claude_haiku', scientific_name: 'Quercus robur', confidence: 0.3 }),
+    );
+    const out = await runParallelIdentify(fakeFile, { runners: { plantnet, claude_haiku: claude } });
+    expect(out.kind).toBe('uncertain');
+    expect(out.attempts).toBeDefined();
+    expect(out.attempts).toHaveLength(2);
+    const sources = out.attempts.map((a) => a.source);
+    expect(sources).toContain('plantnet');
+    expect(sources).toContain('claude_haiku');
+  });
+
+  it('all_failed case: attempts contains one entry with error and confidence 0', async () => {
+    const plantnet: IdentifierRunner = vi.fn(async () => {
+      throw new Error('PlantNet network error');
+    });
+    const out = await runParallelIdentify(fakeFile, { runners: { plantnet } });
+    expect(out.kind).toBe('all_failed');
+    expect(out.attempts).toBeDefined();
+    expect(out.attempts).toHaveLength(1);
+    expect(out.attempts[0].source).toBe('plantnet');
+    expect(out.attempts[0].confidence).toBe(0);
+    expect(out.attempts[0].error).toBeTruthy();
+    expect(typeof out.attempts[0].error).toBe('string');
   });
 });
 

--- a/src/lib/identify-cascade-client.ts
+++ b/src/lib/identify-cascade-client.ts
@@ -92,11 +92,20 @@ export function filterRunnersByHint(
   return out;
 }
 
+export interface IdentifyAttempt {
+  /** Runner/plugin id. */
+  source: string;
+  scientific_name: string | null;
+  confidence: number;
+  /** Set only when this runner threw / errored. */
+  error?: string;
+}
+
 export type ParallelIdentifyOutcome =
-  | { kind: 'winner'; result: UnifiedIdResult; uncertain: false }
-  | { kind: 'uncertain'; result: UnifiedIdResult; uncertain: true }
-  | { kind: 'provisional'; result: UnifiedIdResult; uncertain: false; awaitingConfirmation: true }
-  | { kind: 'all_failed'; errors: Record<string, string> };
+  | { kind: 'winner'; result: UnifiedIdResult; uncertain: false; attempts: IdentifyAttempt[] }
+  | { kind: 'uncertain'; result: UnifiedIdResult; uncertain: true; attempts: IdentifyAttempt[] }
+  | { kind: 'provisional'; result: UnifiedIdResult; uncertain: false; awaitingConfirmation: true; attempts: IdentifyAttempt[] }
+  | { kind: 'all_failed'; errors: Record<string, string>; attempts: IdentifyAttempt[] };
 
 /**
  * Run every supplied identifier in parallel.
@@ -128,7 +137,7 @@ export async function runParallelIdentify(
   const filteredRunners = filterRunnersByHint(opts.runners, opts.taxonHint ?? null);
   const entries = Object.entries(filteredRunners);
   if (entries.length === 0) {
-    return { kind: 'all_failed', errors: { _: 'no runners' } };
+    return { kind: 'all_failed', errors: { _: 'no runners' }, attempts: [] };
   }
 
   const internalCtrl = new AbortController();
@@ -163,22 +172,37 @@ export async function runParallelIdentify(
     if (external) external.removeEventListener('abort', onExternalAbort);
   }
 
+  const buildAttempts = (): IdentifyAttempt[] => {
+    const out: IdentifyAttempt[] = [];
+    if (winner) {
+      const w = winner as { id: string; result: UnifiedIdResult };
+      out.push({ source: w.id, scientific_name: w.result.scientific_name, confidence: w.result.confidence });
+    }
+    for (const { id, result } of results) {
+      out.push({ source: id, scientific_name: result.scientific_name, confidence: result.confidence });
+    }
+    for (const [id, message] of Object.entries(errors)) {
+      out.push({ source: id, scientific_name: null, confidence: 0, error: message });
+    }
+    return out;
+  };
+
   if (winner) {
     const winResult = (winner as { id: string; result: UnifiedIdResult }).result;
     // If this win is only because the new-user lower threshold was applied
     // AND confidence is below the standard threshold, mark it as provisional.
     if (isNewUser && winResult.confidence < 0.5) {
-      return { kind: 'provisional', result: winResult, uncertain: false, awaitingConfirmation: true };
+      return { kind: 'provisional', result: winResult, uncertain: false, awaitingConfirmation: true, attempts: buildAttempts() };
     }
-    return { kind: 'winner', result: winResult, uncertain: false };
+    return { kind: 'winner', result: winResult, uncertain: false, attempts: buildAttempts() };
   }
 
   if (results.length > 0) {
     results.sort((a, b) => b.result.confidence - a.result.confidence);
-    return { kind: 'uncertain', result: results[0].result, uncertain: true };
+    return { kind: 'uncertain', result: results[0].result, uncertain: true, attempts: buildAttempts() };
   }
 
-  return { kind: 'all_failed', errors };
+  return { kind: 'all_failed', errors, attempts: buildAttempts() };
 }
 
 // ─────────────── JSON parsing helpers (shared with vision fallback) ───────────────


### PR DESCRIPTION
Unblocks the progressive-card render: `runParallelIdentify` now returns `attempts: IdentifyAttempt[]` (additive, behavior-preserving) so `buildCardViewModel` can build the audit trace + provisional/cloud view. Existing callers unaffected.

- [x] 27 cascade tests (24 + 3 new: winner/uncertain/all_failed attempts)
- [x] full suite 2451/2451, tsc clean

Spec PR #1107 · plan PR #1117. Next slices: DOM render (C), review_requested, downloads UX, R1/R2/R3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)