### PR TITLE
feat(schema): observations.review_requested flag (#1126 schema)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -307,6 +307,17 @@ ALTER TABLE public.observations ADD COLUMN IF NOT EXISTS content_sensitive boole
 -- Idempotent column add for existing databases (v1.0.x)
 ALTER TABLE public.observations ADD COLUMN IF NOT EXISTS license text CHECK (license IN ('CC BY 4.0','CC BY-NC 4.0','CC0'));
 
+-- #1126 — observer-set "please have the community review this ID" flag.
+-- Distinct from the system-set identifications.needs_review: this is an
+-- explicit observer intent (the card's "I don't know — ask for review"
+-- action). Pure routing/visibility — it does NOT participate in
+-- recompute_consensus nor the research-grade floor. Owner write is
+-- covered by the existing "obs_owner" FOR ALL policy; reads by the
+-- existing obs_public_read / obs_credentialed_read policies.
+ALTER TABLE public.observations ADD COLUMN IF NOT EXISTS review_requested boolean NOT NULL DEFAULT false;
+CREATE INDEX IF NOT EXISTS idx_obs_review_requested
+  ON public.observations(review_requested) WHERE review_requested = true;
+
 -- ============================================================
 -- IDENTIFICATIONS
 -- ============================================================


### PR DESCRIPTION
Schema slice of #1126 (epic #1129). Additive idempotent `review_requested boolean NOT NULL DEFAULT false` + partial index on `public.observations`. Observer-set community-review intent, distinct from system `needs_review`; **pure routing/visibility — no consensus/research-grade impact**. No new RLS (existing `obs_owner` FOR ALL covers owner write; existing read policies cover reads). Gated by `db-validate` (idempotent double-apply). Client write + queue routing follow (C-3 / validate UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)