### PR TITLE
feat(observe): downloads-by-capability chooser; power panel → Advanced (#1127)

### DIFF
--- a/src/components/DownloadChooser.astro
+++ b/src/components/DownloadChooser.astro
@@ -1,0 +1,279 @@
+---
+import { t } from '../i18n/utils';
+import { CAPABILITY_CATALOG } from '../lib/download-capabilities';
+
+interface Props {
+  lang: 'en' | 'es';
+}
+const { lang } = Astro.props;
+const tr = t(lang);
+const dl = tr.observe.downloads;
+const isEs = lang === 'es';
+
+const catalogJson = JSON.stringify(CAPABILITY_CATALOG);
+const i18nJson = JSON.stringify(dl);
+---
+
+<section
+  id="download-chooser"
+  data-lang={lang}
+  class="mb-6 rounded-xl border border-emerald-200 dark:border-emerald-800/60 bg-emerald-50/40 dark:bg-emerald-900/10 p-4"
+>
+  <h3 class="text-sm font-semibold text-emerald-800 dark:text-emerald-300">{dl.heading}</h3>
+  <p class="mt-1 text-xs text-zinc-600 dark:text-zinc-400">{dl.hint}</p>
+
+  <ul id="dc-items" class="mt-3 space-y-2">
+    <li class="text-xs text-zinc-500 italic">{isEs ? 'Cargando…' : 'Loading…'}</li>
+  </ul>
+
+  <details id="dc-advanced" class="mt-3 hidden group">
+    <summary class="cursor-pointer text-xs font-semibold text-zinc-700 dark:text-zinc-300 select-none">
+      {dl.advanced_group}
+    </summary>
+    <p class="mt-2 text-[11px] text-amber-700 dark:text-amber-400">{dl.advanced_note}</p>
+    <ul id="dc-advanced-items" class="mt-2 space-y-2"></ul>
+  </details>
+
+  <div class="mt-4 flex items-center justify-between gap-3 flex-wrap">
+    <p class="text-xs text-zinc-600 dark:text-zinc-400">
+      <span class="font-semibold">{dl.total_label}:</span>
+      <span id="dc-total" class="font-mono">0 MB</span>
+    </p>
+    <button
+      type="button"
+      id="dc-download"
+      class="rounded-lg bg-emerald-700 hover:bg-emerald-800 px-4 py-2 text-sm font-semibold text-white"
+    ></button>
+  </div>
+  <p id="dc-started" class="mt-2 hidden text-[11px] text-emerald-700 dark:text-emerald-400"></p>
+
+  <script type="application/json" id="dc-catalog" set:html={catalogJson}></script>
+  <script type="application/json" id="dc-i18n" set:html={i18nJson}></script>
+</section>
+
+<script>
+  (() => {
+    const root = document.getElementById('download-chooser');
+    if (!root) return;
+
+    type Item = {
+      id: string;
+      target: string;
+      labelEn: string;
+      labelEs: string;
+      capabilityEn: string;
+      capabilityEs: string;
+      sizeMb: number;
+      defaultChecked: boolean;
+      advanced: boolean;
+    };
+
+    const isEs = root.getAttribute('data-lang') === 'es';
+    const STORAGE_KEY = 'rastrum.downloads.selected';
+    const LARGE_ITEM_MB = 100;
+
+    function readJson<T>(id: string, fallback: T): T {
+      try {
+        const el = document.getElementById(id);
+        return el && el.textContent ? (JSON.parse(el.textContent) as T) : fallback;
+      } catch {
+        return fallback;
+      }
+    }
+
+    const catalog = readJson<Item[]>('dc-catalog', []);
+    const i18n = readJson<Record<string, string>>('dc-i18n', {});
+
+    function formatSize(mb: number): string {
+      return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`;
+    }
+
+    function loadSelection(): string[] | null {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed.filter((x) => typeof x === 'string') : null;
+      } catch {
+        return null;
+      }
+    }
+
+    function saveSelection(ids: string[]): void {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+      } catch {
+        /* storage unavailable — selection is in-memory only */
+      }
+    }
+
+    function selectedIds(): string[] {
+      return Array.from(
+        root!.querySelectorAll<HTMLInputElement>('input[data-dc-item]:checked')
+      ).map((c) => c.getAttribute('data-dc-item') || '');
+    }
+
+    function refreshTotal(): void {
+      const sel = new Set(selectedIds());
+      const total = catalog.reduce(
+        (sum, c) => (sel.has(c.id) ? sum + c.sizeMb : sum),
+        0
+      );
+      const totalEl = document.getElementById('dc-total');
+      if (totalEl) totalEl.textContent = formatSize(total);
+      const btn = document.getElementById('dc-download');
+      if (btn) {
+        const tmpl = i18n.download_selected || 'Download selected ({total})';
+        btn.textContent = tmpl.replace('{total}', formatSize(total));
+        (btn as HTMLButtonElement).disabled = sel.size === 0;
+        btn.classList.toggle('opacity-50', sel.size === 0);
+      }
+    }
+
+    function itemRow(c: Item, checked: boolean): HTMLLIElement {
+      const li = document.createElement('li');
+      li.className =
+        'rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-3';
+      const label = isEs ? c.labelEs : c.labelEn;
+      const cap = isEs ? c.capabilityEs : c.capabilityEn;
+      const warn =
+        c.sizeMb >= LARGE_ITEM_MB
+          ? `<span class="ml-2 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 px-2 py-0.5 text-[10px] font-medium">${i18n.data_warning || ''}</span>`
+          : '';
+      li.innerHTML = `
+        <label class="flex items-start gap-3 cursor-pointer">
+          <input type="checkbox" data-dc-item="${c.id}" class="mt-1 h-4 w-4 accent-emerald-700" ${checked ? 'checked' : ''} />
+          <span class="min-w-0 flex-1">
+            <span class="flex items-center flex-wrap gap-x-2">
+              <span class="text-sm font-medium text-zinc-900 dark:text-zinc-100">${label}</span>
+              <span class="text-[11px] font-mono text-zinc-500 dark:text-zinc-400">${formatSize(c.sizeMb)}</span>
+              ${warn}
+            </span>
+            <span class="block text-xs text-zinc-600 dark:text-zinc-400 mt-0.5">${cap}</span>
+          </span>
+        </label>`;
+      const input = li.querySelector<HTMLInputElement>('input[data-dc-item]');
+      if (input) {
+        input.addEventListener('change', () => {
+          saveSelection(selectedIds());
+          refreshTotal();
+        });
+      }
+      return li;
+    }
+
+    function findDownloadControl(item: Item): HTMLElement | null {
+      const list = document.getElementById('identifier-list');
+      if (!list) return null;
+      const prefixByTarget: Record<string, string> = {
+        webllm_phi35_vision: 'vision',
+        onnx_gemma4_vision: 'gemma-vision',
+        birdnet_lite: 'birdnet',
+        onnx_efficientnet_lite0: 'onnx-base',
+        camera_trap_megadetector: 'megadetector',
+        speciesnet_distilled: 'speciesnet',
+        'offline-map': 'pmtiles',
+      };
+      const prefix = prefixByTarget[item.target];
+      if (!prefix) return null;
+      return list.querySelector<HTMLElement>(`#${prefix}-download`);
+    }
+
+    function startDownloads(): void {
+      const sel = selectedIds();
+      if (!sel.length) return;
+      const advanced = document.getElementById('ai-advanced') as HTMLDetailsElement | null;
+      if (advanced) {
+        advanced.open = true;
+        try {
+          advanced.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } catch {
+          /* scroll unsupported — non-fatal */
+        }
+      }
+      const byId = new Map(catalog.map((c) => [c.id, c]));
+      // Defer the clicks so the registry list has a tick to (re)paint.
+      window.setTimeout(() => {
+        for (const id of sel) {
+          const item = byId.get(id);
+          if (!item) continue;
+          try {
+            const ctrl = findDownloadControl(item);
+            if (ctrl) ctrl.click();
+          } catch {
+            /* capability-graph degrade — skip this item silently */
+          }
+        }
+      }, 120);
+      const started = document.getElementById('dc-started');
+      if (started) {
+        started.textContent = i18n.started || '';
+        started.classList.remove('hidden');
+      }
+    }
+
+    async function init(): Promise<void> {
+      const normalList = document.getElementById('dc-items');
+      const advList = document.getElementById('dc-advanced-items');
+      const advWrap = document.getElementById('dc-advanced');
+      if (!normalList) return;
+
+      let availableTargets = new Set<string>();
+      try {
+        const [{ bootstrapIdentifiers }] = await Promise.all([
+          import('../lib/identifiers'),
+        ]);
+        const reg = bootstrapIdentifiers();
+        const plugins = reg.list();
+        const checks = await Promise.all(
+          plugins.map(async (p) => {
+            try {
+              const av = await p.isAvailable();
+              return [p.id, av && av.reason !== 'model_not_bundled'] as const;
+            } catch {
+              return [p.id, false] as const;
+            }
+          })
+        );
+        availableTargets = new Set(
+          checks.filter(([, ok]) => ok).map(([id]) => id)
+        );
+      } catch {
+        availableTargets = new Set();
+      }
+
+      const visible = catalog.filter(
+        (c) => c.target === 'offline-map' || availableTargets.has(c.target)
+      );
+
+      const persisted = loadSelection();
+      const isChecked = (c: Item): boolean =>
+        persisted ? persisted.includes(c.id) : c.defaultChecked;
+
+      normalList.innerHTML = '';
+      const advItems: Item[] = [];
+      for (const c of visible) {
+        if (c.advanced) {
+          advItems.push(c);
+          continue;
+        }
+        normalList.appendChild(itemRow(c, isChecked(c)));
+      }
+
+      if (advItems.length && advList && advWrap) {
+        advWrap.classList.remove('hidden');
+        advList.innerHTML = '';
+        for (const c of advItems) advList.appendChild(itemRow(c, isChecked(c)));
+      }
+
+      const btn = document.getElementById('dc-download');
+      if (btn) btn.addEventListener('click', () => startDownloads());
+
+      refreshTotal();
+    }
+
+    init().catch(() => {
+      /* never throw from the chooser — page must not console-error */
+    });
+  })();
+</script>

--- a/src/components/ProfileEditForm.astro
+++ b/src/components/ProfileEditForm.astro
@@ -1,5 +1,6 @@
 ---
 import { t, routes } from '../i18n/utils';
+import DownloadChooser from "./DownloadChooser.astro";
 
 interface Props {
   lang: 'en' | 'es';
@@ -279,12 +280,19 @@ const speciesnetHosted = Boolean(import.meta.env.PUBLIC_SPECIESNET_WEIGHTS_URL);
       <span id="pipeline-flow-items" class="italic">{lang === 'es' ? 'Cargando…' : 'Loading…'}</span>
     </div>
 
+    <DownloadChooser lang={lang} />
+
     <!-- Registry: lists every Identifier plugin with enable/disable toggles -->
+    <details id="ai-advanced" class="mb-6 group">
+      <summary class="cursor-pointer text-sm font-semibold text-zinc-700 dark:text-zinc-300 select-none">{isEs ? 'Identificación · Avanzado' : 'Identification · Advanced'}</summary>
+      <div class="mt-3">
     <div class="mb-6">
       <ul id="identifier-list" class="space-y-2">
         <li class="text-sm text-zinc-500 italic">{lang === 'es' ? 'Cargando…' : 'Loading…'}</li>
       </ul>
     </div>
+      </div>
+    </details>
 
     <!-- Cross-link to sponsorships surface (issue #656) -->
     <aside class="mb-6 border-l-2 border-emerald-300 dark:border-emerald-700/60 pl-3 py-1 text-xs text-zinc-600 dark:text-zinc-400">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -774,6 +774,17 @@
       "action_dismiss": "Dismiss",
       "review_requested_ack": "Review requested ✓"
     },
+    "downloads": {
+      "heading": "Works without signal — choose what to download",
+      "hint": "Pick the capabilities you need in the field. Nothing downloads until you press the button.",
+      "total_label": "Total",
+      "download_selected": "Download selected ({total})",
+      "data_warning": "Large — use Wi-Fi",
+      "advanced_group": "Advanced · powerful devices",
+      "advanced_note": "Large on-device LLM models. Recommended only on recent, high-memory devices.",
+      "none_selected": "Nothing selected",
+      "started": "Opening Advanced — confirm each download there"
+    },
     "trace": {
       "col_source": "Source",
       "col_where": "Where",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -774,6 +774,17 @@
       "action_dismiss": "Descartar",
       "review_requested_ack": "Revisión solicitada ✓"
     },
+    "downloads": {
+      "heading": "Funciona sin señal — elige qué descargar",
+      "hint": "Elige las capacidades que necesitas en el campo. Nada se descarga hasta que presiones el botón.",
+      "total_label": "Total",
+      "download_selected": "Descargar seleccionados ({total})",
+      "data_warning": "Grande — usa Wi-Fi",
+      "advanced_group": "Avanzado · dispositivos potentes",
+      "advanced_note": "Modelos LLM grandes en el dispositivo. Recomendado solo en equipos recientes con mucha memoria.",
+      "none_selected": "Nada seleccionado",
+      "started": "Abriendo Avanzado — confirma cada descarga ahí"
+    },
     "trace": {
       "col_source": "Fuente",
       "col_where": "Dónde",

--- a/src/lib/download-capabilities-i18n.test.ts
+++ b/src/lib/download-capabilities-i18n.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { CAPABILITY_CATALOG } from './download-capabilities';
+import en from '../i18n/en.json';
+import es from '../i18n/es.json';
+
+describe('download-capabilities i18n parity', () => {
+  it('every CapabilityItem has non-empty EN/ES label + capability strings', () => {
+    for (const c of CAPABILITY_CATALOG) {
+      for (const field of ['labelEn', 'labelEs', 'capabilityEn', 'capabilityEs'] as const) {
+        expect(typeof c[field]).toBe('string');
+        expect(c[field].trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('observe.downloads exists with identical key sets in EN + ES', () => {
+    const enDl = (en as Record<string, any>).observe?.downloads;
+    const esDl = (es as Record<string, any>).observe?.downloads;
+    expect(enDl).toBeTruthy();
+    expect(esDl).toBeTruthy();
+    const enKeys = Object.keys(enDl).sort();
+    const esKeys = Object.keys(esDl).sort();
+    expect(enKeys).toEqual(esKeys);
+    for (const k of enKeys) {
+      expect(typeof enDl[k]).toBe('string');
+      expect(typeof esDl[k]).toBe('string');
+      expect(enDl[k].trim().length).toBeGreaterThan(0);
+      expect(esDl[k].trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/download-capabilities.test.ts
+++ b/src/lib/download-capabilities.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CAPABILITY_CATALOG,
+  degradeCatalog,
+  defaultSelection,
+  liveTotalMb,
+  formatSize,
+} from './download-capabilities';
+
+describe('download-capabilities', () => {
+  it('default selection is EfficientNet + BirdNET', () => {
+    expect(defaultSelection(CAPABILITY_CATALOG)).toEqual(['efficientnet', 'birdnet']);
+  });
+
+  it('live total sums selected item sizes', () => {
+    expect(liveTotalMb(CAPABILITY_CATALOG, ['efficientnet', 'birdnet'])).toBe(68);
+    expect(liveTotalMb(CAPABILITY_CATALOG, ['phi'])).toBe(4096);
+    expect(liveTotalMb(CAPABILITY_CATALOG, [])).toBe(0);
+  });
+
+  it('formatSize renders MB under 1024 and GB at/over', () => {
+    expect(formatSize(68)).toBe('68 MB');
+    expect(formatSize(4096)).toBe('4.0 GB');
+    expect(formatSize(120)).toBe('120 MB');
+  });
+
+  it('degradeCatalog with no available targets keeps only offline-map', () => {
+    const kept = degradeCatalog(CAPABILITY_CATALOG, new Set());
+    expect(kept.map((c) => c.id)).toEqual(['offline-map']);
+  });
+
+  it('degradeCatalog keeps an available target plus offline-map', () => {
+    const kept = degradeCatalog(CAPABILITY_CATALOG, new Set(['onnx_efficientnet_lite0']));
+    expect(kept.map((c) => c.id).sort()).toEqual(['efficientnet', 'offline-map']);
+  });
+
+  it('every advanced item is default-unchecked', () => {
+    for (const c of CAPABILITY_CATALOG) {
+      if (c.advanced) expect(c.defaultChecked).toBe(false);
+    }
+  });
+
+  it('every catalog id is unique', () => {
+    const ids = CAPABILITY_CATALOG.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('EfficientNet + BirdNET are the only non-advanced default-checked items', () => {
+    const defaults = CAPABILITY_CATALOG.filter((c) => c.defaultChecked);
+    expect(defaults.every((c) => !c.advanced)).toBe(true);
+    expect(defaults.map((c) => c.id).sort()).toEqual(['birdnet', 'efficientnet']);
+  });
+});

--- a/src/lib/download-capabilities.ts
+++ b/src/lib/download-capabilities.ts
@@ -1,0 +1,51 @@
+/**
+ * Curated, capability-framed download catalog (#1127). The user-facing
+ * chooser is built from this; the raw identifier registry is "Advanced".
+ * Sizes are approximate MB for the data-cost warning + live total.
+ */
+export interface CapabilityItem {
+  /** Stable id used for selection state + to find the matching registry card. */
+  id: string;
+  /** Registry plugin id whose existing Download control this drives, or 'offline-map'. */
+  target: string;
+  labelEn: string;
+  labelEs: string;
+  capabilityEn: string;
+  capabilityEs: string;
+  sizeMb: number;
+  /** Pre-checked when the user has never chosen (sane default). */
+  defaultChecked: boolean;
+  /** Lives under the collapsed "Advanced · powerful devices" subgroup. */
+  advanced: boolean;
+}
+
+export const CAPABILITY_CATALOG: readonly CapabilityItem[] = [
+  { id: 'efficientnet', target: 'onnx_efficientnet_lite0', labelEn: 'EfficientNet', labelEs: 'EfficientNet', capabilityEn: 'Plants & general species, on-device', capabilityEs: 'Plantas y especies generales, en el dispositivo', sizeMb: 18, defaultChecked: true, advanced: false },
+  { id: 'birdnet', target: 'birdnet_lite', labelEn: 'BirdNET', labelEs: 'BirdNET', capabilityEn: 'Bird songs & calls, on-device', capabilityEs: 'Cantos y llamados de aves, en el dispositivo', sizeMb: 50, defaultChecked: true, advanced: false },
+  { id: 'megadetector', target: 'camera_trap_megadetector', labelEn: 'MegaDetector', labelEs: 'MegaDetector', capabilityEn: 'Camera-trap animal detection, on-device', capabilityEs: 'Detección de fauna en cámaras-trampa, en el dispositivo', sizeMb: 134, defaultChecked: false, advanced: false },
+  { id: 'offline-map', target: 'offline-map', labelEn: 'Offline map', labelEs: 'Mapa sin conexión', capabilityEn: 'Map tiles for field use without signal', capabilityEs: 'Mapas para el campo sin señal', sizeMb: 120, defaultChecked: false, advanced: false },
+  { id: 'phi', target: 'webllm_phi35_vision', labelEn: 'Phi-3.5 Vision', labelEs: 'Phi-3.5 Visión', capabilityEn: 'On-device LLM vision (powerful devices)', capabilityEs: 'Visión LLM en el dispositivo (equipos potentes)', sizeMb: 4096, defaultChecked: false, advanced: true },
+  { id: 'gemma', target: 'onnx_gemma4_vision', labelEn: 'Gemma Vision', labelEs: 'Gemma Visión', capabilityEn: 'On-device LLM vision (powerful devices)', capabilityEs: 'Visión LLM en el dispositivo (equipos potentes)', sizeMb: 3277, defaultChecked: false, advanced: true },
+];
+
+/** Items whose target plugin is unavailable are simply not offered (capability-graph degrade, no errors). 'offline-map' is always kept. */
+export function degradeCatalog(catalog: readonly CapabilityItem[], availableTargets: ReadonlySet<string>): CapabilityItem[] {
+  return catalog.filter((c) => c.target === 'offline-map' || availableTargets.has(c.target));
+}
+
+export function defaultSelection(catalog: readonly CapabilityItem[]): string[] {
+  return catalog.filter((c) => c.defaultChecked).map((c) => c.id);
+}
+
+export function liveTotalMb(catalog: readonly CapabilityItem[], selectedIds: readonly string[]): number {
+  const sel = new Set(selectedIds);
+  return catalog.reduce((sum, c) => (sel.has(c.id) ? sum + c.sizeMb : sum), 0);
+}
+
+/** Human total: ">1024 MB → N.N GB" else "NNN MB". */
+export function formatSize(mb: number): string {
+  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`;
+}
+
+/** Large-item data-cost warning threshold (MB). */
+export const LARGE_ITEM_MB = 100;

--- a/tests/e2e/ai-tab.spec.ts
+++ b/tests/e2e/ai-tab.spec.ts
@@ -28,6 +28,15 @@ const ES_AI_URL = '/es/perfil/ajustes/ai/';
 
 /** Wait until #identifier-list has rendered at least one card (not the loading placeholder). */
 async function waitForRegistry(page: import('@playwright/test').Page) {
+  // #1127: the identifier registry ("power panel") now lives behind the
+  // collapsed "Identificación · Avanzado" <details>. Open it so the
+  // registry content is visible for the assertions below — the registry
+  // itself is unchanged, only relocated behind the disclosure. Idempotent
+  // and safe pre-paint (the <details> is server-rendered static markup).
+  await page.evaluate(() => {
+    const d = document.getElementById('ai-advanced') as HTMLDetailsElement | null;
+    if (d) d.open = true;
+  });
   await page.waitForFunction(() => {
     const list = document.getElementById('identifier-list');
     if (!list) return false;


### PR DESCRIPTION
## What

Final slice of epic #1129 / issue #1127 (decided UX 2026-05-16). The 9-identifier power panel is no longer the default.

- **Pure `src/lib/download-capabilities.ts`** (TDD): capability-framed catalog (EfficientNet 18 MB · BirdNET 50 MB · MegaDetector 134 MB · offline-map 120 MB · Phi/Gemma = advanced), `defaultSelection` (EfficientNet + BirdNET), `liveTotalMb`, `formatSize`, `degradeCatalog` (absent target → simply not offered, no errors). EN/ES parity guard test.
- **`DownloadChooser.astro`**: "Works without signal — choose what to download" with per-item checkbox + capability + size, **live running total**, **data-cost warning** on ≥100 MB items, sane defaults the user can override, heavy WebLLM (Phi ~4 GB / Gemma ~3.2 GB) in a **collapsed "Advanced · powerful devices"** subgroup (default-unchecked, flagged), explicit **"Download selected (NNN MB)"** button — **never auto-downloads**. Selection persisted to `localStorage`.
- **Power panel → Advanced**: the existing `#identifier-list` registry block relocates **verbatim** behind a single collapsed `<details id="ai-advanced">` "Identificación · Avanzado". "Download selected" opens it and clicks each item's **existing** download control (`#vision/gemma-vision/birdnet/onnx-base/megadetector/pmtiles-download`) so the unchanged confirm-dialog + download path runs.

## Safety invariant (verified)

`git diff` on `ProfileEditForm.astro` is **exactly 3 additive changes**: the import, the `<DownloadChooser>` line, and the `<details>` wrapper. **Zero changes** to `paintRegistry`, `wireOnDeviceControls`, `renderPluginCard`, `identifier-card-html.ts`, or `identifier-prefs.ts` → "existing identifier behavior unchanged" holds by construction. The chooser's click-target prefixes were verified against `identifier-card-html.ts`'s `#${idBase}-download` contract — they match exactly, so "per-item control" actually drives the real controls.

## Verification (controller-independent)

- ProfileEditForm diff confirmed limited to the 3 additive changes; selectors cross-checked vs the card-render lib.
- `tsc --noEmit` clean · `vitest run` **2693/2693** (incl. catalog + EN/ES parity guard 10/10) · `build` 255 pages 0 errors.
- e2e `settings.spec.ts` **14/14** against served `dist` — AI/settings pages render, chooser script doesn't crash the page.

Part of #1129. Closes #1127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)