### PR TITLE
fix(tours): improve all + document (#1162)

### DIFF
--- a/docs/runbooks/00-index.md
+++ b/docs/runbooks/00-index.md
@@ -126,5 +126,7 @@ high-level system view.
 | [`mcp-proxy.md`](mcp-proxy.md) | `mcp.rastrum.org` Cloudflare routing for the MCP Edge Function (header + path manipulation, no Worker runtime). |
 | [`onboarding-funnel.md`](onboarding-funnel.md) | First-30-days onboarding-funnel telemetry — drop-off cliffs + retention interventions (#878). |
 | [`onboarding-patterns-audit.md`](onboarding-patterns-audit.md) | 2026-05-22 audit of the current tour against Mobbin's 1000-app onboarding study — strengths, gaps, recommended v1.2 sequencing. |
+| [`tours.md`](tours.md) | All 3 tour surfaces (OnboardingTour, JourneySpotlight + 6 guides, ConsoleOnboarding) — current status, replay events, known issues. |
+| [`tours-backlog.md`](tours-backlog.md) | Surfaces that should have guided tours but don't, ranked by impact. |
 | [`performance-audit.md`](performance-audit.md) | Cache + performance optimization workflow — `npm run analyze` bundle visualiser, Lighthouse budgets (#713). |
 | [`sw-pmtiles-verification.md`](sw-pmtiles-verification.md) | Post-deploy verification that SW pmtiles caching works in the browser (#639). |

--- a/docs/runbooks/tours-backlog.md
+++ b/docs/runbooks/tours-backlog.md
@@ -1,0 +1,146 @@
+# Tours backlog
+
+Surfaces that would benefit from a guided tour but don't have one
+today, plus existing guides that need redesign. Pair with
+[`tours.md`](tours.md) for the live status of what already exists.
+
+Ranked roughly by impact (most-affected user × most-confusing surface).
+
+---
+
+## Tier 1 — redesign existing broken guides
+
+These shipped but are auto-disabled (`activation: 'manual-only'`) because
+the surface they target no longer matches the guide's design. Either
+redesign or remove.
+
+### `guide-observe` — needs progressive-disclosure-aware redesign
+
+The guide expects to point at `#obs2-post-form`, `#obs2-id-card`, and
+`#obs2-save-btn` in sequence. After epic #1129 the obs page is a state
+machine (`#obs2-card-v2` morphing through S0/S1a/S1b/S2/S2′/S3), so the
+targets only exist after the user posts a photo. Two redesign options:
+
+1. **Two-phase guide:** auto-fire on `/observe` for step 1 (target =
+   FAB / file input), then re-fire on `obs2-card-v2` state change for
+   steps 2–4. Requires the loader to listen for a `rastrum:obs2-card-state` event.
+2. **Drop the guide:** the OnboardingTour already has a demo card
+   showing the cascade. A second guide on `/observe` may be redundant.
+
+Recommendation: option 2 unless usability research surfaces confusion.
+
+### `guide-explore` — needs hub-layout retargeting
+
+The current `/explore` is a hub of cards (Map, Recent, Watchlist,
+Species, Validate) — not a tabbed surface. Steps should point at the
+cards directly:
+
+- s1: target the Map card (currently works via the s2 fallback)
+- s2: target the Recent card
+- s3: drop or target Watchlist
+
+Lower priority since the hub is largely self-explanatory.
+
+---
+
+## Tier 2 — high-impact surfaces with NO guide
+
+### `/sponsoring` — sponsor pool UI (M27/M32)
+
+Multi-provider AI sponsoring (Anthropic-direct, Bedrock, OpenAI, Azure,
+Gemini, Vertex) is configurable here. New users won't know what a
+"pool" is. A 3-step guide:
+
+1. Spotlight the provider radio (which proxy backs your usage)
+2. Spotlight the "Donate to platform pool" toggle (the altruistic option)
+3. Spotlight the pool progress bar (where you can see daily caps)
+
+### `/perfil/ajustes/ai` — BYO API keys
+
+7+ providers, each with different key formats. The current screen has
+no in-context help beyond labels. A 2-step guide:
+
+1. Spotlight the provider picker — explain the auto-detect-from-prefix behavior
+2. Spotlight the endpoint field — when it appears (Azure/Bedrock/Vertex) and why
+
+### `?mode=identify` (anon try-before-signup) — Arc pattern
+
+Anon users can identify a photo without signing up via
+`/observe?mode=identify`. The capability is completely undiscoverable —
+no homepage CTA, no chrome affordance. A guide here would be premature;
+fix discoverability first (separate issue), then add a 2-step guide that
+runs once on first identify success and pitches sign-up.
+
+---
+
+## Tier 3 — moderate-impact surfaces
+
+### `/falta-dex` (M08)
+
+The taxonomic gaps panel is conceptually novel. A 3-step guide:
+
+1. Spotlight the missing-taxa list with a 1-line "these are species
+   recorded in your region but not yet by you" explainer.
+2. Spotlight the region pool baseline toggle.
+3. Spotlight the "show missing" localStorage opt-out.
+
+### `/projects` (M29)
+
+Project creation requires drawing a polygon, picking a privacy level,
+inviting members. A 3-step guide could ease the polygon-drawing surface
+which is the steepest part.
+
+### `/chat` (M01)
+
+The new chat surface has 5 read-only tools the LLM can call
+(observation, species, project, camera_station, observer, self_profile).
+Users don't know what they can ask. A single-step "what can I ask?" tip
+with examples would help.
+
+### `/share/obs/?id=` — public observation viewer
+
+Mostly self-explanatory but has a hidden "edit after IDs" badge and a
+photo-gallery with keyboard shortcuts (←/→/Esc). A one-time tip on
+first view would surface these.
+
+---
+
+## Tier 4 — auth-gated guides needing signed-in audit
+
+### `guide-validate` and `guide-export`
+
+Both are `activation: 'first-visit'` but anon visitors never reach the
+auth-gated DOM. Need a signed-in pass to confirm:
+
+- `#validation-queue` exists when signed-in
+- `.suggest-id-btn` exists in the validation row
+- `#taxon-autocomplete` is the right selector for the modern taxon search
+- `#export-format`, `#export-preset`, `#export-download` are still the
+  current IDs after recent export flow rewrites
+
+Tracked separately from this PR because it requires a fixture session.
+
+---
+
+## Tier 5 — ConsoleOnboarding extensions
+
+The console walkthrough is a static modal. Adding a "?" replay button
+in the console header would match the JourneyReplayButton UX. Lower
+priority because the console audience is operators who learned the
+shortcuts the first time.
+
+---
+
+## How to ship a guide from this backlog
+
+Per [`tours.md`](tours.md) § "Adding a new guide":
+
+1. Append a `JourneyGuide` entry to `src/lib/journey-guides.ts`.
+2. Add bilingual i18n strings under `guides.<id>.*`.
+3. Verify each step's target resolves to a visible element on the
+   trigger route — the live-audit script in `tours.md` is the fastest
+   check.
+4. If the surface is auth-gated, set `activation: 'first-visit'` and
+   rely on `waitForTarget`'s 4s timeout to silently no-op for anon.
+5. If the surface has progressive disclosure, set
+   `activation: 'manual-only'` and wire a deliberate replay button.

--- a/docs/runbooks/tours.md
+++ b/docs/runbooks/tours.md
@@ -1,0 +1,123 @@
+# Tours runbook
+
+Rastrum has three discrete tour systems. They serve different purposes,
+fire at different times, and have different bug histories. This runbook
+documents what's live today; pair with module spec
+[`../specs/modules/33-user-journeys-testing.md`](../specs/modules/33-user-journeys-testing.md)
+for original design rationale and
+[`onboarding-patterns-audit.md`](onboarding-patterns-audit.md) for
+strengths/gaps against the Mobbin onboarding study.
+
+---
+
+## 1. `OnboardingTour.astro` — first-run welcome
+
+**Trigger:** signed-in users without `users.onboarding_completed_at` see it
+~600ms after auth resolves. Manual replay via `rastrum:replay-onboarding`
+event (wired from `ProfileEditForm`).
+
+**Steps:** 7 (welcome → FAB/observe-nav → camera FAB → demo card →
+explore → privacy preset → settings/avatar).
+
+**Spotlight engine:** in-component, uses `resolveFirstVisible` from
+`src/lib/onboarding-target.ts` (#1161).
+
+**Recent history:** epic #1160/#1161 — 4 of 7 spotlights were broken
+(2 hidden-blind, 2 dead selectors). Fixed by extracting the helper +
+adding the missing `data-tour` attrs on `Header.astro` /
+`MobileBottomBar.astro`.
+
+**Known issue (not yet fixed):** step 4 first-obs demo card is hardcoded
+to "Quercus robur — Oak / PlantNet / Claude Haiku / 87% confidence" for
+every user regardless of region or interest — flagged in
+[`onboarding-patterns-audit.md`](onboarding-patterns-audit.md) as
+half-baked personalization.
+
+## 2. `JourneySpotlight.astro` + `journey-guides.ts` — contextual tours
+
+**Trigger:** `JourneyGuideLoader` (mounted in `BaseLayout`) matches the
+current route against the registry. If `activation === 'first-visit'`
+and the user hasn't seen the guide, it auto-fires; otherwise users
+trigger via the "?" replay button (`JourneyReplayButton.astro`).
+
+**Spotlight engine:** `JourneySpotlight.astro` — uses the same
+`resolveFirstVisible` helper after the #1162 fix; positionTooltip has
+a defensive `width > 0 || height > 0` check that degrades to a centered
+tooltip if the resolved element happens to be hidden.
+
+**Live status as of 2026-05-23:**
+
+| Guide | Activation | Live status | Notes |
+|---|---|---|---|
+| `guide-observe` | `manual-only` | broken-by-design | s1–s4 targets exist but `display:none` until card-v2 state machine reveals them. Tracked in tours-backlog.md for redesign. |
+| `guide-explore` | `manual-only` | broken-by-design | Current `/explore` is a hub of cards; the s1 (tabs) + s3 (filters) selectors don't match. Tracked for redesign. |
+| `guide-validate` | `first-visit` | auth-gated | Anon visitors silently no-op via the 4s `waitForTarget` timeout. Signed-in audit deferred. |
+| `guide-export` | `first-visit` | auth-gated | Same shape as validate. |
+| `guide-community` | `first-visit` | works | 3 steps; observer card anchor target replaces the dead `[data-follow-btn]` fallback. |
+| `guide-console` | `first-visit` | works | 2 steps (down from 3 — dropped the keyboard-shortcut step; no DOM anchor for it). Signed-in. |
+
+**Replay events:**
+- `rastrum:journey-guide-start` (consumer → spotlight) with `detail: { guideId, steps, lang }`
+- `rastrum:journey-guide-stop`  (consumer → spotlight)
+- `rastrum:replay-guide` (consumer → loader) with `detail: { guideId }`
+- `rastrum:onboarding-event` (spotlight → analytics) — shared with OnboardingTour
+
+**Adding a new guide:**
+
+1. Append a `JourneyGuide` entry to `src/lib/journey-guides.ts`.
+2. Add the bilingual title/body strings under `guides.<id>.stepN_*` in
+   both i18n files.
+3. Verify each step's target selector resolves to a visible element on
+   the trigger route — running the [tours backlog](tours-backlog.md)
+   audit script is the fastest check.
+
+## 3. `console/ConsoleOnboarding.astro` — admin console first-run
+
+**Trigger:** signed-in console users without
+`localStorage.rastrum.console.onboardingDone === 'true'` see a centered
+modal walkthrough.
+
+**Steps:** 5 (welcome → sidebar → roles → keyboard shortcuts → ready).
+
+**Spotlight engine:** NONE — pure modal. No `data-target` selectors, no
+`resolveTarget` logic, no positionTooltip. Immune to the bug class that
+affected OnboardingTour + JourneySpotlight.
+
+**Replay:** not wired today. Closest UX is clearing
+`localStorage.rastrum.console.onboardingDone` then reloading
+`/console/`. Adding a "?" replay button is a backlog item.
+
+**Status:** copy reflects current admin/moderator/expert role model
+(M24, role-model.md). No known issues.
+
+---
+
+## Cross-cutting
+
+**Visibility filter (`isDisplayed`):** lives in
+`src/lib/onboarding-target.ts`. Used by `resolveFirstVisible`. Walks
+ancestor chain checking `getComputedStyle().display !== 'none'`. Used
+in both OnboardingTour and JourneySpotlight after #1162. `visibility:
+hidden` is intentionally NOT filtered (the element still occupies
+layout, so spotlighting it is geometrically valid).
+
+**Analytics:** `rastrum:onboarding-event` is the unified event for both
+OnboardingTour and JourneySpotlight. Operators attach a listener in
+`BaseLayout.astro` to wire whatever analytics backend (PostHog,
+Plausible, internal beacon). See
+[`onboarding-events.md`](onboarding-events.md) for the event schema.
+
+**Mobile breakpoint:** `OnboardingTour` step 1+2's selector
+`[data-tour="fab"],[data-tour="observe-nav"]` is designed for the FAB
+to win on mobile and `observe-nav` to win on desktop, via the visibility
+filter. Manually verified at both breakpoints.
+
+**Replay event reference:**
+
+| Event | Direction | Detail | Consumed by |
+|---|---|---|---|
+| `rastrum:replay-onboarding` | consumer → tour | none | `OnboardingTour.astro` |
+| `rastrum:replay-guide` | consumer → loader | `{ guideId }` | `JourneyGuideLoader.astro` |
+| `rastrum:journey-guide-start` | consumer → spotlight | `{ guideId, steps, lang }` | `JourneySpotlight.astro` |
+| `rastrum:journey-guide-stop` | consumer → spotlight | none | `JourneySpotlight.astro` |
+| `rastrum:onboarding-event` | spotlight → analytics | `{ type, step, … }` | operator-wired |

--- a/src/components/JourneySpotlight.astro
+++ b/src/components/JourneySpotlight.astro
@@ -63,6 +63,8 @@ const l = labels[lang] ?? labels.en;
 </div>
 
 <script>
+  import { resolveFirstVisible } from '../lib/onboarding-target';
+
   interface GuideStep {
     target: string;
     title: string;
@@ -96,14 +98,7 @@ const l = labels[lang] ?? labels.en;
     let returnFocus: HTMLElement | null = null;
 
     function resolveTarget(selector: string): Element | null {
-      const parts = selector.split(',').map(s => s.trim());
-      for (const sel of parts) {
-        try {
-          const el = document.querySelector(sel);
-          if (el) return el;
-        } catch { /* invalid selector */ }
-      }
-      return null;
+      return resolveFirstVisible(selector);
     }
 
     function positionTooltip(targetEl: Element | null): void {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1250,8 +1250,8 @@
         "body": "Map, recent observations, your watchlist — all under Explore."
       },
       "settings": {
-        "title": "Instant identification",
-        "body": "Add a free PlantNet API key in Settings → Preferences for instant plant identification. Takes about 2 minutes."
+        "title": "Your account",
+        "body": "Settings, AI keys, notifications, sign out — all behind your avatar."
       },
       "privacy": {
         "title": "Pick your privacy preset",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1250,8 +1250,8 @@
         "body": "Mapa, observaciones recientes y tu lista de seguimiento — todo bajo Explorar."
       },
       "settings": {
-        "title": "Identificación instantánea",
-        "body": "Agrega una API key gratuita de PlantNet en Ajustes → Preferencias para identificar plantas al instante. Tarda unos 2 minutos."
+        "title": "Tu cuenta",
+        "body": "Ajustes, llaves de IA, notificaciones, cerrar sesión — todo detrás de tu avatar."
       },
       "privacy": {
         "title": "Elige tu privacidad",

--- a/src/lib/journey-guides.ts
+++ b/src/lib/journey-guides.ts
@@ -36,7 +36,11 @@ export const journeyGuides: JourneyGuide[] = [
     id: 'guide-observe',
     triggerRoute: /\/(en\/observe|es\/observar)\/?$/,
     storageKey: 'rastrum.guide.observe',
-    activation: 'first-visit',
+    // 'manual-only' until redesigned for the progressive-disclosure flow —
+    // the s1-s4 targets are revealed by the obs2-card-v2 state machine
+    // AFTER the user posts a photo, so auto-firing on first-visit misses
+    // them all (audited 2026-05-23, see docs/runbooks/tours.md).
+    activation: 'manual-only',
     steps: [
       {
         target: '#obs2-post-form, input[type="file"], [data-dropzone]',
@@ -64,7 +68,10 @@ export const journeyGuides: JourneyGuide[] = [
     id: 'guide-explore',
     triggerRoute: /\/(en\/explore|es\/explorar)\/?$/,
     storageKey: 'rastrum.guide.explore',
-    activation: 'first-visit',
+    // 'manual-only' until retargeted — the current Explore page is a hub
+    // of cards, not a tabbed surface, so the s1 (tabs) and s3 (filters)
+    // selectors don't match. Re-design tracked in tours-backlog.md.
+    activation: 'manual-only',
     steps: [
       {
         target: '[data-explore-tabs], .explore-tabs, main nav, nav[role="tablist"]',
@@ -87,6 +94,9 @@ export const journeyGuides: JourneyGuide[] = [
     id: 'guide-validate',
     triggerRoute: /\/(en\/explore\/validate|es\/explorar\/validar)\/?$/,
     storageKey: 'rastrum.guide.validate',
+    // first-visit, auth-gated — when no targets resolve within
+    // waitForTarget's 4s budget the guide silently no-ops. Signed-in
+    // selector audit tracked in tours-backlog.md.
     activation: 'first-visit',
     steps: [
       {
@@ -110,6 +120,9 @@ export const journeyGuides: JourneyGuide[] = [
     id: 'guide-export',
     triggerRoute: /\/(en\/profile\/export|es\/perfil\/exportar)\/?$/,
     storageKey: 'rastrum.guide.export',
+    // first-visit, auth-gated — when no targets resolve within
+    // waitForTarget's 4s budget the guide silently no-ops. Signed-in
+    // selector audit tracked in tours-backlog.md.
     activation: 'first-visit',
     steps: [
       {
@@ -146,7 +159,7 @@ export const journeyGuides: JourneyGuide[] = [
         bodyKey: 'guides.community.step2_body',
       },
       {
-        target: '[data-follow-btn], #follow-btn, a[href*="/profile/u"]',
+        target: '#community-list a[href*="/profile/u"], [data-observer-card] a',
         titleKey: 'guides.community.step3_title',
         bodyKey: 'guides.community.step3_body',
       },
@@ -167,11 +180,6 @@ export const journeyGuides: JourneyGuide[] = [
         target: '[data-console-health], a[href*="health"], a[href*="salud"]',
         titleKey: 'guides.console.step2_title',
         bodyKey: 'guides.console.step2_body',
-      },
-      {
-        target: '[data-console-keyboard], .keyboard-hint, [data-shortcut]',
-        titleKey: 'guides.console.step3_title',
-        bodyKey: 'guides.console.step3_body',
       },
     ],
   },


### PR DESCRIPTION
## Summary

Closes #1162. Sweep of all 3 tour systems in the repo following the live audit triggered by the user — uncovered the same hidden-blind bug class beyond OnboardingTour plus stale targets across multiple journey guides.

- `JourneySpotlight.astro` now uses `resolveFirstVisible` from `src/lib/onboarding-target.ts` (dedupes logic with OnboardingTour, closes #1162).
- `journey-guides.ts`: switched `guide-observe` and `guide-explore` to `activation: 'manual-only'` until redesigned (their targets don't match the current DOM — observe is progressive disclosure, explore is now a hub layout). Cleaned up dead fallback selectors in `guide-community`, dropped the orphan step 3 of `guide-console`, added audit-deferred doc comments to `guide-validate` + `guide-export`.
- `OnboardingTour` step 7 i18n copy rewrite: "Instant identification" / "Add a free PlantNet API key…" → "Your account" / "Settings, AI keys, notifications, sign out — all behind your avatar." Reflects multi-provider scope post-M32.
- New `docs/runbooks/tours.md` documenting all 3 tour systems, replay events, current status, known issues.
- New `docs/runbooks/tours-backlog.md` ranking missing-tour surfaces by impact (sponsoring, BYO keys, `?mode=identify`, falta-dex, projects, chat, share-obs) and recording the deferred signed-in audit for validate + export guides.

## Test plan

- [x] `npx tsc --noEmit` — zero errors.
- [x] `npx vitest run` — 2722/2722 (no regressions).
- [x] `npx playwright test tests/e2e/onboarding-spotlights.spec.ts --project=chromium` — 3/3 pass (#1161's spec).
- [x] `npm run build` — clean.
- [ ] Manual replay of OnboardingTour on `/en/` (signed-in desktop) — verify step 7 reads "Your account".
- [ ] Manual replay of `guide-community` on `/en/community/observers/` — verify step 3 spotlight lands on an observer card link.

## Follow-ups (out of scope, tracked in `tours-backlog.md`)

- Signed-in audit of `guide-validate` and `guide-export` selectors (tier 4).
- Redesign of `guide-observe` for progressive disclosure, `guide-explore` for hub layout (tier 1).
- New guides for `/sponsoring`, `/perfil/ajustes/ai`, `/falta-dex`, `/projects`, `/chat`, `/share/obs/` (tier 2-3).

Audit context: [`docs/runbooks/tours.md`](docs/runbooks/tours.md), [`docs/runbooks/tours-backlog.md`](docs/runbooks/tours-backlog.md), [`docs/runbooks/onboarding-patterns-audit.md`](docs/runbooks/onboarding-patterns-audit.md). Plan: [`docs/superpowers/plans/2026-05-23-tours-improvements.md`](docs/superpowers/plans/2026-05-23-tours-improvements.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
