### PR TITLE
fix(community): donate page undefined title + bare labels (closes #1148)

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1756,7 +1756,21 @@
       "page_next": "Next",
       "error_cap_below_used": "Total cap cannot be lower than already-used calls ({0}).",
       "error_generic": "Could not save changes."
-    }
+    },
+    "donate_title": "Donate to a platform pool",
+    "donate_subtitle": "Sponsor AI identifications for the whole community by donating calls from one of your validated credentials to an active pool.",
+    "donate_pool_label": "Pool",
+    "donate_model": "Model",
+    "donate_capacity": "Capacity",
+    "donate_calls_label": "Calls to donate",
+    "donate_calls_hint": "Between 10 and 10,000 identification calls.",
+    "donate_credential_label": "Credential to charge",
+    "donate_confirm": "Donate",
+    "donate_success": "Thank you! Your donation has been added to the pool.",
+    "donate_error": "Could not complete the donation. Please try again.",
+    "donate_no_pools": "There are no active pools accepting donations right now.",
+    "donate_no_credentials": "You need a validated credential before you can donate. Add one in the sponsoring console.",
+    "donate_sign_in": "Sign in to donate calls to a platform pool."
   },
   "ai_personal_credential": {
     "toggle_label": "Use for my own identifications",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1756,7 +1756,21 @@
       "page_next": "Siguiente",
       "error_cap_below_used": "El cap total no puede ser menor a las llamadas ya usadas ({0}).",
       "error_generic": "No se pudieron guardar los cambios."
-    }
+    },
+    "donate_title": "Donar a un fondo de la plataforma",
+    "donate_subtitle": "Patrocina identificaciones con IA para toda la comunidad donando llamadas de una de tus credenciales validadas a un fondo activo.",
+    "donate_pool_label": "Fondo",
+    "donate_model": "Modelo",
+    "donate_capacity": "Capacidad",
+    "donate_calls_label": "Llamadas a donar",
+    "donate_calls_hint": "Entre 10 y 10,000 llamadas de identificación.",
+    "donate_credential_label": "Credencial a cargar",
+    "donate_confirm": "Donar",
+    "donate_success": "¡Gracias! Tu donación se ha añadido al fondo.",
+    "donate_error": "No se pudo completar la donación. Inténtalo de nuevo.",
+    "donate_no_pools": "Ahora mismo no hay fondos activos que acepten donaciones.",
+    "donate_no_credentials": "Necesitas una credencial validada antes de poder donar. Añade una en la consola de patrocinio.",
+    "donate_sign_in": "Inicia sesión para donar llamadas a un fondo de la plataforma."
   },
   "ai_personal_credential": {
     "toggle_label": "Usar para mis propias identificaciones",

--- a/src/pages/en/community/donate.astro
+++ b/src/pages/en/community/donate.astro
@@ -5,9 +5,11 @@ import { t } from '../../../i18n/utils';
 
 const lang = 'en';
 const tr = t(lang);
-const sp = (tr as unknown as { sponsoring: { donate_title: string; donate_subtitle: string } }).sponsoring;
+const sp = (tr as unknown as { sponsoring: { donate_title?: string; donate_subtitle?: string } }).sponsoring;
+const pageTitle = sp.donate_title ?? 'Donate to a platform pool';
+const pageDesc = sp.donate_subtitle ?? 'Sponsor AI identifications for the whole community.';
 ---
 
-<BaseLayout title={`${sp.donate_title} — Rastrum`} description={sp.donate_subtitle} lang={lang}>
+<BaseLayout title={`${pageTitle} — Rastrum`} description={pageDesc} lang={lang}>
   <PoolDonateView lang={lang} />
 </BaseLayout>

--- a/src/pages/es/comunidad/donar.astro
+++ b/src/pages/es/comunidad/donar.astro
@@ -5,9 +5,11 @@ import { t } from '../../../i18n/utils';
 
 const lang = 'es';
 const tr = t(lang);
-const sp = (tr as unknown as { sponsoring: { donate_title: string; donate_subtitle: string } }).sponsoring;
+const sp = (tr as unknown as { sponsoring: { donate_title?: string; donate_subtitle?: string } }).sponsoring;
+const pageTitle = sp.donate_title ?? 'Donar a un fondo de la plataforma';
+const pageDesc = sp.donate_subtitle ?? 'Patrocina identificaciones con IA para toda la comunidad.';
 ---
 
-<BaseLayout title={`${sp.donate_title} — Rastrum`} description={sp.donate_subtitle} lang={lang}>
+<BaseLayout title={`${pageTitle} — Rastrum`} description={pageDesc} lang={lang}>
   <PoolDonateView lang={lang} />
 </BaseLayout>


### PR DESCRIPTION
## Bug

`/comunidad/donar` rendered `<title>undefined — Rastrum>` and pool rows as bare `: test-oai` / `: gpt-5.4-mini` (no label). No console error — silent render defect (the class the journey-catalog sweep exists to catch).

## Root cause

The 14 `sponsoring.donate_*` i18n keys that the donate pages + `PoolDonateView` consume were **never added** to `en.json`/`es.json`. → `sp.donate_title` undefined (title) and empty `data-*-label` attributes (bare-`: value` rows).

## Fix

- Added all 14 keys to **both** locale files, EN/ES 1:1, inside the existing `sponsoring` namespace.
- Static localized **title fallback** in both page frontmatters so `undefined` can never reach `<title>` again (defensive even though keys now exist).
- `PoolDonateView.astro` unchanged — its binding was already correct.

Reviewer verified: exact consumed-key coverage (no missing/dead), byte-identical EN/ES key names, single-namespace nesting, genuine Spanish (not copied EN), type-sound casts, no scope creep.

Frontend/i18n only. tsc clean · 2716 vitest (parity intact) · build clean · built titles correct (no "undefined"). Surfaced by the 2026-05-17 journey-catalog sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)