### PR TITLE
fix(onboarding): warm session before PATCH /users to avoid 403

### DIFF
--- a/src/components/OnboardingTour.astro
+++ b/src/components/OnboardingTour.astro
@@ -211,7 +211,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
 />
 
 <script>
-  import { getCachedUser, getSupabase } from '../lib/supabase';
+  import { getCachedSession, getCachedUser, getSupabase } from '../lib/supabase';
   import { resolveFirstVisible } from '../lib/onboarding-target';
 
   type StepDef = { title: string; body: string; target: string | null; kind?: 'privacy_preset' | 'first_observation_demo' };
@@ -282,9 +282,12 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     let sb;
     try { sb = getSupabase(); } catch { return; }
     try {
-      const user = await getCachedUser();
-      if (!user) return;
-      await sb.from('users').update({ onboarding_completed_at: new Date().toISOString() }).eq('id', user.id);
+      // Warm the session before PATCH — getCachedUser() alone returns the
+      // user object but doesn't guarantee the supabase client has rehydrated
+      // its JWT from storage. Same fix shape as #1155 for observation-defaults.
+      const session = await getCachedSession();
+      if (!session) return;
+      await sb.from('users').update({ onboarding_completed_at: new Date().toISOString() }).eq('id', session.user.id);
     } catch { /* env not configured / column missing — fail closed */ }
   }
 
@@ -406,9 +409,10 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     let sb;
     try { sb = getSupabase(); } catch { return; }
     try {
-      const user = await getCachedUser();
-      if (!user) return;
-      await sb.from('users').update({ profile_privacy: PRESET_DEFS[preset] }).eq('id', user.id);
+      // Warm the session before PATCH (#1155 pattern).
+      const session = await getCachedSession();
+      if (!session) return;
+      await sb.from('users').update({ profile_privacy: PRESET_DEFS[preset] }).eq('id', session.user.id);
       persistOnboardingDone().catch(() => { /* env not configured */ });
     } catch { /* env not configured / column missing — fail closed */ }
   }


### PR DESCRIPTION
## Summary

User-reported 403 caught by a Chrome session validating PR #1165:

```
2026-05-24T05:17:03.409Z PATCH /rest/v1/users?id=eq.<uuid> → 403
Build SHA: 767e0553 (PR #1165 merge)
```

Triggered when the OnboardingTour modal closed (Skip / Done) and `persistOnboardingDone()` PATCHed `users.onboarding_completed_at`. Same root cause as #1155 for `observation-defaults` — the Supabase client was using `getCachedUser()` alone, which returns the user but doesn't guarantee the JWT is rehydrated from storage before the next request fires.

## Changes

`src/components/OnboardingTour.astro`:
- `persistOnboardingDone()` — use `getCachedSession()` to warm the session before PATCH (matches #1155 pattern).
- `persistPreset()` — same migration; this one runs when the user picks a privacy preset on step 6.
- Import `getCachedSession` from `../lib/supabase`.

`maybeShow()` (line 695) keeps `getCachedUser()` because it's a SELECT path — the SELECT against `users` doesn't 403 on stale auth (returns empty/null).

## Why two functions, not one

Both fire PATCH /users from the same script block but at different lifecycle points:
- `persistOnboardingDone` fires on modal close (Skip or Done).
- `persistPreset` fires when a privacy preset button is clicked on step 6.

The user dismissing the tour from my automation fired the first one; if a user had clicked a preset before closing, the second one would have fired too.

## Test plan

- [x] `npx tsc --noEmit` — zero errors.
- [x] `npx vitest run` — 2722/2722 (no regressions).
- [ ] Manual replay of tour Skip on production after merge — verify no PATCH /users 403 in network tab.

## Out of scope

- The end-to-end photo upload test couldn't be completed from the Chrome MCP session: `file_upload` was deprecated, raw.githubusercontent.com required new permission, and `media.rastrum.org` blocks CORS from the rastrum.org origin. The observe page rendering + DropZone UI were validated on desktop + mobile in #1163's chrome session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
