### PR TITLE
fix(sync): close #1164 — remove dead taxa upsert + null-island guard

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -242,29 +242,11 @@ async function syncOne(record: ObservationRecord): Promise<void> {
   } else if (hasIdentification && (clientId.status === 'accepted' || clientId.status === 'needs_review')) {
     const supabase = getSupabase();
 
-    // Upsert taxa row so observations.primary_taxon_id can be resolved by
-    // the sync_primary_identification trigger. On conflict (scientific_name
-    // already exists) update common names only — kingdom/family come from
-    // authoritative upstream sources.
-    let taxonId: string | null = null;
-    if (clientId.scientificName) {
-      try {
-        const taxonPayload: Record<string, unknown> = {
-          scientific_name: clientId.scientificName,
-          common_name_es: clientId.commonNameEs ?? null,
-          common_name_en: clientId.commonNameEn ?? null,
-          taxon_rank: 'species',
-        };
-        const { data: taxonRow } = await supabase
-          .from('taxa')
-          .upsert(taxonPayload, { onConflict: 'scientific_name', ignoreDuplicates: false })
-          .select('id')
-          .maybeSingle();
-        if (taxonRow?.id) taxonId = taxonRow.id as string;
-      } catch {
-        // taxa upsert is non-fatal — trigger fallback handles scientific_name lookup
-      }
-    }
+    // taxa rows are written by service_role only — RLS denies client writes
+    // (only `taxa_public_read` SELECT policy exists). `upsert_primary_identification`
+    // accepts a null `p_taxon_id` and the `sync_primary_identification` trigger
+    // resolves it from `scientific_name` server-side. Closes #1164.
+    const taxonId: string | null = null;
 
     // Route through upsert_primary_identification RPC (#589) which honors
     // the UNIQUE(observation_id) WHERE is_primary partial index — demoting
@@ -337,8 +319,12 @@ async function syncOne(record: ObservationRecord): Promise<void> {
 async function triggerEnvEnrichment(record: ObservationRecord): Promise<void> {
   // Guard: skip enrichment when the observation has no GPS coordinates.
   // The edge function requires a location and returns 422 otherwise.
+  // Also reject (0,0) null-island — matches the CLI batch import contract
+  // and catches uninitialized lat/lng that slipped past Number.isFinite.
+  // Closes #1164 (partial — full root cause needs a reproducing obs_id).
   const loc = record.data?.location;
   if (!loc || !Number.isFinite(loc.lat) || !Number.isFinite(loc.lng)) return;
+  if (loc.lat === 0 && loc.lng === 0) return;
 
   const supabase = getSupabase();
   await supabase.functions.invoke('enrich-environment', {


### PR DESCRIPTION
## Summary

Closes #1164.

**Bug 1 — 403 noise on POST /taxa from authenticated client.**
`sync.ts` was calling `.upsert('taxa')` from the authenticated client, but `taxa` only has a SELECT policy (`taxa_public_read`). The try/catch swallowed the 403 functionally — sync still worked — but every signed-in sync emitted noise to network logs and PostgREST audit. Removed the block (~18 lines); `upsert_primary_identification` accepts a null `p_taxon_id` and the `sync_primary_identification` trigger resolves taxon_id from `scientific_name` server-side. This path was already the fallback for the catch case, so no functional change.

**Bug 2 — 422 from `enrich-environment` (partial defense).**
The existing `Number.isFinite(loc.lat) && Number.isFinite(loc.lng)` guard catches null/undefined/NaN but not `(0,0)` null-island. Added a second guard line that rejects (0,0) — matches the CLI batch-import contract per CLAUDE.md.

Honest note: this is a **partial defense**, not a confirmed full fix for the reported 422. The EF (`enrich-environment/index.ts:78`) casts `obs.location as { coordinates }` assuming GeoJSON shape; if PostgREST returns the geography column in a different shape (WKB hex, EWKT string), every call would 422 regardless of GPS validity. To diagnose: need an `observation_id` of a 422 case so we can inspect both the DB row state and the EF's actual response. Filed as follow-up note in the issue.

## Test plan

- [x] `npx tsc --noEmit` — zero errors.
- [x] `npx vitest run` — 2722/2722 (no regressions).
- [ ] Reproducer for Bug 2 — pending an observation_id from the reporter.

## Risk

Both changes are removals of conditional code. Bug 1 removes a path that was already failing silently. Bug 2 adds a stricter guard (one extra line) that can only cause fewer EF calls, never more. No new test added because the existing sync.ts test surface is empty (no path to stub `supabase.functions.invoke`); the change is too small to justify infrastructure work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
