### PR TITLE
chore(observe): #1129 follow-ups — docs sync, prefix guard, card e2e, e2e-for-changed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,10 @@
 > Briefing for AI coding agents (Claude Code, Copilot, Cursor, Codex, …)
 > working in this repo. Read this before making changes.
 >
-> **Last full doc sync:** 2026-05-08 (v1.1.5 Persuasive Tech Audit + schema
-> security invariants — see "Schema security invariants" section below).
+> **Last full doc sync:** 2026-05-17 (epic #1129 Observe AI progressive
+> card — PRs #1142–#1146; see "Observe AI progressive card" section below).
+> Prior sync: 2026-05-08 (v1.1.5 Persuasive Tech Audit + schema security
+> invariants — see "Schema security invariants" section below).
 > Prior sync: 2026-05-01 (v1.2 + 42 field-bug/admin/docs PRs).
 
 ---
@@ -625,6 +627,55 @@ to existing surfaces. Two patterns are now load-bearing across the codebase:
 Full per-PR context: `docs/progress.json` v1.1.5 phase + the per-PR
 runbooks (`docs/runbooks/falta-dex.md`, `docs/runbooks/contextual-suggestions.md`,
 `docs/runbooks/themes.md` once #769 lands).
+
+### Observe AI progressive card (epic #1129)
+
+`#obs2-card-v2` in `ObserveView2.astro` is the **only** identification
+surface — the legacy `#obs2-id-result` block and the `cardV2Enabled`
+flag are gone (C-4). One card morphs through six states (S0/S1a/S1b/
+S2/S2′/S3); the observer's explicit affirmation is sovereign over a
+later cloud upgrade. Five load-bearing rules:
+
+1. **Pure logic stays pure + TDD'd.** `observe-card-{state,sovereignty,
+   audit-trace,vm,vm-input,render,actions}.ts` are DOM-free. Add a card
+   state ⇒ extend `observe-card-actions.ts` (the pure selector), never
+   hand-roll buttons in the renderer. `data-card-state` /
+   `data-card-action` / `data-card-trace[-panel]` are the wiring
+   contract the `<script>` binds to.
+2. **R1–R3 are the consensus firewall — don't regress them.** R1: a
+   machine result is NEVER written `source='human'` (`identification-
+   source.ts`). R2: `capConfidence(source, c)` from the single-source
+   `confidence-ceiling.ts` is applied at **both** `upsert_primary_
+   identification` sites in `sync.ts` (capped sources stay below the
+   ≥0.4 RG floor). R3: the validate/expert queue orders by
+   `source-trust.ts` (human < cloud < capped on-device).
+   `recompute_consensus` + the RG floor are byte-frozen by
+   `tests/unit/consensus-untouched.test.ts`.
+3. **`validation_queue` columns are append-only.** `review_requested`,
+   `current_kingdom`, `current_source` were appended last (CREATE OR
+   REPLACE VIEW rule); the `sync_status`/`obscure_level`/RG gates are
+   unchanged. Queue routing is pure visibility — it must not touch
+   consensus.
+4. **Downloads default to the curated chooser.** `DownloadChooser.astro`
+   (built from pure `download-capabilities.ts`) is the default; the raw
+   9-identifier registry is behind the collapsed `#ai-advanced`
+   `<details>`. "Download selected" clicks the **existing**
+   `#${prefix}-download` controls — `prefixByTarget` must stay in sync
+   with `ON_DEVICE_DL_PREFIX` (`identifier-card-html.ts`), enforced by
+   `tests/unit/download-chooser-prefix-sync.test.ts`. An e2e spec that
+   asserts registry visibility must open `#ai-advanced` first.
+5. **`ObserveView2`'s client `<script>` is e2e-gated.** `tsc`/`vitest`/
+   `build` don't run the page in a browser (the `tr is not defined`
+   class). `tests/e2e/observe-card.spec.ts` drives the card seam
+   deterministically; the CI `test` job (Playwright) is the real gate.
+   `bash scripts/e2e-for-changed.sh` maps a diff → the specs that cover
+   it; local `/profile/*` e2e needs `.env.local` copied into the
+   worktree + a rebuild or it false-fails on `supabaseUrl is required`.
+
+i18n namespaces: `observe.card.*` / `observe.trace.*` /
+`observe.downloads.*` / `validation.*` (EN/ES parity per namespace).
+Full context: `docs/runbooks/observe-progressive-card.md` + the spec
+`docs/superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md`.
 
 ---
 

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -583,6 +583,13 @@
           "label_es": "Analítica con PostHog — snippet con reverse-proxy gestionado (api_host=usage.rastrum.org + ui_host=us.posthog.com), person_profiles=identified_only, autocaptura de excepciones, posthog.reset() al cerrar sesión, build-env cableado en deploy.yml (estuvo silencioso en prod desde el setup del wizard hasta #764), guard de drift del search-index en CI (ci.yml + e2e.yml). 14 puntos de captura: embudo de sign-in, guardado de observaciones, identificación sugerida + promovida, reacciones, follows, comentarios, exports, onboarding, perfil actualizado, instalación de PWA, proyecto creado, credencial de patrocinio añadida, contenido reportado. Ver docs/runbooks/posthog.md.",
           "done": true,
           "done_at": "2026-05-08"
+        },
+        {
+          "id": "observe-ai-progressive-card",
+          "label": "Observe AI progressive result card (epic #1129): one card S0–S3/S2′ replacing result+manual+why; observer-sovereignty resolver; ver-traza audit panel; review_requested community-review flag + kingdom-routed queue; consensus hardening R1–R3 (machine source preserved, confidence capped end-to-end, source-trust queue ordering); downloads-by-capability chooser (power panel → Advanced)",
+          "label_es": "Tarjeta de resultado progresiva de Observar (épica #1129): una tarjeta S0–S3/S2′ que reemplaza resultado+manual+por-qué; resolvedor de soberanía del observador; panel de auditoría ver-traza; bandera review_requested de revisión comunitaria + cola ruteada por reino; endurecimiento de consenso R1–R3 (fuente de máquina preservada, confianza limitada extremo-a-extremo, orden de cola por confianza-fuente); selector de descargas por capacidad (panel avanzado)",
+          "done": true,
+          "done_at": "2026-05-17"
         }
       ]
     },

--- a/docs/runbooks/00-index.md
+++ b/docs/runbooks/00-index.md
@@ -41,6 +41,7 @@ high-level system view.
 | Runbook | Covers |
 |---|---|
 | [`obs-detail-redesign.md`](obs-detail-redesign.md) | Two-column layout, manage panel, atomic photo delete via `delete_photo_atomic` RPC. |
+| [`observe-progressive-card.md`](observe-progressive-card.md) | Epic #1129 — progressive result card (S0–S3/S2′), sovereignty + R1–R3 consensus invariants, `review_requested` queue routing, downloads-by-capability chooser. |
 
 ## Identifier registry (Module 13)
 

--- a/docs/runbooks/observe-progressive-card.md
+++ b/docs/runbooks/observe-progressive-card.md
@@ -1,0 +1,58 @@
+# Observe AI — progressive result card
+
+Epic **#1129** (PRs #1142–#1146, merged 2026-05-17). Spec:
+[`../superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md`](../superpowers/specs/2026-05-16-observe-ai-progressive-card-design.md)
+(integration **approach C** — the card subsumes result + taxon + why).
+
+## What it is
+
+`#obs2-card-v2` in `ObserveView2.astro` is now the **only** identification
+surface. The legacy `#obs2-id-result` block and the `cardV2Enabled` flag
+are gone (C-4). One card morphs through six states; the observer's
+explicit affirmation is sovereign over any later cloud upgrade.
+
+## Load-bearing pieces (do not bypass)
+
+| Concern | Module | Invariant |
+|---|---|---|
+| State selection | `src/lib/observe-card-state.ts` | S1a only when a **non-capped** source ≥ `ACCEPT_THRESHOLD` (0.7). Capped sources are always S1b. No new tunables. |
+| Sovereignty | `src/lib/observe-sovereignty.ts` | `observer_affirmed=false` → cloud re-stamps primary (S2). `true` → cloud is a parallel suggestion (S2′), never overwrites. |
+| Actions | `src/lib/observe-card-actions.ts` | Pure `cardActions(state)`. Add a state ⇒ extend this, not the renderer. |
+| Render | `src/lib/observe-card-render.ts` | Pure string. `data-card-state` / `data-card-action` / `data-card-trace` / `data-card-trace-panel` are the wiring contract `ObserveView2`'s `<script>` binds to. |
+| Audit trace | `src/lib/observe-audit-trace.ts` | "ver traza" is UI over real `identifications` rows + cascade outcomes — **no new data model**. Capped rows flagged honestly. |
+| Source (R1) | `src/lib/identification-source.ts` | A machine result is NEVER written `source='human'`. Affirm/manual-entry ⇒ `human`. |
+| Confidence cap (R2) | `src/lib/confidence-ceiling.ts` | Single source of truth. `capConfidence(source, c)` is applied at **both** `upsert_primary_identification` sites in `sync.ts`. EfficientNet/MegaDetector ≤ 0.4, Phi/Gemma ≤ 0.35 → below the ≥0.4 research-grade floor. |
+| Queue routing (R3 + #1126) | `validation_queue` view + `src/lib/source-trust.ts` | View surfaces `review_requested` / `current_kingdom` / `current_source` (append-only). Queue orders review-requested first, then my-expertise, then source-trust (human < cloud < capped on-device). **`recompute_consensus` + the RG floor are untouched** — proven by `tests/unit/consensus-untouched.test.ts`. |
+| Downloads UX (#1127) | `src/lib/download-capabilities.ts` + `DownloadChooser.astro` | Curated capability chooser is the default; the raw 9-identifier registry is behind the collapsed `#ai-advanced` `<details>`. "Download selected" clicks the **existing** `#${prefix}-download` controls — `prefixByTarget` must stay in sync with `ON_DEVICE_DL_PREFIX` (`identifier-card-html.ts`), enforced by `tests/unit/download-chooser-prefix-sync.test.ts`. |
+
+## State machine
+
+`S0` analyzing · `S1a` high-confidence collapsed "✓ saved" · `S1b`
+weak/capped — Yes / No-other / I-don't-know · `S2` cloud upgrade
+(no observer action) · `S2′` cloud parallel suggestion (observer
+affirmed) · `S3` offline/no-model. Save is available in every state.
+
+## Gotchas
+
+- **Any change to `ObserveView2.astro`'s client `<script>` MUST be
+  e2e-gated.** `tsc`/`vitest`/`build` do not run the page in a browser
+  (the `tr is not defined` class). The CI `test` job (Playwright) is the
+  real gate; auto-merge enforces it. `tests/e2e/observe-card.spec.ts`
+  drives the card seam deterministically; `tests/e2e/ai-tab.spec.ts`
+  covers the relocated registry (opens `#ai-advanced` first).
+- Local e2e on `/profile/*` needs `.env.local` copied into the worktree
+  + a rebuild, or it fails with `supabaseUrl is required` and masks real
+  regressions. `bash scripts/e2e-for-changed.sh` maps a diff to the
+  specs that cover it.
+- i18n namespaces: `observe.card.*` (states + actions), `observe.trace.*`
+  (audit panel), `observe.downloads.*` (chooser), `validation.*` (queue
+  badges). EN/ES parity is enforced per-namespace.
+
+## Consensus integrity (must stay true)
+
+`recompute_consensus` counts only `validated_by`-non-null human
+validations; the research-grade floor is `confidence ≥ 0.4`. The
+progressive card path is local-first **and safe** only because R1–R3
+hold: machine source preserved, confidence capped end-to-end, queue
+ordered by source trust. `tests/unit/consensus-untouched.test.ts` fails
+the build if the weighting expression or RG floor ever drifts.

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -7449,6 +7449,43 @@
           "status": "done"
         }
       ]
+    },
+    "observe-ai-progressive-card": {
+      "phase": "v1.0.x",
+      "title_en": "Observe AI progressive result card (epic #1129)",
+      "title_es": "Tarjeta de resultado progresiva de Observar (épica #1129)",
+      "modules": [
+        "02",
+        "03",
+        "13"
+      ],
+      "subtasks": [
+        {
+          "label_en": "Pure foundation: observe-card-{state,sovereignty,audit-trace,vm,vm-input,render,actions}.ts + identification-source.ts (R1) — TDD",
+          "label_es": "Base pura: observe-card-{state,sovereignty,audit-trace,vm,vm-input,render,actions}.ts + identification-source.ts (R1) — TDD",
+          "done": true
+        },
+        {
+          "label_en": "Render C-1/C-2/C-3/C-4 in ObserveView2: pipeline→CardViewModel seam, six card states, Sí/No-otra/No-sé + sovereignty wiring, ver-traza panel + WhyThisSpecies relocation, cardV2 flag removed (#1122–#1125, PRs #1135/#1139/#1142/#1143)",
+          "label_es": "Render C-1/C-2/C-3/C-4 en ObserveView2: costura pipeline→CardViewModel, seis estados, Sí/No-otra/No-sé + soberanía, panel ver-traza + reubicación de WhyThisSpecies, bandera cardV2 eliminada (#1122–#1125, PRs #1135/#1139/#1142/#1143)",
+          "done": true
+        },
+        {
+          "label_en": "review_requested: schema column + RLS, card write-path, validation_queue surfacing + kingdom routing via users.expert_taxa, opt-in expertise filter (#1126, PRs #1140/#1144)",
+          "label_es": "review_requested: columna de esquema + RLS, ruta de escritura de la tarjeta, exposición en validation_queue + ruteo por reino vía users.expert_taxa, filtro de experticia opt-in (#1126, PRs #1140/#1144)",
+          "done": true
+        },
+        {
+          "label_en": "Consensus hardening R1 (never write machine as human, #1141), R2 (capConfidence end-to-end at both upsert sites), R3 (source-trust queue ordering) — recompute_consensus + RG floor proven unchanged (#1128, PRs #1141/#1145)",
+          "label_es": "Endurecimiento de consenso R1 (nunca escribir máquina como humano, #1141), R2 (capConfidence extremo-a-extremo en ambos upsert), R3 (orden de cola por confianza-fuente) — recompute_consensus + piso RG probados sin cambios (#1128, PRs #1141/#1145)",
+          "done": true
+        },
+        {
+          "label_en": "Downloads-by-capability chooser (DownloadChooser.astro + download-capabilities.ts), power panel relocated behind Advanced <details>; prefix-sync + consensus-untouched + observe-card e2e guards (#1127, PR #1146)",
+          "label_es": "Selector de descargas por capacidad (DownloadChooser.astro + download-capabilities.ts), panel reubicado tras <details> Avanzado; guardas prefix-sync + consensus-untouched + e2e observe-card (#1127, PR #1146)",
+          "done": true
+        }
+      ]
     }
   }
 }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -61,7 +61,7 @@ Remaining:
 
 ## v1.0.x — Post-launch polish — in_progress
 
-**9 of 25 items done.** (Latest done: `posthog-analytics` 2026-05-08 — reverse-proxy snippet + 14 capture sites + exception autocapture + identify/reset on auth + drift CI guards + runbook. See `docs/runbooks/posthog.md`.)
+**10 of 27 items done.** (Latest done: `observe-ai-progressive-card` 2026-05-17 — epic #1129, PRs #1142–#1146: one progressive result card S0–S3/S2′ replacing result+manual+why, observer-sovereignty resolver, ver-traza audit panel, `review_requested` kingdom-routed queue, consensus hardening R1–R3, downloads-by-capability chooser. See `docs/runbooks/observe-progressive-card.md`.)
 
 Remaining:
 
@@ -81,6 +81,7 @@ Remaining:
 - `smoke-test-nightly` — Nightly cron-fired Playwright smoke test against production rastrum.org  _(✓ done — PR #1041, 2026-05-12)_
 - `license-per-record-ui` — UI for per-observation license selection (CC-BY default; CC0, CC-BY-NC, all-rights-reserved options)  _(· planned)_
 - `docs-toc-mobile` — Sticky scrollspy TOC pill row on mobile doc pages (auto-extracts h2s, IntersectionObserver active state)  _(! blocked: Open PR #23 — pending rebase + aria-current fix; reviewed and approved-with-comments)_
+- `observe-ai-progressive-card` — Epic #1129: progressive result card (S0–S3/S2′) replacing result+manual+why; observer-sovereignty resolver; ver-traza audit panel; `review_requested` flag + kingdom-routed queue; consensus hardening R1–R3 (machine source preserved, confidence capped end-to-end, source-trust queue ordering); downloads-by-capability chooser (power panel → Advanced)  _(✓ done — PRs #1142–#1146, 2026-05-17; runbook `docs/runbooks/observe-progressive-card.md`)_
 
 ## v1.1 — UX polish (post-launch brainstorm) — shipped (mostly)
 

--- a/scripts/e2e-for-changed.sh
+++ b/scripts/e2e-for-changed.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# e2e-for-changed.sh — given the files changed on this branch, print the
+# e2e specs that reference the DOM ids / data-attributes they touch.
+#
+# Why: a UI change that relocates or hides a DOM region can pass
+# `tsc` + `vitest` + `npm run build` + `smoke.spec.ts` and still break
+# the spec that targets that exact surface (e.g. #1127 relocated the
+# identifier registry behind a <details> and only `ai-tab.spec.ts`
+# caught it, in CI, after the round-trip). This makes "run the spec for
+# the surface you changed" mechanical instead of memory-dependent.
+#
+# Usage:  bash scripts/e2e-for-changed.sh [base-ref]   (default origin/main)
+# Output: a suggested `npx playwright test …` line, or a note that
+#         smoke coverage is sufficient. Advisory — never fails the build.
+#
+# Bash 3.2 compatible (macOS system bash): no mapfile / assoc arrays.
+
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+# Changed source files on this branch (added/modified, not deleted).
+CHANGED="$(git diff --name-only --diff-filter=d "${BASE}...HEAD" -- \
+  'src/*.astro' 'src/**/*.astro' 'src/**/*.ts' 'src/**/*.tsx' 2>/dev/null || true)"
+
+if [ -z "$CHANGED" ]; then
+  echo "e2e-for-changed: no .astro/.ts UI changes vs ${BASE} — smoke coverage is sufficient."
+  exit 0
+fi
+
+# Collect DOM tokens the changed files define/use: id="x",
+# getElementById('x'), querySelector('#x' / '[data-x]'), data-* names.
+tokens="$(echo "$CHANGED" | tr '\n' '\0' | xargs -0 grep -hoE \
+  'id="[a-zA-Z0-9_-]+"|getElementById\(['"'"'"'"'"'][a-zA-Z0-9_-]+|data-[a-z-]+|#[a-zA-Z][a-zA-Z0-9_-]+' \
+  2>/dev/null \
+  | sed -E 's/^id="//; s/^getElementById\(.//; s/^#//' \
+  | tr -d "\"'" \
+  | sort -u | sed '/^$/d' | grep -vE '^data-?$' || true)"
+
+if [ -z "$tokens" ]; then
+  echo "e2e-for-changed: no DOM ids/data-attrs in the diff — smoke coverage is sufficient."
+  exit 0
+fi
+
+# Which e2e specs reference any of those tokens?
+specs=""
+while IFS= read -r tok; do
+  [ -z "$tok" ] && continue
+  hits="$(grep -rl --include='*.spec.ts' -F "$tok" tests/e2e 2>/dev/null || true)"
+  [ -n "$hits" ] && specs="${specs}${hits}"$'\n'
+done <<EOF
+$tokens
+EOF
+
+specs="$(printf '%s' "$specs" | sort -u | sed '/^$/d')"
+
+if [ -z "$specs" ]; then
+  echo "e2e-for-changed: changed DOM tokens match no dedicated spec — verify smoke.spec.ts + the journey covering this page."
+  exit 0
+fi
+
+echo "e2e-for-changed: the changed DOM surface is referenced by these specs — run them before pushing:"
+echo
+echo "  npx playwright test $(printf '%s ' $specs)--project=chromium"
+echo
+echo "(Build dist with .env.local present + serve it, or /profile/* will fail"
+echo " locally with 'supabaseUrl is required' and mask real regressions.)"

--- a/src/lib/identifier-card-html.ts
+++ b/src/lib/identifier-card-html.ts
@@ -20,6 +20,23 @@ import type { Identifier } from './identifiers/types';
 import type { ModelCacheStatus } from './local-ai';
 import type { CardState } from './identifier-state';
 
+/**
+ * Registry plugin id → DOM id prefix for its download/delete/status/
+ * progress controls. The single source of truth for the
+ * `${prefix}-download` contract. `DownloadChooser`'s `prefixByTarget`
+ * map drives the curated chooser's clicks against these ids; the
+ * `tests/unit/download-chooser-prefix-sync.test.ts` guard fails the
+ * build if the two ever drift (a silent no-op otherwise — #1127).
+ */
+export const ON_DEVICE_DL_PREFIX: Readonly<Record<string, string>> = {
+  webllm_phi35_vision: 'vision',
+  onnx_gemma4_vision: 'gemma-vision',
+  birdnet_lite: 'birdnet',
+  onnx_efficientnet_lite0: 'onnx-base',
+  camera_trap_megadetector: 'megadetector',
+  speciesnet_distilled: 'speciesnet',
+};
+
 export interface ActiveSponsorship {
   sponsor_handle: string;
   daily_limit: number | null;
@@ -122,15 +139,7 @@ function pillFor(state: CardState, t: Strings): string {
 
 function actionsFor(p: PluginCardProps, t: Strings): string {
   const id = escape(p.plugin.id);
-  const onDeviceIds: Record<string, string> = {
-    webllm_phi35_vision: 'vision',
-    onnx_gemma4_vision: 'gemma-vision',
-    birdnet_lite: 'birdnet',
-    onnx_efficientnet_lite0: 'onnx-base',
-    camera_trap_megadetector: 'megadetector',
-    speciesnet_distilled: 'speciesnet',
-  };
-  const dlPrefix = onDeviceIds[p.plugin.id];
+  const dlPrefix = ON_DEVICE_DL_PREFIX[p.plugin.id];
 
   const primaryBtn = (label: string, dataAttr: string, value: string) =>
     `<button type="button" ${escape(dataAttr)}="${escape(value)}" class="rounded-lg bg-emerald-700 hover:bg-emerald-800 px-3 py-1.5 text-xs font-semibold text-white">${label}</button>`;

--- a/tests/e2e/observe-card.spec.ts
+++ b/tests/e2e/observe-card.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Progressive observation card — DOM wiring smoke (#1129 follow-up).
+ *
+ * The pure render/state logic is unit-tested
+ * (observe-card-render/state/vm/*.test.ts). What unit tests can't cover
+ * is the ObserveView2 client `<script>` wiring: the `rastrum:card-vm`
+ * listener rendering into `#obs2-card-v2`, the action buttons, and the
+ * "ver traza" disclosure toggle. This drives that wiring deterministically
+ * by dispatching a synthetic CardViewModel — no Supabase, no media, no
+ * pipeline (mocking is cheaper than a real cascade per docs/qa-policy.md).
+ */
+import { test, expect } from '@playwright/test';
+
+const S1B_VM = {
+  state: 'S1b',
+  sovereignty: 'none',
+  reviewRequested: false,
+  headline: 'Quercus rugosa',
+  sourceLabel: 'onnx_efficientnet_lite0 · 31%',
+  trace: [
+    {
+      source: 'onnx_efficientnet_lite0',
+      where: 'device',
+      scientificName: 'Quercus rugosa',
+      confidence: 0.31,
+      outcome: 'primary',
+      capped: true,
+      createdAt: '2026-05-17T00:00:00.000Z',
+    },
+  ],
+};
+
+for (const path of ['/en/observe/', '/es/observar/']) {
+  test(`progressive card renders + ver-traza toggles on ${path}`, async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+    // The card lives inside the post-form (hidden until the pipeline
+    // finishes). Reveal it, then drive the seam the pipeline uses.
+    await page.evaluate((vm) => {
+      document.getElementById('obs2-post-form')?.classList.remove('hidden');
+      document.dispatchEvent(new CustomEvent('rastrum:card-vm', { detail: vm }));
+    }, S1B_VM);
+
+    const card = page.locator('#obs2-card-v2 [data-card-state="S1b"]');
+    await expect(card).toBeVisible();
+
+    // S1b exposes the three observer actions.
+    await expect(page.locator('#obs2-card-v2 [data-card-action="affirm"]')).toBeVisible();
+    await expect(page.locator('#obs2-card-v2 [data-card-action="other"]')).toBeVisible();
+    await expect(page.locator('#obs2-card-v2 [data-card-action="review"]')).toBeVisible();
+
+    // "ver traza" is collapsed by default, opens on click.
+    const panel = page.locator('#obs2-card-v2 [data-card-trace-panel]');
+    await expect(panel).toBeHidden();
+    await page.locator('#obs2-card-v2 [data-card-trace]').first().click();
+    await expect(panel).toBeVisible();
+    // Capped on-device source is honestly flagged in the trace.
+    await expect(panel).toContainText('onnx_efficientnet_lite0');
+
+    expect(errors, `pageerror on ${path}`).toEqual([]);
+  });
+}

--- a/tests/unit/download-chooser-prefix-sync.test.ts
+++ b/tests/unit/download-chooser-prefix-sync.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #1127 hardening guard.
+ *
+ * `DownloadChooser.astro`'s "Download selected" clicks the EXISTING
+ * registry download control by id (`#${prefix}-download`). The prefix
+ * map lives inline in the Astro <script>; the authoritative
+ * registry-id → prefix contract is `ON_DEVICE_DL_PREFIX` in
+ * `identifier-card-html.ts` (plus `pmtiles` for the offline-map
+ * local-data card). If the two ever drift, the chooser silently
+ * no-ops (it's intentionally fail-soft), so a human would never see
+ * an error — only "nothing downloaded". This test fails the build
+ * instead.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { ON_DEVICE_DL_PREFIX } from '../../src/lib/identifier-card-html';
+import { CAPABILITY_CATALOG } from '../../src/lib/download-capabilities';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const chooserSrc = readFileSync(
+  resolve(here, '../../src/components/DownloadChooser.astro'),
+  'utf8',
+);
+
+/** Pull the `prefixByTarget` object literal out of the .astro <script> as a plain map. */
+function parsePrefixByTarget(src: string): Record<string, string> {
+  const m = src.match(/prefixByTarget[^=]*=\s*\{([\s\S]*?)\}/);
+  if (!m) throw new Error('prefixByTarget literal not found in DownloadChooser.astro');
+  const map: Record<string, string> = {};
+  for (const pair of m[1].matchAll(/['"]?([\w-]+)['"]?\s*:\s*['"]([\w-]+)['"]/g)) {
+    map[pair[1]] = pair[2];
+  }
+  return map;
+}
+
+describe('DownloadChooser prefix map ↔ identifier-card-html contract', () => {
+  const prefixByTarget = parsePrefixByTarget(chooserSrc);
+
+  it('extracts a non-empty prefix map from the chooser', () => {
+    expect(Object.keys(prefixByTarget).length).toBeGreaterThan(0);
+  });
+
+  it('every on-device target prefix matches ON_DEVICE_DL_PREFIX exactly', () => {
+    for (const [target, prefix] of Object.entries(prefixByTarget)) {
+      if (target === 'offline-map') continue; // local-data card, asserted below
+      expect(
+        ON_DEVICE_DL_PREFIX[target],
+        `prefixByTarget['${target}']='${prefix}' but identifier-card-html maps it to '${ON_DEVICE_DL_PREFIX[target]}'`,
+      ).toBe(prefix);
+    }
+  });
+
+  it("offline-map routes to the pmtiles local-data card", () => {
+    expect(prefixByTarget['offline-map']).toBe('pmtiles');
+  });
+
+  it('every catalog item with an on-device/offline target is covered by the chooser map', () => {
+    for (const item of CAPABILITY_CATALOG) {
+      // The chooser only needs a prefix for items it can actually trigger.
+      if (item.target === 'offline-map' || item.target in ON_DEVICE_DL_PREFIX) {
+        expect(
+          prefixByTarget[item.target],
+          `catalog item '${item.id}' (target '${item.target}') has no entry in DownloadChooser.prefixByTarget`,
+        ).toBeTruthy();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

The four close-out follow-ups recommended after epic #1129 merged.

1. **Doc/roadmap sync** — `docs/runbooks/observe-progressive-card.md` (state machine, sovereignty + R1–R3 consensus invariants, `review_requested` queue routing, downloads chooser) + 00-index row; `progress.json` v1.0.x item + `tasks.json` entry + `tasks.md` narrative; `CLAUDE.md` doc-sync stamp → 2026-05-17 + a new "Observe AI progressive card" conventions subsection. The 6-PR epic was previously invisible to `progress.json` (the roadmap source of truth per CLAUDE.md).
2. **Coupling guard** — `tests/unit/download-chooser-prefix-sync.test.ts`: `identifier-card-html.ts`'s registry-id→prefix map is now exported (`ON_DEVICE_DL_PREFIX`, behavior-identical refactor); the test imports it and parses `DownloadChooser.astro`'s `prefixByTarget`, failing the build if they drift. The chooser is intentionally fail-soft, so drift would otherwise be a silent "nothing downloaded".
3. **Card e2e** — `tests/e2e/observe-card.spec.ts`: drives the `rastrum:card-vm` seam with a synthetic CardViewModel (no Supabase/media/pipeline); asserts the card renders, S1b exposes affirm/other/review, and "ver traza" toggles the trace panel + capped flag. Closes the e2e gap that let #1146 ship before CI caught it.
4. **`scripts/e2e-for-changed.sh`** — maps a branch diff's DOM ids/data-attrs → the e2e specs referencing them; prints the `npx playwright` line to run pre-push. Validated: against the epic diff it surfaces `ai-tab.spec.ts` + `observe-card.spec.ts` (exactly what would have prevented the #1146 round-trip). Bash 3.2 compatible; advisory.

## Verification (controller-independent)

- `tsc --noEmit` clean · `vitest run` **2716/2716** (incl. new guard 4/4) · `build` 255 pages 0 errors.
- `observe-card.spec.ts` **2/2** vs served `dist` (EN + ES, deterministic, Supabase-free).
- `e2e-for-changed.sh` smoke-run vs `origin/main~8` correctly lists `ai-tab` + `observe-card` + `settings` + `journey-photo-id-cascade`.
- `progress.json` / `tasks.json` valid JSON, minimal diffs (6 / 37 lines, no reformat).
- `identifier-card-html.ts` refactor is a pure extract — `actionsFor` output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)