### PR TITLE
refactor(observe): extract 5 simple templates from ObserveView2 (PR1/3 of #1023)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -7,6 +7,11 @@ import TaxonAutocomplete from "./TaxonAutocomplete.astro";
 import ActiveObserversBanner from "./ActiveObserversBanner.astro";
 import ContextualSpeciesChips from "./ContextualSpeciesChips.astro";
 import WhyThisSpecies from "./WhyThisSpecies.astro";
+import IdentifyOnlyResult from "./observe/IdentifyOnlyResult.astro";
+import NoRunnersBlock from "./observe/NoRunnersBlock.astro";
+import AudioSkippedWarning from "./observe/AudioSkippedWarning.astro";
+import CapabilityCaption from "./observe/CapabilityCaption.astro";
+import AiModeSelector from "./observe/AiModeSelector.astro";
 import { t } from "../i18n/utils";
 import { HABITATS, WEATHERS } from "../lib/observation-enums";
 
@@ -75,34 +80,12 @@ const weathers = WEATHERS;
     </button>
   </div>
 
-  <!-- AI capability caption — single positive line, replaces the prior
-       multi-line banner with 4❌ (#942 PR5 redo). JS rewrites the inner
-       text once detectRunners() resolves. Hidden until then to avoid
-       layout shift. -->
-  <p id="obs2-capability-caption" class="hidden text-xs text-zinc-500 dark:text-zinc-400 text-center">
-    <span id="obs2-capability-text">{isEs ? "Verificando modelos…" : "Checking models…"}</span>
-    <a id="obs2-setup-link" href={isEs ? "/es/perfil/editar#on-device-ai-section" : "/en/profile/edit#on-device-ai-section"}
-      class="hidden ml-1 text-emerald-600 dark:text-emerald-400 underline hover:no-underline">
-      {isEs ? "configurar →" : "set up →"}
-    </a>
-  </p>
+  <CapabilityCaption lang={lang} />
 
   <!-- Contextual hint (shown briefly after file drop) -->
   <div id="obs2-file-hint" class="hidden rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30 px-3 py-2 text-xs text-blue-800 dark:text-blue-300 transition-all"></div>
 
-  <!-- AI mode selector (#296) — hidden by default; revealed only when
-       ≥2 modes are usable (#942 PR5 redo). A selector with one usable
-       option + disabled siblings reads as broken UI. -->
-  <div id="obs2-ai-mode-selector" class="hidden">
-    <div class="flex items-center gap-2 flex-wrap">
-      <span class="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0">{isEs ? "Fuente de IA:" : "AI source:"}</span>
-      <div class="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs" role="group" aria-label={isEs ? "Fuente de IA" : "AI source"}>
-        <button type="button" id="obs2-mode-sponsored" data-mode="sponsored" class="obs2-mode-btn px-3 py-1.5 font-medium transition-colors">{isEs ? "Patrocinado" : "Sponsored"}</button>
-        <button type="button" id="obs2-mode-own-key" data-mode="own-key" class="obs2-mode-btn px-3 py-1.5 font-medium transition-colors border-l border-zinc-200 dark:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed">{isEs ? "Llave propia" : "Own key"}</button>
-        <button type="button" id="obs2-mode-local" data-mode="local" class="obs2-mode-btn px-3 py-1.5 font-medium transition-colors border-l border-zinc-200 dark:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed">{isEs ? "Solo local" : "Local only"}</button>
-      </div>
-    </div>
-  </div>
+  <AiModeSelector lang={lang} />
 
   <!-- Pipeline section (hidden until files added) -->
   <div id="obs2-pipeline-section" class="hidden space-y-3">
@@ -126,32 +109,7 @@ const weathers = WEATHERS;
     </div>
   </div>
 
-  <!-- Audio-skipped warning (#278) — shown when audio node skipped due to BirdNET not downloaded -->
-  <div id="obs2-audio-skip-warn" class="hidden rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30 p-4 space-y-3">
-    <div class="flex items-start gap-3">
-      <span class="text-2xl shrink-0">🎵</span>
-      <div class="space-y-1">
-        <p class="font-semibold text-amber-800 dark:text-amber-300 text-sm">
-          {isEs ? "Audio sin identificar — BirdNET no descargado" : "Audio not identified — BirdNET not downloaded"}
-        </p>
-        <p class="text-xs text-zinc-600 dark:text-zinc-400">
-          {isEs
-            ? "Tu grabación de audio no pudo ser identificada porque BirdNET no está instalado. Descárgalo gratis (~50 MB) para identificar cantos de ave en tu dispositivo."
-            : "Your audio recording couldn't be identified because BirdNET isn't installed. Download it free (~50 MB) to identify bird calls on your device."}
-        </p>
-      </div>
-    </div>
-    <div class="flex flex-wrap gap-2">
-      <a href={isEs ? "/es/perfil/editar#on-device-ai-section" : "/en/profile/edit#on-device-ai-section"}
-        class="min-h-[40px] rounded-xl bg-emerald-700 hover:bg-emerald-800 text-white font-semibold text-xs px-4 flex items-center transition-colors">
-        {isEs ? "Descargar BirdNET" : "Download BirdNET"}
-      </a>
-      <button type="button" id="obs2-audio-skip-continue"
-        class="min-h-[40px] rounded-xl border border-zinc-300 dark:border-zinc-700 text-xs px-4 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors">
-        {isEs ? "Guardar sin identificar" : "Save without identification"}
-      </button>
-    </div>
-  </div>
+  <AudioSkippedWarning lang={lang} />
 
   <!-- Post-process form (hidden until pipeline done) -->
   <form id="obs2-post-form" class="hidden space-y-5" novalidate>
@@ -322,53 +280,9 @@ const weathers = WEATHERS;
          The identify-only mode is accessible via /observe?mode=identify. -->
   </form>
 
-  <!-- Identify-only result (shown when ?mode=identify, pipeline done, user skips save) -->
-  <div id="obs2-identify-result" class="hidden rounded-xl border border-emerald-200 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 p-5 space-y-3">
-    <p class="font-semibold text-emerald-800 dark:text-emerald-300 text-center">
-      {isEs ? "Identificación completa" : "Identification complete"}
-    </p>
-    <div id="obs2-identify-species-card" class="space-y-1 text-center"></div>
-    <div class="border-t border-emerald-200 dark:border-emerald-800 pt-3 space-y-2">
-      <p class="text-xs text-zinc-500 dark:text-zinc-400 text-center">
-        {isEs
-          ? "¿Quieres que esta observación ayude a la ciencia?"
-          : "Want this sighting to help science?"}
-      </p>
-      <button type="button" id="obs2-contribute-btn"
-        class="w-full min-h-[44px] rounded-xl bg-emerald-700 hover:bg-emerald-800 text-white font-semibold text-sm transition-colors">
-        {isEs ? "Sí, guardar en Rastrum" : "Yes, save to Rastrum"}
-      </button>
-      <button type="button" id="obs2-identify-done-btn"
-        class="w-full text-xs text-zinc-400 hover:text-zinc-600 underline py-1">
-        {isEs ? "No gracias" : "No thanks"}
-      </button>
-    </div>
-  </div>
+  <IdentifyOnlyResult lang={lang} />
 
-  <!-- No-runners empty state (#274) -->
-  <div id="obs2-no-runners" class="hidden rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/40 p-5 space-y-3">
-    <p class="font-semibold text-amber-800 dark:text-amber-300">
-      {isEs ? "🔧 Sin modelos de IA configurados" : "🔧 No AI models configured"}
-    </p>
-    <div class="text-xs text-zinc-600 dark:text-zinc-400 space-y-1">
-      <p>{isEs ? "Para identificar especies automáticamente:" : "To identify species automatically:"}</p>
-      <ul class="list-disc list-inside space-y-0.5 ml-1">
-        <li>{isEs ? "Descarga BirdNET para cantos de ave (gratis, ~50 MB)" : "Download BirdNET for bird calls (free, ~50 MB)"}</li>
-        <li>{isEs ? "Agrega una llave de PlantNet para plantas (gratis, 500/día)" : "Add a PlantNet API key for plants (free, 500/day)"}</li>
-        <li>{isEs ? "Agrega una llave de Claude para identificación general" : "Add a Claude key for general identification"}</li>
-      </ul>
-    </div>
-    <div class="flex gap-3 flex-wrap">
-      <a href={isEs ? "/es/perfil/editar#on-device-ai-section" : "/en/profile/edit#on-device-ai-section"}
-        class="min-h-[40px] rounded-xl bg-emerald-700 hover:bg-emerald-800 text-white font-semibold text-xs px-4 flex items-center transition-colors">
-        {isEs ? "Configurar IA →" : "Set up AI →"}
-      </a>
-      <button type="button" id="obs2-no-runners-continue"
-        class="min-h-[40px] rounded-xl border border-zinc-300 dark:border-zinc-700 text-xs px-4 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors">
-        {isEs ? "Guardar sin identificar →" : "Save without ID →"}
-      </button>
-    </div>
-  </div>
+  <NoRunnersBlock lang={lang} />
 
   <!-- Identification failed — show the actual reason (#identify-reliability) -->
   <div id="obs2-identify-error" class="hidden rounded-xl border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-4 space-y-3">

--- a/src/components/observe/AiModeSelector.astro
+++ b/src/components/observe/AiModeSelector.astro
@@ -1,0 +1,19 @@
+---
+interface Props { lang: "en" | "es"; }
+const { lang } = Astro.props;
+const isEs = lang === "es";
+---
+
+<!-- AI mode selector (#296) — hidden by default; revealed only when
+     ≥2 modes are usable (#942 PR5 redo). A selector with one usable
+     option + disabled siblings reads as broken UI. -->
+<div id="obs2-ai-mode-selector" class="hidden">
+  <div class="flex items-center gap-2 flex-wrap">
+    <span class="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0">{isEs ? "Fuente de IA:" : "AI source:"}</span>
+    <div class="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs" role="group" aria-label={isEs ? "Fuente de IA" : "AI source"}>
+      <button type="button" id="obs2-mode-sponsored" data-mode="sponsored" class="obs2-mode-btn px-3 py-1.5 font-medium transition-colors">{isEs ? "Patrocinado" : "Sponsored"}</button>
+      <button type="button" id="obs2-mode-own-key" data-mode="own-key" class="obs2-mode-btn px-3 py-1.5 font-medium transition-colors border-l border-zinc-200 dark:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed">{isEs ? "Llave propia" : "Own key"}</button>
+      <button type="button" id="obs2-mode-local" data-mode="local" class="obs2-mode-btn px-3 py-1.5 font-medium transition-colors border-l border-zinc-200 dark:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed">{isEs ? "Solo local" : "Local only"}</button>
+    </div>
+  </div>
+</div>

--- a/src/components/observe/AudioSkippedWarning.astro
+++ b/src/components/observe/AudioSkippedWarning.astro
@@ -1,0 +1,32 @@
+---
+interface Props { lang: "en" | "es"; }
+const { lang } = Astro.props;
+const isEs = lang === "es";
+---
+
+<!-- Audio-skipped warning (#278) — shown when audio node skipped due to BirdNET not downloaded -->
+<div id="obs2-audio-skip-warn" class="hidden rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30 p-4 space-y-3">
+  <div class="flex items-start gap-3">
+    <span class="text-2xl shrink-0">🎵</span>
+    <div class="space-y-1">
+      <p class="font-semibold text-amber-800 dark:text-amber-300 text-sm">
+        {isEs ? "Audio sin identificar — BirdNET no descargado" : "Audio not identified — BirdNET not downloaded"}
+      </p>
+      <p class="text-xs text-zinc-600 dark:text-zinc-400">
+        {isEs
+          ? "Tu grabación de audio no pudo ser identificada porque BirdNET no está instalado. Descárgalo gratis (~50 MB) para identificar cantos de ave en tu dispositivo."
+          : "Your audio recording couldn't be identified because BirdNET isn't installed. Download it free (~50 MB) to identify bird calls on your device."}
+      </p>
+    </div>
+  </div>
+  <div class="flex flex-wrap gap-2">
+    <a href={isEs ? "/es/perfil/editar#on-device-ai-section" : "/en/profile/edit#on-device-ai-section"}
+      class="min-h-[40px] rounded-xl bg-emerald-700 hover:bg-emerald-800 text-white font-semibold text-xs px-4 flex items-center transition-colors">
+      {isEs ? "Descargar BirdNET" : "Download BirdNET"}
+    </a>
+    <button type="button" id="obs2-audio-skip-continue"
+      class="min-h-[40px] rounded-xl border border-zinc-300 dark:border-zinc-700 text-xs px-4 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors">
+      {isEs ? "Guardar sin identificar" : "Save without identification"}
+    </button>
+  </div>
+</div>

--- a/src/components/observe/CapabilityCaption.astro
+++ b/src/components/observe/CapabilityCaption.astro
@@ -1,0 +1,17 @@
+---
+interface Props { lang: "en" | "es"; }
+const { lang } = Astro.props;
+const isEs = lang === "es";
+---
+
+<!-- AI capability caption — single positive line, replaces the prior
+     multi-line banner with 4❌ (#942 PR5 redo). JS rewrites the inner
+     text once detectRunners() resolves. Hidden until then to avoid
+     layout shift. -->
+<p id="obs2-capability-caption" class="hidden text-xs text-zinc-500 dark:text-zinc-400 text-center">
+  <span id="obs2-capability-text">{isEs ? "Verificando modelos…" : "Checking models…"}</span>
+  <a id="obs2-setup-link" href={isEs ? "/es/perfil/editar#on-device-ai-section" : "/en/profile/edit#on-device-ai-section"}
+    class="hidden ml-1 text-emerald-600 dark:text-emerald-400 underline hover:no-underline">
+    {isEs ? "configurar →" : "set up →"}
+  </a>
+</p>

--- a/src/components/observe/IdentifyOnlyResult.astro
+++ b/src/components/observe/IdentifyOnlyResult.astro
@@ -1,0 +1,28 @@
+---
+interface Props { lang: "en" | "es"; }
+const { lang } = Astro.props;
+const isEs = lang === "es";
+---
+
+<!-- Identify-only result (shown when ?mode=identify, pipeline done, user skips save) -->
+<div id="obs2-identify-result" class="hidden rounded-xl border border-emerald-200 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 p-5 space-y-3">
+  <p class="font-semibold text-emerald-800 dark:text-emerald-300 text-center">
+    {isEs ? "Identificación completa" : "Identification complete"}
+  </p>
+  <div id="obs2-identify-species-card" class="space-y-1 text-center"></div>
+  <div class="border-t border-emerald-200 dark:border-emerald-800 pt-3 space-y-2">
+    <p class="text-xs text-zinc-500 dark:text-zinc-400 text-center">
+      {isEs
+        ? "¿Quieres que esta observación ayude a la ciencia?"
+        : "Want this sighting to help science?"}
+    </p>
+    <button type="button" id="obs2-contribute-btn"
+      class="w-full min-h-[44px] rounded-xl bg-emerald-700 hover:bg-emerald-800 text-white font-semibold text-sm transition-colors">
+      {isEs ? "Sí, guardar en Rastrum" : "Yes, save to Rastrum"}
+    </button>
+    <button type="button" id="obs2-identify-done-btn"
+      class="w-full text-xs text-zinc-400 hover:text-zinc-600 underline py-1">
+      {isEs ? "No gracias" : "No thanks"}
+    </button>
+  </div>
+</div>

--- a/src/components/observe/NoRunnersBlock.astro
+++ b/src/components/observe/NoRunnersBlock.astro
@@ -1,0 +1,30 @@
+---
+interface Props { lang: "en" | "es"; }
+const { lang } = Astro.props;
+const isEs = lang === "es";
+---
+
+<!-- No-runners empty state (#274) -->
+<div id="obs2-no-runners" class="hidden rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/40 p-5 space-y-3">
+  <p class="font-semibold text-amber-800 dark:text-amber-300">
+    {isEs ? "🔧 Sin modelos de IA configurados" : "🔧 No AI models configured"}
+  </p>
+  <div class="text-xs text-zinc-600 dark:text-zinc-400 space-y-1">
+    <p>{isEs ? "Para identificar especies automáticamente:" : "To identify species automatically:"}</p>
+    <ul class="list-disc list-inside space-y-0.5 ml-1">
+      <li>{isEs ? "Descarga BirdNET para cantos de ave (gratis, ~50 MB)" : "Download BirdNET for bird calls (free, ~50 MB)"}</li>
+      <li>{isEs ? "Agrega una llave de PlantNet para plantas (gratis, 500/día)" : "Add a PlantNet API key for plants (free, 500/day)"}</li>
+      <li>{isEs ? "Agrega una llave de Claude para identificación general" : "Add a Claude key for general identification"}</li>
+    </ul>
+  </div>
+  <div class="flex gap-3 flex-wrap">
+    <a href={isEs ? "/es/perfil/editar#on-device-ai-section" : "/en/profile/edit#on-device-ai-section"}
+      class="min-h-[40px] rounded-xl bg-emerald-700 hover:bg-emerald-800 text-white font-semibold text-xs px-4 flex items-center transition-colors">
+      {isEs ? "Configurar IA →" : "Set up AI →"}
+    </a>
+    <button type="button" id="obs2-no-runners-continue"
+      class="min-h-[40px] rounded-xl border border-zinc-300 dark:border-zinc-700 text-xs px-4 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors">
+      {isEs ? "Guardar sin identificar →" : "Save without ID →"}
+    </button>
+  </div>
+</div>

--- a/tests/unit/save-consolidation.test.ts
+++ b/tests/unit/save-consolidation.test.ts
@@ -39,6 +39,14 @@ const SRC = readFileSync(
   'utf8',
 );
 
+// #1023 PR1 — the no-runners empty state was extracted to its own
+// component. The affordance contract (≤1 button, "Set up AI" as link)
+// is still pinned, just sourced from the new file.
+const NO_RUNNERS_SRC = readFileSync(
+  join(process.cwd(), 'src/components/observe/NoRunnersBlock.astro'),
+  'utf8',
+);
+
 // Strip Astro comments and HTML comments so they don't generate false
 // positives when an id is mentioned inside a "removed by PR #N" note.
 function stripBlock(s: string, open: string, close: string): string {
@@ -128,8 +136,8 @@ describe('save consolidation — at most 1 primary + 1 secondary per surface', (
     // and the "Save without ID" continuation button (<button>). Any third
     // affordance must not be a button — links are fine because they don't
     // share the primary-action affordance.
-    const block = SRC.match(
-      /<div\s+id=["']obs2-no-runners["'][\s\S]*?<\/div>\s*<\/div>/,
+    const block = NO_RUNNERS_SRC.match(
+      /<div\s+id=["']obs2-no-runners["'][\s\S]*<\/div>\s*<\/div>/,
     );
     expect(
       block,
@@ -144,8 +152,8 @@ describe('save consolidation — at most 1 primary + 1 secondary per surface', (
     // anchor pointing to /profile/edit, while the "ship anyway" path is the
     // single secondary button. If both became buttons we'd lose the
     // affordance distinction and break the Fogg ability hierarchy.
-    const block = SRC.match(
-      /<div\s+id=["']obs2-no-runners["'][\s\S]*?<\/div>\s*<\/div>/,
+    const block = NO_RUNNERS_SRC.match(
+      /<div\s+id=["']obs2-no-runners["'][\s\S]*<\/div>\s*<\/div>/,
     );
     expect(block).not.toBeNull();
     expect(block![0]).toMatch(/<a\s[^>]*href=[^>]*profile\/edit/);


### PR DESCRIPTION
## Summary

PR1 of the incremental refactor for #1023 (ObserveView2.astro 1530 LOC). Extracts 5 markup-only subcomponents into `src/components/observe/`.

| Before | After | Delta |
|---:|---:|---:|
| 1530 | 1444 | **-86 LOC** |

## What's in this PR

| File | LOC | Responsibility |
|---|---:|---|
| `CapabilityCaption.astro` | 17 | PlantNet/Cloud AI status caption + setup link |
| `AiModeSelector.astro` | 19 | Sponsored / Own-key / Local segmented control |
| `IdentifyOnlyResult.astro` | 28 | `#obs2-identify-result` block |
| `NoRunnersBlock.astro` | 30 | `#obs2-no-runners` empty state |
| `AudioSkippedWarning.astro` | 32 | `#obs2-audio-skip-warn` |

All 5 are pure templates — no JS, no state, no `<script>` touched. The client state machine in `ObserveView2.astro` still binds to the same DOM ids and data-attrs (the invariant `reference_observeview2_script_e2e_gate` warns about).

`save-consolidation.test.ts` updated to point its `obs2-no-runners` affordance assertion at the new file — same contract (1 button + 1 link), new SoT.

## What's NOT in this PR (deferred to PR2/PR3 per #1023 recommendation)

- `PostObservationForm.astro` (~250 LOC with state)
- `PipelineSection.astro` (state + escape hatch)
- `observe-state-machine.ts` (~700 LOC of client `<script>`)

Acceptance criterion "ObserveView2.astro < 300 LOC" is multi-PR. This PR is PR1/3.

## Test plan
- [x] `npx tsc --noEmit` — exit 0
- [x] `npx vitest run save-consolidation observe` — 127/127 passed
- [x] `npm run build` — 255 pages, both `/en/observe/` and `/es/observar/` render
- [x] `npx playwright test observe-card observe-v2-empty-state` — 8/8 passed (confirms client `<script>` still binds correctly)
- [ ] Required CI checks green

Refs #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)