### PR TITLE
fix(consensus): R2 confidence-cap end-to-end + R3 source-trust queue ordering (#1128)

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -1637,7 +1637,8 @@ SELECT
     WHERE x.observation_id = o.id
       AND x.validated_by IS NOT NULL)         AS distinct_voter_count,
   o.review_requested                          AS review_requested,
-  t.kingdom                                   AS current_kingdom
+  t.kingdom                                   AS current_kingdom,
+  i.source                                    AS current_source
 FROM public.observations o
 LEFT JOIN public.identifications i
        ON i.observation_id = o.id AND i.is_primary = true

--- a/src/components/ValidationQueueView.astro
+++ b/src/components/ValidationQueueView.astro
@@ -86,6 +86,7 @@ const sharePathBase = '/share/obs/';
 
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { sourceTrustRank } from '../lib/source-trust';
   import type { ValidationQueueRow } from '../lib/types';
 
   const root = document.querySelector<HTMLElement>('.rastrum-validation-queue');
@@ -158,6 +159,9 @@ const sharePathBase = '/share/obs/';
       const expertiseBadge = inMyExpertise(r)
         ? `<span class="inline-block rounded bg-sky-100 dark:bg-sky-900/40 text-sky-800 dark:text-sky-200 text-[10px] px-1.5 py-0.5 mr-1">${escapeText(labels.labelExpertise)}</span>`
         : '';
+      const sourceBadge = r.current_source
+        ? `<span class="inline-block rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 text-[10px] px-1.5 py-0.5 mr-1">${escapeText(r.current_source)}</span>`
+        : '';
 
       let cta = '';
       if (!userId) {
@@ -183,7 +187,7 @@ const sharePathBase = '/share/obs/';
               ${hasId ? escapeText(r.current_scientific_name!) : (labels.labelNoId ?? '')}
               ${conf !== null ? `<span class="not-italic font-normal text-xs text-zinc-500 ml-1">${conf}%</span>` : ''}
             </p>
-            <p class="text-xs text-zinc-500 truncate">${reviewBadge}${expertiseBadge}${date}${region}</p>
+            <p class="text-xs text-zinc-500 truncate">${reviewBadge}${expertiseBadge}${sourceBadge}${date}${region}</p>
             <p class="text-xs text-zinc-400">${observer}${votes ? ' · ' + votes : ''}</p>
           </div>
         </div>
@@ -315,6 +319,9 @@ const sharePathBase = '/share/obs/';
             const ae = inMyExpertise(a.r) ? 0 : 1;
             const be = inMyExpertise(b.r) ? 0 : 1;
             if (ae !== be) return ae - be;
+            const at = sourceTrustRank(a.r.current_source);
+            const bt = sourceTrustRank(b.r.current_source);
+            if (at !== bt) return at - bt;
             return a.idx - b.idx;
           })
           .map((x) => x.r);

--- a/src/lib/confidence-ceiling.test.ts
+++ b/src/lib/confidence-ceiling.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { capConfidence, ceilingForSource, CONFIDENCE_CEILING } from './confidence-ceiling';
+
+describe('#1128 R2 — confidence ceiling', () => {
+  it('caps on-device sources below the research-grade floor', () => {
+    expect(capConfidence('onnx_efficientnet_lite0', 0.9)).toBe(0.4);
+    expect(capConfidence('phi_vision', 0.95)).toBe(0.35);
+    expect(capConfidence('camera_trap_megadetector', 1)).toBe(0.4);
+  });
+
+  it('leaves cloud / human / unknown sources uncapped', () => {
+    expect(capConfidence('plantnet', 0.92)).toBe(0.92);
+    expect(capConfidence('claude_sonnet', 0.99)).toBe(0.99);
+    expect(capConfidence('human', 1)).toBe(1);
+    expect(capConfidence(null, 0.8)).toBe(0.8);
+  });
+
+  it('clamps negative confidence to 0', () => {
+    expect(capConfidence('onnx_efficientnet_lite0', -1)).toBe(0);
+  });
+
+  it('ceilingForSource resolves known + unknown sources', () => {
+    expect(ceilingForSource('phi_vision')).toBe(0.35);
+    expect(ceilingForSource(undefined)).toBe(1);
+  });
+
+  it('every on-device key ceiling is ≤ the 0.4 research-grade promotion', () => {
+    for (const key of [
+      'onnx_efficientnet_lite0',
+      'camera_trap_megadetector',
+      'phi_vision',
+      'webllm_phi35_vision',
+      'onnx_gemma4_vision',
+    ]) {
+      expect(CONFIDENCE_CEILING[key]).toBeLessThanOrEqual(0.4);
+    }
+  });
+});

--- a/src/lib/confidence-ceiling.ts
+++ b/src/lib/confidence-ceiling.ts
@@ -1,0 +1,25 @@
+/**
+ * Per-source confidence ceiling — the single source of truth. Capped
+ * on-device identifiers can never exceed these, which keeps them below
+ * the ≥0.4 research-grade floor (consensus integrity, #1128 R2). Cloud /
+ * human / unknown sources are uncapped (ceiling 1).
+ */
+export const CONFIDENCE_CEILING: Readonly<Record<string, number>> = {
+  onnx_efficientnet_lite0: 0.4,
+  camera_trap_megadetector: 0.4,
+  webllm_phi35_vision: 0.35,
+  phi_vision: 0.35,
+  onnx_gemma4_vision: 0.35,
+  speciesnet: 0.85,
+};
+
+export function ceilingForSource(source: string | null | undefined): number {
+  if (!source) return 1;
+  return CONFIDENCE_CEILING[source] ?? 1;
+}
+
+/** Clamp a confidence into [0, ceilingForSource(source)]. */
+export function capConfidence(source: string | null | undefined, confidence: number | null | undefined): number {
+  const c = Number.isFinite(confidence as number) ? (confidence as number) : 0;
+  return Math.max(0, Math.min(ceilingForSource(source), c));
+}

--- a/src/lib/observe-card-vm-input.ts
+++ b/src/lib/observe-card-vm-input.ts
@@ -7,18 +7,7 @@ import type { IdentifyAttempt } from './identify-cascade-client';
 import type { CardVmInput } from './observe-card-vm';
 import type { IdResult } from './observe-card-state';
 import type { IdAttempt } from './observe-audit-trace';
-
-const CEILING: Record<string, number> = {
-  onnx_efficientnet_lite0: 0.4,
-  camera_trap_megadetector: 0.4,
-  webllm_phi35_vision: 0.35,
-  phi_vision: 0.35,
-  onnx_gemma4_vision: 0.35,
-  speciesnet: 0.85,
-};
-function ceilingFor(source: string): number {
-  return CEILING[source] ?? 1; // cloud / uncapped / unknown
-}
+import { ceilingForSource } from './confidence-ceiling';
 
 const CLOUD_SOURCES = new Set<string>(['plantnet', 'claude_haiku', 'claude_sonnet']);
 function isCloud(source: string): boolean {
@@ -47,7 +36,7 @@ export function attemptsToCardVmInput(
       scientificName: b.scientific_name as string,
       confidence: b.confidence,
       source: b.source,
-      confidenceCeiling: ceilingFor(b.source),
+      confidenceCeiling: ceilingForSource(b.source),
     };
   };
   const provisional = bestOf((s) => !isCloud(s));

--- a/src/lib/source-trust.test.ts
+++ b/src/lib/source-trust.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { sourceTrustRank } from './source-trust';
+
+describe('#1128 R3 — source trust rank', () => {
+  it('ranks human primary first', () => {
+    expect(sourceTrustRank('human')).toBe(0);
+  });
+
+  it('ranks cloud sources second', () => {
+    expect(sourceTrustRank('plantnet')).toBe(1);
+    expect(sourceTrustRank('claude_sonnet')).toBe(1);
+  });
+
+  it('ranks capped on-device sources third', () => {
+    expect(sourceTrustRank('onnx_efficientnet_lite0')).toBe(2);
+    expect(sourceTrustRank('phi_vision')).toBe(2);
+  });
+
+  it('ranks null / unknown last', () => {
+    expect(sourceTrustRank(null)).toBe(3);
+    expect(sourceTrustRank('something_unknown')).toBe(3);
+  });
+
+  it('orders cloud before capped on-device', () => {
+    expect(sourceTrustRank('plantnet')).toBeLessThan(sourceTrustRank('phi_vision'));
+  });
+});

--- a/src/lib/source-trust.ts
+++ b/src/lib/source-trust.ts
@@ -1,0 +1,15 @@
+/**
+ * Source-trust rank for validate/expert queue ordering (#1128 R3). Lower
+ * rank surfaces earlier so on-device-first volume doesn't bury
+ * higher-signal items under capped guesses. NOT a consensus weight — pure
+ * queue ordering/visibility.
+ */
+const CLOUD = new Set(['plantnet', 'claude_haiku', 'claude_sonnet', 'bedrock', 'openai', 'azure_openai', 'gemini', 'vertex_ai']);
+const CAPPED_ON_DEVICE = new Set(['onnx_efficientnet_lite0', 'camera_trap_megadetector', 'phi_vision', 'webllm_phi35_vision', 'onnx_gemma4_vision', 'birdnet_lite', 'onnx_offline']);
+
+export function sourceTrustRank(source: string | null | undefined): number {
+  if (source === 'human') return 0;       // a human primary needing more validators
+  if (source && CLOUD.has(source)) return 1;
+  if (source && CAPPED_ON_DEVICE.has(source)) return 2;
+  return 3;                               // null / unknown — lowest signal
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -17,6 +17,7 @@ import {
   type SyncDoneDetail, type SyncProgressDetail, type SyncRowDetail,
 } from './sync-events';
 import { resolveIdentificationSource } from './identification-source';
+import { capConfidence } from './confidence-ceiling';
 
 export interface SyncResult {
   synced: number;
@@ -277,12 +278,13 @@ async function syncOne(record: ObservationRecord): Promise<void> {
     // fire — the observation button stays "Guardando…" forever.
     let clientIdErr: unknown = null;
     try {
+      const resolvedSource = resolveIdentificationSource({ machineSource: clientId.source, hasMachineResult: !!clientId.source && clientId.source !== 'human' });
       const rpcPromise = supabase.rpc('upsert_primary_identification', {
         p_observation_id: record.id,
         p_scientific_name: clientId.scientificName,
         p_taxon_id: taxonId,
-        p_confidence: Math.max(0, Math.min(1, clientId.confidence ?? 0)),
-        p_source: resolveIdentificationSource({ machineSource: clientId.source, hasMachineResult: !!clientId.source && clientId.source !== 'human' }),
+        p_confidence: capConfidence(resolvedSource, clientId.confidence ?? 0),
+        p_source: resolvedSource,
         p_raw_response: {
           common_name_en: clientId.commonNameEn,
           common_name_es: clientId.commonNameEs,
@@ -461,7 +463,7 @@ async function triggerIdentify(observationId: string): Promise<void> {
       p_observation_id: observationId,
       p_scientific_name: correctedName,
       p_taxon_id: null,
-      p_confidence: r.confidence,
+      p_confidence: capConfidence(r.source, r.confidence),
       p_source: r.source,
       p_raw_response: trace as unknown as object,
     });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -209,6 +209,8 @@ export interface ValidationQueueRow {
   review_requested: boolean;
   /** #1126 — kingdom of the current primary ID's taxon (NULL when no ID). Used for expert kingdom pre-routing. */
   current_kingdom: string | null;
+  /** #1128 R3 — source of the current primary ID (NULL when no ID). Drives source-trust queue ordering. */
+  current_source: string | null;
 }
 
 export type UserRole = 'admin' | 'moderator' | 'expert' | 'researcher';

--- a/tests/unit/confidence-cap-end-to-end.test.ts
+++ b/tests/unit/confidence-cap-end-to-end.test.ts
@@ -1,0 +1,30 @@
+/**
+ * #1128 R2 guard — proves the per-source confidence cap is wired at
+ * BOTH upsert_primary_identification call sites in sync.ts (the
+ * client-id path + the cascade-winner path). Pure string asserts; no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const sync = readFileSync(resolve(here, '../../src/lib/sync.ts'), 'utf8');
+
+describe('#1128 R2 confidence cap is wired end-to-end', () => {
+  it('imports capConfidence from ./confidence-ceiling', () => {
+    expect(sync).toContain("import { capConfidence } from './confidence-ceiling';");
+  });
+
+  it('caps the client-id path with the resolved source', () => {
+    expect(sync).toContain('capConfidence(resolvedSource, clientId.confidence ?? 0)');
+  });
+
+  it('caps the cascade-winner path with its source', () => {
+    expect(sync).toContain('capConfidence(r.source, r.confidence)');
+  });
+
+  it('no longer clamps the client-id confidence to [0,1] unconditionally', () => {
+    expect(sync).not.toContain('Math.max(0, Math.min(1, clientId.confidence ?? 0))');
+  });
+});

--- a/tests/unit/consensus-untouched.test.ts
+++ b/tests/unit/consensus-untouched.test.ts
@@ -52,3 +52,36 @@ describe('#1126 validation_queue routing is read-only', () => {
     expect(viewDef).toContain('t.kingdom');
   });
 });
+
+describe('#1128 R3 validation_queue surfaces source, consensus untouched', () => {
+  const m = schema.match(
+    /CREATE OR REPLACE VIEW public\.validation_queue AS[\s\S]*?;\n/,
+  );
+  const viewDef = m ? m[0] : '';
+
+  it('still does not call recompute_consensus', () => {
+    expect(viewDef).not.toContain('recompute_consensus');
+  });
+
+  it('still gates on the unchanged research-grade column', () => {
+    expect(viewDef).toContain('COALESCE(i.is_research_grade, false) = false');
+  });
+
+  it('still surfaces review_requested + kingdom', () => {
+    expect(viewDef).toContain('o.review_requested');
+    expect(viewDef).toContain('t.kingdom');
+  });
+
+  it('now also surfaces the current ID source (R3 surface)', () => {
+    expect(viewDef).toContain('i.source');
+  });
+
+  it('keeps the consensus expert weighting + research-grade floor verbatim', () => {
+    expect(schema).toContain(
+      'SUM(CASE WHEN u.is_expert AND t.kingdom = ANY(u.expert_taxa) THEN 3.0 ELSE 1.0 END)',
+    );
+    expect(schema).toContain(
+      'IF NEW.is_research_grade = true AND COALESCE(NEW.confidence, 0) < 0.4 THEN',
+    );
+  });
+});


### PR DESCRIPTION
## What

Consensus hardening **R2 + R3** (R1 already shipped in #1141). Pure cap + routing — `recompute_consensus`, `enforce_research_grade_quality`, and the ≥0.4 research-grade floor are byte-untouched (proven by the extended `consensus-untouched` guard).

**R2 — confidence cap end-to-end.** The per-source ceiling map (was a private copy in `observe-card-vm-input.ts`) is now one pure `src/lib/confidence-ceiling.ts` (`ceilingForSource` + `capConfidence`). `sync.ts` previously wrote a bare `Math.max(0, Math.min(1, …))` clamp at both `upsert_primary_identification` sites — now `capConfidence(source, …)` so an EfficientNet/MegaDetector (0.4) / Phi-Gemma (0.35) guess can **never** reach the research-grade floor. `observe-card-vm-input.ts` consumes the shared module (identical values). TDD + `tests/unit/confidence-cap-end-to-end.test.ts` proves the cap is wired at both sites.

**R3 — source/confidence-aware queue.** `validation_queue` gets `i.source AS current_source` appended last (append-only rule; joins/WHERE/gates byte-unchanged). New pure `src/lib/source-trust.ts` ranks `human < cloud < capped-on-device < unknown`. `ValidationQueueView` inserts a source-trust band **between** the #1126 my-expertise band and the server-order tiebreak (so on-device-first volume doesn't bury higher-signal items) and renders a neutral source chip. Non-destructive — pure ordering/visibility.

## Verification (controller-independent)

- Diffs reviewed; `sync.ts` grep confirms `capConfidence` at lines 286 + 466, **no remaining** bare clamp; schema view shows `current_source` appended last with gates unchanged.
- `tsc --noEmit` clean · `vitest run` **2702/2702** (incl. `confidence-ceiling`, `source-trust`, `confidence-cap-end-to-end`, extended `consensus-untouched`) · `build` 255 pages 0 errors.
- e2e (`smoke` + `observe-form` + `journey-expert-validate` + `journey-observer-offline`) **34 passed** against served `dist`; only the unrelated local missing-Supabase-env `/profile/` artifact fails (green in CI).
- `db-validate` (schema applied twice) is the authoritative idempotency gate.

Part of #1129. Closes #1128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)