### PR TITLE
feat(taxon-hints): add Reptile, Amphibian, Fish, Arachnid chips

### DIFF
--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -34,12 +34,16 @@ const initialSubmitLabel = identifyOnly ? submitIdentifyLabel : submitFullLabel;
 // taxon-hint chip strings (extracted to typed locals for the JSX)
 const taxonHintStrings = (tr.observe as unknown as { taxon_hint?: Record<string, string> }).taxon_hint ?? {};
 const taxonHintLabel = taxonHintStrings.label ?? (isEs ? '¿Qué viste?' : 'What did you see?');
-const taxonHintPlant   = taxonHintStrings.plant   ?? (isEs ? 'Planta'   : 'Plant');
-const taxonHintBird    = taxonHintStrings.bird    ?? (isEs ? 'Ave'      : 'Bird');
-const taxonHintMammal  = taxonHintStrings.mammal  ?? (isEs ? 'Mamífero' : 'Mammal');
-const taxonHintInsect  = taxonHintStrings.insect  ?? (isEs ? 'Insecto'  : 'Insect');
-const taxonHintFungus  = taxonHintStrings.fungus  ?? (isEs ? 'Hongo'    : 'Fungus');
-const taxonHintClear   = taxonHintStrings.clear   ?? (isEs ? 'Quitar pista' : 'Clear hint');
+const taxonHintPlant     = taxonHintStrings.plant     ?? (isEs ? 'Planta'    : 'Plant');
+const taxonHintBird      = taxonHintStrings.bird      ?? (isEs ? 'Ave'       : 'Bird');
+const taxonHintMammal    = taxonHintStrings.mammal    ?? (isEs ? 'Mamífero'  : 'Mammal');
+const taxonHintInsect    = taxonHintStrings.insect    ?? (isEs ? 'Insecto'   : 'Insect');
+const taxonHintFungus    = taxonHintStrings.fungus    ?? (isEs ? 'Hongo'     : 'Fungus');
+const taxonHintReptile   = taxonHintStrings.reptile   ?? (isEs ? 'Reptil'    : 'Reptile');
+const taxonHintAmphibian = taxonHintStrings.amphibian ?? (isEs ? 'Anfibio'   : 'Amphibian');
+const taxonHintFish      = taxonHintStrings.fish      ?? (isEs ? 'Pez'       : 'Fish');
+const taxonHintArachnid  = taxonHintStrings.arachnid  ?? (isEs ? 'Arácnido'  : 'Arachnid');
+const taxonHintClear     = taxonHintStrings.clear     ?? (isEs ? 'Quitar pista' : 'Clear hint');
 const observeStringsForLabels = tr.observe as unknown as Record<string, string>;
 const shareLabel = observeStringsForLabels.share ?? (isEs ? 'Compartir' : 'Share');
 const shareUnavailableHint = observeStringsForLabels.share_unavailable_hint ?? (isEs ? 'Guarda primero la observación para compartirla.' : 'Save the observation first to share.');
@@ -234,7 +238,11 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
           <button type="button" data-hint="Plantae" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🌿</span> {taxonHintPlant}</button>
           <button type="button" data-hint="Animalia.Aves" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🐦</span> {taxonHintBird}</button>
           <button type="button" data-hint="Animalia.Mammalia" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🐾</span> {taxonHintMammal}</button>
+          <button type="button" data-hint="Animalia.Reptilia" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🦎</span> {taxonHintReptile}</button>
+          <button type="button" data-hint="Animalia.Amphibia" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🐸</span> {taxonHintAmphibian}</button>
           <button type="button" data-hint="Animalia.Insecta" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🐛</span> {taxonHintInsect}</button>
+          <button type="button" data-hint="Animalia.Arachnida" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🕷️</span> {taxonHintArachnid}</button>
+          <button type="button" data-hint="Animalia.Actinopterygii" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🐟</span> {taxonHintFish}</button>
           <button type="button" data-hint="Fungi" class="taxon-chip min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"><span aria-hidden="true">🍄</span> {taxonHintFungus}</button>
           <button type="button" id="taxon-hint-clear" class="hidden min-h-9 px-2.5 py-1 rounded-full text-xs font-medium border border-transparent text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-200 underline">{taxonHintClear}</button>
         </div>
@@ -1239,7 +1247,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
   // ── Taxon hint chips (ux-quick-taxon-chips) ──────────────────────────
   // Tapping a chip primes the cascade by filtering runners (e.g. 🐦 drops
   // PlantNet, prefers Phi/Claude). Default state = no hint.
-  type TaxonHint = 'Plantae' | 'Animalia.Aves' | 'Animalia.Mammalia' | 'Animalia.Insecta' | 'Fungi';
+  type TaxonHint = 'Plantae' | 'Animalia.Aves' | 'Animalia.Mammalia' | 'Animalia.Insecta' | 'Animalia.Reptilia' | 'Animalia.Amphibia' | 'Animalia.Actinopterygii' | 'Animalia.Arachnida' | 'Fungi';
   let activeTaxonHint: TaxonHint | null = null;
   const taxonChipBtns = document.querySelectorAll<HTMLButtonElement>('.taxon-chip');
   const taxonClearBtn = document.getElementById('taxon-hint-clear');

--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -69,9 +69,25 @@ const weathers = WEATHERS;
       class="obs2-taxon-chip flex items-center gap-1.5 rounded-full border border-zinc-300 dark:border-zinc-600 px-3 py-1 text-sm text-zinc-600 dark:text-zinc-400 transition-colors hover:border-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-400">
       🐾 {isEs ? 'Mamífero' : 'Mammal'}
     </button>
+    <button type="button" data-hint="Animalia.Reptilia"
+      class="obs2-taxon-chip flex items-center gap-1.5 rounded-full border border-zinc-300 dark:border-zinc-600 px-3 py-1 text-sm text-zinc-600 dark:text-zinc-400 transition-colors hover:border-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-400">
+      🦎 {isEs ? 'Reptil' : 'Reptile'}
+    </button>
+    <button type="button" data-hint="Animalia.Amphibia"
+      class="obs2-taxon-chip flex items-center gap-1.5 rounded-full border border-zinc-300 dark:border-zinc-600 px-3 py-1 text-sm text-zinc-600 dark:text-zinc-400 transition-colors hover:border-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-400">
+      🐸 {isEs ? 'Anfibio' : 'Amphibian'}
+    </button>
     <button type="button" data-hint="Animalia.Insecta"
       class="obs2-taxon-chip flex items-center gap-1.5 rounded-full border border-zinc-300 dark:border-zinc-600 px-3 py-1 text-sm text-zinc-600 dark:text-zinc-400 transition-colors hover:border-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-400">
       🐛 {isEs ? 'Insecto' : 'Insect'}
+    </button>
+    <button type="button" data-hint="Animalia.Arachnida"
+      class="obs2-taxon-chip flex items-center gap-1.5 rounded-full border border-zinc-300 dark:border-zinc-600 px-3 py-1 text-sm text-zinc-600 dark:text-zinc-400 transition-colors hover:border-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-400">
+      🕷️ {isEs ? 'Arácnido' : 'Arachnid'}
+    </button>
+    <button type="button" data-hint="Animalia.Actinopterygii"
+      class="obs2-taxon-chip flex items-center gap-1.5 rounded-full border border-zinc-300 dark:border-zinc-600 px-3 py-1 text-sm text-zinc-600 dark:text-zinc-400 transition-colors hover:border-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-400">
+      🐟 {isEs ? 'Pez' : 'Fish'}
     </button>
     <button type="button" data-hint="Fungi"
       class="obs2-taxon-chip flex items-center gap-1.5 rounded-full border border-zinc-300 dark:border-zinc-600 px-3 py-1 text-sm text-zinc-600 dark:text-zinc-400 transition-colors hover:border-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-400">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -922,6 +922,10 @@
       "mammal": "Mammal",
       "insect": "Insect",
       "fungus": "Fungus",
+      "reptile": "Reptile",
+      "amphibian": "Amphibian",
+      "fish": "Fish",
+      "arachnid": "Arachnid",
       "clear": "Clear hint"
     },
     "share": "Share",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -922,6 +922,10 @@
       "mammal": "Mamífero",
       "insect": "Insecto",
       "fungus": "Hongo",
+      "reptile": "Reptil",
+      "amphibian": "Anfibio",
+      "fish": "Pez",
+      "arachnid": "Arácnido",
       "clear": "Quitar pista"
     },
     "share": "Compartir",

--- a/src/lib/identify-cascade-client.ts
+++ b/src/lib/identify-cascade-client.ts
@@ -45,6 +45,10 @@ export type TaxonHint =
   | 'Animalia.Aves'
   | 'Animalia.Mammalia'
   | 'Animalia.Insecta'
+  | 'Animalia.Reptilia'
+  | 'Animalia.Amphibia'
+  | 'Animalia.Actinopterygii'
+  | 'Animalia.Arachnida'
   | 'Fungi';
 
 export interface RunParallelIdentifyOptions {


### PR DESCRIPTION
## Motivation

Reported by a user in Oaxaca trying to register a salamander/toad observation — there was no matching chip, leaving them with no AI routing hint for one of the most biodiverse taxa in Mexico.

## Changes

Extends the quick-taxon chip row from 5 → 9 groups:

| Emoji | ES | EN | Hint value |
|---|---|---|---|
| 🦎 | Reptil | Reptile | `Animalia.Reptilia` |
| 🐸 | Anfibio | Amphibian | `Animalia.Amphibia` |
| 🐟 | Pez | Fish | `Animalia.Actinopterygii` |
| 🕷️ | Arácnido | Arachnid | `Animalia.Arachnida` |

**Routing:** All four follow the same `Animalia.*` rule already in `filterRunnersByHint` — PlantNet is dropped (plant-only, 403s on animals), vision LLMs handle the cascade. No new routing logic needed.

## Files changed
- `identify-cascade-client.ts` — TaxonHint union extended
- `ObservationForm.astro` — new chips + strings + local type
- `ObserveView2.astro` — matching chips
- `i18n/es.json` + `i18n/en.json` — new keys: reptile, amphibian, fish, arachnid