### PR TITLE
feat(observe): render C-1 — pipeline → CardViewModel seam

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -426,6 +426,8 @@ import { SYNC_EVENTS, type SyncRowDetail } from '../lib/sync-events';
 import { getObservationDefaults, setObservationDefaults } from '../lib/observation-defaults';
 import { selfHealChunk } from '../lib/chunk-reload';
 import { resolveRunnerSet, type RunnerAvailability } from '../lib/observe-runner-set';
+import { attemptsToCardVmInput } from '../lib/observe-card-vm-input';
+import { buildCardViewModel } from '../lib/observe-card-vm';
 
 // ── State ──────────────────────────────────────────────────────────────────
 const lang = document.documentElement.lang === 'es' ? 'es' : 'en';
@@ -435,6 +437,7 @@ let pipelineState: PipelineState | null = null;
 let location: { lat: number; lng: number; accuracyM: number; altitudeM: number | null } | null = null;
 let bestResult: { scientific_name: string; common_name_en: string | null; confidence: number; source: string } | null = null;
 let identifyErrorReason: string | null = null;
+let cardAttempts: import('../lib/identify-cascade-client').IdentifyAttempt[] = [];
 
 // ── Taxon hint chips (#ux-quick-taxon-chips) ──────────────────────────────
 import type { TaxonHint } from '../lib/identify-cascade-client';
@@ -951,6 +954,7 @@ async function runPipeline(state: PipelineState) {
         } else {
           const abort = new AbortController();
           const out = await runParallelIdentify(pf.file as File, { runners, taxonHint: selectedTaxonHint }, abort.signal);
+          cardAttempts = cardAttempts.concat(out.attempts ?? []);
           if (out.kind === 'winner' || out.kind === 'uncertain') {
             const r = out.result;
             setNodeState(state, node.id, 'done', {
@@ -1155,6 +1159,22 @@ function startGPS() {
 function showPostForm() {
   // Hide the escape hatch once we get to the post-form.
   pipelineEscape?.classList.add('hidden');
+  // #1122 — additive: expose the progressive-card view model. No DOM
+  // change yet (consumers wire in #1123). Never blocks the form.
+  try {
+    const hasOnDeviceModel = cardAttempts.some(
+      (a) => !['plantnet', 'claude_haiku', 'claude_sonnet'].includes(a.source),
+    );
+    const cardVm = buildCardViewModel(
+      attemptsToCardVmInput(cardAttempts, {
+        observerAffirmed: false,
+        online: navigator.onLine,
+        hasOnDeviceModel,
+        now: new Date().toISOString(),
+      }),
+    );
+    document.dispatchEvent(new CustomEvent('rastrum:card-vm', { detail: cardVm }));
+  } catch { /* VM seam is additive — never block the form */ }
   postForm?.classList.remove('hidden');
   // id card is always shown so user can always enter/edit species
   if (bestResult) {
@@ -1400,6 +1420,7 @@ document.getElementById('obs2-new-btn')?.addEventListener('click', () => {
   location = null;
   bestResult = null;
   identifyErrorReason = null;
+  cardAttempts = [];
   pipelineState = null;
   // Reset taxon hint chip selection
   selectedTaxonHint = null;

--- a/src/lib/observe-card-vm-input.test.ts
+++ b/src/lib/observe-card-vm-input.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { attemptsToCardVmInput } from './observe-card-vm-input';
+import type { IdentifyAttempt } from './identify-cascade-client';
+
+const ctx = { observerAffirmed: false, online: true, hasOnDeviceModel: true, now: '2026-05-17T00:00:00Z' };
+
+describe('attemptsToCardVmInput', () => {
+  it('picks best on-device as provisional and best cloud as cloud', () => {
+    const attempts: IdentifyAttempt[] = [
+      { source: 'onnx_efficientnet_lite0', scientific_name: 'Quercus sp.', confidence: 0.31 },
+      { source: 'plantnet', scientific_name: 'Quercus rugosa', confidence: 0.94 },
+      { source: 'claude_haiku', scientific_name: 'Quercus sp.', confidence: 0.6 },
+    ];
+    const vm = attemptsToCardVmInput(attempts, ctx);
+    expect(vm.provisional).toEqual({ scientificName: 'Quercus sp.', confidence: 0.31, source: 'onnx_efficientnet_lite0', confidenceCeiling: 0.4 });
+    expect(vm.cloud).toEqual({ scientificName: 'Quercus rugosa', confidence: 0.94, source: 'plantnet', confidenceCeiling: 1 });
+    expect(vm.observerAffirmed).toBe(false);
+    expect(vm.online).toBe(true);
+    expect(vm.hasOnDeviceModel).toBe(true);
+  });
+
+  it('maps every attempt into the trace with correct where + isPrimary on the cloud winner', () => {
+    const attempts: IdentifyAttempt[] = [
+      { source: 'onnx_efficientnet_lite0', scientific_name: 'Quercus sp.', confidence: 0.31 },
+      { source: 'plantnet', scientific_name: 'Quercus rugosa', confidence: 0.94 },
+    ];
+    const vm = attemptsToCardVmInput(attempts, ctx);
+    expect(vm.attempts).toEqual([
+      { source: 'onnx_efficientnet_lite0', where: 'device', scientificName: 'Quercus sp.', confidence: 0.31, isPrimary: false, createdAt: '2026-05-17T00:00:00Z' },
+      { source: 'plantnet', where: 'cloud', scientificName: 'Quercus rugosa', confidence: 0.94, isPrimary: true, createdAt: '2026-05-17T00:00:00Z' },
+    ]);
+  });
+
+  it('errored attempts: scientificName null, never provisional/cloud, never primary', () => {
+    const attempts: IdentifyAttempt[] = [
+      { source: 'plantnet', scientific_name: null, confidence: 0, error: 'quota' },
+      { source: 'onnx_efficientnet_lite0', scientific_name: 'Quercus sp.', confidence: 0.3 },
+    ];
+    const vm = attemptsToCardVmInput(attempts, ctx);
+    expect(vm.cloud).toBeNull();
+    expect(vm.provisional?.source).toBe('onnx_efficientnet_lite0');
+    const pn = vm.attempts.find(a => a.source === 'plantnet');
+    expect(pn).toEqual({ source: 'plantnet', where: 'cloud', scientificName: null, confidence: 0, isPrimary: false, createdAt: '2026-05-17T00:00:00Z' });
+  });
+
+  it('no usable attempts → provisional and cloud null, trace still maps', () => {
+    const vm = attemptsToCardVmInput([{ source: 'plantnet', scientific_name: null, confidence: 0, error: 'x' }], ctx);
+    expect(vm.provisional).toBeNull();
+    expect(vm.cloud).toBeNull();
+    expect(vm.attempts).toHaveLength(1);
+  });
+
+  it('phi/gemma/megadetector/speciesnet ceilings are correct; provisional is highest-confidence device', () => {
+    const attempts: IdentifyAttempt[] = [
+      { source: 'webllm_phi35_vision', scientific_name: 'A', confidence: 0.2 },
+      { source: 'speciesnet', scientific_name: 'B', confidence: 0.8 },
+    ];
+    const vm = attemptsToCardVmInput(attempts, ctx);
+    expect(vm.provisional).toEqual({ scientificName: 'B', confidence: 0.8, source: 'speciesnet', confidenceCeiling: 0.85 });
+  });
+});

--- a/src/lib/observe-card-vm-input.ts
+++ b/src/lib/observe-card-vm-input.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure mapper: cascade IdentifyAttempt[] + run context → CardVmInput.
+ * The cascade has no per-attempt timestamp, so all trace rows share
+ * ctx.now (acceptable v1 — buildAuditTrace sorts stably). No DOM/network.
+ */
+import type { IdentifyAttempt } from './identify-cascade-client';
+import type { CardVmInput } from './observe-card-vm';
+import type { IdResult } from './observe-card-state';
+import type { IdAttempt } from './observe-audit-trace';
+
+const CEILING: Record<string, number> = {
+  onnx_efficientnet_lite0: 0.4,
+  camera_trap_megadetector: 0.4,
+  webllm_phi35_vision: 0.35,
+  phi_vision: 0.35,
+  onnx_gemma4_vision: 0.35,
+  speciesnet: 0.85,
+};
+function ceilingFor(source: string): number {
+  return CEILING[source] ?? 1; // cloud / uncapped / unknown
+}
+
+const CLOUD_SOURCES = new Set<string>(['plantnet', 'claude_haiku', 'claude_sonnet']);
+function isCloud(source: string): boolean {
+  return CLOUD_SOURCES.has(source);
+}
+
+export interface AttemptsToVmContext {
+  observerAffirmed: boolean;
+  online: boolean;
+  hasOnDeviceModel: boolean;
+  /** ISO timestamp applied to every trace row (cascade has no per-attempt time). */
+  now: string;
+}
+
+export function attemptsToCardVmInput(
+  attempts: IdentifyAttempt[],
+  ctx: AttemptsToVmContext,
+): CardVmInput {
+  const usable = attempts.filter((a) => !a.error && a.scientific_name);
+  const bestOf = (pred: (s: string) => boolean): IdResult | null => {
+    const pool = usable.filter((a) => pred(a.source));
+    if (pool.length === 0) return null;
+    const b = pool.reduce((m, a) => (a.confidence > m.confidence ? a : m));
+    return {
+      scientificName: b.scientific_name as string,
+      confidence: b.confidence,
+      source: b.source,
+      confidenceCeiling: ceilingFor(b.source),
+    };
+  };
+  const provisional = bestOf((s) => !isCloud(s));
+  const cloud = bestOf((s) => isCloud(s));
+  const primarySource = cloud?.source ?? provisional?.source ?? null;
+
+  const trace: IdAttempt[] = attempts.map((a) => ({
+    source: a.source,
+    where: isCloud(a.source) ? 'cloud' : 'device',
+    scientificName: a.error ? null : a.scientific_name,
+    confidence: a.confidence,
+    isPrimary: !a.error && !!a.scientific_name && a.source === primarySource,
+    createdAt: ctx.now,
+  }));
+
+  return {
+    provisional,
+    cloud,
+    observerAffirmed: ctx.observerAffirmed,
+    online: ctx.online,
+    hasOnDeviceModel: ctx.hasOnDeviceModel,
+    attempts: trace,
+  };
+}


### PR DESCRIPTION
Closes #1122 (epic #1129). Additive seam: pure `attemptsToCardVmInput` mapper + ObserveView2 dispatches `rastrum:card-vm` from `showPostForm`. **No DOM/behavior change** (21 insertions, 0 deletions). Unblocks C-2 (#1123).

- [x] 5 TDD tests for the mapper; full suite 2460/2460; tsc clean; build 255 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)