### PR TITLE
fix(profile): align PublicProfileViewV2 with sprite-fallback parity

### DIFF
--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -255,6 +255,7 @@ const sponsoringI18n = {
   import { showToast } from '../lib/toast';
   import { openConfirmDialog } from '../lib/confirm-dialog';
   import { tierForKarma } from '../lib/karma-frame';
+  import { basemapStyleUrl, installSpriteFallback } from '../lib/map-style';
 
   type Lang = 'en' | 'es';
 
@@ -662,8 +663,6 @@ const sponsoringI18n = {
           const profileId = profile.id;
           const profileLang = lang;
           const isDark = document.documentElement.classList.contains('dark');
-          const STYLE_LIGHT = 'https://tiles.openfreemap.org/styles/liberty';
-          const STYLE_DARK  = 'https://tiles.openfreemap.org/styles/dark';
 
           const initProfileMap = async () => {
             const maplibregl = (await import('maplibre-gl')).default;
@@ -674,12 +673,18 @@ const sponsoringI18n = {
 
             const map = new maplibregl.Map({
               container: containerId,
-              style: isDark ? STYLE_DARK : STYLE_LIGHT,
+              style: basemapStyleUrl(isDark),
               zoom: 2,
               center: [0, 20],
               attributionControl: { compact: true },
               scrollZoom: false,         // disable scroll-zoom (mobile-friendly)
             });
+
+            // #1166 — parity with ExploreMap / MapPicker / CommunityMapView:
+            // register a 1x1 transparent fallback for any basemap sprite icon
+            // that fails to load, so a slow/blocked sprite doesn't spam the
+            // console with `circle-11` missing warnings.
+            installSpriteFallback(map);
 
             // Hide skeleton once map tiles load
             const skeleton = mapContainer.querySelector<HTMLElement>('[data-pp-map-skeleton]');

--- a/tests/unit/public-profile-sprite-fallback.test.ts
+++ b/tests/unit/public-profile-sprite-fallback.test.ts
@@ -1,0 +1,46 @@
+/**
+ * #1166 — PR #1116 installed `installSpriteFallback()` on ExploreMap,
+ * MapPicker, and CommunityMapView so a slow/blocked OpenFreeMap sprite
+ * degrades to a 1x1 transparent fallback instead of spamming the console
+ * with `circle-11` missing warnings. `PublicProfileViewV2.astro` was
+ * missed — when the user reported a network-level (`status: 0`) tile
+ * failure from Android Chrome on `/en/u/?username=…`, this map was the
+ * one without the handler.
+ *
+ * Source-assertion test (mirrors `observe-success-cta-gated.test.ts`) —
+ * the wiring is inside an Astro client `<script>` and doesn't lend
+ * itself to a happy-dom unit. The behaviour of the helper itself is
+ * already covered by `map-style.test.ts`; this spec only pins the
+ * parity with the other three map surfaces.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('PublicProfileViewV2 sprite fallback parity (#1166)', () => {
+  const src = readFileSync(
+    join(process.cwd(), 'src/components/PublicProfileViewV2.astro'),
+    'utf8',
+  );
+
+  it('imports basemapStyleUrl + installSpriteFallback from map-style', () => {
+    expect(src).toMatch(
+      /import\s*\{[^}]*\binstallSpriteFallback\b[^}]*\}\s*from\s*['"]\.\.\/lib\/map-style['"]/,
+    );
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bbasemapStyleUrl\b[^}]*\}\s*from\s*['"]\.\.\/lib\/map-style['"]/,
+    );
+  });
+
+  it('uses basemapStyleUrl(isDark) instead of inline OpenFreeMap URLs', () => {
+    expect(src).toMatch(/style:\s*basemapStyleUrl\(\s*isDark\s*\)/);
+    // Inline style URL constants from the pre-fix code must be gone so
+    // the shared helper remains the single source of truth.
+    expect(src).not.toMatch(/https:\/\/tiles\.openfreemap\.org\/styles\/liberty/);
+    expect(src).not.toMatch(/https:\/\/tiles\.openfreemap\.org\/styles\/dark/);
+  });
+
+  it('installs the sprite fallback on the map instance', () => {
+    expect(src).toMatch(/installSpriteFallback\(\s*map\s*\)/);
+  });
+});

--- a/tests/unit/public-profile-sprite-fallback.test.ts
+++ b/tests/unit/public-profile-sprite-fallback.test.ts
@@ -36,8 +36,8 @@ describe('PublicProfileViewV2 sprite fallback parity (#1166)', () => {
     expect(src).toMatch(/style:\s*basemapStyleUrl\(\s*isDark\s*\)/);
     // Inline style URL constants from the pre-fix code must be gone so
     // the shared helper remains the single source of truth.
-    expect(src).not.toMatch(/https:\/\/tiles\.openfreemap\.org\/styles\/liberty/);
-    expect(src).not.toMatch(/https:\/\/tiles\.openfreemap\.org\/styles\/dark/);
+    expect(src).not.toContain('https://tiles.openfreemap.org/styles/liberty');
+    expect(src).not.toContain('https://tiles.openfreemap.org/styles/dark');
   });
 
   it('installs the sprite fallback on the map instance', () => {


### PR DESCRIPTION
## Summary

PR #1116 installed `installSpriteFallback()` in 3 of 4 map-bearing components; `PublicProfileViewV2.astro` was omitted. Aligns it.

The original report (#1166) — `AJAXError: Failed to fetch (0)` + `circle-11` missing on mobile Android — was triaged as **client-side**, not a 3P outage: `curl -A "Android"` confirmed OpenFreeMap returns HTTP 200 + CORS OK + planet active + sprite present. Closing comment on the issue documents that. This PR fixes the orthogonal real gap.

## Test plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npx vitest run map-style public-profile-sprite-fallback profile` — 56 passed
- [x] `npm run build` — 255 pages
- [ ] Required CI checks green

Closes #1166
Related: #1116 (sprite fallback original)

🤖 Generated with [Claude Code](https://claude.com/claude-code)