### PR TITLE
feat(qa): CI-enforced journey catalog (route spine + flow overlay)

### DIFF
--- a/docs/journey-audit-2026-05-15.md
+++ b/docs/journey-audit-2026-05-15.md
@@ -7,6 +7,11 @@
 > regression. Companion to [`qa-policy.md`](qa-policy.md) (test policy)
 > and [`fogg-audit.md`](fogg-audit.md) (v1.1.5 persuasive-tech audit).
 
+> **Living successor:** completeness is now owned by the CI-enforced
+> [`journey-catalog.md`](journey-catalog.md). This file remains the
+> immutable 2026-05-15/16 audit record; for "is every route covered"
+> consult the catalog, not this snapshot.
+
 ---
 
 ## 1. Two journey systems — reconciled

--- a/docs/journey-catalog.md
+++ b/docs/journey-catalog.md
@@ -83,7 +83,7 @@
 | `exploreValidate` | /en/explore/validate | /es/explorar/validar | authed | R+W | — | 2026-05-16 |  |
 | `exploreWatchlist` | /en/explore/watchlist | /es/explorar/seguimiento | authed | R | journey-watchlist-rare-species-alert.spec.ts | never |  |
 | `faq` | /en/faq | /es/preguntas-frecuentes | anon | R | — | never |  |
-| `fieldGuide` | /enfield-guide | /esguia-de-campo | anon | R | — | never |  |
+| `fieldGuide` | /en/explore/trails/field-guide | /es/explorar/senderos/guia-de-campo | anon | R | — | never | #1130 |
 | `home` | /en | /es | anon | R | journey-guest-browse.spec.ts | 2026-05-16 |  |
 | `identify` | /en/observe | /es/observar | anon | R+W | — | never |  |
 | `inbox` | /en/inbox | /es/bandeja | authed | R | — | never |  |

--- a/docs/journey-catalog.md
+++ b/docs/journey-catalog.md
@@ -1,0 +1,161 @@
+# Journey Catalog
+
+> CI-enforced, provably-complete catalog of every Rastrum route + the
+> end-to-end journeys over them. The §1 spine is diffed against
+> `routes` (`src/i18n/utils.ts`) ∪ `CONSOLE_TABS.routeKey`
+> (`src/lib/console-tabs.ts`) by `tests/unit/journey-catalog-complete.test.ts`
+> — a new/removed route fails CI until this file is updated.
+>
+> Historical point-in-time audit: [`journey-audit-2026-05-15.md`](journey-audit-2026-05-15.md).
+> CI policy: [`qa-policy.md`](qa-policy.md).
+
+## How to read
+
+- **Auth**: `anon` (no login) · `authed` (any signed-in user) ·
+  `role:admin|moderator|expert` (console/privileged).
+- **R/W**: `R` read-only surface · `R+W` has write affordances (a
+  read-only sweep must not submit writes here without per-item consent).
+- **Spec**: covering `tests/e2e/journey-*.spec.ts`, or `—`.
+- **Verified**: `YYYY-MM-DD` of the last real Chrome verification, or
+  `never`. Update in-place when you sweep (see §3).
+
+## §1 Route spine
+
+<!-- spine:start -->
+| routeKey | EN path | ES path | Auth | R/W | Spec | Verified | Issues |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `about` | /en/about | /es/acerca | anon | R | — | never |  |
+| `chat` | /en/chat | /es/chat | anon | R+W | journey-chat-find-species-and-observe.spec.ts | 2026-05-16 |  |
+| `community` | /en/community | /es/comunidad | anon | R | — | never |  |
+| `communityDonate` | /en/community/donate | /es/comunidad/donar | authed | R+W | — | never |  |
+| `communityMap` | /en/community/map | /es/comunidad/mapa | anon | R | — | never |  |
+| `communityObservers` | /en/community/observers | /es/comunidad/observadores | anon | R | — | never |  |
+| `console` | /en/console | /es/consola | role:expert | R+W | — | never |  |
+| `consoleAnomalies` | /en/console/anomalies | /es/consola/anomalias | role:admin | R+W | — | never |  |
+| `consoleApi` | /en/console/api | /es/consola/api | role:admin | R+W | — | never |  |
+| `consoleAudit` | /en/console/audit | /es/consola/auditoria | role:admin | R+W | — | never |  |
+| `consoleBadges` | /en/console/badges | /es/consola/insignias | role:admin | R+W | — | never |  |
+| `consoleBioblitz` | /en/console/bioblitz | /es/consola/bioblitz | role:admin | R+W | — | never |  |
+| `consoleCredentials` | /en/console/credentials | /es/consola/credenciales | role:admin | R+W | — | never |  |
+| `consoleCron` | /en/console/cron | /es/consola/cron | role:admin | R+W | — | never |  |
+| `consoleErrors` | /en/console/errors | /es/consola/errores | role:admin | R+W | — | 2026-05-16 |  |
+| `consoleExpertApplications` | /en/console/expert-applications | /es/consola/aplicaciones-expertas | role:admin | R+W | — | never |  |
+| `consoleExpertExpertise` | /en/console/expertise | /es/consola/experiencia | role:expert | R+W | — | never |  |
+| `consoleExpertOverrides` | /en/console/overrides | /es/consola/correcciones | role:expert | R+W | — | never |  |
+| `consoleExpertTaxonNotes` | /en/console/taxon-notes | /es/consola/notas-taxon | role:expert | R+W | — | never |  |
+| `consoleExpertValidation` | /en/console/validation | /es/consola/validacion | role:expert | R+W | — | never |  |
+| `consoleExperts` | /en/console/experts | /es/consola/expertos | role:admin | R+W | — | never |  |
+| `consoleFeatureFlags` | /en/console/features | /es/consola/caracteristicas | role:admin | R+W | — | never |  |
+| `consoleFeedback` | /en/console/feedback | /es/consola/retroalimentacion | role:admin | R+W | — | never |  |
+| `consoleFlags` | /en/console/flags | /es/consola/banderas | role:admin | R+W | — | never |  |
+| `consoleFollows` | /en/console/follows | /es/consola/seguimientos | role:admin | R+W | — | never |  |
+| `consoleForensics` | /en/console/forensics | /es/consola/forenses | role:admin | R+W | — | never |  |
+| `consoleHealth` | /en/console/health | /es/consola/salud | role:admin | R+W | journey-admin-health.spec.ts | 2026-05-16 |  |
+| `consoleIdentifications` | /en/console/identifications | /es/consola/identificaciones | role:admin | R+W | — | never |  |
+| `consoleKarma` | /en/console/karma | /es/consola/karma | role:admin | R+W | — | never |  |
+| `consoleMedia` | /en/console/media | /es/consola/medios | role:admin | R+W | — | never |  |
+| `consoleModAppeals` | /en/console/appeals | /es/consola/apelaciones | role:moderator | R+W | — | never |  |
+| `consoleModBans` | /en/console/bans | /es/consola/suspensiones | role:moderator | R+W | — | never |  |
+| `consoleModComments` | /en/console/comments | /es/consola/comentarios | role:moderator | R+W | — | never |  |
+| `consoleModDisputes` | /en/console/disputes | /es/consola/disputas | role:moderator | R+W | — | never |  |
+| `consoleModFlagQueue` | /en/console/flag-queue | /es/consola/cola-banderas | role:moderator | R+W | journey-mod-flags.spec.ts | 2026-05-16 |  |
+| `consoleNotifications` | /en/console/notifications | /es/consola/notificaciones | role:admin | R+W | — | never |  |
+| `consoleObservations` | /en/console/observations | /es/consola/observaciones | role:admin | R+W | — | 2026-05-16 | #1112 |
+| `consoleProjects` | /en/console/projects | /es/consola/proyectos-admin | role:admin | R+W | — | never |  |
+| `consoleProposals` | /en/console/proposals | /es/consola/propuestas | role:admin | R+W | — | never |  |
+| `consoleSync` | /en/console/sync | /es/consola/sync | role:admin | R+W | — | never |  |
+| `consoleTaxa` | /en/console/taxa | /es/consola/taxa | role:admin | R+W | — | never |  |
+| `consoleTaxonChanges` | /en/console/taxon-changes | /es/consola/cambios-taxon | role:admin | R+W | — | never |  |
+| `consoleUsers` | /en/console/users | /es/consola/usuarios | role:admin | R+W | — | 2026-05-16 |  |
+| `consoleWatchlists` | /en/console/watchlists | /es/consola/listas-vigilancia | role:admin | R+W | — | never |  |
+| `consoleWebhooks` | /en/console/webhooks | /es/consola/webhooks | role:admin | R+W | — | never |  |
+| `dex` | /en/profile/dex | /es/perfil/dex | authed | R | journey-falta-dex-region-pool.spec.ts | 2026-05-16 |  |
+| `discover` | /en/discover | /es/descubrir | anon | R | — | never |  |
+| `docs` | /en/docs | /es/docs | anon | R | — | never |  |
+| `explore` | /en/explore | /es/explorar | anon | R | journey-guest-browse.spec.ts | 2026-05-16 |  |
+| `exploreMap` | /en/explore/map | /es/explorar/mapa | anon | R | — | 2026-05-16 | #1113 |
+| `explorePits` | /en/explore/pits | /es/explorar/pits | anon | R | — | never |  |
+| `explorePlaces` | /en/explore/places | /es/explorar/lugares | anon | R | journey-guest-browse.spec.ts | 2026-05-16 |  |
+| `exploreRecent` | /en/explore/recent | /es/explorar/recientes | anon | R | journey-guest-browse.spec.ts | 2026-05-16 |  |
+| `exploreSpecies` | /en/explore/species | /es/explorar/especies | anon | R | journey-guest-browse.spec.ts | 2026-05-16 |  |
+| `exploreSpeciesDetail` | /en/explore/species | /es/explorar/especies | anon | R | — | never |  |
+| `exploreTrails` | /en/explore/trails | /es/explorar/senderos | anon | R | — | never |  |
+| `exploreValidate` | /en/explore/validate | /es/explorar/validar | authed | R+W | — | 2026-05-16 |  |
+| `exploreWatchlist` | /en/explore/watchlist | /es/explorar/seguimiento | authed | R | journey-watchlist-rare-species-alert.spec.ts | never |  |
+| `faq` | /en/faq | /es/preguntas-frecuentes | anon | R | — | never |  |
+| `fieldGuide` | /enfield-guide | /esguia-de-campo | anon | R | — | never |  |
+| `home` | /en | /es | anon | R | journey-guest-browse.spec.ts | 2026-05-16 |  |
+| `identify` | /en/observe | /es/observar | anon | R+W | — | never |  |
+| `inbox` | /en/inbox | /es/bandeja | authed | R | — | never |  |
+| `leaderboard` | /en/community/leaderboard | /es/comunidad/tabla-de-lideres | anon | R | — | never |  |
+| `observe` | /en/observe | /es/observar | anon | R+W | journey-observer-first-obs.spec.ts | 2026-05-16 |  |
+| `privacy` | /en/privacy | /es/privacidad | anon | R | — | never |  |
+| `profile` | /en/profile | /es/perfil | authed | R | — | never |  |
+| `profileAdminExperts` | /en/profile/admin/experts | /es/perfil/admin/expertos | authed | R | — | never |  |
+| `profileAppeal` | /en/profile/appeal | /es/perfil/apelar | authed | R | — | never |  |
+| `profileEdit` | /en/profile/edit | /es/perfil/editar | authed | R+W | — | never |  |
+| `profileExpertApply` | /en/profile/expert-apply | /es/perfil/aplicar-experto | authed | R+W | — | never |  |
+| `profileExport` | /en/profile/export | /es/perfil/exportar | authed | R | journey-researcher-export.spec.ts | 2026-05-16 |  |
+| `profileFollowers` | /en/profile/u | /es/perfil/u | authed | R | — | never |  |
+| `profileFollowing` | /en/profile/u | /es/perfil/u | authed | R | — | never |  |
+| `profileImpact` | /en/profile/impact | /es/perfil/impacto | authed | R | — | never |  |
+| `profileImport` | /en/profile/import | /es/perfil/importar | authed | R+W | — | never |  |
+| `profileImportCameraTrap` | /en/profile/import/camera-trap | /es/perfil/importar/camara-trampa | authed | R+W | — | never |  |
+| `profileNotifications` | /en/profile/notifications | /es/perfil/notificaciones | authed | R | — | never |  |
+| `profileObservations` | /en/profile/observations | /es/perfil/observaciones | authed | R | — | never |  |
+| `profileSettings` | /en/profile/settings | /es/perfil/ajustes | authed | R | — | never |  |
+| `profileSettingsData` | /en/profile/settings/data | /es/perfil/ajustes/data | authed | R+W | — | never |  |
+| `profileSettingsDeveloper` | /en/profile/settings/developer | /es/perfil/ajustes/developer | authed | R+W | — | never |  |
+| `profileSettingsPreferences` | /en/profile/settings/preferences | /es/perfil/ajustes/preferences | authed | R+W | — | never |  |
+| `profileSettingsPrivacy` | /en/profile/settings/privacy | /es/perfil/ajustes/privacy | authed | R+W | — | never |  |
+| `profileSettingsProfile` | /en/profile/settings/profile | /es/perfil/ajustes/profile | authed | R+W | — | never |  |
+| `profileTokens` | /en/profile/tokens | /es/perfil/tokens | authed | R+W | — | never |  |
+| `profileUser` | /en/profile/u | /es/perfil/u | authed | R | — | never |  |
+| `profileValidate` | /en/profile/validate | /es/perfil/validar | authed | R+W | — | never |  |
+| `projectNew` | /en/projects/new | /es/proyectos/nuevo | authed | R+W | — | never |  |
+| `projects` | /en/projects | /es/proyectos | anon | R | — | 2026-05-16 |  |
+| `publicProfile` | /en/u | /es/u | anon | R | — | 2026-05-16 |  |
+| `signIn` | /en/sign-in | /es/ingresar | anon | R | journey-magic-link-pkce-callback.spec.ts | never |  |
+| `sponsoredBy` | /en/profile/sponsored-by | /es/perfil/patrocinado-por | anon | R | — | never |  |
+| `sponsoring` | /en/profile/sponsoring | /es/perfil/patrocinios | authed | R+W | — | never |  |
+| `terms` | /en/terms | /es/terminos | anon | R | — | never |  |
+<!-- spine:end -->
+
+## §2 Journey-flow overlay
+
+End-to-end flows as an ordered `routeKey` sequence → guarding spec.
+Reading aid; not drift-checked (every route is already proven present
+by §1).
+
+| Flow | Route sequence | Spec |
+| --- | --- | --- |
+| guest-browse | `home` → `explore` → `exploreRecent` → `explorePlaces` → `exploreSpecies` | `journey-guest-browse.spec.ts` |
+| first-observation | `observe` → `profileObservations` → `publicProfile` | `journey-observer-first-obs.spec.ts` |
+| identify-cascade | `observe` (photo → cascade UI) | `journey-photo-id-cascade.spec.ts` |
+| share-observation | `publicProfile` → `/share/obs/?id=` (locale-neutral) | `journey-share-observation-public.spec.ts` |
+| watchlist | `exploreWatchlist` | `journey-watchlist-rare-species-alert.spec.ts` |
+| social-engage | `publicProfile` → `inbox` → `profileFollowers` → `profileFollowing` | `journey-social-engage.spec.ts` |
+| projects-camera | `projects` → `projectNew` | `journey-projects-create-and-join.spec.ts`, `journey-camera-station-import.spec.ts` |
+| researcher-export | `profileExport` | `journey-researcher-export.spec.ts` |
+| moderation-triage | `consoleModFlagQueue` → `consoleObservations` | `journey-mod-flags.spec.ts`, `journey-admin-health.spec.ts` |
+| falta-dex | `dex` | `journey-falta-dex-region-pool.spec.ts` |
+| auth-magic-link | `signIn` → `/auth/callback/` (locale-neutral) | `journey-magic-link-pkce-callback.spec.ts` |
+| auth-passkey | `profileSettingsPrivacy` | `journey-passkey-enroll-then-verify.spec.ts` |
+| onboarding | `home` (replay tour) | `journey-onboarding-tour-replay.spec.ts` |
+| offline-pwa | `observe` (offline) | `journey-observer-offline.spec.ts` |
+| mobile-chrome | `home` (mobile viewport) | `journey-mobile-core.spec.ts` |
+| chat-ask-rastrum | `chat` (deep-link `?attach=`) | `journey-chat-find-species-and-observe.spec.ts` (model mocked) |
+
+## §3 Sweep procedure
+
+Read-only Chrome, signed-in. Walk §1 top-to-bottom. Per route:
+`read_console_messages` with an error pattern + `read_network_requests`
+(media/5xx); screenshot visual surfaces (map, observe form, lists).
+On a clean route, set its `Verified` cell to the sweep date **in the
+same PR**. A route marked `R+W` must not have writes submitted in a
+read-only sweep without explicit per-item user consent. New bug → file
+an issue, add its `#ref` to the route's `Issues` cell.
+
+`/auth/callback/` and `/share/obs/` are intentionally locale-neutral
+(no `routeKey`); they ride the `auth-magic-link` / `share-observation`
+flows in §2 and are not §1 spine rows.

--- a/docs/qa-policy.md
+++ b/docs/qa-policy.md
@@ -173,6 +173,9 @@ finishes wiring it into the `verify` job.
 - `docs/runbooks/ci-smoke-checks.md` — what to do when a smoke job goes red.
 - `.github/workflows/ci.yml`, `db-validate.yml`, `pr-audit.yml` — the
   workflows behind the required checks.
+- [`journey-catalog.md`](journey-catalog.md) — CI-enforced, provably-
+  complete route + journey catalog (the list sweeps run against;
+  `tests/unit/journey-catalog-complete.test.ts` keeps it from rotting).
 
 ---
 

--- a/docs/superpowers/plans/2026-05-16-journey-catalog.md
+++ b/docs/superpowers/plans/2026-05-16-journey-catalog.md
@@ -1,0 +1,442 @@
+# Journey Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a CI-enforced, provably-complete journey catalog so manual Chrome / e2e sweeps run against a list that cannot silently rot.
+
+**Architecture:** A human-curated markdown doc (`docs/journey-catalog.md`) whose §1 "route spine" (one fenced row per route) is mechanically diffed against the route sources of truth by a new vitest, mirroring `tests/unit/dynamic-routes-parity.test.ts`. A §2 journey-flow overlay groups routes into named end-to-end flows (reading aid, not drift-checked).
+
+**Tech Stack:** Markdown, Vitest (`node:fs`), TypeScript. No new deps. Docs + one test + two cross-link edits. One PR on branch `feat/journey-catalog` (worktree `.worktrees/journey-catalog` already exists).
+
+**Spec:** `docs/superpowers/specs/2026-05-16-journey-catalog-design.md` (read it; it is authoritative if this plan disagrees).
+
+**Sources of truth (confirmed):**
+- `src/i18n/utils.ts` → `export const routes` — **95 keys**.
+- `src/lib/console-tabs.ts` → `export const CONSOLE_TABS` — 39 unique `routeKey`s, all already a subset of `routes`. Union = 95.
+
+**Worktree env constraint:** all paths below are relative to the worktree root `/Users/artemiopadilla/Documents/repos/GitHub/personal/rastrum/.worktrees/journey-catalog`. `cd` there for every command. Subagents: you cannot run git — the controller commits; stage files explicitly (never `git add -A` in a worktree).
+
+---
+
+## File structure
+
+- **Create** `docs/journey-catalog.md` — the living catalog (§1 fenced route-spine table, §2 journey-flow overlay, §3 sweep procedure, cross-links).
+- **Create** `tests/unit/journey-catalog-complete.test.ts` — the drift-check.
+- **Modify** `docs/qa-policy.md` — add a §7 References bullet pointing at the catalog.
+- **Modify** `docs/journey-audit-2026-05-15.md` — add a one-line forward pointer near the top ("living catalog supersedes this snapshot's completeness role").
+- **Throwaway, NOT committed:** `/tmp/gen-spine.mjs` — generates the 95 spine rows; deleted before commit.
+
+---
+
+### Task 1: Generate and author `docs/journey-catalog.md`
+
+**Files:**
+- Create: `docs/journey-catalog.md`
+- Throwaway: `/tmp/gen-spine.mjs` (delete before commit)
+
+- [ ] **Step 1: Write the spine generator**
+
+Create `/tmp/gen-spine.mjs` (plain node, regex-parses the TS sources — node cannot import `.ts`):
+
+```js
+import { readFileSync } from 'node:fs';
+
+const ROOT = process.cwd(); // run from worktree root
+
+// --- routes: key -> {en, es} ---
+const utils = readFileSync(`${ROOT}/src/i18n/utils.ts`, 'utf8');
+const routesBlock = utils.match(/export const routes[^{]*\{([\s\S]*?)\n\};/)[1];
+const routeRe = /^\s{2}([a-zA-Z][a-zA-Z0-9]*):\s*\{\s*en:\s*'([^']*)',\s*es:\s*'([^']*)'/gm;
+const routes = {};
+for (const m of routesBlock.matchAll(routeRe)) routes[m[1]] = { en: m[2], es: m[3] };
+
+// --- console-tabs: routeKey -> role ---
+const ct = readFileSync(`${ROOT}/src/lib/console-tabs.ts`, 'utf8');
+const consoleRole = {};
+for (const m of ct.matchAll(/routeKey:\s*'([^']+)'[^}]*?role:\s*'([^']+)'|role:\s*'([^']+)'[^}]*?routeKey:\s*'([^']+)'/g)) {
+  if (m[1]) consoleRole[m[1]] = m[2];
+  else consoleRole[m[4]] = m[3];
+}
+
+// --- anon vs authed heuristic (deterministic; curate exceptions in Step 3) ---
+const ANON = new Set(['home','explore','exploreMap','exploreRecent','exploreSpecies',
+  'explorePlaces','exploreSpeciesDetail','exploreTrails','explorePits','fieldGuide',
+  'observe','identify','about','docs','signIn','publicProfile','community',
+  'communityObservers','communityMap','leaderboard','discover','privacy','terms','faq',
+  'sponsoredBy','projects','projectNew','chat']);
+
+const keys = Object.keys(routes).sort();
+const rows = keys.map(k => {
+  const r = routes[k];
+  const enPath = '/en' + (r.en || '');
+  const esPath = '/es' + (r.es || '');
+  const auth = consoleRole[k] ? `role:${consoleRole[k]}`
+             : ANON.has(k) ? 'anon' : 'authed';
+  return `| \`${k}\` | ${enPath || '/en'} | ${esPath || '/es'} | ${auth} | R | — | never |  |`;
+});
+console.log(`${keys.length} rows`);
+console.log(rows.join('\n'));
+```
+
+- [ ] **Step 2: Run it and capture the rows**
+
+Run: `cd .worktrees/journey-catalog && node /tmp/gen-spine.mjs`
+Expected: first line `95 rows`, then 95 pipe-delimited lines. Keep this output — it is the §1 table body.
+
+- [ ] **Step 3: Write `docs/journey-catalog.md`**
+
+Use this exact skeleton. Paste the 95 generated rows between the fences (after the header + separator rows already shown). Then apply the curation rules below to specific cells.
+
+````markdown
+# Journey Catalog
+
+> CI-enforced, provably-complete catalog of every Rastrum route + the
+> end-to-end journeys over them. The §1 spine is diffed against
+> `routes` (`src/i18n/utils.ts`) ∪ `CONSOLE_TABS.routeKey`
+> (`src/lib/console-tabs.ts`) by `tests/unit/journey-catalog-complete.test.ts`
+> — a new/removed route fails CI until this file is updated.
+>
+> Historical point-in-time audit: [`journey-audit-2026-05-15.md`](journey-audit-2026-05-15.md).
+> CI policy: [`qa-policy.md`](qa-policy.md).
+
+## How to read
+
+- **Auth**: `anon` (no login) · `authed` (any signed-in user) ·
+  `role:admin|moderator|expert` (console/privileged).
+- **R/W**: `R` read-only surface · `R+W` has write affordances (a
+  read-only sweep must not submit writes here without per-item consent).
+- **Spec**: covering `tests/e2e/journey-*.spec.ts`, or `—`.
+- **Verified**: `YYYY-MM-DD` of the last real Chrome verification, or
+  `never`. Update in-place when you sweep (see §3).
+
+## §1 Route spine
+
+<!-- spine:start -->
+| `routeKey` | EN path | ES path | Auth | R/W | Spec | Verified | Issues |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+PASTE THE 95 GENERATED ROWS HERE
+<!-- spine:end -->
+
+## §2 Journey-flow overlay
+
+End-to-end flows as an ordered `routeKey` sequence → guarding spec.
+Reading aid; not drift-checked (every route is already proven present
+by §1).
+
+| Flow | Route sequence | Spec |
+| --- | --- | --- |
+| guest-browse | `home` → `explore` → `exploreRecent` → `explorePlaces` → `exploreSpecies` | `journey-guest-browse.spec.ts` |
+| first-observation | `observe` → `profileObservations` → `publicProfile` | `journey-observer-first-obs.spec.ts` |
+| identify-cascade | `observe` (photo → cascade UI) | `journey-photo-id-cascade.spec.ts` |
+| share-observation | `publicProfile` → `/share/obs/?id=` (locale-neutral) | `journey-share-observation-public.spec.ts` |
+| watchlist | `exploreWatchlist` | `journey-watchlist-rare-species-alert.spec.ts` |
+| social-engage | `publicProfile` → `inbox` → `profileFollowers` → `profileFollowing` | `journey-social-engage.spec.ts` |
+| projects-camera | `projects` → `projectNew` | `journey-projects-create-and-join.spec.ts`, `journey-camera-station-import.spec.ts` |
+| researcher-export | `profileExport` | `journey-researcher-export.spec.ts` |
+| moderation-triage | `consoleModFlagQueue` → `consoleObservations` | `journey-mod-flags.spec.ts`, `journey-admin-health.spec.ts` |
+| falta-dex | `dex` | `journey-falta-dex-region-pool.spec.ts` |
+| auth-magic-link | `signIn` → `/auth/callback/` (locale-neutral) | `journey-magic-link-pkce-callback.spec.ts` |
+| auth-passkey | `profileSettingsPrivacy` | `journey-passkey-enroll-then-verify.spec.ts` |
+| onboarding | `home` (replay tour) | `journey-onboarding-tour-replay.spec.ts` |
+| offline-pwa | `observe` (offline) | `journey-observer-offline.spec.ts` |
+| mobile-chrome | `home` (mobile viewport) | `journey-mobile-core.spec.ts` |
+| chat-ask-rastrum | `chat` (deep-link `?attach=`) | `journey-chat-find-species-and-observe.spec.ts` (model mocked) |
+
+## §3 Sweep procedure
+
+Read-only Chrome, signed-in. Walk §1 top-to-bottom. Per route:
+`read_console_messages` with an error pattern + `read_network_requests`
+(media/5xx); screenshot visual surfaces (map, observe form, lists).
+On a clean route, set its `Verified` cell to the sweep date **in the
+same PR**. A route marked `R+W` must not have writes submitted in a
+read-only sweep without explicit per-item user consent. New bug → file
+an issue, add its `#ref` to the route's `Issues` cell.
+
+`/auth/callback/` and `/share/obs/` are intentionally locale-neutral
+(no `routeKey`); they ride the `auth-magic-link` / `share-observation`
+flows in §2 and are not §1 spine rows.
+````
+
+- [ ] **Step 4: Curate the generated cells (deterministic rules)**
+
+Apply exactly these edits to the pasted rows:
+
+1. **R+W** (change `R` → `R+W`) for: `observe`, `identify`,
+   `profileEdit`, `profileSettingsProfile`, `profileSettingsPreferences`,
+   `profileSettingsData`, `profileSettingsDeveloper`,
+   `profileSettingsPrivacy`, `profileTokens`, `profileExpertApply`,
+   `profileImport`, `profileImportCameraTrap`, `projectNew`,
+   `sponsoring`, `communityDonate`, `exploreValidate`,
+   `profileValidate`, `chat`, and every `console*` / `consoleMod*` /
+   `consoleExpert*` key (all console tabs have write affordances).
+2. **Verified = 2026-05-16** for the routes the 2026-05-16 sweep
+   actually covered: `home`, `explore`, `explorePlaces`,
+   `exploreRecent`, `exploreSpecies`, `observe`, `exploreMap`,
+   `publicProfile`, `projects`, `profileExport`, `dex`,
+   `exploreValidate`, `chat`, `consoleUsers`, `consoleHealth`,
+   `consoleErrors`, `consoleObservations`, `consoleModFlagQueue`.
+   All other rows keep `never` (honest — not aspirational).
+3. **Issues**: `consoleObservations` → `#1112`; `exploreMap` →
+   `#1113`.
+4. **Spec**: fill from `ls tests/e2e/journey-*.spec.ts` where a spec
+   clearly covers the route (e.g. `exploreRecent`/`explore`/`home` →
+   `journey-guest-browse.spec.ts`; `observe` →
+   `journey-observer-first-obs.spec.ts`; `chat` →
+   `journey-chat-find-species-and-observe.spec.ts`;
+   `consoleHealth` → `journey-admin-health.spec.ts`;
+   `consoleModFlagQueue` → `journey-mod-flags.spec.ts`; `dex` →
+   `journey-falta-dex-region-pool.spec.ts`; `exploreWatchlist` →
+   `journey-watchlist-rare-species-alert.spec.ts`; `profileExport` →
+   `journey-researcher-export.spec.ts`). Leave `—` where no spec
+   clearly maps; do not invent filenames — verify each against
+   `ls tests/e2e/`.
+
+- [ ] **Step 5: Delete the throwaway generator**
+
+Run: `rm /tmp/gen-spine.mjs`
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .worktrees/journey-catalog
+git add docs/journey-catalog.md
+git commit -m "docs(qa): journey catalog — route spine + flow overlay"
+```
+
+---
+
+### Task 2: Drift-check test (TDD: catalog is the data, test guards it)
+
+**Files:**
+- Create: `tests/unit/journey-catalog-complete.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/unit/journey-catalog-complete.test.ts` with exactly:
+
+```ts
+/**
+ * Journey-catalog completeness gate.
+ *
+ * docs/journey-catalog.md §1 "route spine" must list EXACTLY the route
+ * keys in `routes` (src/i18n/utils.ts) ∪ `CONSOLE_TABS.routeKey`
+ * (src/lib/console-tabs.ts). A new/removed route fails CI until the
+ * catalog is updated — the rot mode that silently stale-d
+ * journey-audit-2026-05-15.md (PR #1103 squash race) becomes impossible.
+ *
+ * Mirrors tests/unit/dynamic-routes-parity.test.ts (vitest + node:fs).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { routes } from '../../src/i18n/utils';
+import { CONSOLE_TABS } from '../../src/lib/console-tabs';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const CATALOG = resolve(REPO_ROOT, 'docs/journey-catalog.md');
+
+function spineKeys(): string[] {
+  const md = readFileSync(CATALOG, 'utf8');
+  const start = md.indexOf('<!-- spine:start -->');
+  const end = md.indexOf('<!-- spine:end -->');
+  expect(start, 'missing <!-- spine:start --> fence').toBeGreaterThanOrEqual(0);
+  expect(end, 'missing <!-- spine:end --> fence').toBeGreaterThan(start);
+  const block = md.slice(start, end);
+  const keys: string[] = [];
+  // A spine key line: first cell is a backticked identifier and nothing else.
+  const re = /^\|\s*`([A-Za-z][A-Za-z0-9]*)`\s*\|/gm;
+  for (const m of block.matchAll(re)) keys.push(m[1]);
+  return keys;
+}
+
+const required = new Set<string>([
+  ...Object.keys(routes),
+  ...CONSOLE_TABS.map((t) => t.routeKey),
+]);
+
+describe('journey catalog — spine completeness', () => {
+  const keys = spineKeys();
+
+  it('has no duplicate spine rows', () => {
+    const dupes = keys.filter((k, i) => keys.indexOf(k) !== i);
+    expect(dupes, `duplicate spine rows: ${[...new Set(dupes)].join(', ')}`).toEqual([]);
+  });
+
+  it('lists every required route (no missing)', () => {
+    const missing = [...required].filter((k) => !keys.includes(k)).sort();
+    expect(
+      missing,
+      `journey catalog §1 is missing routes (add a spine row):\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('has no stale/unknown routes (no extras)', () => {
+    const extra = keys.filter((k) => !required.has(k)).sort();
+    expect(
+      extra,
+      `journey catalog §1 has rows for routes not in routes/CONSOLE_TABS (removed from manifest?):\n  ${extra.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('journey catalog — Verified column hygiene', () => {
+  it('every Verified cell is `never` or YYYY-MM-DD', () => {
+    const md = readFileSync(CATALOG, 'utf8');
+    const block = md.slice(
+      md.indexOf('<!-- spine:start -->'),
+      md.indexOf('<!-- spine:end -->'),
+    );
+    const bad: string[] = [];
+    for (const line of block.split('\n')) {
+      const m = line.match(/^\|\s*`([A-Za-z][A-Za-z0-9]*)`\s*\|/);
+      if (!m) continue;
+      const cells = line.split('|').map((c) => c.trim());
+      // cells: ['', routeKey, en, es, auth, rw, spec, verified, issues, '']
+      const verified = cells[7];
+      if (verified !== 'never' && !/^\d{4}-\d{2}-\d{2}$/.test(verified)) {
+        bad.push(`${m[1]}: "${verified}"`);
+      }
+    }
+    expect(
+      bad,
+      `Verified must be 'never' or YYYY-MM-DD:\n  ${bad.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect PASS against the populated catalog**
+
+Run: `cd .worktrees/journey-catalog && npx vitest run tests/unit/journey-catalog-complete.test.ts`
+Expected: 4 tests, all PASS. (The catalog from Task 1 is complete, so the gate is green.)
+
+- [ ] **Step 3: Prove the gate actually catches drift (do NOT commit this)**
+
+Temporarily delete one spine row (e.g. the `` `home` `` line) from `docs/journey-catalog.md`, rerun the command.
+Expected: the "lists every required route" test FAILS with `journey catalog §1 is missing routes … home`.
+Then `git checkout docs/journey-catalog.md` to restore. This verifies the gate fails when it should — the TDD "watch it fail" step, done locally, not committed.
+
+- [ ] **Step 4: Full suite green**
+
+Run: `cd .worktrees/journey-catalog && npm run test 2>&1 | tail -3`
+Expected: all test files pass (baseline ~2426 + 4 new = ~2430).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/journey-catalog
+git add tests/unit/journey-catalog-complete.test.ts
+git commit -m "test(qa): journey-catalog spine drift-check (#dynamic-routes-parity pattern)"
+```
+
+---
+
+### Task 3: Cross-links
+
+**Files:**
+- Modify: `docs/qa-policy.md` (the `## 7. References` list)
+- Modify: `docs/journey-audit-2026-05-15.md` (forward pointer near top)
+
+- [ ] **Step 1: Add the qa-policy reference**
+
+In `docs/qa-policy.md`, find the `## 7. References` bullet list (ends with the `.github/workflows/...` line) and append one bullet:
+
+```markdown
+- [`journey-catalog.md`](journey-catalog.md) — CI-enforced, provably-
+  complete route + journey catalog (the list sweeps run against;
+  `tests/unit/journey-catalog-complete.test.ts` keeps it from rotting).
+```
+
+- [ ] **Step 2: Add the journey-audit forward pointer**
+
+In `docs/journey-audit-2026-05-15.md`, immediately after the
+`> **Status:**` blockquote near the top (the first `> ` block under
+the title), add a new blockquote line:
+
+```markdown
+> **Living successor:** completeness is now owned by the CI-enforced
+> [`journey-catalog.md`](journey-catalog.md). This file remains the
+> immutable 2026-05-15/16 audit record; for "is every route covered"
+> consult the catalog, not this snapshot.
+```
+
+If a `docs/journey-sweep-2026-05-16` PR (#1118) is still open at
+execution time, that is fine — this pointer is additive and does not
+conflict (different lines). Note it in the PR description.
+
+- [ ] **Step 3: Verify both render (no broken relative links)**
+
+Run: `cd .worktrees/journey-catalog && npm run build 2>&1 | tail -3`
+Expected: build completes (docs are not built pages, but this confirms
+nothing else broke). Then visually confirm the two relative links
+`journey-catalog.md` resolve (same `docs/` dir).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd .worktrees/journey-catalog
+git add docs/qa-policy.md docs/journey-audit-2026-05-15.md
+git commit -m "docs(qa): cross-link journey-catalog from qa-policy + audit doc"
+```
+
+---
+
+### Task 4: Final verification + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Gate**
+
+```bash
+cd .worktrees/journey-catalog
+npx tsc --noEmit            # clean
+npm run test 2>&1 | tail -3 # all green incl. 4 new
+npm run build 2>&1 | tail -3 # 255 pages, no errors
+git status --porcelain      # only the 4 intended files; NO /tmp leak, no node_modules
+```
+Expected: tsc clean; suite green; build clean; `git status` shows only
+`docs/journey-catalog.md`, `tests/unit/journey-catalog-complete.test.ts`,
+`docs/qa-policy.md`, `docs/journey-audit-2026-05-15.md` committed and a
+clean tree.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+cd /Users/artemiopadilla/Documents/repos/GitHub/personal/rastrum
+gh pr create --base main --head feat/journey-catalog \
+  --title "feat(qa): CI-enforced journey catalog (route spine + flow overlay)" \
+  --body "Implements docs/superpowers/specs/2026-05-16-journey-catalog-design.md. New docs/journey-catalog.md (95 spine rows = routes ∪ CONSOLE_TABS.routeKey) + tests/unit/journey-catalog-complete.test.ts (drift-check mirroring dynamic-routes-parity.test.ts) + cross-links. Docs+test only; no schema/RLS/route code. Verified: tsc clean, full vitest green (+4), build clean."
+```
+
+- [ ] **Step 3: Arm auto-merge**
+
+```bash
+gh pr merge --squash --auto feat/journey-catalog
+```
+
+(Single feature branch, no follow-up pushes planned — squash will
+capture the full branch; no #1103-style race.)
+
+---
+
+## Self-review
+
+**Spec coverage:** Component 1 (catalog doc) → Task 1. Component 2
+(drift-check test) → Task 2. Component 3 (honest initial population) →
+Task 1 Step 4 rules (`2026-05-16` only for swept routes, else `never`).
+Cross-links + rollout → Task 3. Non-goals respected (no generator
+committed — `/tmp/gen-spine.mjs` is throwaway; overlay not drift-checked;
+no route/schema code). Success criteria → Task 2 tests assert
+exact-set + dup + Verified-format.
+
+**Placeholder scan:** No TBD/TODO. The one "PASTE THE 95 GENERATED ROWS
+HERE" marker is an explicit, mechanical instruction with the generator
+producing the exact content in the prior step — not a hand-wave.
+
+**Type/name consistency:** `spine:start`/`spine:end` fences identical in
+spec, catalog skeleton (Task 1 Step 3) and test parser (Task 2). Column
+order (routeKey|EN|ES|Auth|R/W|Spec|Verified|Issues) identical in
+generator, skeleton, curation rules, and the test's `cells[7] =
+verified` index (0=‘’,1=routeKey,…,7=verified). `routes` + `CONSOLE_TABS`
+import paths match the confirmed exports. Test count "+4" matches the 4
+`it()` blocks written.

--- a/docs/superpowers/specs/2026-05-16-journey-catalog-design.md
+++ b/docs/superpowers/specs/2026-05-16-journey-catalog-design.md
@@ -1,0 +1,166 @@
+# Journey Catalog — design
+
+> A CI-enforced, provably-complete catalog of every Rastrum route +
+> the end-to-end journeys over them, so manual Chrome / e2e sweeps can
+> be checked against a list that cannot silently rot.
+
+**Status:** approved 2026-05-16. Supersedes the *completeness* role of
+the dated `docs/journey-audit-2026-05-15.md` (which remains the
+immutable point-in-time audit record).
+
+---
+
+## Problem
+
+`journey-audit-2026-05-15.md` is a dated snapshot whose coverage matrix
+was *reconstructed from issues*, not derived from the route manifest.
+It silently went stale (PR #1103 squash-merged at its first commit; two
+follow-up commits never reached main) and is not provably exhaustive —
+there is nothing that forces it to list every route. A sweep run from
+it can only be as complete as a hand-maintained list. We need a catalog
+whose completeness is **mechanically enforced** against the actual
+route sources of truth.
+
+## Sources of truth (the spine)
+
+1. `src/i18n/utils.ts` → `export const routes: Record<string, Record<Locale,string>>`
+   — the public + signed-in route manifest (~41 keys, e.g. `home`,
+   `exploreMap`, `profileExport`, `signIn`).
+2. `src/lib/console-tabs.ts` → `export const CONSOLE_TABS: ConsoleTab[]`
+   — each tab carries `routeKey`, `role`, `i18nKey` (41 console
+   routeKeys).
+
+The catalog's required key set is exactly
+`Object.keys(routes) ∪ CONSOLE_TABS.map(t => t.routeKey)`. Some console
+`routeKey`s also appear in `routes`; the union de-dupes them, so a
+console route that is also in `routes` is **one** catalog row, not two.
+
+## Components
+
+### Component 1 — `docs/journey-catalog.md` (new living doc)
+
+**§1 Route spine table.** One row per key in the required set. The
+entire spine table (and only it) is wrapped in HTML-comment fences so
+the test parser can scope itself and ignore any other markdown table in
+the doc:
+
+```
+<!-- spine:start -->
+| `routeKey` | EN path | ES path | Auth | R/W | Spec | Verified | Issues |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `home` | / | / | anon | R | journey-guest-browse.spec.ts | 2026-05-16 |  |
+| … one row per required key … |
+<!-- spine:end -->
+```
+
+Strict, machine-parseable row format — the first cell is the route key
+wrapped in backticks and nothing else.
+
+- **Auth**: one of `anon`, `authed`, `role:admin`, `role:moderator`,
+  `role:expert` (console rows take their `role` from `CONSOLE_TABS`).
+- **R/W**: `R` (read-only surface) or `R+W` (has write affordances) —
+  drives whether a sweep may exercise it read-only.
+- **Spec**: the covering `tests/e2e/journey-*.spec.ts` filename, or `—`
+  if none.
+- **Verified**: `YYYY-MM-DD` of the last *real Chrome* verification, or
+  the literal `never`. Honest by construction — unswept routes say
+  `never`, not a hopeful date.
+- **Issues**: open/closed `#refs` affecting that route, or blank.
+
+**§2 Journey-flow overlay.** Named end-to-end flows as an ordered
+`routeKey` sequence → the `journey-*.spec.ts` that guards the flow.
+Initial set (extend as the product grows): `guest-browse`,
+`first-observation`, `identify-cascade`, `share-observation`,
+`watchlist`, `social-engage`, `projects-camera`, `researcher-export`,
+`moderation-triage`, `falta-dex`, `auth-magic-link`, `auth-passkey`,
+`onboarding`, `offline-pwa`, `mobile-chrome`, `chat-ask-rastrum`.
+Human-curated; **not** drift-checked (every route is already provably
+present via §1 — the overlay is a reading aid that groups them).
+
+**§3 Sweep procedure.** The read-only Chrome method: signed-in, walk
+the §1 table top-to-bottom, per route capture console errors
+(`read_console_messages` with an error pattern) + network requests
+(media/5xx), screenshot the visual ones. On a clean route, bump its
+`Verified` cell to the sweep date in the same PR. Cross-links to
+`journey-audit-2026-05-15.md` (historical provenance) and
+`qa-policy.md` (CI policy).
+
+### Component 2 — `tests/unit/journey-catalog-complete.test.ts`
+
+Mirrors `tests/unit/dynamic-routes-parity.test.ts` (vitest, `node:fs`,
+`REPO_ROOT = resolve(__dirname, '..', '..')`).
+
+1. Read `docs/journey-catalog.md`. Extract the §1 spine route keys with
+   a strict regex: a catalog key line matches
+   `^\|\s*\`([A-Za-z][A-Za-z0-9]*)\`\s*\|` between the `<!-- spine:start -->`
+   and `<!-- spine:end -->` HTML-comment fences (the fences scope the
+   parser so prose tables elsewhere can't be misread).
+2. Import `routes` from `src/i18n/utils.ts` and `CONSOLE_TABS` from
+   `src/lib/console-tabs.ts`. Compute `required = new Set([...Object.keys(routes), ...CONSOLE_TABS.map(t => t.routeKey)])`.
+3. Assert `catalogKeys` (as a Set) **equals** `required`:
+   - `required \ catalog` → fail: "Journey catalog missing routes: …"
+   - `catalog \ required` → fail: "Journey catalog has stale/unknown
+     routes (removed from manifest?): …"
+4. Assert no duplicate key rows in the spine.
+5. Assert every `Verified` cell is either `never` or matches
+   `^\d{4}-\d{2}-\d{2}$` (guards against freeform/aspirational text).
+
+Any new or removed route now turns this required CI check red until the
+catalog row is added/removed — the rot mode that bit
+`journey-audit-2026-05-15.md` becomes impossible.
+
+### Component 3 — initial population (honest)
+
+Generate the spine once from `routes` + `CONSOLE_TABS`. Fill columns:
+
+- Routes Chrome-swept on **2026-05-16** (per the §8 sweep that this
+  work follows): `Verified = 2026-05-16`.
+- Everything not swept that day (onboarding, offline/PWA,
+  mobile-chrome, social *write* actions, auth flows, sponsor/expert
+  surfaces, dynamic detail pages, etc.): `Verified = never`. Truthful,
+  not aspirational.
+- `Spec` filled by matching existing `tests/e2e/journey-*.spec.ts` to
+  routes; `—` where none.
+- `Issues`: attach `#1112` (consoleObservations), `#1113` (exploreMap)
+  and any other open route-scoped refs.
+
+## Non-goals
+
+- Not a generator — the doc is the human-curated source; the test only
+  enforces *completeness of the spine*, not the metadata values.
+- The journey-flow overlay (§2) is not drift-checked.
+- No new runtime/route code; no schema/RLS/Edge-Function changes. This
+  is docs + one unit test.
+
+## Testing
+
+- `tests/unit/journey-catalog-complete.test.ts` is the feature's own
+  test (it *is* the enforcement).
+- Add a deliberately-missing-row and a deliberately-extra-row case in
+  the test file's own fixtures? No — the test runs against the real
+  committed catalog; its correctness is validated by: (a) it passes
+  with the fully-populated catalog, (b) a temporary local edit removing
+  one row makes it fail with the right message (verified during
+  implementation, not committed).
+- Full suite (`npm run test`) must stay green; `npm run build` and
+  `npx tsc --noEmit` unaffected (docs + test only).
+
+## Rollout
+
+1. Add `docs/journey-catalog.md` fully populated from the manifest.
+2. Add `tests/unit/journey-catalog-complete.test.ts`; confirm green.
+3. Cross-link from `qa-policy.md` and from
+   `journey-audit-2026-05-15.md` (a forward pointer: "living catalog
+   supersedes this snapshot's completeness role").
+4. One PR. The test becomes a normal required check via the existing
+   `test` job (no branch-protection change needed — it's just another
+   vitest file).
+
+## Success criteria
+
+- Every `routes` key and every `CONSOLE_TABS.routeKey` has exactly one
+  catalog spine row; CI fails otherwise.
+- A future sweep updates only `Verified`/`Issues` cells; adding a route
+  without cataloging it is impossible to merge.
+- `journey-audit-2026-05-15.md` remains valid as a dated record and now
+  points forward to the catalog.

--- a/tests/unit/journey-catalog-complete.test.ts
+++ b/tests/unit/journey-catalog-complete.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Journey-catalog completeness gate.
+ *
+ * docs/journey-catalog.md §1 "route spine" must list EXACTLY the route
+ * keys in `routes` (src/i18n/utils.ts) ∪ `CONSOLE_TABS.routeKey`
+ * (src/lib/console-tabs.ts). A new/removed route fails CI until the
+ * catalog is updated — the rot mode that silently stale-d
+ * journey-audit-2026-05-15.md (PR #1103 squash race) becomes impossible.
+ *
+ * Mirrors tests/unit/dynamic-routes-parity.test.ts (vitest + node:fs).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { routes } from '../../src/i18n/utils';
+import { CONSOLE_TABS } from '../../src/lib/console-tabs';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const CATALOG = resolve(REPO_ROOT, 'docs/journey-catalog.md');
+
+function spineBlock(): string {
+  const md = readFileSync(CATALOG, 'utf8');
+  const start = md.indexOf('<!-- spine:start -->');
+  const end = md.indexOf('<!-- spine:end -->');
+  expect(start, 'missing <!-- spine:start --> fence').toBeGreaterThanOrEqual(0);
+  expect(end, 'missing <!-- spine:end --> fence').toBeGreaterThan(start);
+  return md.slice(start, end);
+}
+
+function spineKeys(): string[] {
+  const keys: string[] = [];
+  // Negative lookahead on `routeKey` so the table's column-name header
+  // is excluded even if it ever gets backticked (spec skeleton form).
+  const re = /^\|\s*`(?!routeKey`)([A-Za-z][A-Za-z0-9]*)`\s*\|/gm;
+  for (const m of spineBlock().matchAll(re)) keys.push(m[1]);
+  return keys;
+}
+
+const required = new Set<string>([
+  ...Object.keys(routes),
+  ...CONSOLE_TABS.map((t) => t.routeKey),
+]);
+
+describe('journey catalog — spine completeness', () => {
+  const keys = spineKeys();
+
+  it('has no duplicate spine rows', () => {
+    const dupes = keys.filter((k, i) => keys.indexOf(k) !== i);
+    expect(dupes, `duplicate spine rows: ${[...new Set(dupes)].join(', ')}`).toEqual([]);
+  });
+
+  it('lists every required route (no missing)', () => {
+    const missing = [...required].filter((k) => !keys.includes(k)).sort();
+    expect(
+      missing,
+      `journey catalog §1 is missing routes (add a spine row):\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('has no stale/unknown routes (no extras)', () => {
+    const extra = keys.filter((k) => !required.has(k)).sort();
+    expect(
+      extra,
+      `journey catalog §1 has rows for routes not in routes/CONSOLE_TABS (removed from manifest?):\n  ${extra.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('journey catalog — Verified column hygiene', () => {
+  it('every Verified cell is `never` or YYYY-MM-DD', () => {
+    const bad: string[] = [];
+    for (const line of spineBlock().split('\n')) {
+      const m = line.match(/^\|\s*`(?!routeKey`)([A-Za-z][A-Za-z0-9]*)`\s*\|/);
+      if (!m) continue;
+      const cells = line.split('|').map((c) => c.trim());
+      // cells: ['', routeKey, en, es, auth, rw, spec, verified, issues, '']
+      const verified = cells[7];
+      if (verified !== 'never' && !/^\d{4}-\d{2}-\d{2}$/.test(verified)) {
+        bad.push(`${m[1]}: "${verified}"`);
+      }
+    }
+    expect(
+      bad,
+      `Verified must be 'never' or YYYY-MM-DD:\n  ${bad.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-05-16-journey-catalog-design.md` (brainstorm → spec → plan → subagent-driven execution with two-stage review per task).

## What

- **`docs/journey-catalog.md`** (new) — §1 fenced route spine: one row per `routes` key (`src/i18n/utils.ts`) ∪ `CONSOLE_TABS.routeKey` (`src/lib/console-tabs.ts`) = 95 rows, columns `routeKey · EN · ES · Auth · R/W · Spec · Verified · Issues`. §2 named journey-flow overlay → `journey-*.spec.ts`. §3 read-only Chrome sweep procedure.
- **`tests/unit/journey-catalog-complete.test.ts`** (new) — drift-check mirroring `dynamic-routes-parity.test.ts`: asserts the spine == required set (missing/extra/dup directions) + Verified-cell hygiene (`never`|`YYYY-MM-DD`). Adding/removing a route fails CI until the catalog is updated — the rot mode that silently stale-d `journey-audit-2026-05-15.md` becomes impossible.
- Cross-links from `qa-policy.md` §7 + a "Living successor" pointer in the dated `journey-audit-2026-05-15.md` (which stays the immutable snapshot).

## Honest by construction

`Verified` = `2026-05-16` only for the 18 routes the real Chrome sweep covered; the other 77 are `never` (not aspirational). `#1112`/`#1113` attached to the routes they affect.

## Surfaced a real anomaly

The catalog's own purpose caught it: `routes.fieldGuide` in `src/i18n/utils.ts` is missing the leading slash every other route has (→ `/enfield-guide`). Filed as **#1130** (out of scope here — this PR shows the correct sweepable path + tags the issue, doesn't change the route manifest).

## Verification

tsc clean · 2452/2452 vitest (incl. 4 new, drift-proven) · build clean. Docs + 1 test + 2 additive cross-links; no schema/RLS/route code. Spec-compliance + code-quality reviewed per task + a final whole-implementation review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)