### PR TITLE
fix(share-obs): detect broken hero image before Ask-my-AI fetch

### DIFF
--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -629,7 +629,9 @@ const lang: 'en' | 'es' = 'en';
           const noResultLabel = askAiBtn.dataset.labelNoResult ?? 'AI could not identify.';
 
           const heroImg = document.querySelector<HTMLImageElement>('[data-photo-hero] img');
-          if (!heroImg?.src) {
+          // Guard: no src, or image failed to load (broken img — naturalWidth === 0
+          // when the network request errored, e.g. ERR Failed to fetch from media CDN).
+          if (!heroImg?.src || (heroImg.complete && heroImg.naturalWidth === 0)) {
             askAiBtn.textContent = noPhotoLabel;
             setTimeout(() => { askAiBtn.textContent = idleLabel; }, 3000);
             return;

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -629,8 +629,11 @@ const lang: 'en' | 'es' = 'en';
           const noResultLabel = askAiBtn.dataset.labelNoResult ?? 'AI could not identify.';
 
           const heroImg = document.querySelector<HTMLImageElement>('[data-photo-hero] img');
-          // Guard: no src, or image failed to load (broken img — naturalWidth === 0
-          // when the network request errored, e.g. ERR Failed to fetch from media CDN).
+          // Guard: no src, or image definitively failed to load.
+          // We only treat it as broken when complete===true AND naturalWidth===0,
+          // which means the browser finished attempting to load and got nothing.
+          // If complete===false the image is still in-flight (slow connection) —
+          // let the fetch() attempt proceed; it may succeed or surface a real error.
           if (!heroImg?.src || (heroImg.complete && heroImg.naturalWidth === 0)) {
             askAiBtn.textContent = noPhotoLabel;
             setTimeout(() => { askAiBtn.textContent = idleLabel; }, 3000);


### PR DESCRIPTION
## Problem

When the observation photo fails to load from `media.rastrum.org` (network error / CDN hiccup), `heroImg.src` is still populated with the URL — but `heroImg.naturalWidth === 0`, which is the browser's standard signal for a broken image.

The previous guard only checked `!heroImg?.src`, so the subsequent `fetch(heroImg.src)` would throw a network error and fall into the generic `catch` block, showing **"Identification failed"** instead of the more accurate **"No photo available."**

Bug reported via in-app feedback:
- URL: `/share/obs/?id=3c941c81-72b8-490c-a0db-d514095290e6`
- Failed request: `GET https://media.rastrum.org/observations/3c941c81.../ffc94af4....jpg → ERR Failed to fetch`
- Device: Android Chrome 148

## Fix

Extend the hero image guard in `wireCommunityIds` to also check `heroImg.complete && heroImg.naturalWidth === 0` (standard broken-image detection), and show the existing `noPhotoLabel` ("No photo available.") early-return path instead of letting the fetch fail generically.

```diff
- if (!heroImg?.src) {
+ // Guard: no src, or image failed to load (broken img — naturalWidth === 0
+ // when the network request errored, e.g. ERR Failed to fetch from media CDN).
+ if (!heroImg?.src || (heroImg.complete && heroImg.naturalWidth === 0)) {
```

## Testing

- Open any observation detail page where the media CDN image is unavailable (can simulate by blocking `media.rastrum.org` in DevTools Network → Block request URL)
- Click "Ask my AI"
- Should show "No photo available." (3s) then reset, instead of "Identification failed"