### PR TITLE
fix(i18n): routes.fieldGuide missing leading slash (closes #1130)

### DIFF
--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -34,7 +34,7 @@ export const routes: Record<string, Record<Locale, string>> = {
   exploreSpeciesDetail: { en: '/explore/species', es: '/explorar/especies' },
   exploreTrails:    { en: '/explore/trails', es: '/explorar/senderos' },
   explorePits:      { en: '/explore/pits',   es: '/explorar/pits' },
-  fieldGuide:       { en: 'field-guide',     es: 'guia-de-campo' },
+  fieldGuide:       { en: '/explore/trails/field-guide', es: '/explorar/senderos/guia-de-campo' },
   exploreValidate: { en: '/explore/validate', es: '/explorar/validar' },
   observe: { en: '/observe', es: '/observar' },
   about: { en: '/about', es: '/acerca' },

--- a/tests/unit/routes-leading-slash.test.ts
+++ b/tests/unit/routes-leading-slash.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Every `routes` entry must be a leading-slash path (or empty for `home`).
+ * Guards the #1130 class: a missing leading slash makes locale-prefix
+ * concatenation produce broken URLs like `/enfield-guide`.
+ */
+import { describe, it, expect } from 'vitest';
+import { routes } from '../../src/i18n/utils';
+
+describe('routes — leading-slash invariant (#1130)', () => {
+  for (const [key, pair] of Object.entries(routes)) {
+    for (const lang of ['en', 'es'] as const) {
+      it(`routes.${key}.${lang} is '' or starts with '/'`, () => {
+        const v = pair[lang];
+        expect(
+          v === '' || v.startsWith('/'),
+          `routes.${key}.${lang} = ${JSON.stringify(v)} — must be '' (home only) or start with '/'`,
+        ).toBe(true);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Bug

`routes.fieldGuide` in `src/i18n/utils.ts` was `{ en: 'field-guide', es: 'guia-de-campo' }` — the only entry (besides `home: ''`) without the leading slash every other route has. `getLocalizedPath` does `` `/${lang}${path}` ``, so this produced the broken `/enfield-guide` / `/esguia-de-campo` and silently broke the language toggle on that page (the alternate-locale matcher never matched the bare slug). Surfaced by the journey-catalog (#1131).

## Fix

`{ en: '/explore/trails/field-guide', es: '/explorar/senderos/guia-de-campo' }` — full paths matching the actual shipped pages (`src/pages/{en/explore/trails/field-guide,es/explorar/senderos/guia-de-campo}/index.astro`). Verified `routeTree.parent` is breadcrumb-label metadata only (not path-composed), so a full-path value is correct and cannot double-compose. Reviewer independently confirmed paths→real pages, consumer safety, and that the language toggle now works.

## Regression guard

New `tests/unit/routes-leading-slash.test.ts`: every `routes` entry × both langs must be `''` (home only) or start with `/`. Closes the whole class — a future missing-slash route fails CI.

Frontend/i18n only; no schema/RLS. tsc clean · 2645 vitest (incl. 190 new) · 255-page build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)