### PR TITLE
fix(pipeline-stepper): align event detail shape with dispatcher

### DIFF
--- a/src/components/PipelineStepper.astro
+++ b/src/components/PipelineStepper.astro
@@ -319,9 +319,13 @@ const labels = {
   });
 
   // ── Pipeline event listener ──────────────────────────────────────────────
+  // Event detail shape matches the dispatcher in ObserveView2.astro (#942):
+  // `{ nodes: PipelineNode[] }`. The previous code expected a `state` envelope
+  // that ObserveView2 never emitted, so this listener silently no-op'd and
+  // every step popover stayed empty in production. Aligns with PipelineGraph.
   document.addEventListener('rastrum:pipeline-update', (e: Event) => {
-    const event = e as CustomEvent<{ state: PipelineState }>;
-    const { state } = event.detail;
-    if (state?.nodes) render(state.nodes);
+    const event = e as CustomEvent<{ nodes: PipelineState['nodes'] }>;
+    const { nodes } = event.detail;
+    if (nodes) render(nodes);
   });
 </script>


### PR DESCRIPTION
## Summary

User reported clicking step circles in the `/observe` pipeline stepper opens **empty popover cards**. Root cause discovered during live validation: a shape mismatch between dispatcher and listener that made the listener silently no-op since #942 shipped.

```ts
// PipelineStepper.astro:322 (before — broken)
const event = e as CustomEvent<{ state: PipelineState }>;
const { state } = event.detail;
if (state?.nodes) render(state.nodes);  // state is undefined → never calls render

// ObserveView2.astro:1187 + pipeline-engine.ts:310 (dispatchers)
new CustomEvent('rastrum:pipeline-update', { detail: { nodes } })  // no `state` envelope
```

Aligned with `PipelineGraph.astro:266-268`'s already-working `ev.detail.nodes` shape.

## What this fixes

- Empty popover cards when tapping any of the 3 step circles (Photo / Identify / Save).
- Step circles always showing the initial "Pending" state (1/2/3 numbers, blue label) even when nodes had transitioned to done/running/failed. The `aria-label="… — Pending"` and label color were both broken.

The status line BELOW the stepper kept working ("Ready (1/1)", "Processing…") because that text is set directly inside `updatePipelineUI()` — only the event-driven popover + circle state was broken.

## Live verification

Started dev server, navigated to `/en/observe/`, dispatched a synthetic pipeline-update event with 5 nodes (input/identify/merge/location/save):

| Before | After |
|---|---|
| All circles: "Pending" / numbered 1-2-3 | Photo ✓, Identify ✓, Save ⟳ (~5s) |
| Tap Identify → empty white card | Tap Identify → "✓ identify · plantnet · ✓ merge" |

Screenshot captured during validation.

## Test plan

- [x] `npx tsc --noEmit` — zero errors.
- [x] `npx vitest run` — 2722/2722 (no regressions).
- [x] Manual replay on `localhost:4321/en/observe/` with synthetic pipeline event — popover + circles render correctly.
- [ ] After merge + deploy, real photo upload flow on prod — verify behavior matches live test.

## Risk

Single-file 4-line change. The listener now reads the same shape the dispatcher already sends; `PipelineGraph.astro` has been doing this since before the stepper existed and works fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
