### PR TITLE
fix(onboarding): unbreak spotlight tour (#1160)

### DIFF
--- a/docs/runbooks/00-index.md
+++ b/docs/runbooks/00-index.md
@@ -125,5 +125,6 @@ high-level system view.
 | [`cron-secret-rotation.md`](cron-secret-rotation.md) | `CRON_SECRET` rotation playbook — Vault first, then GitHub Secret, then re-run `db-apply`. |
 | [`mcp-proxy.md`](mcp-proxy.md) | `mcp.rastrum.org` Cloudflare routing for the MCP Edge Function (header + path manipulation, no Worker runtime). |
 | [`onboarding-funnel.md`](onboarding-funnel.md) | First-30-days onboarding-funnel telemetry — drop-off cliffs + retention interventions (#878). |
+| [`onboarding-patterns-audit.md`](onboarding-patterns-audit.md) | 2026-05-22 audit of the current tour against Mobbin's 1000-app onboarding study — strengths, gaps, recommended v1.2 sequencing. |
 | [`performance-audit.md`](performance-audit.md) | Cache + performance optimization workflow — `npm run analyze` bundle visualiser, Lighthouse budgets (#713). |
 | [`sw-pmtiles-verification.md`](sw-pmtiles-verification.md) | Post-deploy verification that SW pmtiles caching works in the browser (#639). |

--- a/docs/runbooks/onboarding-patterns-audit.md
+++ b/docs/runbooks/onboarding-patterns-audit.md
@@ -1,0 +1,211 @@
+# Onboarding patterns audit — Rastrum vs. Mobbin study
+
+A walkthrough of Rastrum's current onboarding against the patterns
+identified in Mobbin's onboarding study (~1000 apps). First drafted
+2026-05-22; revised 2026-05-23 after live Chrome verification revealed
+the tour itself is partially broken in production.
+
+> **Companion runbooks:** [`onboarding-events.md`](onboarding-events.md)
+> (DOM events + replay hook) and [`onboarding-funnel.md`](onboarding-funnel.md)
+> (7 milestone events).
+
+---
+
+## TL;DR
+
+The earlier draft of this doc was too generous. Verifying live against
+`rastrum.org` on 2026-05-23 (desktop 1440px, signed-in user) showed that
+**4 of the tour's 7 steps render with a broken or missing spotlight on
+the default homepage.** The accessibility layer (ARIA dialog, focus trap,
+cross-device dedupe) does work, but the spotlight feature it's wrapped
+around does not. Several "personalization" claims also collapse on
+inspection — the privacy preset writes silently, the first-obs demo is
+hardcoded `Quercus robur` for everyone, and 3 of the 7 funnel events
+have no cron firing them.
+
+The right ordering is to fix the broken foundations before adding new
+patterns from the Mobbin study.
+
+---
+
+## Current surface (verified 2026-05-23)
+
+| Piece | Where | Verified state |
+|---|---|---|
+| Spotlight tour | `src/components/OnboardingTour.astro` | 7 steps. ARIA dialog + focus trap + Esc/Tab/Arrow keys work. **4 of 4 spotlight steps fail** on default desktop homepage (see "Verified broken" below). |
+| Trigger gate | `localStorage` flag + server `users.onboarding_completed_at` | Works. Cross-device dedupe is real. |
+| Replay | `rastrum:replay-onboarding` event from `ProfileEditForm` | Works. |
+| Telemetry | `rastrum:onboarding-event` + PostHog | Tour completion / dismiss fires. **3 of 7 funnel events are not wired** — `onboarding-events` Edge Function doesn't exist on disk; `first_id_accepted`, `7d_return`, `30d_return` cited as "v1.5 follow-up" in [`onboarding-funnel.md`](onboarding-funnel.md). |
+| Pre-auth try-the-product | `/{en,es}/{identify,identificar}` → 301 to `/observe?mode=identify` | Page exists, but **the anon homepage CTA points to `/observe` (which requires auth chrome to do anything)**. Nothing surfaces `?mode=identify` to anonymous users. Half-baked: capability exists, discoverability zero. |
+| First-obs celebration | `FirstObservationCelebration.astro` | Fires after first sync. No founder note, no handwritten signature — pure system copy. |
+| Privacy preset | Tour step 5 → `persistPreset()` (line 415) | Writes `users.profile_privacy` and advances to next step. **No "your profile is ready" preview** — the choice has no visible consequence to the user. |
+| First-obs demo | Tour step 3 → `renderFirstObsDemo()` (line 467) | Renders a hardcoded card: PlantNet ✓ → Claude Haiku — → *Quercus robur* 87%. Same content for every user regardless of region, interest, or prior signal. |
+
+---
+
+## Verified broken in production (2026-05-23 Chrome inspection)
+
+Steps reproduced by dispatching `rastrum:replay-onboarding` on
+`https://rastrum.org/en/` at desktop viewport (1440px), signed-in user,
+and stepping through with `#onb-next` clicks while reading
+`#onb-spotlight-ring.getBoundingClientRect()` and the resolved target's
+state at each step.
+
+| Step | Tooltip title | Designed selector | Verified outcome |
+|---|---|---|---|
+| 0 | Welcome to Rastrum | none (center) | ✅ centered modal renders as expected |
+| 1 | Start observing | `[data-tour="fab"],[data-tour="observe-nav"]` | ❌ matches FAB (which is `display:none` ancestor `sm:hidden`); ring renders at `(-8, -8, 16, 16)`; tooltip clipped against top-left edge |
+| 2 | Identify mode | `[data-tour="fab"]` | ❌ same failure mode as step 1 (FAB hidden on desktop) |
+| 3 | See how identification works | none (center) | ✅ centered demo card renders — but content is hardcoded |
+| 4 | Explore | `[data-tour="explore-tab"],[data-tour="explore-nav"]` | ❌ **neither selector exists anywhere in the codebase** — MobileBottomBar uses `discover-tab`, Header has no `explore-nav`. Falls back to centered modal, no spotlight |
+| 5 | Privacy preset | none (center) | ✅ centered modal + 3-button picker renders. Selection has no visible effect. |
+| 6 | Settings / BYO key | `[data-tour="profile-tab"],[data-tour="avatar-btn"]` | ❌ **neither selector exists anywhere in the codebase**. Falls back to centered modal, no spotlight |
+
+### Root cause #1 — `resolveTarget` ignores visibility
+
+```ts
+// OnboardingTour.astro:290–298
+function resolveTarget(selector: string | null): Element | null {
+  if (!selector) return null;
+  const parts = selector.split(',').map(s => s.trim());
+  for (const sel of parts) {
+    const el = document.querySelector(sel);
+    if (el) return el;   // ← returns first match, even if display:none
+  }
+  return null;
+}
+```
+
+`document.querySelector('[data-tour="fab"]')` matches the FAB element
+even when its ancestor `<nav id="mobile-bottom-bar">` is `display:none`
+(the `sm:hidden` Tailwind class hides the whole bottom bar at ≥640px).
+`getBoundingClientRect()` then returns `0, 0, 0, 0`, the ring lands at
+`(-PAD, -PAD, 2·PAD, 2·PAD)` = `(-8, -8, 16, 16)`, and the tooltip
+placement logic (lines 357–365) snaps to the top-left corner because
+"prefer below the spotlight" puts y = 0 + margin.
+
+**Fix:** filter by `offsetParent !== null` before returning.
+
+```ts
+const el = document.querySelector(sel);
+if (el && (el as HTMLElement).offsetParent !== null) return el;
+```
+
+One-liner; preserves the comma-separated fallback semantics.
+
+### Root cause #2 — selectors that do not exist
+
+```bash
+$ grep -rn 'data-tour=' src --include='*.astro'
+src/components/MobileBottomBar.astro:68: data-tour="fab"
+src/components/MobileBottomBar.astro:85: data-tour="discover-tab"
+src/components/Header.astro:155:         data-tour="observe-nav"
+```
+
+The tour expects `explore-tab`, `explore-nav`, `profile-tab`, and
+`avatar-btn`. **None of these are in the codebase.** This was probably
+a chrome rename (Discover → Explore landed in #?) where the tour
+selectors weren't migrated. Steps 4 and 6 have been silently broken
+since.
+
+**Fix:** add the missing attributes to existing elements:
+- `data-tour="explore-nav"` on the Explore link in `Header.astro`
+- `data-tour="explore-tab"` on the existing Discover/Explore button in `MobileBottomBar.astro` (or rename the tour selector to `discover-tab`)
+- `data-tour="avatar-btn"` on the avatar button in `Header.astro`
+- `data-tour="profile-tab"` on the profile tab in `MobileBottomBar.astro`
+
+### Root cause #3 — no regression test for selector→DOM linkage
+
+The tour has unit tests (`tests/unit/onboarding-*.test.ts`) but none
+verify that every `target` selector in `STEPS` resolves to a visible
+element on the rendered page. An e2e test that drives the tour through
+all 7 steps on `/en/` and asserts `#onb-spotlight-ring` is positioned
+over a real element (not at `(-8, -8)`) would have caught both bugs.
+
+---
+
+## Pattern-by-pattern audit
+
+Patterns are grouped by leverage. The earlier draft had a generous
+"✅ already strong" column; live verification collapsed most of it into
+"exists but doesn't deliver the pattern".
+
+### ⚠️ Things that technically exist but don't deliver the pattern
+
+These are the items I previously called strengths. Each needs work
+before it actually counts.
+
+| Pattern | What "exists" | Why it doesn't deliver | What would close it |
+|---|---|---|---|
+| **Try before signup** (Arc) | `/identify` route 301s to `/observe?mode=identify`. Cascade runs anonymously. | Anon homepage CTA points to `/observe` (no auth needed to land there, but the obvious UX path is sign-in). Nothing on the anon homepage advertises "try the AI without an account". | Add a second hero CTA on anon homepage: "Try identifying a photo — no account needed →". Wire to `/observe?mode=identify`. ~10 minutes. |
+| **Education in context** (Cake Equity, Todoist) | Spotlight tooltips on real DOM elements (FAB, header nav). | (1) 4 of 4 spotlight steps are broken (see "Verified broken"). (2) Even when fixed, this is still the **pop-up overlay** pattern Mural REPLACED to get +10% week-1 retention. Calling it "context" was generous. | Fix the spotlights first. Then add a real "education in context": empty-state hints inside Observe / Explore / Profile when the user lands there for the first time. |
+| **Personalization with effect** (privacy preset) | Step 5 writes `users.profile_privacy` immediately on click. | The user clicks "Researcher" and the tour just advances. No "your profile shows: real name, location, streak" preview. The write is invisible. | After preset selection, render a 2-row preview of what's now public/signed-in/private. ~20 LOC. |
+| **First-obs demo within tour** (Endel / Bitepal "your plan is ready") | Tour step 3 renders a fake cascade card. | Card is hardcoded *Quercus robur — Oak 87%* (lines 60–61). Same content for a birder, a herpetologist, a marine biologist. Endel/Bitepal show YOUR data; this is a screenshot. | Use the user's `interests` (does not exist yet — see "Multi-intent picker" below) to pick a species the user actually cares about. Until interests exist, at least vary by detected device locale: oak for EN, encino for ES-MX, etc. |
+| **Funnel instrumentation** | `onboarding:signed_up`, `:first_observation`, `:first_follow`, `:first_comment` fire from client code. | Per [`onboarding-funnel.md`](onboarding-funnel.md) line 86: `first_id_accepted`, `7d_return`, `30d_return` → "cron not yet created — v1.5 follow-up". Verified: `supabase/functions/onboarding-events/` does not exist. **4 of 7 events fire; 3 silently don't.** | Create the EF + cron schedule. The SQL queries to find new accepted IDs, 7-day returns, and 30-day returns are straightforward. |
+
+### ✅ Things that genuinely work
+
+The honest list.
+
+| Pattern | Why it counts |
+|---|---|
+| Accessibility primitives | ARIA dialog + focus trap + Esc/Tab/Arrow keys + `aria-modal` + step indicator `aria-live`. This part is solid and shouldn't be touched while fixing the rest. |
+| Cross-device dedupe | `users.onboarding_completed_at` server-side flag prevents the tour from re-running after `localStorage` is cleared (incognito, ITP, new device). Most of the apps in the study didn't do this. |
+| Replay path | `rastrum:replay-onboarding` event reopens the tour from anywhere (currently wired from `ProfileEditForm`). Documented + tested. |
+| 4 funnel events that DO fire | `signed_up`, `first_observation`, `first_follow`, `first_comment` are wired correctly. |
+
+### ❌ Missing — highest expected leverage
+
+Same as before; these are net-new patterns from the study, not
+pre-existing surfaces.
+
+| Pattern | Why it matters for Rastrum | Concrete intervention |
+|---|---|---|
+| **Persistent onboarding checklist** (Mural — +10% week-1 retention) | The 4 working funnel events are already tracked. A checklist is the UI render of that data. The tour fires once; the checklist survives dismissal. | Dismissable checklist card on profile/home: 5 items mapped to existing events. Persisted via `users.onboarding_checklist_dismissed_at`. |
+| **Pre-permission priming screen** (Brilliant) | Rastrum cold-prompts 3 OS permissions (camera, GPS, notifications) + a 2.4 GB model download. Highest-friction step. | One custom screen per permission before the OS prompt. Pair notifications with existing Kairos copy. |
+| **Multi-intent goal picker** (Headspace — +10% trial conversion) | Rastrum users are heterogeneous (birders, citizen-science, casual, researchers). Currently treated identically. | 1-screen "Why are you here?" multi-select. Drives: default Explore tab, default region, default Kairos taxa. New `users.interests text[]` column. |
+| **Founder's touch at aha moment** (Airbnb, Basecamp, One Year) | Rastrum is solo-developed in MX with LatAm focus — highly on-brand. | Spanish handwritten note + signature in `FirstObservationCelebration.astro`. Two i18n strings, no schema change. |
+| **Value-before-cost on heavy ask** | The 2.4 GB WebLLM download is Rastrum's equivalent of "show value before price". | Before the download prompt: "Your offline cascade will recognize ~12,000 species. Works without internet." |
+
+---
+
+## Recommended sequencing (revised 2026-05-23)
+
+The earlier draft put a new checklist at #1. After Chrome verification,
+**fixing the broken tour comes first**. There's no point adding new
+patterns on top of a spotlight system whose 4 spotlight steps don't
+work.
+
+0. **Fix the tour itself** — tracked in [#1160](https://github.com/ArtemioPadilla/rastrum/issues/1160):
+   - `resolveTarget` visibility check (1 line)
+   - Add the 4 missing `data-tour` attributes
+   - Add e2e regression test that asserts each step's spotlight lands on a visible non-corner element
+1. **Wire the 3 missing funnel events** — create `supabase/functions/onboarding-events/` + cron schedule. Until this lands, retention analysis can't see past day 0.
+2. **Personalize what's already half-personalized** — first-obs demo picks a species from device locale; privacy preset shows a preview after selection.
+3. **Onboarding checklist** (Mural pattern).
+4. **Pre-permission priming** (Brilliant pattern).
+5. **Multi-intent picker** (Headspace pattern).
+6. **Founder note** (Airbnb / Basecamp / One Year pattern).
+7. **Anon homepage CTA for `/identify`** (Arc pattern) — currently the capability exists but is hidden.
+
+Items 0 and 1 are bug-fix work. Items 2–7 are net-new.
+
+---
+
+## What we deliberately won't copy
+
+- **Long onboarding for its own sake.** Duolingo's 60-step flow works because the product IS the flow. Rastrum's product happens after the first photo — extra screens just delay the aha.
+- **Notifications-first onboarding.** Fitness/finance apps frame onboarding around a habit contract. Rastrum's notification model is Kairos (seasonal nudges), not daily streak shaming.
+- **Personalized paywall plans.** Free product; not relevant in v1.
+
+---
+
+## References
+
+- Mobbin onboarding study (YouTube, 2026-05) — source of the patterns.
+- [`onboarding-events.md`](onboarding-events.md) — DOM event contract.
+- [`onboarding-funnel.md`](onboarding-funnel.md) — 7-event PostHog funnel
+  (note: 3 events not yet wired despite the runbook).
+- [`../specs/modules/18-onboarding.md`](../specs/modules/18-onboarding.md) — original spec.
+- CLAUDE.md *"Persuasive Tech (Fogg) — v1.1.5 conventions"* — adjacent
+  pattern guidance.

--- a/docs/superpowers/plans/2026-05-23-onboarding-tour-spotlight-fix.md
+++ b/docs/superpowers/plans/2026-05-23-onboarding-tour-spotlight-fix.md
@@ -1,0 +1,568 @@
+# Onboarding Tour Spotlight Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 4 of 7 onboarding tour spotlight steps that fail on the default homepage (issue [#1160](https://github.com/ArtemioPadilla[/](https://github.com/ArtemioPadilla)rastrum/issues/1160)) by (a) filtering hidden elements out of `resolveTarget`, (b) adding the 4 missing `data-tour` attributes to existing UI elements, and (c) adding a Playwright regression spec that catches both classes of failure.
+
+**Architecture:** Extract `OnboardingTour.astro`'s inline `resolveTarget` into a pure `src/lib/onboarding-target.ts` helper that filters elements by `offsetParent !== null` (the standard visibility check that catches all `display:none` ancestors). Unit-test the helper directly in vitest+happy-dom; add the missing `data-tour="explore-nav"`, `data-tour="explore-tab"`, `data-tour="profile-tab"`, and `data-tour="avatar-btn"` attributes to `Header.astro`, `MobileBottomBar.astro`, and `MegaMenu.astro` (via a new optional prop). Write the e2e regression spec **first** (RED) so each subsequent task moves it incrementally toward GREEN.
+
+**Tech Stack:** Astro 5 + TypeScript, vitest + happy-dom for unit tests, Playwright (chromium project) for e2e.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/lib/onboarding-target.ts` — pure helpers `isElementVisible(el)` + `resolveFirstVisible(selector, doc?)`. ~25 LOC.
+- `tests/unit/onboarding-target.test.ts` — 5 unit tests covering empty selector, visible match, hidden first / visible second fallback, all-hidden, and direct visibility check.
+- `tests/e2e/onboarding-spotlights.spec.ts` — Playwright spec asserting spotlight ring lands on a real visible element for steps 1, 2, and 4 (steps 0/3/5 are intentionally center-positioned; step 6 requires signed-in state and is covered by manual verification + the unit test of the helper).
+
+**Modify:**
+- `src/components/OnboardingTour.astro` (lines 213–298, the `<script>` block): import + use the new helper instead of the inline `resolveTarget`.
+- `src/components/MegaMenu.astro` (lines 19–74): add optional `dataTour?: string` prop, forward to the trigger button as `data-tour={dataTour}`.
+- `src/components/Header.astro`: add `dataTour="explore-nav"` to the Explore `<MegaMenu>` (line 164–172) and `data-tour="avatar-btn"` to the avatar `<button>` at line 229.
+- `src/components/MobileBottomBar.astro`: add `data-tour="explore-tab"` to the Discover tab at line 85 (keep the existing `data-tour="discover-tab"` for backward compat) and `data-tour="profile-tab"` to the Profile tab starting at line 89.
+
+---
+
+## Task 1: Add Playwright regression spec (RED)
+
+**Files:**
+- Create: `tests/e2e/onboarding-spotlights.spec.ts`
+
+This task lands the test in a red state — it will fail against the current code on `main`. Tasks 2 and 3 turn it green incrementally.
+
+- [ ] **Step 1: Write the failing e2e spec**
+
+Create `tests/e2e/onboarding-spotlights.spec.ts`:
+
+```ts
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Regression for issue #1160 — the spotlight tour was matching hidden
+ * `data-tour="fab"` ancestors on desktop and falling through to selectors
+ * that did not exist for Explore / Settings. This spec drives the
+ * `rastrum:replay-onboarding` event (which bypasses the signed-in gate
+ * via lines 682-689 of OnboardingTour.astro) and asserts that every
+ * non-center step lands the ring on a real, on-viewport element.
+ *
+ * Coverage: steps 1, 2, 4 on the chromium (desktop) project against the
+ * anon homepage. Step 6 (avatar) requires a signed-in session and is
+ * covered by manual verification + the helper's unit tests. Mobile
+ * coverage is manual — the mobile bottom bar's FAB lives inside
+ * `#mbb-authed` which only renders for signed-in users.
+ */
+test.describe('Onboarding tour spotlights', () => {
+  async function readRing(page: Page) {
+    return await page.evaluate(() => {
+      const r = document.getElementById('onb-spotlight-ring');
+      if (!r) return { found: false } as const;
+      const rect = r.getBoundingClientRect();
+      return {
+        found: true as const,
+        hidden: r.classList.contains('hidden'),
+        x: rect.x,
+        y: rect.y,
+        w: rect.width,
+        h: rect.height,
+      };
+    });
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/en/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForSelector('#onboarding-tour', { state: 'attached' });
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('rastrum:replay-onboarding'));
+    });
+    await page.waitForSelector('#onboarding-tour:not(.hidden)');
+    // Welcome step has no spotlight by design — click Start to advance to step 1.
+    await page.locator('#onb-next').click();
+  });
+
+  test('step 1 lands on a visible element, not the viewport corner', async ({ page }) => {
+    const ring = await readRing(page);
+    expect(ring.found).toBe(true);
+    if (!ring.found) return;
+    expect(ring.hidden).toBe(false);
+    // Failure mode was rect (-8, -8, 16, 16). A real target is > 24px wide
+    // (smallest button is ~44px) and positioned at positive coords.
+    expect(ring.w).toBeGreaterThan(24);
+    expect(ring.x).toBeGreaterThan(0);
+    expect(ring.y).toBeGreaterThan(0);
+  });
+
+  test('step 2 lands on a visible element', async ({ page }) => {
+    await page.locator('#onb-next').click(); // → step 2
+    const ring = await readRing(page);
+    expect(ring.found).toBe(true);
+    if (!ring.found) return;
+    expect(ring.hidden).toBe(false);
+    expect(ring.w).toBeGreaterThan(24);
+    expect(ring.x).toBeGreaterThan(0);
+    expect(ring.y).toBeGreaterThan(0);
+  });
+
+  test('step 4 (Explore) lands on a visible element', async ({ page }) => {
+    await page.locator('#onb-next').click(); // → step 2
+    await page.locator('#onb-next').click(); // → step 3 (demo, center)
+    await page.locator('#onb-next').click(); // → step 4 (Explore)
+    const ring = await readRing(page);
+    expect(ring.found).toBe(true);
+    if (!ring.found) return;
+    expect(ring.hidden).toBe(false);
+    expect(ring.w).toBeGreaterThan(24);
+    expect(ring.x).toBeGreaterThan(0);
+    expect(ring.y).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec to verify it fails on main**
+
+Run:
+
+```bash
+npx playwright test tests/e2e/onboarding-spotlights.spec.ts --project=chromium
+```
+
+Expected: 3 failures. Each test fails on either `expect(ring.w).toBeGreaterThan(24)` (steps 1, 2 — ring is `16` because FAB is hidden) or `expect(ring.hidden).toBe(false)` (step 4 — selectors don't exist, ring is hidden).
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/e2e/onboarding-spotlights.spec.ts
+git commit -m "test(onboarding): regression spec for spotlight tour failures (#1160)"
+```
+
+---
+
+## Task 2: Pure visibility helper + wire into OnboardingTour (GREEN for steps 1, 2)
+
+**Files:**
+- Create: `src/lib/onboarding-target.ts`
+- Create: `tests/unit/onboarding-target.test.ts`
+- Modify: `src/components/OnboardingTour.astro` (lines 213–214 imports, lines 290–298 function body)
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `tests/unit/onboarding-target.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { isElementVisible, resolveFirstVisible } from '../../src/lib/onboarding-target';
+
+describe('isElementVisible', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('returns true for an element rendered in the DOM', () => {
+    const el = document.createElement('div');
+    el.id = 'visible';
+    document.body.appendChild(el);
+    expect(isElementVisible(el)).toBe(true);
+  });
+
+  it('returns false when an ancestor is display:none', () => {
+    const parent = document.createElement('nav');
+    parent.style.display = 'none';
+    const child = document.createElement('a');
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    expect(isElementVisible(child)).toBe(false);
+  });
+});
+
+describe('resolveFirstVisible', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('returns null when no parts match anything in the DOM', () => {
+    expect(resolveFirstVisible('[data-tour="ghost"]')).toBeNull();
+  });
+
+  it('returns the element when a single selector matches and is visible', () => {
+    const el = document.createElement('a');
+    el.setAttribute('data-tour', 'observe-nav');
+    document.body.appendChild(el);
+    expect(resolveFirstVisible('[data-tour="observe-nav"]')).toBe(el);
+  });
+
+  it('falls through to second selector when first matches a hidden element', () => {
+    // Mirrors the production bug: FAB inside a `sm:hidden` parent on desktop.
+    const hiddenParent = document.createElement('nav');
+    hiddenParent.style.display = 'none';
+    const fab = document.createElement('a');
+    fab.setAttribute('data-tour', 'fab');
+    hiddenParent.appendChild(fab);
+    document.body.appendChild(hiddenParent);
+
+    const visibleNav = document.createElement('a');
+    visibleNav.setAttribute('data-tour', 'observe-nav');
+    document.body.appendChild(visibleNav);
+
+    const out = resolveFirstVisible('[data-tour="fab"],[data-tour="observe-nav"]');
+    expect(out).toBe(visibleNav);
+  });
+
+  it('returns null when first matches a hidden element and second does not match', () => {
+    const hiddenParent = document.createElement('nav');
+    hiddenParent.style.display = 'none';
+    const fab = document.createElement('a');
+    fab.setAttribute('data-tour', 'fab');
+    hiddenParent.appendChild(fab);
+    document.body.appendChild(hiddenParent);
+
+    expect(resolveFirstVisible('[data-tour="fab"],[data-tour="observe-nav"]')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run unit tests to verify they fail**
+
+```bash
+npx vitest run tests/unit/onboarding-target.test.ts
+```
+
+Expected: all 6 tests fail with "Cannot find module '../../src/lib/onboarding-target'".
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/lib/onboarding-target.ts`:
+
+```ts
+/**
+ * Pure helpers for the OnboardingTour spotlight target resolution.
+ *
+ * Extracted from `src/components/OnboardingTour.astro` (issue #1160) so
+ * the visibility-filtering rule can be unit-tested. `resolveFirstVisible`
+ * preserves the comma-separated fallback semantics of the original code
+ * but skips elements whose ancestor chain renders them un-measurable —
+ * `getBoundingClientRect()` would otherwise return 0×0 and the spotlight
+ * ring would land at the viewport corner.
+ */
+
+export function isElementVisible(el: Element): boolean {
+  return (el as HTMLElement).offsetParent !== null;
+}
+
+export function resolveFirstVisible(
+  selector: string,
+  doc: Pick<Document, 'querySelector'> = document,
+): Element | null {
+  const parts = selector.split(',').map((s) => s.trim()).filter(Boolean);
+  for (const sel of parts) {
+    const el = doc.querySelector(sel);
+    if (el && isElementVisible(el)) return el;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run unit tests to verify they pass**
+
+```bash
+npx vitest run tests/unit/onboarding-target.test.ts
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Wire the helper into OnboardingTour.astro**
+
+In `src/components/OnboardingTour.astro`, find the existing import on line 214 and add the new one:
+
+```ts
+  import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { resolveFirstVisible } from '../lib/onboarding-target';
+```
+
+Then replace the `resolveTarget` body (currently lines 290–298):
+
+```ts
+  function resolveTarget(selector: string | null): Element | null {
+    if (!selector) return null;
+    const parts = selector.split(',').map(s => s.trim());
+    for (const sel of parts) {
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+```
+
+…with the thin wrapper:
+
+```ts
+  function resolveTarget(selector: string | null): Element | null {
+    if (!selector) return null;
+    return resolveFirstVisible(selector);
+  }
+```
+
+- [ ] **Step 6: Run typecheck + unit tests + the partial e2e**
+
+```bash
+npx tsc --noEmit
+npx vitest run tests/unit/onboarding-target.test.ts
+npx playwright test tests/e2e/onboarding-spotlights.spec.ts --project=chromium
+```
+
+Expected:
+- `tsc`: zero errors.
+- vitest: 6/6 pass.
+- Playwright: **step 1 passes** (now falls through to visible `observe-nav`), **step 2 passes** (no fallback; falls through to nothing → `resolveTarget` returns null → tooltip centers but ring stays hidden, satisfying `ring.hidden===true` would *fail*… see Note below). **Step 4 still fails** because the selectors don't exist yet.
+
+> **Note on step 2:** the only selector is `[data-tour="fab"]` (no fallback). When the helper filters it out as hidden, `resolveTarget` returns null and the tour positions the tooltip centered with `ring.hidden=true`. The current e2e expects `ring.hidden===false`. This is intentional — Task 3 will not fix step 2 by adding a selector (the camera FAB legitimately doesn't exist on desktop). The cleanest resolution is to update the tour's step 2 selector to also include `[data-tour="observe-nav"]` as a desktop fallback. See Step 7.
+
+- [ ] **Step 7: Add desktop fallback to step 2 selector**
+
+In `src/components/OnboardingTour.astro` around lines 184–187 (the second entry in the `STEPS` JSON literal), change:
+
+```ts
+    {
+      title: stepsData.quick_id.title,
+      body: stepsData.quick_id.body,
+      target: '[data-tour="fab"]',
+    },
+```
+
+to:
+
+```ts
+    {
+      title: stepsData.quick_id.title,
+      body: stepsData.quick_id.body,
+      target: '[data-tour="fab"],[data-tour="observe-nav"]',
+    },
+```
+
+Re-run the partial e2e:
+
+```bash
+npx playwright test tests/e2e/onboarding-spotlights.spec.ts --project=chromium
+```
+
+Expected: **steps 1 and 2 pass**. Step 4 still fails (selectors not yet present).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/onboarding-target.ts tests/unit/onboarding-target.test.ts src/components/OnboardingTour.astro
+git commit -m "fix(onboarding): filter hidden targets in resolveTarget (#1160)"
+```
+
+---
+
+## Task 3: Add the 4 missing `data-tour` attrs (GREEN for step 4)
+
+**Files:**
+- Modify: `src/components/MegaMenu.astro` (Props interface around line 19, frontmatter destructure around line 37, button at line 56)
+- Modify: `src/components/Header.astro` (the Explore MegaMenu at line 164, the avatar button at line 229)
+- Modify: `src/components/MobileBottomBar.astro` (the Discover tab at line 85, the Profile tab at line 89)
+
+- [ ] **Step 1: Teach MegaMenu to forward a `data-tour` prop**
+
+In `src/components/MegaMenu.astro`, add `dataTour?: string;` to the `Props` interface:
+
+```ts
+interface Props {
+  lang: 'en' | 'es';
+  trigger: string;
+  columns: Column[];
+  align?: 'left' | 'right';
+  active?: boolean;
+  accent?: 'stone' | 'teal' | 'emerald' | 'sky';
+  cols?: 2 | 3;
+  /**
+   * Optional onboarding-tour marker. When set, forwarded as
+   * `data-tour={dataTour}` on the trigger button so the spotlight
+   * helper can resolve to it.
+   */
+  dataTour?: string;
+}
+```
+
+Add it to the destructure:
+
+```ts
+const {
+  lang,
+  trigger,
+  columns,
+  align = 'right',
+  active = false,
+  accent = 'stone',
+  cols = 3,
+  dataTour,
+} = Astro.props;
+```
+
+Forward it on the button (line 56):
+
+```astro
+  <button
+    id={`${id}-btn`}
+    type="button"
+    data-tour={dataTour}
+    class:list={[
+```
+
+- [ ] **Step 2: Set the data-tour on the Explore MegaMenu in Header**
+
+In `src/components/Header.astro` around lines 164–172, add the prop:
+
+```astro
+      <MegaMenu
+        lang={locale}
+        trigger={tr.nav.explore}
+        columns={exploreColumns}
+        align="left"
+        active={expActive}
+        accent="teal"
+        cols={2}
+        dataTour="explore-nav"
+      />
+```
+
+- [ ] **Step 3: Set data-tour on the avatar button in Header**
+
+In `src/components/Header.astro` at line 229, add `data-tour="avatar-btn"`:
+
+```astro
+        <button id="avatar-btn" data-tour="avatar-btn" aria-label="Account menu" class="block rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-500">
+```
+
+- [ ] **Step 4: Add explore-tab + profile-tab in MobileBottomBar**
+
+In `src/components/MobileBottomBar.astro` around line 82–88, update the Discover tab to carry both selectors (preserve `discover-tab` for backward compat):
+
+```astro
+    <a href={discoverPath} class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      discoverActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]} data-tour="explore-tab discover-tab">
+```
+
+Wait — `data-tour` is a single token attribute in the selectors (`[data-tour="explore-tab"]` is an exact match). Use TWO attributes via separate elements OR pick one. The pragmatic call here is to rename the attribute value to `explore-tab` and drop `discover-tab` (the tour is the only consumer; no other code references `discover-tab`). Verify before changing:
+
+```bash
+grep -rn 'data-tour="discover-tab"\|"discover-tab"' src tests --include='*.astro' --include='*.ts' --include='*.tsx'
+```
+
+Expected: only the one line in `MobileBottomBar.astro` (the declaration). If true, replace it cleanly:
+
+```astro
+    ]} data-tour="explore-tab">
+```
+
+If grep returns other references, keep both via separate markers (e.g. wrap the SVG in a `<span data-tour="discover-tab">`). For Rastrum today, only the one declaration exists.
+
+Then add `data-tour="profile-tab"` to the Profile tab at line 89:
+
+```astro
+    <a href={profilePath} data-tour="profile-tab" class:list={[
+      'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
+      profActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
+    ]}>
+```
+
+- [ ] **Step 5: Run typecheck + e2e**
+
+```bash
+npx tsc --noEmit
+npx playwright test tests/e2e/onboarding-spotlights.spec.ts --project=chromium
+```
+
+Expected:
+- `tsc`: zero errors.
+- Playwright: **all 3 tests pass** (steps 1, 2, and 4 all land on visible elements).
+
+- [ ] **Step 6: Manual verification of step 6 + mobile breakpoint**
+
+The e2e (Task 1) runs on the `chromium` project (desktop, anon homepage) and covers steps 1, 2, and 4. Two things need manual verification because they need a signed-in session and/or a different viewport:
+
+**(a) Step 6 (Settings / avatar) on desktop.** The avatar button is only rendered when `#avatar-wrap` is unhidden by client auth resolution. Run the dev server and sign in:
+
+```bash
+npm run dev
+# Open http://localhost:4321/en/ at >= 1280px wide, sign in.
+# In the browser console:
+#   window.dispatchEvent(new CustomEvent('rastrum:replay-onboarding'))
+# Click Next 6 times to reach step 7 of 7 ("Settings" / "BYO key").
+```
+
+Expected: spotlight ring is positioned over the avatar button (top-right of header). Tooltip placed below or above it. NOT at the top-left corner.
+
+**(b) Mobile breakpoint (signed-in).** On mobile the FAB IS visible, so steps 1+2 should land on the FAB (not fall through to `observe-nav`). Open Chrome DevTools → Toggle device toolbar → pick an iPhone or 375px width, then replay the tour signed-in:
+
+Expected:
+- step 1: ring on the green FAB (center-bottom)
+- step 2: ring on the FAB
+- step 4: ring on the Explore tab (right of FAB)
+- step 6: ring on the Profile tab (far right)
+- no ring in the top-left corner at any step
+
+- [ ] **Step 7: Run the full test suite as a smoke check**
+
+```bash
+npm run test
+npm run build
+```
+
+Expected: vitest run is green (734+ tests pass, including the new 6), build emits 209+ pages with zero errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/MegaMenu.astro src/components/Header.astro src/components/MobileBottomBar.astro
+git commit -m "fix(onboarding): wire missing data-tour attrs for explore + profile + avatar (#1160)"
+```
+
+---
+
+## Task 4: Open the pull request
+
+**Files:** none (git + gh only).
+
+- [ ] **Step 1: Push the branch and open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "fix(onboarding): unbreak spotlight tour (#1160)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #1160. Fixes 4 of 7 onboarding tour spotlight steps that have been silently broken on the default homepage.
+
+- `resolveTarget` now filters out hidden elements (`offsetParent === null`) so the comma-separated selector fallback actually walks past invisible matches. Extracted to `src/lib/onboarding-target.ts` for unit testing.
+- Added the missing `data-tour` attributes: `explore-nav` (via a new `MegaMenu` prop), `explore-tab`, `profile-tab`, `avatar-btn`.
+- Tour step 2 now falls through to `observe-nav` on desktop instead of resolving to the hidden mobile-only FAB.
+- New Playwright spec asserts the spotlight ring lands on a real element (rect > 24px wide, positive coords) for steps 1, 2, and 4. Steps 6 verified manually.
+
+## Test plan
+
+- [x] \`npx vitest run tests/unit/onboarding-target.test.ts\` — 6/6 pass.
+- [x] \`npx playwright test tests/e2e/onboarding-spotlights.spec.ts --project=chromium\` — 3/3 pass.
+- [x] \`npm run test\` — full suite green.
+- [x] \`npm run build\` — 209+ pages emit cleanly.
+- [x] Manual replay on \`/en/\` and \`/es/\` (desktop + mobile-chrome): rings land on the right elements at every non-center step.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Verify CI starts**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: every required check (typecheck, vitest, db-validate, e2e, build) runs and goes green. The new e2e spec must run on the `chromium` project and pass.
+
+---
+
+## Out of scope (deliberately deferred)
+
+The audit doc lists 5 more onboarding patterns (checklist, pre-permission priming, multi-intent picker, founder note, anon homepage `/identify` CTA). All are net-new features and have separate sequencing notes in [`docs/runbooks/onboarding-patterns-audit.md`](../../runbooks/onboarding-patterns-audit.md). This PR fixes the foundation; the next layer lands as separate PRs.
+
+The 3 missing funnel events (`first_id_accepted`, `7d_return`, `30d_return`) also defer — they need a new Edge Function + cron schedule. Tracked separately in the audit doc; out of scope for this PR.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -169,6 +169,7 @@ const docColumns = [
         active={expActive}
         accent="teal"
         cols={2}
+        dataTour="explore-nav"
       />
 
       <a href={getLocalizedPath(lang, routes.chat[locale] + '/')}
@@ -226,7 +227,7 @@ const docColumns = [
       <SyncPill lang={locale} />
       <BellIcon lang={locale} />
       <div id="avatar-wrap" class="hidden relative shrink-0">
-        <button id="avatar-btn" aria-label="Account menu" class="block rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-500">
+        <button id="avatar-btn" data-tour="avatar-btn" aria-label="Account menu" class="block rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-500">
           <span
             id="header-avatar-frame"
             class="inline-block rounded-full ring-offset-2 ring-offset-white dark:ring-offset-zinc-900"

--- a/src/components/MegaMenu.astro
+++ b/src/components/MegaMenu.astro
@@ -33,6 +33,12 @@ interface Props {
    * M28 Explore mega-menu uses 2 (Biodiversity + Community).
    */
   cols?: 2 | 3;
+  /**
+   * Optional onboarding-tour marker. When set, forwarded as
+   * `data-tour={dataTour}` on the trigger button so the spotlight
+   * helper can resolve to it.
+   */
+  dataTour?: string;
 }
 const {
   lang,
@@ -42,6 +48,7 @@ const {
   active = false,
   accent = 'stone',
   cols = 3,
+  dataTour,
 } = Astro.props;
 const safeTriggerId = trigger
   .normalize('NFKD')
@@ -56,6 +63,7 @@ const id = `megamenu-${safeTriggerId || 'menu'}`;
   <button
     id={`${id}-btn`}
     type="button"
+    data-tour={dataTour}
     class:list={[
       'relative flex items-center gap-1 pb-1 transition-colors',
       'after:content-[""] after:absolute after:left-0 after:right-0 after:-bottom-3 after:h-[2px] after:rounded after:transition-transform after:origin-left',

--- a/src/components/MobileBottomBar.astro
+++ b/src/components/MobileBottomBar.astro
@@ -82,14 +82,14 @@ const discoverActive  = isActiveSection(currentPath, 'discover',     lang);
     <a href={discoverPath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
       discoverActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
-    ]} data-tour="discover-tab">
+    ]} data-tour="explore-tab">
       <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
       <span>{tr.nav.bottom.discover}</span>
     </a>
     <a href={profilePath} class:list={[
       'flex flex-col items-center justify-center gap-0.5 py-1 text-[10px]',
       profActive ? 'text-emerald-600 dark:text-emerald-400' : 'text-zinc-500 dark:text-zinc-400'
-    ]}>
+    ]} data-tour="profile-tab">
       <svg aria-hidden="true" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
       <span>{tr.nav.bottom.profile}</span>
     </a>

--- a/src/components/OnboardingTour.astro
+++ b/src/components/OnboardingTour.astro
@@ -183,7 +183,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     {
       title: stepsData.quick_id.title,
       body: stepsData.quick_id.body,
-      target: '[data-tour="fab"]',
+      target: '[data-tour="fab"],[data-tour="observe-nav"]',
     },
     {
       title: firstObsDemoStep.title,
@@ -212,6 +212,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
 
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { resolveFirstVisible } from '../lib/onboarding-target';
 
   type StepDef = { title: string; body: string; target: string | null; kind?: 'privacy_preset' | 'first_observation_demo' };
 
@@ -289,12 +290,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
 
   function resolveTarget(selector: string | null): Element | null {
     if (!selector) return null;
-    const parts = selector.split(',').map(s => s.trim());
-    for (const sel of parts) {
-      const el = document.querySelector(sel);
-      if (el) return el;
-    }
-    return null;
+    return resolveFirstVisible(selector);
   }
 
   function getSpotlightRect(el: Element): DOMRect {

--- a/src/lib/onboarding-target.ts
+++ b/src/lib/onboarding-target.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure helpers for the OnboardingTour spotlight target resolution.
+ *
+ * Extracted from `src/components/OnboardingTour.astro` (issue #1160) so
+ * the display-filtering rule can be unit-tested. `resolveFirstVisible`
+ * preserves the comma-separated fallback semantics of the original code
+ * but skips elements whose ancestor chain has `display:none` — those
+ * elements report `getBoundingClientRect()` as 0×0 and the spotlight
+ * ring would otherwise land at the viewport corner. `visibility:hidden`
+ * is intentionally NOT filtered here: such elements still occupy layout,
+ * so spotlighting them is geometrically valid even if unusual.
+ */
+
+export function isDisplayed(el: Element): boolean {
+  // Walk the ancestor chain — `offsetParent === null` is the standard browser
+  // idiom but happy-dom does not implement it; getComputedStyle is portable.
+  let cur: Element | null = el;
+  while (cur) {
+    if (getComputedStyle(cur).display === 'none') return false;
+    cur = cur.parentElement;
+  }
+  return true;
+}
+
+export function resolveFirstVisible(selector: string): Element | null {
+  const parts = selector.split(',').map((s) => s.trim()).filter(Boolean);
+  for (const sel of parts) {
+    const el = document.querySelector(sel);
+    if (el && isDisplayed(el)) return el;
+  }
+  return null;
+}

--- a/tests/e2e/onboarding-spotlights.spec.ts
+++ b/tests/e2e/onboarding-spotlights.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Regression for issue #1160 — the spotlight tour was matching hidden
+ * `data-tour="fab"` ancestors on desktop and falling through to selectors
+ * that did not exist for Explore / Settings. This spec drives the
+ * `rastrum:replay-onboarding` event (which bypasses the signed-in gate
+ * via lines 682-689 of OnboardingTour.astro) and asserts that every
+ * non-center step lands the ring on a real, on-viewport element.
+ *
+ * Coverage: steps 1, 2, 4 on the chromium (desktop) project against the
+ * anon homepage. Step 6 (avatar) requires a signed-in session and is
+ * covered by manual verification + the helper's unit tests. Mobile
+ * coverage is manual — the mobile bottom bar's FAB lives inside
+ * `#mbb-authed` which only renders for signed-in users.
+ */
+test.describe('Onboarding tour spotlights', () => {
+  async function readRing(page: Page) {
+    return await page.evaluate(() => {
+      const r = document.getElementById('onb-spotlight-ring');
+      if (!r) return { found: false } as const;
+      const rect = r.getBoundingClientRect();
+      return {
+        found: true as const,
+        hidden: r.classList.contains('hidden'),
+        x: rect.x,
+        y: rect.y,
+        w: rect.width,
+        h: rect.height,
+      };
+    });
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/en/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForSelector('#onboarding-tour', { state: 'attached' });
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('rastrum:replay-onboarding'));
+    });
+    await page.waitForSelector('#onboarding-tour:not(.hidden)');
+    // Welcome step has no spotlight by design — click Start to advance to step 1.
+    await page.locator('#onb-next').click();
+  });
+
+  test('step 1 lands on a visible element, not the viewport corner', async ({ page }) => {
+    const ring = await readRing(page);
+    expect(ring.found).toBe(true);
+    if (!ring.found) return;
+    expect(ring.hidden).toBe(false);
+    // Failure mode was rect (-8, -8, 16, 16). A real target is > 24px wide
+    // (smallest button is ~44px) and positioned at positive coords.
+    expect(ring.w).toBeGreaterThan(24);
+    expect(ring.x).toBeGreaterThan(0);
+    expect(ring.y).toBeGreaterThan(0);
+  });
+
+  test('step 2 lands on a visible element', async ({ page }) => {
+    await page.locator('#onb-next').click(); // → step 2
+    const ring = await readRing(page);
+    expect(ring.found).toBe(true);
+    if (!ring.found) return;
+    expect(ring.hidden).toBe(false);
+    expect(ring.w).toBeGreaterThan(24);
+    expect(ring.x).toBeGreaterThan(0);
+    expect(ring.y).toBeGreaterThan(0);
+  });
+
+  test('step 4 (Explore) lands on a visible element', async ({ page }) => {
+    await page.locator('#onb-next').click(); // → step 2
+    await page.locator('#onb-next').click(); // → step 3 (demo, center)
+    await page.locator('#onb-next').click(); // → step 4 (Explore)
+    const ring = await readRing(page);
+    expect(ring.found).toBe(true);
+    if (!ring.found) return;
+    expect(ring.hidden).toBe(false);
+    expect(ring.w).toBeGreaterThan(24);
+    expect(ring.x).toBeGreaterThan(0);
+    expect(ring.y).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/onboarding-target.test.ts
+++ b/tests/unit/onboarding-target.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { isDisplayed, resolveFirstVisible } from '../../src/lib/onboarding-target';
+
+describe('isDisplayed', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('returns true for an element rendered in the DOM', () => {
+    const el = document.createElement('div');
+    el.id = 'visible';
+    document.body.appendChild(el);
+    expect(isDisplayed(el)).toBe(true);
+  });
+
+  it('returns false when an ancestor is display:none', () => {
+    const parent = document.createElement('nav');
+    parent.style.display = 'none';
+    const child = document.createElement('a');
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+    expect(isDisplayed(child)).toBe(false);
+  });
+});
+
+describe('resolveFirstVisible', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('returns null when no parts match anything in the DOM', () => {
+    expect(resolveFirstVisible('[data-tour="ghost"]')).toBeNull();
+  });
+
+  it('returns the element when a single selector matches and is visible', () => {
+    const el = document.createElement('a');
+    el.setAttribute('data-tour', 'observe-nav');
+    document.body.appendChild(el);
+    expect(resolveFirstVisible('[data-tour="observe-nav"]')).toBe(el);
+  });
+
+  it('falls through to second selector when first matches a hidden element', () => {
+    // Mirrors the production bug: FAB inside a `sm:hidden` parent on desktop.
+    const hiddenParent = document.createElement('nav');
+    hiddenParent.style.display = 'none';
+    const fab = document.createElement('a');
+    fab.setAttribute('data-tour', 'fab');
+    hiddenParent.appendChild(fab);
+    document.body.appendChild(hiddenParent);
+
+    const visibleNav = document.createElement('a');
+    visibleNav.setAttribute('data-tour', 'observe-nav');
+    document.body.appendChild(visibleNav);
+
+    const out = resolveFirstVisible('[data-tour="fab"],[data-tour="observe-nav"]');
+    expect(out).toBe(visibleNav);
+  });
+
+  it('returns null when first matches a hidden element and second does not match', () => {
+    const hiddenParent = document.createElement('nav');
+    hiddenParent.style.display = 'none';
+    const fab = document.createElement('a');
+    fab.setAttribute('data-tour', 'fab');
+    hiddenParent.appendChild(fab);
+    document.body.appendChild(hiddenParent);
+
+    expect(resolveFirstVisible('[data-tour="fab"],[data-tour="observe-nav"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1160. Fixes the 4 of 7 onboarding tour spotlight steps that were silently broken on the default homepage.

- `resolveTarget` now filters out hidden elements via an ancestor `display:none` walk (extracted to `src/lib/onboarding-target.ts` so the rule can be unit-tested in happy-dom — `offsetParent` is unimplemented there).
- Added the 4 missing `data-tour` attributes: `explore-nav` (via a new optional `dataTour?` prop on `MegaMenu`), `avatar-btn` (on the Header avatar button), `explore-tab` (renamed from `discover-tab` on the bottom-bar Discover tab — only declaration in the repo, no orphaned consumers), `profile-tab` (on the bottom-bar Profile tab).
- Step 2's selector now falls through to `[data-tour="observe-nav"]` on desktop instead of resolving to the mobile-only FAB.
- New Playwright spec `tests/e2e/onboarding-spotlights.spec.ts` asserts the ring lands on a real element (rect > 24px wide, positive coords) for steps 1, 2, and 4. Step 6 (avatar) and mobile coverage are manual — both need a signed-in session that the spec deliberately doesn't depend on.

Full audit + sequencing context: [`docs/runbooks/onboarding-patterns-audit.md`](docs/runbooks/onboarding-patterns-audit.md). Plan: [`docs/superpowers/plans/2026-05-23-onboarding-tour-spotlight-fix.md`](docs/superpowers/plans/2026-05-23-onboarding-tour-spotlight-fix.md).

## Test plan

- [x] `npx vitest run tests/unit/onboarding-target.test.ts` — 6/6 pass.
- [x] `npx playwright test tests/e2e/onboarding-spotlights.spec.ts --project=chromium` — 3/3 pass.
- [x] `npx vitest run` — 2722/2722 (no regressions in the 2716 prior tests).
- [x] `npx tsc --noEmit` — zero errors.
- [x] `npm run build` — 255 pages emit cleanly.
- [ ] Manual desktop replay signed-in (step 6 / avatar): expect ring on avatar button, not corner.
- [ ] Manual mobile-chrome replay signed-in (DevTools device toolbar, ~375px): expect rings on FAB (steps 1+2), Explore tab (step 4), Profile tab (step 6).

## Follow-up (not in this PR)

`src/components/JourneySpotlight.astro` has its own `resolveTarget` with the same hidden-blind logic. It degrades gracefully (centers tooltip on 0×0 rect rather than rendering a corner ring), so it isn't broken — but the two surfaces now have divergent contracts for the same problem. Filing a separate follow-up issue to import `resolveFirstVisible` there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
