### PR TITLE
feat(observe): render C-4 — audit trace panel + relocate WhyThisSpecies + remove flag (#1125)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -165,24 +165,14 @@ const weathers = WEATHERS;
 
     <!-- Identification result card -->
     <div id="obs2-id-card" class="rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 p-4">
-      <!-- AI result (hidden when no bestResult) -->
-      <div id="obs2-id-result" class="hidden">
-        <div class="flex items-start justify-between gap-2">
-          <div>
-            <p id="obs2-species" class="font-semibold italic text-zinc-900 dark:text-zinc-100"></p>
-            <p id="obs2-common" class="text-sm text-zinc-500 dark:text-zinc-400"></p>
-          </div>
-          <span id="obs2-conf" class="shrink-0"></span>
-        </div>
-        <!-- obs2-id-edit removed (#942 PR7 redo): manual input is always
-             visible directly below; toggle was redundant. -->
-        <!-- "Why this species?" — issue #736 — curated marks + reference photos -->
-        <WhyThisSpecies lang={lang} />
-      </div>
-      <!-- #1123 C-2: progressive card v2 (flag-gated; hidden until rastrum:card-vm fires AND ?card=v2 / localStorage rastrum.obs2.cardV2) -->
+      <!-- #1125 C-4: the progressive card is the only identification surface. -->
       <div id="obs2-card-v2" class="hidden"></div>
-      <!-- Manual entry — always visible so user can enter species even when AI returns nothing -->
-      <div id="obs2-id-manual" class="mt-2">
+      <!-- "Why this species?" (issue #736) — relocated inside the card's
+           audit disclosure (#1125 C-4). Hidden until "ver traza" opens. -->
+      <WhyThisSpecies lang={lang} />
+      <!-- Manual entry — on-demand only; revealed by the card's
+           "✎ No, es otra…" action or the WhyThisSpecies report button. -->
+      <div id="obs2-id-manual" class="mt-2 hidden">
         <label for="obs2-taxon-input" id="obs2-taxon-label" class="block text-xs text-zinc-500 dark:text-zinc-400 mb-1">
           {isEs ? "Nombre científico (opcional)" : "Scientific name (optional)"}
         </label>
@@ -452,10 +442,6 @@ let observerAffirmed = false;
 let observerAffirmedTaxon: string | null = null;
 let reviewRequested = false;
 
-// #1123 C-2 — progressive card, flag-gated. OFF ⇒ zero behavior change.
-const cardV2Enabled =
-  new URLSearchParams(window.location.search).get('card') === 'v2' ||
-  localStorage.getItem('rastrum.obs2.cardV2') === '1';
 const cardStrings: CardStrings = {
   analyzing: tr.observe.card.analyzing,
   savedPrefix: tr.observe.card.saved,
@@ -476,6 +462,20 @@ const cardStrings: CardStrings = {
   actionAdopt: tr.observe.card.action_adopt,
   actionDismiss: tr.observe.card.action_dismiss,
   reviewRequestedAck: tr.observe.card.review_requested_ack,
+  traceColSource: tr.observe.trace.col_source,
+  traceColWhere: tr.observe.trace.col_where,
+  traceColPrediction: tr.observe.trace.col_prediction,
+  traceColConfidence: tr.observe.trace.col_confidence,
+  traceColOutcome: tr.observe.trace.col_outcome,
+  traceWhereDevice: tr.observe.trace.where_device,
+  traceWhereCloud: tr.observe.trace.where_cloud,
+  traceOutcomePrefilter: tr.observe.trace.outcome_prefilter,
+  traceOutcomePrimary: tr.observe.trace.outcome_primary,
+  traceOutcomeNonprimary: tr.observe.trace.outcome_nonprimary,
+  traceCapped: tr.observe.trace.capped,
+  traceConsensusPending: tr.observe.trace.consensus_pending,
+  traceExportJson: tr.observe.trace.export_json,
+  traceNoAttempts: tr.observe.trace.no_attempts,
 };
 
 function redispatchCardVm() {
@@ -497,13 +497,11 @@ function redispatchCardVm() {
 }
 
 document.addEventListener('rastrum:card-vm', (e) => {
-  if (!cardV2Enabled) return;
   const el = document.getElementById('obs2-card-v2');
   if (!el) return;
   const vm = (e as CustomEvent).detail as import('../lib/observe-card-vm').CardViewModel;
   el.innerHTML = renderProgressiveCardHtml(vm, cardStrings);
   el.classList.remove('hidden');
-  document.getElementById('obs2-id-result')?.classList.add('hidden');
   // approach C: manual entry becomes on-demand (revealed by "No, es otra…").
   document.getElementById('obs2-id-manual')?.classList.add('hidden');
   el.querySelectorAll<HTMLButtonElement>('[data-card-action]').forEach((btn) => {
@@ -531,6 +529,21 @@ document.addEventListener('rastrum:card-vm', (e) => {
         el.querySelector('[data-card-actions]')?.classList.add('hidden');
       }
     });
+  });
+  const tracePanel = el.querySelector('[data-card-trace-panel]');
+  el.querySelector('[data-card-trace]')?.addEventListener('click', () => {
+    if (!tracePanel) return;
+    const wasHidden = tracePanel.hasAttribute('hidden');
+    if (wasHidden) tracePanel.removeAttribute('hidden');
+    else tracePanel.setAttribute('hidden', '');
+    const wts = document.getElementById('why-this-species');
+    if (wts && wasHidden) {
+      if (vm.headline) wts.dataset.scientificName = vm.headline;
+      wts.classList.remove('hidden');
+    }
+  });
+  el.querySelector('[data-card-trace-json]')?.addEventListener('click', () => {
+    try { void navigator.clipboard?.writeText(JSON.stringify(vm.trace, null, 2)); } catch { /* clipboard denied */ }
   });
 });
 
@@ -772,32 +785,6 @@ if (!localStorage.getItem(SKIP_SAVE_MIGRATION_KEY) && !identifyMode) {
   setTimeout(() => { notice.style.opacity = '0'; notice.style.transition = 'opacity 0.3s'; setTimeout(() => notice.remove(), 350); }, 6000);
 }
 const idCard          = document.getElementById('obs2-id-card');
-const speciesEl       = document.getElementById('obs2-species');
-const commonEl        = document.getElementById('obs2-common');
-const confEl          = document.getElementById('obs2-conf');
-
-/**
- * Render an SVG confidence ring (replaces the old % text pill).
- * Mirrors src/components/ConfidenceRing.astro — same color thresholds:
- * emerald ≥ 0.85, amber 0.50–0.85, red < 0.50.
- */
-function renderConfidenceRing(confidence: number): string {
-  const c = Math.max(0, Math.min(1, Number.isFinite(confidence) ? confidence : 0));
-  const size = 32, stroke = 3;
-  const r = (size - stroke) / 2;
-  const circumference = 2 * Math.PI * r;
-  const dash = (circumference * c).toFixed(2);
-  const gap  = (circumference - circumference * c).toFixed(2);
-  const colorClass = c >= 0.85 ? 'text-emerald-500' : c >= 0.5 ? 'text-amber-500' : 'text-red-500';
-  const pct = Math.round(c * 100);
-  return `<span class="relative inline-flex items-center justify-center ${colorClass}" style="width:${size}px;height:${size}px" role="img" aria-label="${pct}% confidence">
-    <svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" class="absolute inset-0 -rotate-90" aria-hidden="true">
-      <circle cx="${size/2}" cy="${size/2}" r="${r}" fill="none" stroke="currentColor" stroke-opacity="0.15" stroke-width="${stroke}"/>
-      <circle cx="${size/2}" cy="${size/2}" r="${r}" fill="none" stroke="currentColor" stroke-width="${stroke}" stroke-linecap="round" stroke-dasharray="${dash} ${gap}"/>
-    </svg>
-    <span class="relative text-[9px] font-semibold tabular-nums leading-none">${pct}</span>
-  </span>`;
-}
 
 // ── Resume banner ──────────────────────────────────────────────────────────
 (async () => {
@@ -1260,26 +1247,14 @@ function showPostForm() {
   postForm?.classList.remove('hidden');
   // id card is always shown so user can always enter/edit species
   if (bestResult) {
-    if (!cardV2Enabled) {
-      document.getElementById('obs2-id-result')?.classList.remove('hidden');
-      if (speciesEl) speciesEl.textContent = bestResult.scientific_name;
-      if (commonEl) commonEl.textContent = bestResult.common_name_en ?? '';
-      if (confEl) confEl.innerHTML = renderConfidenceRing(bestResult.confidence);
-      const labelEl = document.getElementById('obs2-taxon-label');
-      if (labelEl) labelEl.textContent = isEs ? 'Editar identificación' : 'Edit identification';
-    }
     const taxonInputEl = document.getElementById('obs2-taxon-input') as HTMLInputElement | null;
     if (taxonInputEl && !taxonInputEl.value) taxonInputEl.value = bestResult.scientific_name;
     const wts = document.getElementById('why-this-species');
     if (wts) {
       wts.dataset.source = bestResult.source;
       wts.dataset.scientificName = bestResult.scientific_name;
-      if (!cardV2Enabled) wts.classList.remove('hidden');
     }
   }
-
-  // obs2-id-edit handler removed (#942 PR7 redo) — manual input is always
-  // visible directly below the AI result; toggle was redundant.
 }
 
 // "Report incorrect" from the WhyThisSpecies panel (issue #736).
@@ -1369,9 +1344,7 @@ postForm?.addEventListener('submit', async (e) => {
     }));
 
     const machineName = bestResult?.scientific_name || '';
-    const observerOwned = cardV2Enabled && (
-      observerAffirmed || (!!taxonInput && taxonInput !== machineName)
-    );
+    const observerOwned = observerAffirmed || (!!taxonInput && taxonInput !== machineName);
     const identifiedSpecies = taxonInput || observerAffirmedTaxon || machineName;
 
     const obs = await saveObservationToOutbox({
@@ -1391,7 +1364,7 @@ postForm?.addEventListener('submit', async (e) => {
       license: licenseTyped,
       lifeStage: (lifeStageVal || null) as import('../lib/observe').ObservationDraft['lifeStage'],
       vitalStatus: (vitalStatusVal || null) as import('../lib/observe').ObservationDraft['vitalStatus'],
-      reviewRequested: cardV2Enabled ? reviewRequested : undefined,
+      reviewRequested,
     });
 
     // Fire sync without blocking success UX. Try immediately; if the
@@ -1518,12 +1491,12 @@ document.getElementById('obs2-new-btn')?.addEventListener('click', () => {
   pipelineSection?.classList.add('hidden');
   postForm?.classList.add('hidden');
   successEl?.classList.add('hidden');
-  // Reset id card: hide the AI result section, clear taxon input, restore label
-  document.getElementById('obs2-id-result')?.classList.add('hidden');
+  // Reset id card: clear taxon input, restore label, re-hide manual entry
   const taxonReset = document.getElementById('obs2-taxon-input') as HTMLInputElement | null;
   if (taxonReset) taxonReset.value = '';
   const labelReset = document.getElementById('obs2-taxon-label');
   if (labelReset) labelReset.textContent = isEs ? 'Nombre científico (opcional)' : 'Scientific name (optional)';
+  document.getElementById('obs2-id-manual')?.classList.add('hidden');
   window.scrollTo(0, 0);
 });
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -774,6 +774,22 @@
       "action_dismiss": "Dismiss",
       "review_requested_ack": "Review requested ✓"
     },
+    "trace": {
+      "col_source": "Source",
+      "col_where": "Where",
+      "col_prediction": "Prediction",
+      "col_confidence": "Confidence",
+      "col_outcome": "Outcome",
+      "where_device": "device",
+      "where_cloud": "cloud",
+      "outcome_prefilter": "pre-filter",
+      "outcome_primary": "primary",
+      "outcome_nonprimary": "non-primary",
+      "capped": "capped — can't reach research grade",
+      "consensus_pending": "Awaiting community validation. AI guesses never count as human validation.",
+      "export_json": "Export JSON",
+      "no_attempts": "No identification attempts yet."
+    },
     "active_banner": {
       "today_n": "Today {count} people are observing in {region} · join in",
       "today_one": "Today 1 person is observing in {region} · join in",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -774,6 +774,22 @@
       "action_dismiss": "Descartar",
       "review_requested_ack": "Revisión solicitada ✓"
     },
+    "trace": {
+      "col_source": "Fuente",
+      "col_where": "Dónde",
+      "col_prediction": "Predicción",
+      "col_confidence": "Confianza",
+      "col_outcome": "Resultado",
+      "where_device": "dispositivo",
+      "where_cloud": "nube",
+      "outcome_prefilter": "pre-filtro",
+      "outcome_primary": "primaria",
+      "outcome_nonprimary": "no primaria",
+      "capped": "limitado — no alcanza grado de investigación",
+      "consensus_pending": "En espera de validación comunitaria. Las estimaciones de IA nunca cuentan como validación humana.",
+      "export_json": "Exportar JSON",
+      "no_attempts": "Aún no hay intentos de identificación."
+    },
     "active_banner": {
       "today_n": "Hoy {count} personas observan en {region} · únete",
       "today_one": "Hoy 1 persona observa en {region} · únete",

--- a/src/lib/observe-card-render.test.ts
+++ b/src/lib/observe-card-render.test.ts
@@ -22,6 +22,20 @@ const S: CardStrings = {
   actionAdopt: 'adopt',
   actionDismiss: 'dismiss',
   reviewRequestedAck: 'review requested',
+  traceColSource: 'Source',
+  traceColWhere: 'Where',
+  traceColPrediction: 'Prediction',
+  traceColConfidence: 'Confidence',
+  traceColOutcome: 'Outcome',
+  traceWhereDevice: 'device',
+  traceWhereCloud: 'cloud',
+  traceOutcomePrefilter: 'pre-filter',
+  traceOutcomePrimary: 'primary',
+  traceOutcomeNonprimary: 'non-primary',
+  traceCapped: 'capped floor',
+  traceConsensusPending: 'awaiting community validation',
+  traceExportJson: 'Export JSON',
+  traceNoAttempts: 'no identification attempts yet',
 };
 const vm = (o: Partial<CardViewModel>): CardViewModel => ({
   state: 'S0', sovereignty: 'none', reviewRequested: false, trace: [], headline: null, sourceLabel: null, ...o,
@@ -87,6 +101,27 @@ describe('renderProgressiveCardHtml', () => {
   it('S0 and S1a render no actions row', () => {
     expect(renderProgressiveCardHtml(vm({ state: 'S0' }), S)).not.toContain('data-card-actions');
     expect(renderProgressiveCardHtml(vm({ state: 'S1a', headline: 'X', sourceLabel: 'p · 9%' }), S)).not.toContain('data-card-actions');
+  });
+  it('renders a trace panel with one entry on S1b', () => {
+    const h = renderProgressiveCardHtml(vm({
+      state: 'S1b', headline: 'Quercus sp.',
+      trace: [{ source: 'plantnet', where: 'cloud', scientificName: 'Quercus sp.', confidence: 0.6, outcome: 'primary', capped: false, createdAt: '2026-05-16T00:00:00Z' }],
+    }), S);
+    expect(h).toContain('data-card-trace-panel');
+    expect(h).toContain('data-card-trace-json');
+    expect(h).toContain('plantnet');
+    expect(h).toContain('awaiting community validation');
+  });
+  it('flags a capped entry in the trace panel', () => {
+    const h = renderProgressiveCardHtml(vm({
+      state: 'S1b', headline: 'Quercus sp.',
+      trace: [{ source: 'phi_vision', where: 'device', scientificName: 'Quercus sp.', confidence: 0.3, outcome: 'non-primary', capped: true, createdAt: '2026-05-16T00:00:00Z' }],
+    }), S);
+    expect(h).toContain('capped floor');
+  });
+  it('shows the no-attempts fallback when trace is empty', () => {
+    const h = renderProgressiveCardHtml(vm({ state: 'S1b', headline: 'Quercus sp.', trace: [] }), S);
+    expect(h).toContain('no identification attempts yet');
   });
   it('escapes HTML in headline/sourceLabel (no injection)', () => {
     const h = renderProgressiveCardHtml(vm({ state: 'S1a', headline: '<img src=x onerror=1>', sourceLabel: 'a&b' }), S);

--- a/src/lib/observe-card-render.ts
+++ b/src/lib/observe-card-render.ts
@@ -1,4 +1,5 @@
 import type { CardViewModel } from './observe-card-vm';
+import type { TraceEntry } from './observe-audit-trace';
 import { cardActions, type CardAction } from './observe-card-actions';
 
 export interface CardStrings {
@@ -21,6 +22,20 @@ export interface CardStrings {
   actionAdopt: string;
   actionDismiss: string;
   reviewRequestedAck: string;
+  traceColSource: string;
+  traceColWhere: string;
+  traceColPrediction: string;
+  traceColConfidence: string;
+  traceColOutcome: string;
+  traceWhereDevice: string;
+  traceWhereCloud: string;
+  traceOutcomePrefilter: string;
+  traceOutcomePrimary: string;
+  traceOutcomeNonprimary: string;
+  traceCapped: string;
+  traceConsensusPending: string;
+  traceExportJson: string;
+  traceNoAttempts: string;
 }
 
 function esc(raw: string | null): string {
@@ -104,6 +119,25 @@ function renderS3(s: CardStrings): string {
 <p class="text-xs text-zinc-500 dark:text-zinc-400">${s.willIdentifyOnSync}</p>`;
 }
 
+function traceRow(e: TraceEntry, s: CardStrings): string {
+  const where = e.where === 'cloud' ? s.traceWhereCloud : s.traceWhereDevice;
+  const outcome =
+    e.outcome === 'pre-filter' ? s.traceOutcomePrefilter :
+    e.outcome === 'primary'    ? s.traceOutcomePrimary :
+    s.traceOutcomeNonprimary;
+  const pred = e.scientificName ? `<span class="italic">${esc(e.scientificName)}</span>` : '—';
+  const conf = `${Math.round(e.confidence * 100)}%`;
+  const cap = e.capped ? ` <span class="text-amber-700 dark:text-amber-400">⚠ ${esc(s.traceCapped)}</span>` : '';
+  return `<tr class="border-t border-zinc-100 dark:border-zinc-800"><td class="py-1 pr-2">${esc(e.source)}</td><td class="py-1 pr-2">${esc(where)}</td><td class="py-1 pr-2">${pred}</td><td class="py-1 pr-2">${conf}</td><td class="py-1">${esc(outcome)}${cap}</td></tr>`;
+}
+
+function renderTracePanel(vm: CardViewModel, s: CardStrings): string {
+  const rows = vm.trace.length
+    ? vm.trace.map((e) => traceRow(e, s)).join('')
+    : `<tr><td colspan="5" class="py-2 text-zinc-500 dark:text-zinc-400">${esc(s.traceNoAttempts)}</td></tr>`;
+  return `<div data-card-trace-panel hidden class="mt-3 pt-3 border-t border-zinc-200 dark:border-zinc-700"><table class="w-full text-xs text-left"><thead class="text-zinc-500 dark:text-zinc-400"><tr><th class="py-1 pr-2 font-medium">${esc(s.traceColSource)}</th><th class="py-1 pr-2 font-medium">${esc(s.traceColWhere)}</th><th class="py-1 pr-2 font-medium">${esc(s.traceColPrediction)}</th><th class="py-1 pr-2 font-medium">${esc(s.traceColConfidence)}</th><th class="py-1 font-medium">${esc(s.traceColOutcome)}</th></tr></thead><tbody>${rows}</tbody></table><p class="text-xs text-zinc-500 dark:text-zinc-400 mt-2">${esc(s.traceConsensusPending)}</p><button type="button" data-card-trace-json class="mt-2 underline text-xs">${esc(s.traceExportJson)}</button></div>`;
+}
+
 export function renderProgressiveCardHtml(vm: CardViewModel, s: CardStrings): string {
   let inner: string;
   switch (vm.state) {
@@ -115,5 +149,6 @@ export function renderProgressiveCardHtml(vm: CardViewModel, s: CardStrings): st
     case 'S3':      inner = renderS3(s); break;
   }
   const actions = actionsRow(vm, s);
-  return `<div data-card-state="${vm.state}" class="observe-card p-3 rounded-lg bg-white dark:bg-zinc-800 shadow-sm">${inner}${actions}</div>`;
+  const trace = renderTracePanel(vm, s);
+  return `<div data-card-state="${vm.state}" class="observe-card p-3 rounded-lg bg-white dark:bg-zinc-800 shadow-sm">${inner}${actions}${trace}</div>`;
 }


### PR DESCRIPTION
## What

Final render slice of the progressive observation card (epic #1129, issue #1125). The card is now the **only** identification surface (spec integration "approach C").

- **Audit "ver traza" panel** (pure, TDD in `observe-card-render.ts`): the existing `data-card-trace` button toggles a hidden panel built from `vm.trace` — one row per attempt (source · device/cloud · prediction · confidence · typed outcome), capped-source honesty flag (`⚠ can't reach research grade`), a consensus-pending line, and a JSON-export button. New `observe.trace.*` i18n namespace, EN/ES parity.
- **`WhyThisSpecies` relocated** out of the deleted `#obs2-id-result` to a card sibling, hidden until the trace disclosure opens it. Dataset wiring + `rastrum:why-this-species-report` handler preserved.
- **Flag removed**: `cardV2Enabled` and every conditional deleted; `#obs2-id-result` (+ now-dead `renderConfidenceRing`/`speciesEl`/`commonEl`/`confEl`) deleted; `#obs2-id-manual` is on-demand-only (`hidden`, revealed by "✎ No, es otra…" or the report button). Submit sovereignty + `reviewRequested` are now unconditional.

## Verification (controller-independent)

- `git diff` reviewed; grep confirms **no remaining `cardV2Enabled`/`obs2-id-result`/`renderConfidenceRing`/`speciesEl`/`commonEl`/`confEl`** references.
- `tsc --noEmit` exit 0, zero output · `vitest run` **2677/2677** · `build` 255 pages 0 errors.
- **e2e gate** (card script now always active on `/observe/`): smoke + `observe-form` + `journey-photo-id-cascade` run against served `dist` in a real browser — **all observe pages/journeys pass, 26 passed**. The only 2 fails are the local missing-Supabase-env `/profile/` `supabaseUrl is required` artifact (unrelated, green in CI).

## Scope

In: trace disclosure + WhyThisSpecies relocation + flag/legacy-path removal. Out: queue routing (#1126), R2/R3 (#1128), downloads UX (#1127). Related: #1023.

Part of #1129. Closes #1125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)