### PR TITLE
feat(qa): per-route JS bundle budgets via size-limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,16 +114,40 @@ jobs:
             exit 1
           fi
 
-      - name: Report bundle size
+      - name: Bundle budgets (size-limit)
+        # Per-route brotli budgets — config at `.size-limit.cjs`,
+        # rationale at `.size-limit.md`. Exits non-zero when any route's
+        # JS chunks exceed its budget; the JSON output is rendered as a
+        # markdown table in $GITHUB_STEP_SUMMARY for at-a-glance review.
         run: |
-          echo "## Build size" >> $GITHUB_STEP_SUMMARY
-          du -sh dist >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+          echo "## Bundle budgets" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Largest files" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          find dist -type f \( -name '*.js' -o -name '*.css' -o -name '*.html' \) \
-            -exec du -h {} + | sort -rh | head -20 >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          # Run twice: once for the human-readable terminal output the job
+          # log shows, once with --json so we can build a Step Summary
+          # table. Both invocations read the same config and dist/.
+          npx size-limit | tee size-limit.txt || gate_status=$?
+          gate_status="${gate_status:-0}"
+          npx size-limit --json > size-limit.json 2>/dev/null || true
+          if [ -s size-limit.json ]; then
+            echo "| Route | Size (brotli) | Budget | Status |" >> $GITHUB_STEP_SUMMARY
+            echo "|---|---:|---:|:---:|" >> $GITHUB_STEP_SUMMARY
+            node -e '
+              const rows = JSON.parse(require("fs").readFileSync("size-limit.json", "utf8"));
+              const kb = (n) => (n / 1024).toFixed(2) + " kB";
+              const lines = rows.map(r => {
+                const pct = ((r.size / r.sizeLimit) * 100).toFixed(0);
+                const icon = r.passed ? "PASS" : "FAIL";
+                return `| ${r.name} | ${kb(r.size)} (${pct}%) | ${kb(r.sizeLimit)} | ${icon} |`;
+              });
+              console.log(lines.join("\n"));
+            ' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "_(size-limit JSON unavailable — see job log)_" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "_See [\`.size-limit.md\`](../blob/main/.size-limit.md) for per-route rationale and override convention._" >> $GITHUB_STEP_SUMMARY
+          exit "$gate_status"
 
   # TODO (v0.1 module scope): unit + RLS + e2e tests once docs/specs/infra/testing.md is implemented.
   # test:

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,0 +1,75 @@
+// Per-route JS bundle budgets for Rastrum's static Astro build.
+//
+// Each entry below maps a public route → a budget over the JS chunks
+// referenced by that route's emitted `dist/<route>/index.html`.
+//
+// Why dynamic resolution? Astro emits content-hashed filenames
+// (`/_astro/Foo.<hash>.js`) that change every build. Hard-coding paths
+// would force us to edit this file on every chunk-name churn. Instead we
+// scan the HTML for `/_astro/*.js` references at config-load time so the
+// path arrays we hand to size-limit always reflect the real referenced
+// set.
+//
+// Budgets are derived from the current baseline (May 2026) plus ~20%
+// headroom rounded to a clean number — see `.size-limit.md` for the
+// per-route rationale and the v1.1 override convention.
+//
+// To rebaseline: run `npm run build`, then `node scripts/bundle-budgets-report.mjs`
+// to see current numbers and adjust the `limit` here in the same PR.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DIST = path.resolve(__dirname, 'dist');
+
+// Routes covered by the gate. Each entry MUST exist post-build; if Astro
+// renames a slug we want to fail loudly so the gate stays honest.
+//
+// Order matches what we report in $GITHUB_STEP_SUMMARY (home first, then
+// the hot paths).
+// Limits are brotli-compressed — that's what users actually pay for over
+// the network. Baseline (May 2026) sizes + ~20% headroom rounded clean:
+//
+//   home    34.92 kB → 50 kB
+//   observe 48.49 kB → 65 kB
+//   console  7.11 kB → 12 kB
+//   species 35.02 kB → 50 kB
+//   chat    36.58 kB → 50 kB
+//
+// Override convention: raise a budget in this file with a one-line PR-
+// comment justification (see `docs/qa-policy.md` §6). NEVER raise as a
+// CI re-run workaround.
+const ROUTES = [
+  { name: 'home (en)',         html: 'en/index.html',                   limit: '50 KB' },
+  { name: 'observe (en)',      html: 'en/observe/index.html',           limit: '65 KB' },
+  { name: 'console (en)',      html: 'en/console/index.html',           limit: '12 KB' },
+  { name: 'species (en)',      html: 'en/explore/species/index.html',   limit: '50 KB' },
+  { name: 'chat (en)',         html: 'en/chat/index.html',              limit: '50 KB' },
+];
+
+function chunksFor(htmlRel) {
+  const htmlAbs = path.join(DIST, htmlRel);
+  if (!fs.existsSync(htmlAbs)) {
+    // Treat a missing HTML as a config error rather than silently passing —
+    // the gate should never be a no-op.
+    throw new Error(
+      `[.size-limit.cjs] expected ${htmlAbs} after build; route slug renamed? ` +
+      `Update the ROUTES table or run \`npm run build\` first.`,
+    );
+  }
+  const html = fs.readFileSync(htmlAbs, 'utf8');
+  const refs = Array.from(html.matchAll(/\/_astro\/[A-Za-z0-9._-]+\.js/g))
+    .map(m => m[0])
+    .filter((v, i, a) => a.indexOf(v) === i)
+    .sort();
+  return refs.map(ref => path.join('dist', ref));
+}
+
+module.exports = ROUTES.map(r => ({
+  name: r.name,
+  path: chunksFor(r.html),
+  limit: r.limit,
+  // Brotli is the default compressor. Astro ships brotli-friendly chunks
+  // already and CDN-served bytes are what users actually pay for.
+  brotli: true,
+}));

--- a/.size-limit.md
+++ b/.size-limit.md
@@ -1,0 +1,61 @@
+# Per-route bundle budgets — rationale
+
+Rastrum is a PWA targeting Latin America. Bundle is **install-time cost**
+on first paint and **transfer cost** on every reload, not just a local
+load-time worry. This file documents the per-route JS budgets enforced by
+`size-limit` (config: [`.size-limit.cjs`](.size-limit.cjs); CI: `verify`
+job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
+
+Limits are **brotli-compressed bytes** — that's what users actually pay
+for over the network. Baseline measurements taken May 2026; +20%
+headroom rounded clean.
+
+| Route | Baseline | Budget | Rationale |
+|---|---|---|---|
+| `en/` (home) | 34.92 kB | **50 kB** | Hero + chips + onboarding tour. The first impression — every byte here is paid on cold install. Headroom for one more home widget. |
+| `en/observe/` | 48.49 kB | **65 kB** | The biggest legitimately-heavy route — observation form + map picker + camera FAB + on-device AI bootstrap. Headroom: one new identifier card or sovereignty surface. |
+| `en/console/` | 7.11 kB | **12 kB** | Admin shell only — most tabs lazy-load. Anything over 12 kB on the entry shell means too much eagerly loaded for non-admins to even render the empty case. |
+| `en/explore/species/` | 35.02 kB | **50 kB** | Search + species cards + map. Headroom: filter chips, no full new view. |
+| `en/chat/` | 36.58 kB | **50 kB** | Threads list + composer. Headroom: one new chat action surface. |
+
+## What the gate catches
+
+- A new dep (10 KB+) imported into a top-level page → matches a budget.
+- A heavy component imported eagerly when it should be lazy → matches.
+- A regex blob, base64 asset, or word-list shipped to the client → matches.
+
+## What the gate doesn't catch
+
+- Sub-route inflation (e.g., `/profile/edit/`, `/projects/detail/`). v1
+  budget is one entry per top-level section; sub-routes inherit from the
+  section budget by convention. Add a row here if a sub-route warrants
+  its own ceiling.
+- CSS / image / font growth — JS is the long pole on first paint.
+- Service worker / WebLLM model weights — those live in
+  `PERSISTENT_CACHES` and are budgeted separately by SW versioning.
+
+## Override convention
+
+Budgets are **policy**, not a ceiling discovered by hand-wavy
+estimation. When a route legitimately needs more headroom (real new
+feature, not a regression):
+
+1. **Raise the budget in this PR**, not a follow-up. Reviewer sees the
+   new shape next to the rationale.
+2. **One-line justification in the PR description**:
+   > Raises `chat` budget 50 → 60 kB: ships voice-input dictation
+   > (Issue #1234). Brotli baseline now 54.1 kB.
+3. **Never raise via CI re-run.** If the gate fails, fix the cause or
+   raise the budget. Don't `gh run rerun` and hope the flake gods are
+   generous.
+
+If a route's brotli size has *grown without intent* (drive-by import,
+upstream lib regression, etc.), revert the offending import and re-run.
+The gate exists exactly so this conversation happens **before** merge.
+
+## Sub-route equivalents
+
+The English route is the canonical one — Spanish slugs (`/observar/`,
+`/consola/`, `/explorar/especies/`) ship the same chunks because both
+locales render the same components. Adding the EN form to `.size-limit.cjs`
+is sufficient; if an ES-only divergence ever appears, mirror the entry.

--- a/docs/qa-policy.md
+++ b/docs/qa-policy.md
@@ -108,8 +108,9 @@ Snapshot as of 2026-05-13 (`main` branch protection):
 | `audit`   | `pr-audit.yml`           | Karma audit (module 23) — schema invariants, link rot, etc. |
 | `test`    | `ci.yml` → `test` job    | Vitest unit suite. |
 | `validate`| `db-validate.yml`        | Idempotent SQL apply twice against Postgres 17 + PostGIS 3.4. Includes the RLS regression suite, schema security invariants, **and the RLS policy-coverage check** (`scripts/check-rls-coverage.sh`) that fails the PR when a new `CREATE POLICY` ships without a paired assertion in `tests/sql/rls.sql` and no entry in `tests/sql/rls-coverage-allowlist.txt` — see issue #1172. |
-| `verify`  | `ci.yml` → `verify` job  | Typecheck, build, search-index drift, `define:vars` check, bundle-size baseline. Deno EF contract tests join once Tier 1a lands. |
+| `verify`  | `ci.yml` → `verify` job  | Typecheck, build, search-index drift, `define:vars` check, per-route JS bundle budgets (`bundle-budgets` step — see below). Deno EF contract tests join once Tier 1a lands. |
 | `coverage` | `ci.yml` → `verify` job step "Coverage floor (#1174)" | `npm run test:coverage`; floor in `tests/coverage-floor.txt`; -5% vs baseline. |
+| `bundle-budgets` | `ci.yml` → `verify` → "Bundle budgets (size-limit)" step | Per-route brotli-compressed JS budgets enforced by `size-limit` (config: `.size-limit.cjs`; rationale: `.size-limit.md`). Five routes covered v1: home, observe, console, species, chat. Exits non-zero when any route's chunks exceed budget; emits a markdown table to `$GITHUB_STEP_SUMMARY`. |
 | `CodeQL`                       | GitHub default | Security scan parent. |
 | `Analyze (javascript-typescript)` | GitHub default | CodeQL sub-job. |
 | `GitGuardian Security Checks`  | GitGuardian app | Secret scanning. |
@@ -189,6 +190,25 @@ Do **not** lower the floor to make a red CI green. If a PR drops
 coverage by more than 5 points, the right move is to add a happy-path
 test for the new code; if that's truly out of scope, fall back to the
 §5 override procedure and file the follow-up issue.
+
+### Bundle-budget override knob (#1173)
+
+The `bundle-budgets` step gates PRs on per-route JS size. When a route
+**legitimately** needs more headroom (real new feature, not a regression
+from a drive-by import), raise the budget in the same PR:
+
+1. Edit the relevant `limit` in [`.size-limit.cjs`](../.size-limit.cjs).
+   The file lives at the repo root and lists one entry per route.
+2. **One-line justification in the PR description**, e.g.:
+   > Raises `chat` budget 50 → 60 kB: ships voice-input dictation
+   > (#1234). Brotli baseline now 54.1 kB.
+3. **Never** raise via `gh run rerun`. The gate exists so this
+   conversation happens before merge; treating a failure as flake
+   defeats the gate's purpose.
+
+If a budget grows without a feature attached, revert the offending
+import instead of raising. The per-route rationale lives in
+[`.size-limit.md`](../.size-limit.md).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rastrum",
-  "version": "2026.5.3",
+  "version": "2026.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rastrum",
-      "version": "2026.5.3",
+      "version": "2026.5.5",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.2",
         "@astrojs/tailwind": "^6.0.2",
@@ -31,11 +31,13 @@
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.59.1",
         "@resvg/resvg-js": "^2.6.2",
+        "@size-limit/file": "^12.1.0",
         "@tauri-apps/cli": "^2",
         "@vitest/coverage-v8": "^4.1.5",
         "happy-dom": "^20.9.0",
         "jsdom": "^29.0.2",
         "satori": "^0.26.0",
+        "size-limit": "^12.1.0",
         "vitest": "^4.1.5"
       },
       "engines": {
@@ -2718,6 +2720,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4105,6 +4120,16 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7053,15 +7078,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
@@ -8811,6 +8827,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/negotiator": {
@@ -10810,6 +10836,34 @@
         "npm": ">=10.8.2"
       }
     },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -11157,6 +11211,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/tar-fs": {

--- a/package.json
+++ b/package.json
@@ -58,11 +58,13 @@
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.59.1",
     "@resvg/resvg-js": "^2.6.2",
+    "@size-limit/file": "^12.1.0",
     "@tauri-apps/cli": "^2",
     "@vitest/coverage-v8": "^4.1.5",
     "happy-dom": "^20.9.0",
     "jsdom": "^29.0.2",
     "satori": "^0.26.0",
+    "size-limit": "^12.1.0",
     "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Summary

Closes #1173. Replaces passive `du -sh dist` in ci.yml with size-limit gates per route.

| Route | Baseline (brotli) | Budget | Headroom |
|---|---:|---:|---:|
| home (en) | 34.92 kB | 50 kB | 43% |
| observe (en) | 48.49 kB | 65 kB | 34% |
| console (en) | 7.11 kB | 12 kB | 69% |
| explore/species (en) | 35.02 kB | 50 kB | 43% |
| chat (en) | 36.58 kB | 50 kB | 37% |

## Key design decisions

1. **Brotli, not raw.** Users transfer brotli-compressed bytes — that's what costs them. Gate on what users feel.
2. **Dynamic config.** `.size-limit.cjs` scans `dist/<route>/index.html` per build for `/_astro/*.js` references, so chunk-hash churn doesn't require config edits.
3. **Per-route specificity.** Inflating home doesn't fail observe — the gate names the offending route.

## Test plan
- [x] `npx size-limit` baseline → 5/5 green, exit 0
- [x] Simulated regression (200 KB blob → home) → home fails by 185.51 kB, others green, exit 1
- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 2729/2729 passed
- [x] `npm run build` — 255 pages
- [ ] Required CI checks green

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)