### PR TITLE
feat(console): actor-scoped bulk-ack of function errors (closes #1137)

### DIFF
--- a/src/components/ConsoleErrorsView.astro
+++ b/src/components/ConsoleErrorsView.astro
@@ -575,7 +575,7 @@ const eFilterByCode = (errorsNs?.filterByCode as string) ?? 'Filter by code';
     document.getElementById('errors-auto-refresh')?.addEventListener('change', (ev) => {
       setAutoRefresh((ev.target as HTMLInputElement).checked);
     });
-    document.getElementById('errors-bulk-ack')?.addEventListener('click', (ev) => {
+    document.getElementById('errors-bulk-ack')?.addEventListener('click', async (ev) => {
       // Hard-stop any chance of a native form submit/reset eating the
       // click (the #1133 symptom: no slide-over + filters reset to
       // "— any —"). preventDefault + stopPropagation keep the form
@@ -589,14 +589,23 @@ const eFilterByCode = (errorsNs?.filterByCode as string) ?? 'Filter by code';
       const summary = document.getElementById('error-ack-bulk-summary');
       const notesEl = document.getElementById('error-ack-bulk-notes') as HTMLTextAreaElement | null;
       if (notesEl) notesEl.value = '';
+      // Resolve the free-text actor input (uuid OR username) to the
+      // function_errors.actor_id uuid exactly as the table query does
+      // (loadRows → resolveActorId). Both the summary and the payload
+      // use this resolved id so the slide-over scope matches what the
+      // server-side bulk handler will actually narrow by.
+      const actorId = f.actor ? await resolveActorId(f.actor) : undefined;
       const pieces: string[] = [];
       if (f.fn) pieces.push(`fn=${f.fn}`);
       if (f.code) pieces.push(`code=${f.code}`);
       if (f.from) pieces.push(`from=${f.from}`);
       if (f.to) pieces.push(`to=${f.to}`);
-      // actor is intentionally omitted — ErrorAcknowledgeBulkFilters has no
-      // actorId; the bulk call is NOT actor-scoped, so showing actor here
-      // would misrepresent the real server-side scope.
+      // actor is now forwarded to ErrorAcknowledgeBulkFilters.actorId and
+      // scoped server-side (handler .eq('actor_id', …)), so showing it
+      // here accurately reflects the real bulk scope (#1137). When the
+      // free-text input can't be resolved to a uuid the payload carries
+      // no actor scope, so we say so rather than misrepresent it.
+      if (f.actor) pieces.push(actorId ? `actor=${actorId}` : `actor=${f.actor} (unresolved — NOT scoped)`);
       pieces.push(`state=${stateUnackOnly ? 'unack' : 'all'}`);
       if (summary) summary.textContent = pieces.length ? `Filters: ${pieces.join(' · ')}` : 'No filters set — will scope to ALL unacknowledged rows.';
       document.dispatchEvent(new CustomEvent('console:slideover-open', {
@@ -604,7 +613,7 @@ const eFilterByCode = (errorsNs?.filterByCode as string) ?? 'Filter by code';
           id: 'console-slideover-error-ack-bulk',
           title: 'Acknowledge all matching errors',
           action: 'error.acknowledge_bulk',
-          payload: { filters: { functionName: f.fn, code: f.code, from: f.from, to: f.to } },
+          payload: { filters: { functionName: f.fn, code: f.code, from: f.from, to: f.to, actorId } },
         },
       }));
     });

--- a/src/lib/admin-client.ts
+++ b/src/lib/admin-client.ts
@@ -107,6 +107,7 @@ export interface ErrorAcknowledgeBulkFilters {
   code?: string;
   from?: string;
   to?: string;
+  actorId?: string;
 }
 interface ErrorAcknowledgeBulkPayload {
   filters: ErrorAcknowledgeBulkFilters;

--- a/supabase/functions/admin/handlers/error-acknowledge-bulk.ts
+++ b/supabase/functions/admin/handlers/error-acknowledge-bulk.ts
@@ -6,6 +6,7 @@ const FiltersSchema = z.object({
   code: z.string().max(120).optional(),
   from: z.string().datetime().optional(),
   to: z.string().datetime().optional(),
+  actorId: z.string().uuid().optional(),
 });
 
 const Payload = z.object({
@@ -46,6 +47,9 @@ export const errorAcknowledgeBulkHandler: ActionHandler<Payload> = {
     if (filters.to) {
       candidateQuery = candidateQuery.lte('created_at', filters.to);
     }
+    if (filters.actorId) {
+      candidateQuery = candidateQuery.eq('actor_id', filters.actorId);
+    }
 
     const { data: candidates, error: selectErr } = await candidateQuery;
     if (selectErr) throw new Error(`error.acknowledge_bulk select: ${selectErr.message}`);
@@ -60,7 +64,7 @@ export const errorAcknowledgeBulkHandler: ActionHandler<Payload> = {
       };
     }
 
-    const { error: updateErr, count } = await admin
+    let updateQuery = admin
       .from('function_errors')
       .update({
         acknowledged_at: acknowledgedAt,
@@ -69,6 +73,11 @@ export const errorAcknowledgeBulkHandler: ActionHandler<Payload> = {
       }, { count: 'exact' })
       .in('id', ids)
       .is('acknowledged_at', null);
+    if (filters.actorId) {
+      updateQuery = updateQuery.eq('actor_id', filters.actorId);
+    }
+
+    const { error: updateErr, count } = await updateQuery;
 
     if (updateErr) throw new Error(`error.acknowledge_bulk update: ${updateErr.message}`);
 


### PR DESCRIPTION
## Why

The #1133 fix had to **omit** actor from the bulk-ack confirmation summary because `ErrorAcknowledgeBulkFilters` had no `actorId` and the admin EF couldn't scope a bulk acknowledge by actor (showing it would have misrepresented scope → over-acknowledge risk). This closes that capability gap end-to-end.

## Changes (3 files)

- **`admin-client.ts`** — `ErrorAcknowledgeBulkFilters` += `actorId?: string` (round-trips via the result type).
- **EF handler `error-acknowledge-bulk.ts`** — Zod `actorId: z.string().uuid().optional()` (rejected at the dispatcher boundary if non-uuid); conditional `.eq('actor_id', actorId)` applied to **both** the count/preview SELECT and the UPDATE (identical scope, strictly tighter, never broadened); absent-actorId behavior byte-identical; `.in(ids)` / `.is(acknowledged_at,null)` / `count:'exact'` invariants intact; admin-role gate + `admin_audit` byte-unchanged.
- **`ConsoleErrorsView.astro`** — bulk path reuses the table's existing `resolveActorId()` (free-text→uuid, not reinvented), forwards a resolved uuid (or nothing), and the summary honestly labels an unresolvable actor `(unresolved — NOT scoped)`. The #1133 honesty invariant is **preserved**.

Single-row ack untouched. No schema/RLS/secret. Reviewer did a deep privileged-path pass: SELECT vs UPDATE scoping verified identical, Zod enforced before any DB op, column (`function_errors.actor_id` uuid) cross-checked vs schema + single-row handler + table query, no scope creep.

## ⚠️ Deploy side-effect

Per CLAUDE.md PR #62, merging this auto-redeploys **only the `admin` Edge Function** (changed file under `supabase/functions/admin/`). No new env vars, secrets, or schema/migration.

## Verification

tsc clean · 2716 vitest · build clean. Surfaced from the #1133 fix; completes the tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)