### PR TITLE
feat(qa): Vitest coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,31 @@ jobs:
       - name: Unit tests (Vitest)
         run: npm test
 
+      - name: Coverage floor (#1174)
+        # Re-runs the unit suite with v8 coverage, parses
+        # coverage/coverage-summary.json, compares against
+        # tests/coverage-floor.txt, fails when current < floor.
+        # The json-summary reporter is wired into vitest.config.ts's
+        # coverage.reporter array — do NOT pass --reporter=json-summary
+        # to vitest itself (that's the *test* reporter, not the
+        # coverage reporter, and it 404s the loader).
+        run: |
+          set -euo pipefail
+          npm run test:coverage 2>&1 | tail -5
+          CURRENT=$(jq -r '.total.lines.pct' coverage/coverage-summary.json)
+          FLOOR=$(grep -v '^#' tests/coverage-floor.txt | tail -n1)
+          DELTA=$(awk -v c="$CURRENT" -v f="$FLOOR" 'BEGIN{printf "%.2f", c-f}')
+          {
+            echo "## Coverage report"
+            echo ""
+            echo "Lines coverage: ${CURRENT}% (floor: ${FLOOR}%, delta: ${DELTA}%)"
+            echo ""
+            echo "| current | floor | delta |"
+            echo "|---:|---:|---:|"
+            echo "| ${CURRENT}% | ${FLOOR}% | ${DELTA}% |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          awk -v c="$CURRENT" -v f="$FLOOR" 'BEGIN{exit (c<f)?1:0}'
+
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ playwright-report/
 test-results/
 .lighthouseci/
 
+# Vitest coverage artifacts (floor lives in tests/coverage-floor.txt)
+coverage/
+
 # Brainstorming companion (superpowers skill)
 .superpowers/
 

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ db-backfill-taxon-id: ## One-time backfill: resolve primary_taxon_id on observat
 	@echo "Done. Verify with: make db-tables"
 
 ## Docs & checks
-.PHONY: lint typecheck test docs-check
+.PHONY: lint typecheck test docs-check coverage-update
 lint: ## (Placeholder — wire up eslint once code lands)
 	@echo "TODO: eslint in v0.1. No app code yet."
 
@@ -151,6 +151,15 @@ test: ## Run unit tests (vitest)
 
 test-coverage: ## Run unit tests with coverage report
 	npm run test:coverage
+
+coverage-update: ## Suggest new coverage floor (raise after refactors)
+	@npm run test:coverage > /dev/null 2>&1
+	@CURRENT=$$(jq -r '.total.lines.pct' coverage/coverage-summary.json); \
+	 FLOOR=$$(grep -v '^#' tests/coverage-floor.txt | tail -n1); \
+	 NEW=$$(awk -v c=$$CURRENT 'BEGIN{printf "%d", c-5}'); \
+	 echo "Current: $$CURRENT% — Current floor: $$FLOOR%"; \
+	 echo "Suggested new floor (current - 5): $$NEW%"; \
+	 echo "If raising the floor, edit tests/coverage-floor.txt and refresh the captured-on header."
 
 docs-check: ## Verify module index lists every module spec present on disk
 	@echo "Specs on disk:"

--- a/docs/qa-policy.md
+++ b/docs/qa-policy.md
@@ -109,6 +109,7 @@ Snapshot as of 2026-05-13 (`main` branch protection):
 | `test`    | `ci.yml` → `test` job    | Vitest unit suite. |
 | `validate`| `db-validate.yml`        | Idempotent SQL apply twice against Postgres 17 + PostGIS 3.4. |
 | `verify`  | `ci.yml` → `verify` job  | Typecheck, build, search-index drift, `define:vars` check, bundle-size baseline. Deno EF contract tests join once Tier 1a lands. |
+| `coverage` | `ci.yml` → `verify` job step "Coverage floor (#1174)" | `npm run test:coverage`; floor in `tests/coverage-floor.txt`; -5% vs baseline. |
 | `CodeQL`                       | GitHub default | Security scan parent. |
 | `Analyze (javascript-typescript)` | GitHub default | CodeQL sub-job. |
 | `GitGuardian Security Checks`  | GitGuardian app | Secret scanning. |
@@ -162,6 +163,32 @@ failure (issue auto-open, email, Slack — pick one). Do not gate PRs on it.
 
 The Deno EF contract suite is on track to clear all four once Tier 1a
 finishes wiring it into the `verify` job.
+
+### Coverage floor (#1174)
+
+The `coverage` step is the cheapest possible quality gate: it captures
+today's line-coverage number and trips when a PR drops more than 5
+percentage points below it. The floor lives in
+[`tests/coverage-floor.txt`](../tests/coverage-floor.txt) as a single
+number plus a header comment naming the capture date and SHA.
+
+The floor **stays put** between PRs — improvements happen organically,
+and we don't push for *more* coverage on every change.
+
+A PR can **raise the floor in the same PR** when a refactor genuinely
+removes branches (so coverage % rises without adding tests). Procedure:
+
+1. Run `make coverage-update` locally — prints current %, current
+   floor, and the suggested new floor (current − 5).
+2. Bump the number in `tests/coverage-floor.txt` and refresh the
+   `# Captured <date> on main @ <sha>` header.
+3. Commit both files in the same PR that did the refactor; the CI step
+   will validate against the new floor.
+
+Do **not** lower the floor to make a red CI green. If a PR drops
+coverage by more than 5 points, the right move is to add a happy-path
+test for the new code; if that's truly out of scope, fall back to the
+§5 override procedure and file the follow-up issue.
 
 ---
 

--- a/tests/coverage-floor.txt
+++ b/tests/coverage-floor.txt
@@ -1,0 +1,4 @@
+# Captured 2026-05-24 on main @ 6cc66df1ed0bd87929a145676e8a0889f59491eb
+# Measures src/lib/**/*.ts (per vitest.config.ts coverage.include)
+# Floor is baseline - 5; raise via make coverage-update when refactor genuinely improves coverage.
+47

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     // @huggingface/transformers v4 even in browser-only builds). The mock is
     // defined inline in the test file — no exclusion needed here.
     coverage: {
-      reporter: ['text', 'json'],
+      reporter: ['text', 'json', 'json-summary'],
       include: ['src/lib/**/*.ts'],
       exclude: ['**/*.test.ts'],
     },


### PR DESCRIPTION
## Summary

Closes #1174. Captures today's `src/lib/**/*.ts` lines coverage as a floor and gates regressions at floor - 5%.

| metric | value |
|---|---|
| Baseline (current) | 52.45% |
| Floor (committed) | 47% |
| Buffer | 5.45% |
| Pinned SHA | 6cc66df |

## Notable fix

The issue's `npm run test:coverage -- --reporter=json-summary` doesn't work — `--reporter=` targets the *test* reporter (vitest's `Reporter` interface), not the coverage reporter. Fixed by adding `'json-summary'` to `coverage.reporter` in `vitest.config.ts`; `npm run test:coverage` alone now writes `coverage/coverage-summary.json` deterministically.

## Test plan
- [x] `npm run test:coverage` → `coverage/coverage-summary.json` ✓
- [x] Simulated CI pass (current=52.45, floor=47) → exit 0
- [x] Simulated CI fail (floor=99.99) → exit 1
- [x] `make coverage-update` lists current + suggested floor
- [x] `npx tsc --noEmit` clean
- [ ] Required CI checks green

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)