### PR TITLE
fix(dev): inline logo component to silence dev-toolbar audit fetch errors

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import { t, getLocalizedPath, getDocPath, getAlternateUrl, routes, type Locale } from '../i18n/utils';
 import { resolveChromeMode } from '../lib/chrome-mode';
+import RastrumLogo from './RastrumLogo.astro';
 
 interface Props {
   lang: string;
@@ -59,7 +60,7 @@ const mLinkClass = 'text-zinc-500 dark:text-zinc-400';
       <div class="sm:col-span-2 lg:col-span-2 space-y-3">
         <a href={getLocalizedPath(lang, '/')}
            class="inline-flex items-center gap-2 text-emerald-600 dark:text-emerald-400 font-bold text-lg">
-          <img src="/rastrum-logo.svg" alt="" class="w-6 h-6" width="24" height="24" loading="lazy" />
+          <RastrumLogo class="w-6 h-6" width={24} height={24} />
           Rastrum
         </a>
         <p class="text-sm text-zinc-500 dark:text-zinc-400">{tr.footer.tagline}</p>
@@ -137,7 +138,7 @@ const mLinkClass = 'text-zinc-500 dark:text-zinc-400';
       <div class="space-y-2">
         <a href={getLocalizedPath(lang, '/')}
            class="inline-flex items-center gap-2 text-emerald-600 dark:text-emerald-400 font-bold">
-          <img src="/rastrum-logo.svg" alt="" class="w-5 h-5" width="20" height="20" loading="lazy" />
+          <RastrumLogo class="w-5 h-5" width={20} height={20} />
           Rastrum
         </a>
         <p class="text-xs text-zinc-400 dark:text-zinc-500">{tr.footer.tagline}</p>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,6 +3,7 @@ import { t, getLocalizedPath, getAlternateLocale, getAlternateUrl, routes, type 
 import { isActiveSection } from '../lib/chrome-helpers';
 import BellIcon from './BellIcon.astro';
 import MegaMenu from './MegaMenu.astro';
+import RastrumLogo from './RastrumLogo.astro';
 import MobileBottomBar from './MobileBottomBar.astro';
 import MobileDrawer from './MobileDrawer.astro';
 import SyncPill from './SyncPill.astro';
@@ -139,7 +140,7 @@ const docColumns = [
     <!-- Lockup -->
     <a href={getLocalizedPath(lang, '/')} class="flex flex-col leading-tight">
       <span class="flex items-center gap-2 text-lg font-bold text-emerald-600 dark:text-emerald-400">
-        <img src="/rastrum-logo.svg" alt="" class="w-7 h-7" width="28" height="28" />
+        <RastrumLogo class="w-7 h-7" width={28} height={28} />
         Rastrum
       </span>
       <span class="hidden md:block text-[11px] text-zinc-500 dark:text-zinc-400 -mt-0.5 ml-9">

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -1,5 +1,6 @@
 ---
 import { t, getLocalizedPath, getDocPath, getAlternateLocale, getAlternateUrl, routes, docPages, type Locale } from '../i18n/utils';
+import RastrumLogo from './RastrumLogo.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -72,7 +73,7 @@ const getDocLabel = (key: string) => (tr.docs.sections as Record<string, string>
 >
   <div class="flex items-center justify-between p-3 border-b border-zinc-200 dark:border-zinc-800">
     <span class="text-emerald-600 dark:text-emerald-400 font-bold flex items-center gap-2">
-      <img src="/rastrum-logo.svg" alt="" class="w-6 h-6" width="24" height="24" />
+      <RastrumLogo class="w-6 h-6" width={24} height={24} />
       Rastrum
     </span>
     <button

--- a/src/components/RastrumLogo.astro
+++ b/src/components/RastrumLogo.astro
@@ -1,0 +1,67 @@
+---
+interface Props {
+  class?: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+  loading?: 'eager' | 'lazy';
+}
+const { class: cls = '', width = 24, height = 24, alt } = Astro.props;
+---
+{
+  alt ? (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 100 100"
+      width={width}
+      height={height}
+      class={cls}
+      role="img"
+      aria-label={alt}
+    >
+      <title>{alt}</title>
+      <path d="M 0 100 C 0 20, 20 0, 100 0 C 100 80, 80 100, 0 100 Z" fill="#2E8B57" />
+      <path d="M 0 100 C 40 60, 60 40, 100 0 C 100 80, 80 100, 0 100 Z" fill="#247548" />
+      <g stroke="#4AC27E" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.6">
+        <path d="M 5 95 C 35 65, 65 35, 95 5" />
+        <path d="M 25 75 C 20 55, 10 40" />
+        <path d="M 45 55 C 35 35, 20 20" />
+        <path d="M 45 55 C 65 65, 80 80" />
+        <path d="M 75 25 C 85 35, 90 45" />
+      </g>
+      <g transform="translate(0, -1)" fill="#FFFFFF">
+        <path d="M 30 58 C 33 52, 40 49, 50 49 C 60 49, 67 52, 70 58 C 74 64, 74 70, 69 74 C 66 78, 60 79, 55 75 C 52 78, 48 78, 45 75 C 40 79, 34 78, 31 74 C 26 70, 26 64, 30 58 Z" />
+        <ellipse cx="27" cy="44" rx="6.5" ry="8" transform="rotate(-35 27 44)" />
+        <ellipse cx="40" cy="29" rx="7" ry="8.5" transform="rotate(-12 40 29)" />
+        <ellipse cx="60" cy="29" rx="7" ry="8.5" transform="rotate(12 60 29)" />
+        <ellipse cx="73" cy="44" rx="6.5" ry="8" transform="rotate(35 73 44)" />
+      </g>
+    </svg>
+  ) : (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 100 100"
+      width={width}
+      height={height}
+      class={cls}
+      aria-hidden="true"
+    >
+      <path d="M 0 100 C 0 20, 20 0, 100 0 C 100 80, 80 100, 0 100 Z" fill="#2E8B57" />
+      <path d="M 0 100 C 40 60, 60 40, 100 0 C 100 80, 80 100, 0 100 Z" fill="#247548" />
+      <g stroke="#4AC27E" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.6">
+        <path d="M 5 95 C 35 65, 65 35, 95 5" />
+        <path d="M 25 75 C 20 55, 10 40" />
+        <path d="M 45 55 C 35 35, 20 20" />
+        <path d="M 45 55 C 65 65, 80 80" />
+        <path d="M 75 25 C 85 35, 90 45" />
+      </g>
+      <g transform="translate(0, -1)" fill="#FFFFFF">
+        <path d="M 30 58 C 33 52, 40 49, 50 49 C 60 49, 67 52, 70 58 C 74 64, 74 70, 69 74 C 66 78, 60 79, 55 75 C 52 78, 48 78, 45 75 C 40 79, 34 78, 31 74 C 26 70, 26 64, 30 58 Z" />
+        <ellipse cx="27" cy="44" rx="6.5" ry="8" transform="rotate(-35 27 44)" />
+        <ellipse cx="40" cy="29" rx="7" ry="8.5" transform="rotate(-12 40 29)" />
+        <ellipse cx="60" cy="29" rx="7" ry="8.5" transform="rotate(12 60 29)" />
+        <ellipse cx="73" cy="44" rx="6.5" ry="8" transform="rotate(35 73 44)" />
+      </g>
+    </svg>
+  )
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import RastrumLogo from '../components/RastrumLogo.astro';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const site = 'https://rastrum.org';
 const ogImage = `${site}/rastrum-logo-512.png`;
@@ -73,7 +74,7 @@ const descriptionEs = 'Plataforma open-source de observación de biodiversidad p
   </head>
   <body>
     <main>
-      <img src={`${base}/rastrum-logo.svg`} alt="Rastrum" />
+      <RastrumLogo width={80} height={80} alt="Rastrum" />
       <h1>Rastrum</h1>
       <p class="tagline">Identify any living thing, anywhere · Identifica cualquier ser vivo, donde sea</p>
       <p class="desc">{description}<br /><br />{descriptionEs}</p>


### PR DESCRIPTION
## Summary

User-reported: 10+ console errors on \`localhost:4321/en/observe/\` from Astro dev-toolbar's audit \`match\` function, all \`TypeError: Failed to fetch\` against \`/rastrum-logo.svg\`. The asset loads fine in the browser, but the audit's programmatic fetch races/mishandles, flooding the dev console.

**Fix**: extract the logo into \`src/components/RastrumLogo.astro\` (inline SVG, ~70 LOC). Replace 5 \`<img src=\"/rastrum-logo.svg\">\` callsites (Header, Footer ×2, MobileDrawer, locale-picker hero).

## Bonus benefits

- **Zero HTTP requests for the logo in prod** — was 5 per page render before browser cache dedup'd subsequent ones
- **Faster LCP on locale-picker hero** — inline beats fetch
- **a11y consistency** — explicit \`role=\"img\" + aria-label\` when branded, \`aria-hidden=\"true\"\` when decorative. Was inconsistent across the 5 callsites.

## Why retain \`public/rastrum-logo.svg\`

\`public/sw.js:130\` uses it as the Web Push notification icon. Service worker can't inline SVG — needs a real URL.

## Test plan

- [x] \`npx tsc --noEmit\` — exit 0
- [x] \`npx vitest run\` — 2772/2772 passed
- [x] \`npm run build\` — 255 pages
- [ ] Required CI checks green
- [ ] Manual: visit \`localhost:4321/en/observe/\` post-merge, confirm zero \`Failed to fetch /rastrum-logo.svg\` in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)