### PR TITLE
fix(settings): SeasonalThemePicker TDZ ReferenceError on Preferences (closes #1149)

### DIFF
--- a/src/components/SeasonalThemePicker.astro
+++ b/src/components/SeasonalThemePicker.astro
@@ -115,6 +115,11 @@ const communityEmptyLabel = lang === 'es'
   );
   const effectiveLabel = document.getElementById('season-effective-label');
 
+  // Declared before paint()'s first call below — paint() reads this in its
+  // community-deselect loop, so it must be initialized before module-eval
+  // reaches `paint(readStoredChoice())` (TDZ guard, issue #1149).
+  let communityButtons: HTMLButtonElement[] = [];
+
   function effectiveText(choice: SeasonalThemeChoice): string {
     if (choice !== 'auto') return '';
     const auto = pickSeasonalTheme();
@@ -157,7 +162,6 @@ const communityEmptyLabel = lang === 'es'
 
   const communityList = document.getElementById('community-themes-list');
   const communityEmpty = document.getElementById('community-themes-empty');
-  let communityButtons: HTMLButtonElement[] = [];
 
   function applyCommunityTheme(theme: CommunityTheme) {
     // Write the slug as the stored choice (prefixed) so it survives reload


### PR DESCRIPTION
## Bug

`/{es,en}/perfil/ajustes/preferences` threw on load: `ReferenceError: Cannot access 's' before initialization` in `SeasonalThemePicker`. `paint(readStoredChoice())` executes at module-eval and `paint()` reads `communityButtons`, but `let communityButtons` was declared *after* that call → temporal dead zone. Minified names (`communityButtons`→`s`, `paint`→`u`) match the issue trace exactly.

## Fix

Move the single `let communityButtons: HTMLButtonElement[] = [];` declaration above `paint`'s first invocation. One binding moved + a `why` comment; no behavior change (still `[]`-initialized, still reassigned in `renderCommunityThemes`).

Reviewer independently traced the full module eval order: TDZ eliminated, **no second latent use-before-init**, behavior preserved, no dead code.

No unit test added — it's a bundler/browser eval-order defect not reproducible by tsc/vitest/astro-build (none run the IIFE in an engine); forcing a fake test would prove nothing. Verified by source eval-order proof + rebuilt-bundle inspection (new artifact hash, `s` initialized before `u` defined).

Frontend-only. tsc clean · 2716 vitest · 255-page build. Surfaced by the 2026-05-17 journey-catalog sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)