### PR TITLE
feat(qa): RLS policy-coverage gate in db-validate

### DIFF
--- a/.github/workflows/db-validate.yml
+++ b/.github/workflows/db-validate.yml
@@ -274,6 +274,16 @@ jobs:
         run: |
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/sql/rls.sql
 
+      - name: RLS policy coverage
+        # Static check (no DB required): every CREATE POLICY in
+        # supabase-schema.sql must be paired with an assertion in
+        # tests/sql/rls.sql, or listed in tests/sql/rls-coverage-allowlist.txt
+        # with a justification. Enforces CLAUDE.md "Don't enable a Supabase
+        # RLS policy without testing it" as a CI gate (issue #1172, epic
+        # #1031 Tier 2a).
+        run: |
+          bash scripts/check-rls-coverage.sh
+
       - name: Run chat-function regression suite
         run: |
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f tests/sql/chat.sql

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,18 @@ moving it post-install requires rewriting every geometry/geography
 column reference. The advisor's "Extension in Public" warning for
 `postgis` is accepted with that rationale.
 
+**RLS policy-coverage gate (#1172).** Every `CREATE POLICY` in
+`supabase-schema.sql` must be paired with an assertion in
+`tests/sql/rls.sql` — at minimum, any reference to the policy's
+`<schema>.<table>` in the test file counts; an explicit
+`-- policy:<schema>.<table>.<name>` marker is preferred for precision.
+`scripts/check-rls-coverage.sh` (wired into `db-validate.yml`)
+enforces this on every PR. When testing a policy is genuinely out of
+scope for a PR, append the entry to `tests/sql/rls-coverage-allowlist.txt`
+with a `# justification:` comment — this is the deferral mechanism, not
+a free pass. When *touching* a policy that has an allowlist entry,
+prefer migrating it to a real assertion so the backlog drains over time.
+
 ### Module spec convention
 - Implementation specs live at `docs/specs/modules/NN-*.md`, numbered
   sequentially. **The module spec wins** when it disagrees with

--- a/docs/qa-policy.md
+++ b/docs/qa-policy.md
@@ -107,7 +107,7 @@ Snapshot as of 2026-05-13 (`main` branch protection):
 |---|---|---|
 | `audit`   | `pr-audit.yml`           | Karma audit (module 23) — schema invariants, link rot, etc. |
 | `test`    | `ci.yml` → `test` job    | Vitest unit suite. |
-| `validate`| `db-validate.yml`        | Idempotent SQL apply twice against Postgres 17 + PostGIS 3.4. |
+| `validate`| `db-validate.yml`        | Idempotent SQL apply twice against Postgres 17 + PostGIS 3.4. Includes the RLS regression suite, schema security invariants, **and the RLS policy-coverage check** (`scripts/check-rls-coverage.sh`) that fails the PR when a new `CREATE POLICY` ships without a paired assertion in `tests/sql/rls.sql` and no entry in `tests/sql/rls-coverage-allowlist.txt` — see issue #1172. |
 | `verify`  | `ci.yml` → `verify` job  | Typecheck, build, search-index drift, `define:vars` check, bundle-size baseline. Deno EF contract tests join once Tier 1a lands. |
 | `CodeQL`                       | GitHub default | Security scan parent. |
 | `Analyze (javascript-typescript)` | GitHub default | CodeQL sub-job. |

--- a/scripts/check-rls-coverage.sh
+++ b/scripts/check-rls-coverage.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# check-rls-coverage.sh — fail when a CREATE POLICY in supabase-schema.sql
+# has no paired assertion in tests/sql/rls.sql and is not listed in the
+# allowlist at tests/sql/rls-coverage-allowlist.txt.
+#
+# Why: a broken RLS policy is a silent data leak. CLAUDE.md "Things you
+# should NOT do without asking" explicitly bans shipping an RLS policy
+# without testing it. This script turns that convention into a gate
+# wired in .github/workflows/db-validate.yml.
+#
+# How:
+#   1. Parse every CREATE POLICY "<name>" ON <schema.table> from
+#      docs/specs/infra/supabase-schema.sql (handles both quoted and
+#      unquoted policy names; dedupes idempotent DROP+CREATE pairs).
+#   2. Determine which are covered by tests/sql/rls.sql via:
+#        - explicit `-- policy:<schema>.<table>.<name>` markers, OR
+#        - fallback: any reference to `<schema>.<table>` in the test file
+#          (covers `INSERT INTO public.users`, `SELECT … FROM public.users`,
+#          etc.).
+#   3. Read tests/sql/rls-coverage-allowlist.txt and skip those entries.
+#   4. Exit non-zero if anything is left untested + not allowlisted.
+#
+# Usage:  bash scripts/check-rls-coverage.sh
+# Exits 0 if every policy is tested or allowlisted, non-zero otherwise.
+# Linked: issue #1172 (epic #1031 Tier 2a).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SCHEMA_FILE="docs/specs/infra/supabase-schema.sql"
+TESTS_FILE="tests/sql/rls.sql"
+ALLOWLIST_FILE="tests/sql/rls-coverage-allowlist.txt"
+
+for f in "$SCHEMA_FILE" "$TESTS_FILE"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: required file missing: $f"
+    exit 2
+  fi
+done
+
+# ─── 1. Extract policies ─────────────────────────────────────────────────────
+# Match `CREATE POLICY <name|"name"> ON <schema>.<table>` and emit
+# `<schema>.<table>.<name>` on stdout. Awk is more reliable than a single
+# extended grep across the quoted/unquoted/case variants we ship.
+policies_raw=$(awk '
+  /^[[:space:]]*CREATE POLICY/ {
+    line = $0
+    # strip leading "CREATE POLICY"
+    sub(/^[[:space:]]*CREATE POLICY[[:space:]]+/, "", line)
+
+    # policy name: quoted or bare identifier up to whitespace.
+    if (substr(line, 1, 1) == "\"") {
+      # quoted
+      rest = substr(line, 2)
+      qpos = index(rest, "\"")
+      if (qpos == 0) next
+      name = substr(rest, 1, qpos - 1)
+      line = substr(rest, qpos + 2)  # skip closing quote
+    } else {
+      # bare identifier
+      n = match(line, /[[:space:]]/)
+      if (n == 0) next
+      name = substr(line, 1, n - 1)
+      line = substr(line, n + 1)
+    }
+
+    # expect "ON <schema>.<table>"
+    sub(/^[[:space:]]+/, "", line)
+    if (substr(line, 1, 3) != "ON " && substr(line, 1, 3) != "ON\t") next
+    line = substr(line, 4)
+    sub(/^[[:space:]]+/, "", line)
+
+    # capture <schema>.<table>
+    if (match(line, /^[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*/) == 0) next
+    target = substr(line, RSTART, RLENGTH)
+
+    printf("%s.%s\n", target, name)
+  }
+' "$SCHEMA_FILE" | sort -u)
+
+policy_count=$(printf '%s\n' "$policies_raw" | grep -c . || true)
+
+if [ "$policy_count" -eq 0 ]; then
+  echo "ERROR: no CREATE POLICY statements parsed from $SCHEMA_FILE — parser regression?"
+  exit 2
+fi
+
+# ─── 2. Extract test coverage ────────────────────────────────────────────────
+# Two signals count as "tested":
+#
+# (a) Explicit markers — lines like
+#       -- policy:public.users.users_public_read
+#     The precision mechanism. Recommended for new policies.
+explicit_markers=$(grep -oE '^[[:space:]]*--[[:space:]]*policy:[A-Za-z0-9_]+\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+' "$TESTS_FILE" \
+  | sed -E 's/^[[:space:]]*--[[:space:]]*policy:[[:space:]]*//' \
+  | sort -u || true)
+
+# (b) Name-based hit — the policy's bare name appears as a word anywhere
+#     in the test file. Strict enough that injecting a new policy on an
+#     already-tested table still fails the gate (acceptance criterion #4
+#     of issue #1172), while loose enough that simply mentioning the
+#     policy name in a NOTICE / comment / SET-LOCAL is sufficient.
+test_words=$(grep -oE '\b[A-Za-z_][A-Za-z0-9_]+\b' "$TESTS_FILE" | sort -u || true)
+
+# ─── 3. Read allowlist ───────────────────────────────────────────────────────
+allowlist=""
+if [ -f "$ALLOWLIST_FILE" ]; then
+  allowlist=$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST_FILE" \
+    | sed -E 's/[[:space:]]*#.*$//' \
+    | sed -E 's/[[:space:]]+$//' \
+    | grep -E '^[A-Za-z0-9_]+\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+$' \
+    | sort -u || true)
+fi
+allowlist_count=$(printf '%s\n' "$allowlist" | grep -c . || true)
+
+# ─── 4. Compute untested ─────────────────────────────────────────────────────
+tested_count=0
+untested=""
+
+while IFS= read -r policy; do
+  [ -z "$policy" ] && continue
+  # `policy` is "<schema>.<table>.<name>"; isolate the bare policy name.
+  policy_name=$(printf '%s' "$policy" | awk -F. '{ print $NF }')
+
+  is_tested=0
+
+  # (a) explicit marker hit?
+  if printf '%s\n' "$explicit_markers" | grep -Fxq "$policy" 2>/dev/null; then
+    is_tested=1
+  fi
+
+  # (b) policy name appears as a word in the test file?
+  if [ "$is_tested" -eq 0 ]; then
+    if printf '%s\n' "$test_words" | grep -Fxq "$policy_name" 2>/dev/null; then
+      is_tested=1
+    fi
+  fi
+
+  if [ "$is_tested" -eq 1 ]; then
+    tested_count=$((tested_count + 1))
+    continue
+  fi
+
+  # not tested — allowlisted?
+  if printf '%s\n' "$allowlist" | grep -Fxq "$policy" 2>/dev/null; then
+    continue
+  fi
+
+  untested="${untested}${policy}
+"
+done <<< "$policies_raw"
+
+untested_count=$(printf '%s' "$untested" | grep -c . || true)
+
+# ─── 5. Report + exit ────────────────────────────────────────────────────────
+echo "policies: $policy_count"
+echo "tested: $tested_count"
+echo "allowlisted: $allowlist_count"
+echo "untested-not-allowlisted: $untested_count"
+
+if [ "$untested_count" -gt 0 ]; then
+  echo
+  echo "FAIL: $untested_count policy/policies have no paired assertion in $TESTS_FILE"
+  echo "      and are not listed in $ALLOWLIST_FILE."
+  echo
+  echo "Fix one of:"
+  echo "  (a) Add an assertion in $TESTS_FILE that touches the policy's table"
+  echo "      (any reference to <schema>.<table> counts; an explicit"
+  echo "       \`-- policy:<schema>.<table>.<name>\` marker is preferred)."
+  echo "  (b) Add the entry to $ALLOWLIST_FILE with a # justification: comment"
+  echo "      if testing is genuinely out of scope for this PR."
+  echo
+  echo "Untested policies:"
+  printf '%s' "$untested" | sed 's/^/  - /'
+  exit 1
+fi
+
+echo
+echo "OK: every CREATE POLICY in $SCHEMA_FILE is paired with an assertion"
+echo "    in $TESTS_FILE or is justified in $ALLOWLIST_FILE."
+exit 0

--- a/tests/sql/rls-coverage-allowlist.txt
+++ b/tests/sql/rls-coverage-allowlist.txt
@@ -1,0 +1,209 @@
+# tests/sql/rls-coverage-allowlist.txt
+#
+# Allowlist of CREATE POLICY entries that have no paired assertion in
+# tests/sql/rls.sql today. The check-rls-coverage.sh gate (wired into
+# .github/workflows/db-validate.yml) treats anything here as "tested by
+# convention" so the gate is green on day one without a 100-hour backfill.
+#
+# Format: one entry per line.
+#   <schema>.<table>.<policy_name>
+# Optional trailing `# justification: …` comment.
+#
+# When adding a new RLS policy in docs/specs/infra/supabase-schema.sql:
+#   1. PREFERRED: add an assertion in tests/sql/rls.sql (the policy's
+#      bare name must appear somewhere in the file — an explicit
+#      `-- policy:<schema>.<table>.<name>` marker is best).
+#   2. If testing is genuinely out of scope for this PR, append the
+#      `<schema>.<table>.<policy>` entry here with a `# justification:`
+#      comment explaining why.
+#
+# When touching an existing policy in a PR, prefer migrating its allowlist
+# entry to a real assertion — this is how we drain the backlog over time.
+# Per issue #1172 + epic #1031 Tier 2a.
+#
+# Initial seed: 2026-05-24 — see PR closing #1172.
+
+public.activity_events.activity_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.activity_events.activity_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.activity_events.activity_self_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_action_proposals.admin_action_proposals_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_action_proposals.admin_action_proposals_no_client_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_anomalies.admin_anomalies_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_anomalies.admin_anomalies_no_client_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_audit.admin_audit_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_audit.admin_audit_no_client_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_health_digests.admin_health_digests_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_health_digests.admin_health_digests_no_client_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_webhook_deliveries.admin_webhook_deliveries_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_webhook_deliveries.admin_webhook_deliveries_no_client_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_webhooks.admin_webhooks_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.admin_webhooks.admin_webhooks_no_client_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_errors_log.ai_errors_log_party_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_rate_limits.ai_rate_limits_no_client_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_rate_limits.ai_rate_limits_no_client_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_rate_limits.ai_rate_limits_no_client_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_usage_monthly.ai_usage_monthly_no_client_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_usage_monthly.ai_usage_monthly_no_client_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_usage_monthly.ai_usage_monthly_no_client_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_usage_monthly.ai_usage_monthly_party_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_usage.ai_usage_no_client_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_usage.ai_usage_no_client_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_usage.ai_usage_no_client_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ai_usage.ai_usage_party_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.anon_rate_limit.anon_rate_limit_service_only  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.api_usage.api_usage_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.api_usage.api_usage_read_admin  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.app_feature_flags.feature_flags_no_client_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.app_feature_flags.feature_flags_no_client_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.app_feature_flags.feature_flags_no_client_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.app_feature_flags.feature_flags_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.badges.badges_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ban_appeals.ban_appeals_mod_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ban_appeals.ban_appeals_no_client_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ban_appeals.ban_appeals_no_client_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ban_appeals.ban_appeals_self_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.ban_appeals.ban_appeals_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.blocks.blocks_owner_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.blocks.blocks_owner_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.blocks.blocks_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.camera_station_periods.camera_station_periods_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.camera_station_periods.camera_station_periods_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.camera_stations.camera_stations_owner_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.camera_stations.camera_stations_owner_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.camera_stations.camera_stations_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.camera_stations.camera_stations_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.community_themes.community_themes_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.community_themes.community_themes_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.community_themes.community_themes_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.dwc_export_log.dwc_export_log_owner_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.dwc_export_log.dwc_export_log_service_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.events.events_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.expert_applications.expert_apps_insert_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.expert_applications.expert_apps_read_admin  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.expert_applications.expert_apps_read_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.featured_observers.featured_observers_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.follows.follows_followee_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.follows.follows_owner_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.follows.follows_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.follows.follows_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.follows.follows_self_manage  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.function_errors.function_errors_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.function_errors.function_errors_no_client_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.gc_orphan_media_log.gc_orphan_media_log_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.identification_reactions.idreact_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.identification_reactions.idreact_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.identification_reactions.idreact_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.identifications.id_owner  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.identifications.id_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.identifications.id_validator_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.identifications.id_validator_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.identifications.id_validator_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.institutional_affiliations.affiliations_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.institutions.institutions_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.iso_countries.iso_countries_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.kairos_subscriptions.kairos_subs_delete_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.kairos_subscriptions.kairos_subs_insert_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.kairos_subscriptions.kairos_subs_select_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.kairos_subscriptions.kairos_subs_update_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.karma_config.karma_config_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.karma_events.karma_events_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.karma_events.karma_events_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.karma_milestones.karma_milestones_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.karma_rarity_multipliers.karma_rarity_multipliers_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.karma_thresholds.karma_thresholds_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.media_files.media_owner  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.media_files.media_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.migration_windows.migration_windows_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.notifications_sent.notifications_sent_no_client_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.notifications_sent.notifications_sent_no_client_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.notifications_sent.notifications_sent_no_client_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.notifications.notif_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.notifications.notif_no_client_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.notifications.notif_owner_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.notifications.notif_owner_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.notifications.notif_owner_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observation_comments.comments_authenticated_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observation_comments.comments_mod_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observation_comments.comments_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observation_comments.comments_self_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observation_reactions.obsreact_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observation_reactions.obsreact_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observation_reactions.obsreact_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observations.obs_collaborator_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.observations.obs_credentialed_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.photo_reactions.photoreact_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.photo_reactions.photoreact_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.photo_reactions.photoreact_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.pits.pits_authenticated_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.pits.pits_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.places.places_owner_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.places.places_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.places.places_user_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.pool_consumption.pool_consumption_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.pool_usage_daily.pool_usage_daily_owner_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.pool_user_usage.pool_user_usage_owner_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.project_members.project_members_owner_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.project_members.project_members_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.projects.projects_owner_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.projects.projects_owner_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.projects.projects_owner_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.projects.projects_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.push_subscriptions.push_subs_delete_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.push_subscriptions.push_subs_insert_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.push_subscriptions.push_subs_select_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.rate_limit_buckets.rate_limit_no_client_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.regional_taxa_baseline.regional_baseline_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.reports.reports_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.reports.reports_mod_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.reports.reports_owner_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.reports.reports_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.spatial_ref_sys.spatial_ref_sys_world_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.species_list_items.species_list_items_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.species_list_items.species_list_items_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.species_lists.species_lists_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.species_lists.species_lists_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsor_credentials.sponsor_credentials_owner_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsor_pools.sponsor_pools_owner_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsor_pools.sponsor_pools_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsorship_requests.sponsorship_requests_no_client_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsorship_requests.sponsorship_requests_no_client_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsorship_requests.sponsorship_requests_no_client_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsorship_requests.sponsorship_requests_party_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsorships.sponsorships_party_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sponsorships.sponsorships_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.surprise_events.surprise_events_self_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.surprise_events.surprise_events_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sync_failures.sync_failures_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.sync_failures.sync_failures_read_admin  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.taxa.taxa_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.taxon_range_index.taxon_range_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.taxon_rarity.taxon_rarity_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.taxon_traits.taxon_traits_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.taxon_usage_history.taxon_usage_history_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.trails.trails_owner_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.trails.trails_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_api_tokens.tokens_delete_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_api_tokens.tokens_select_own  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_badges.user_badges_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_badges.user_badges_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_bans.user_bans_mod_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_bans.user_bans_no_client_delete  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_bans.user_bans_no_client_insert  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_bans.user_bans_no_client_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_expertise.user_expertise_facet_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_expertise.user_expertise_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_expertise.user_expertise_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_roles.user_roles_admin_or_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_roles.user_roles_no_self_write  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_streaks.streaks_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.user_streaks.streaks_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.users.users_self_update  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.users.users_update_self_privacy  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.watchlists.watchlists_admin_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.watchlists.watchlists_self  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.weekly_validator_rewards.validator_rewards_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+public.wrapped_cache.wrapped_cache_self_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+storage.objects.media_authenticated_list  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+storage.objects.media_insert_authenticated  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+storage.objects.media_public_read  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched
+storage.objects.media_update_authenticated  # justification: initial seed 2026-05-24; backfill per-PR as policies are touched


### PR DESCRIPTION
## Summary

Closes #1172. Adds a static-analysis gate that fails CI when a `CREATE POLICY` in `supabase-schema.sql` has no corresponding block in `tests/sql/rls.sql` and isn't explicitly allowlisted.

| metric | count |
|---|---|
| Unique policies (after dedup) | 190 |
| Already tested | 6 |
| Allowlisted (seed) | 184 |
| Untested-not-allowlisted | 0 ✅ |

The allowlist is the deferral mechanism — backfill happens per-PR as policies are touched. Adding a new policy without a test OR allowlist entry now fails the gate.

## Test plan
- [x] Baseline: `bash scripts/check-rls-coverage.sh` → exit 0
- [x] Delete allowlist line → exit 1 with violation name
- [x] Inject `CREATE POLICY "fake" ON public.users …` → exit 1, `fake` in untested list
- [x] `npx tsc --noEmit` clean
- [ ] Required CI checks green

Closes #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)