### PR TITLE
feat(ux): offline banner with proper i18n + dismiss (PR1/5 of #1180)

### DIFF
--- a/src/components/OfflineBanner.astro
+++ b/src/components/OfflineBanner.astro
@@ -6,7 +6,13 @@
  * user knows their actions are being saved locally and will sync later.
  *
  * Mounted in BaseLayout. SSR-safe — renders the markup hidden, JS
- * flips it on/off after hydration.
+ * flips it on/off after hydration. Dismissable per-session: once the
+ * user clicks Dismiss, the banner stays hidden even if `online`/
+ * `offline` events fire again until the page reloads.
+ *
+ * First slice of #1180 (graceful degradation on poor connectivity).
+ * Follow-ups (retry backoff, auth lock messaging, optimistic UI, PWA
+ * offline fallback) are tracked in #1180 and ship as separate PRs.
  */
 import type { Locale } from '../i18n/utils';
 import { t } from '../i18n/utils';
@@ -14,33 +20,53 @@ import { t } from '../i18n/utils';
 interface Props { lang: Locale }
 const { lang } = Astro.props;
 const tr = t(lang);
-const profile = tr.profile as unknown as Record<string, string>;
-const offline = profile.offline_banner ?? (lang === 'es'
-  ? 'Sin conexión — guardando localmente. Sincronizaremos cuando vuelvas a tener internet.'
-  : "Offline — saving locally. We'll sync when you're back online.");
+const text = tr.offline.banner.text;
+const dismissLabel = tr.offline.banner.dismiss;
 ---
 
 <div
   id="rastrum-offline-banner"
   role="status"
   aria-live="polite"
-  class="hidden fixed top-0 inset-x-0 z-40 bg-amber-500 text-amber-950 text-xs font-medium px-3 py-1.5 text-center shadow"
+  class="hidden fixed top-0 inset-x-0 z-40 bg-amber-100 text-amber-800 text-xs font-medium px-3 py-1.5 shadow"
 >
-  <span class="inline-flex items-center gap-1.5">
-    <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M5.636 5.636a9 9 0 0112.728 12.728M3 3l18 18M9.879 9.879a3 3 0 014.242 4.242"/>
-    </svg>
-    {offline}
-  </span>
+  <div class="max-w-5xl mx-auto flex items-center justify-center gap-2">
+    <span class="inline-flex items-center gap-1.5">
+      <svg aria-hidden="true" class="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5.636 5.636a9 9 0 0112.728 12.728M3 3l18 18M9.879 9.879a3 3 0 014.242 4.242"/>
+      </svg>
+      <span>{text}</span>
+    </span>
+    <button
+      id="rastrum-offline-dismiss"
+      type="button"
+      class="ml-2 underline underline-offset-2 hover:no-underline focus:outline-none focus:ring-2 focus:ring-amber-700 focus:ring-offset-1 focus:ring-offset-amber-100 rounded-sm"
+    >{dismissLabel}</button>
+  </div>
 </div>
 
 <script is:inline>
   (function () {
-    const el = document.getElementById('rastrum-offline-banner');
-    if (!el) return;
-    function paint() { el.classList.toggle('hidden', navigator.onLine); }
-    paint();
-    window.addEventListener('online',  paint);
-    window.addEventListener('offline', paint);
+    var banner = document.getElementById('rastrum-offline-banner');
+    var dismissBtn = document.getElementById('rastrum-offline-dismiss');
+    if (!banner) return;
+    var dismissed = false;
+    function update() {
+      if (dismissed) return;
+      if (navigator.onLine) {
+        banner.classList.add('hidden');
+      } else {
+        banner.classList.remove('hidden');
+      }
+    }
+    if (dismissBtn) {
+      dismissBtn.addEventListener('click', function () {
+        dismissed = true;
+        banner.classList.add('hidden');
+      });
+    }
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    update();
   })();
 </script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -416,6 +416,12 @@
     "location": "Location",
     "date": "Date"
   },
+  "offline": {
+    "banner": {
+      "text": "You're offline — changes will sync when connection returns",
+      "dismiss": "Dismiss"
+    }
+  },
   "auth": {
     "sign_in": "Sign in",
     "sign_out": "Sign out",
@@ -694,7 +700,6 @@
     "sync_pill_syncing": "Syncing…",
     "sync_pill_offline": "Offline",
     "sync_pill_aria": "Sync pending observations",
-    "offline_banner": "Offline — saving locally. We'll sync when you're back online.",
     "public_profile_title": "Observer profile",
     "public_profile_not_found": "Observer not found.",
     "public_profile_private": "This profile is private.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -416,6 +416,12 @@
     "location": "Ubicación",
     "date": "Fecha"
   },
+  "offline": {
+    "banner": {
+      "text": "Sin conexión — los cambios se sincronizarán cuando vuelva la conexión",
+      "dismiss": "Cerrar"
+    }
+  },
   "auth": {
     "sign_in": "Iniciar sesión",
     "sign_out": "Cerrar sesión",
@@ -694,7 +700,6 @@
     "sync_pill_syncing": "Sincronizando…",
     "sync_pill_offline": "Sin conexión",
     "sync_pill_aria": "Sincronizar observaciones pendientes",
-    "offline_banner": "Sin conexión — guardando localmente. Sincronizaremos cuando vuelvas a tener internet.",
     "public_profile_title": "Perfil del observador",
     "public_profile_not_found": "Observador no encontrado.",
     "public_profile_private": "Este perfil es privado.",

--- a/tests/unit/offline-banner.test.ts
+++ b/tests/unit/offline-banner.test.ts
@@ -1,0 +1,163 @@
+/**
+ * #1180 (first slice) — DOM-shape contract for the OfflineBanner.
+ *
+ * Background:
+ *   The issue's first "Desired behavior" item is a non-intrusive banner
+ *   surfacing `navigator.onLine === false`. Without a regression guard,
+ *   a future refactor (e.g. wiring the banner to a different signal
+ *   like a sync-queue retry counter, or dropping the ARIA live-region)
+ *   could silently degrade the affordance — the banner would still
+ *   render but assistive tech would miss the state change.
+ *
+ * Why source-string assertion instead of a happy-dom render:
+ *   The behaviour we care about lives in an Astro `<script is:inline>`,
+ *   which Vitest + happy-dom does not execute the same way the browser
+ *   does. The DOM shape (ids, ARIA attributes, i18n key references,
+ *   network-event listener wiring) is faithfully represented in the
+ *   source. Same approach as `save-consolidation.test.ts` and the
+ *   public-profile-sprite-fallback spec — a project convention.
+ *
+ * What this test pins:
+ *   1. The component file exists.
+ *   2. ARIA role="status" + aria-live="polite" are present (a11y).
+ *   3. The script binds to `navigator.onLine` + `online`/`offline`
+ *      window events (the actual signal — not a poll, not a timer).
+ *   4. The dismiss button exists and the click handler is wired.
+ *   5. The component references `offline.banner.text` / `.dismiss` so
+ *      the EN/ES i18n parity (CLAUDE.md hard rule) holds at the source.
+ *   6. Both i18n files declare `offline.banner.{text,dismiss}` and the
+ *      EN copy contains the expected substring.
+ *   7. BaseLayout mounts the component (so the banner is page-global,
+ *      not opt-in per route).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const COMPONENT_PATH = join(
+  process.cwd(),
+  'src/components/OfflineBanner.astro',
+);
+const BASE_LAYOUT_PATH = join(
+  process.cwd(),
+  'src/layouts/BaseLayout.astro',
+);
+const EN_PATH = join(process.cwd(), 'src/i18n/en.json');
+const ES_PATH = join(process.cwd(), 'src/i18n/es.json');
+
+describe('OfflineBanner — file presence (#1180 slice 1)', () => {
+  it('OfflineBanner.astro exists', () => {
+    expect(existsSync(COMPONENT_PATH)).toBe(true);
+  });
+});
+
+describe('OfflineBanner — DOM shape + accessibility', () => {
+  const src = readFileSync(COMPONENT_PATH, 'utf8');
+
+  it('has a stable id for the banner root', () => {
+    expect(src).toMatch(/id=["']rastrum-offline-banner["']/);
+  });
+
+  it('declares role="status" so AT announces it as a non-modal update', () => {
+    expect(src).toMatch(/role=["']status["']/);
+  });
+
+  it('declares aria-live="polite" — the issue calls this out explicitly', () => {
+    // "polite" not "assertive": connection loss is informational, not
+    // urgent — assertive would interrupt the user's current screen-reader
+    // focus.
+    expect(src).toMatch(/aria-live=["']polite["']/);
+  });
+
+  it('renders the banner hidden by default (SSR-safe — JS unhides)', () => {
+    // Without this, anyone who loads the page online sees a flash of
+    // offline copy before the first-paint script runs.
+    expect(src).toMatch(/class=["'][^"']*\bhidden\b/);
+  });
+});
+
+describe('OfflineBanner — network-state wiring', () => {
+  const src = readFileSync(COMPONENT_PATH, 'utf8');
+
+  it('reads navigator.onLine to seed initial state', () => {
+    expect(src).toMatch(/navigator\.onLine/);
+  });
+
+  it('subscribes to the window "online" event', () => {
+    expect(src).toMatch(/addEventListener\(\s*['"]online['"]/);
+  });
+
+  it('subscribes to the window "offline" event', () => {
+    expect(src).toMatch(/addEventListener\(\s*['"]offline['"]/);
+  });
+});
+
+describe('OfflineBanner — dismiss affordance', () => {
+  const src = readFileSync(COMPONENT_PATH, 'utf8');
+
+  it('renders a dismiss <button> with a stable id', () => {
+    expect(src).toMatch(/id=["']rastrum-offline-dismiss["']/);
+    expect(src).toMatch(/<button[^>]*\bid=["']rastrum-offline-dismiss["']/);
+  });
+
+  it('wires a click handler on the dismiss button', () => {
+    expect(src).toMatch(
+      /rastrum-offline-dismiss[\s\S]*addEventListener\(\s*['"]click['"]/,
+    );
+  });
+});
+
+describe('OfflineBanner — i18n key references', () => {
+  const src = readFileSync(COMPONENT_PATH, 'utf8');
+
+  it('references tr.offline.banner.text for the banner copy', () => {
+    expect(src).toMatch(/offline\.banner\.text/);
+  });
+
+  it('references tr.offline.banner.dismiss for the dismiss label', () => {
+    expect(src).toMatch(/offline\.banner\.dismiss/);
+  });
+});
+
+describe('OfflineBanner — EN/ES i18n parity (#1180 slice 1)', () => {
+  const en = JSON.parse(readFileSync(EN_PATH, 'utf8')) as Record<
+    string,
+    Record<string, Record<string, string>>
+  >;
+  const es = JSON.parse(readFileSync(ES_PATH, 'utf8')) as Record<
+    string,
+    Record<string, Record<string, string>>
+  >;
+
+  it('en.json declares offline.banner.text + offline.banner.dismiss', () => {
+    expect(en.offline?.banner?.text).toBeTypeOf('string');
+    expect(en.offline?.banner?.dismiss).toBeTypeOf('string');
+  });
+
+  it('es.json declares offline.banner.text + offline.banner.dismiss', () => {
+    expect(es.offline?.banner?.text).toBeTypeOf('string');
+    expect(es.offline?.banner?.dismiss).toBeTypeOf('string');
+  });
+
+  it('EN copy mentions "offline"', () => {
+    expect(en.offline.banner.text.toLowerCase()).toContain('offline');
+  });
+
+  it('ES copy mentions "sin conexión"', () => {
+    expect(es.offline.banner.text.toLowerCase()).toContain('sin conexión');
+  });
+});
+
+describe('OfflineBanner — mounted in BaseLayout', () => {
+  const src = readFileSync(BASE_LAYOUT_PATH, 'utf8');
+
+  it('imports OfflineBanner from the components dir', () => {
+    expect(src).toMatch(
+      /import\s+OfflineBanner\s+from\s+['"][.\/]+components\/OfflineBanner\.astro['"]/,
+    );
+  });
+
+  it('renders <OfflineBanner lang={...} /> in the body', () => {
+    expect(src).toMatch(/<OfflineBanner\s+lang=\{[^}]+\}\s*\/>/);
+  });
+});


### PR DESCRIPTION
## Summary

PR1/5 of #1180. The previous stub OfflineBanner had bad i18n (under `profile.*`) and no dismiss. This PR fixes that minimum-viable layer.

- New `offline.banner.{text,dismiss}` i18n namespace, EN/ES
- Dismiss button + session-sticky dismissed flag
- ARIA: `role="status" aria-live="polite"` (preserved)
- 18 source-string assertions

## Deferred to follow-up PRs (per #1180 desired behaviors)

| # | Behavior | Scope |
|---|---|---|
| 2 | Retry with backoff in `sync.ts` | medium |
| 3 | Graceful auth-lock messaging | medium |
| 4 | Optimistic UI with stale cache indicator | large |
| 5 | Service-worker offline fallback page | medium |

## Test plan
- [x] `npx tsc --noEmit` — exit 0
- [x] `npx vitest run` — 2772/2772 passed
- [x] `npm run build` — 255 pages
- [ ] Manual: DevTools → Network → Offline → reload → banner appears, dismiss → hidden, online → still hidden until reload
- [ ] Required CI checks green

Refs #1180

🤖 Generated with [Claude Code](https://claude.com/claude-code)