### PR TITLE
fix(observe): gate claude_eligibility RPC behind getCachedSession

### DIFF
--- a/src/lib/sponsorships.test.ts
+++ b/src/lib/sponsorships.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { detectAnyKind, detectKind } from './sponsorships';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+// Mock supabase BEFORE importing sponsorships so getCachedSession + getSupabase
+// resolve through the mocked module. This mirrors the observation-defaults
+// test pattern from #1155.
+const mockedSession = { current: null as { user: { id: string } } | null };
+const rpcSpy = vi.fn();
+
+vi.mock('./supabase', () => ({
+  getCachedSession: () => Promise.resolve(mockedSession.current),
+  getSupabase: () => ({ rpc: rpcSpy }),
+}));
+
+import { detectAnyKind, detectKind, getClaudeEligibility } from './sponsorships';
 
 describe('detectKind (legacy — Anthropic only)', () => {
   it('matches sk-ant-api03-*', () => {
@@ -31,5 +43,45 @@ describe('detectAnyKind (M32 — multi-provider)', () => {
     expect(detectAnyKind('{"accessKeyId":"x"}')).toBeNull();
     expect(detectAnyKind('{"type":"service_account"}')).toBeNull();
     expect(detectAnyKind('')).toBeNull();
+  });
+});
+
+// Regression for #1167 — RPC was firing before the JWT was hydrated (or for
+// anon callers entirely), spamming the console with 401s from PostgREST.
+describe('getClaudeEligibility (session gate)', () => {
+  beforeEach(() => {
+    rpcSpy.mockReset();
+    mockedSession.current = null;
+  });
+
+  it('returns defaults without calling rpc when session is null (anon / cold load)', async () => {
+    const out = await getClaudeEligibility();
+    expect(rpcSpy).not.toHaveBeenCalled();
+    expect(out).toEqual({ has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 });
+  });
+
+  it('calls rpc when a session is present', async () => {
+    mockedSession.current = { user: { id: 'user-1' } };
+    rpcSpy.mockResolvedValue({
+      data: [{ has_sponsor: true, has_pool: false, pool_used_today: 0, pool_cap_today: 0 }],
+      error: null,
+    });
+    const out = await getClaudeEligibility();
+    expect(rpcSpy).toHaveBeenCalledTimes(1);
+    expect(rpcSpy).toHaveBeenCalledWith('claude_eligibility');
+    expect(out.has_sponsor).toBe(true);
+  });
+
+  it('propagates rpc errors as Error (auth present but server failed)', async () => {
+    mockedSession.current = { user: { id: 'user-1' } };
+    rpcSpy.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(getClaudeEligibility()).rejects.toThrow('boom');
+  });
+
+  it('returns defaults when rpc returns an empty array', async () => {
+    mockedSession.current = { user: { id: 'user-1' } };
+    rpcSpy.mockResolvedValue({ data: [], error: null });
+    const out = await getClaudeEligibility();
+    expect(out).toEqual({ has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 });
   });
 });

--- a/src/lib/sponsorships.ts
+++ b/src/lib/sponsorships.ts
@@ -326,6 +326,17 @@ export interface ClaudeEligibility {
 }
 
 export async function getClaudeEligibility(): Promise<ClaudeEligibility> {
+  // Gate on a hydrated session before calling the RPC. The function has
+  // `GRANT EXECUTE TO authenticated` only — PostgREST 401s for anon, and
+  // even for authenticated callers a cold page load can fire the RPC
+  // before the Supabase client has loaded the JWT from storage. Both
+  // paths look the same on the wire and spammed the console with 401s
+  // (issue #1167). The SQL function's `IF v_uid IS NULL THEN RETURN
+  // defaults` branch returns the same shape, so anon callers get the
+  // same answer without the round trip.
+  // Same fix shape as #1155 (PATCH users 403 → getCachedSession() first).
+  const session = await getCachedSession();
+  if (!session) return { has_sponsor: false, has_pool: false, pool_used_today: 0, pool_cap_today: 0 };
   const sb = getSupabase();
   const { data, error } = await sb.rpc('claude_eligibility');
   if (error) throw new Error(error.message);


### PR DESCRIPTION
## Summary

Cold-load 401 race on `/rest/v1/rpc/claude_eligibility`. Same shape as #1155 (PATCH users 403) — RPC fires before JWT is hydrated, PostgREST rejects with 401 before the function's anon branch can return defaults.

**Fix:** `getCachedSession()` gate in `getClaudeEligibility()`. When session is null, return the same defaults shape the SQL branch would return. No network round-trip, no noisy 401.

Two POST sites confirmed (`ObserveView2.astro:703` on-mount + `:857` files-dropped listener) — both covered by the single call-site fix.

## Test plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npx vitest run sponsorships claude-availability` — 31 passed
- [x] `npm run build` — 255 pages
- [ ] Required CI checks green
- [ ] After merge: verify no `rpc/claude_eligibility` 401s in next anon session on `/es/observar/`

Closes #1167
Related: #1155 (canonical pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)