### PR TITLE
feat(home): hide personal chips for anon + sign-in CTA

### DIFF
--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -21,6 +21,13 @@ const leaderboardHref = lang === 'es' ? '/es/comunidad/tabla-de-lideres/' : '/en
 const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
 ---
 
+<!-- HomeChips lives OUTSIDE the .home-widgets section because it self-gates:
+     the signed-in chip nav stays hidden by default and is revealed by
+     getCachedUser(); the anon CTA replaces it. Putting it inside the
+     section would keep the anon CTA hidden for visitors (the parent
+     section starts .hidden and is only unhidden after auth resolution). -->
+<HomeChips lang={lang} />
+
 <section
   class="home-widgets hidden mb-8 space-y-6"
   data-lang={lang}
@@ -74,7 +81,6 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
   </div>
 
   <HomeHero lang={lang} />
-  <HomeChips lang={lang} />
 
   <!-- #710 Daily Challenge -->
   <div class="home-widgets-challenge hidden">

--- a/src/components/home/HomeChips.astro
+++ b/src/components/home/HomeChips.astro
@@ -8,14 +8,28 @@ const inboxHref = lang === 'es' ? '/es/bandeja/' : '/en/inbox/';
 const validateHref = lang === 'es' ? '/es/consola/validacion/' : '/en/console/validation/';
 const faltaDexHref = lang === 'es' ? '/es/perfil/dex/' : '/en/profile/dex/';
 const watchlistHref = lang === 'es' ? '/es/explorar/seguimiento/' : '/en/explore/watchlist/';
+const signInHref = lang === 'es' ? '/es/ingresar/' : '/en/sign-in/';
 ---
 
-<nav class="hc-root grid grid-cols-2 sm:grid-cols-4 gap-2 mb-6" data-lang={lang} aria-label="Home actions">
+<!-- Signed-in: personalized shortcut chips. Starts hidden; the auth-aware
+     script below reveals this nav only when getCachedUser() resolves to a
+     user. The four destinations all require a session and would land the
+     visitor on a sign-in wall, so we never paint them for anon. -->
+<nav class="hc-root hidden grid grid-cols-2 sm:grid-cols-4 gap-2 mb-6" data-lang={lang} aria-label="Home actions">
   <a class="hc-tile" href={inboxHref} data-key="inbox"><span class="hc-icon" aria-hidden="true">📬</span><span class="hc-label">{c.inbox}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
   <a class="hc-tile" href={validateHref} data-key="validate"><span class="hc-icon" aria-hidden="true">🔍</span><span class="hc-label">{c.validate}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
   <a class="hc-tile" href={faltaDexHref} data-key="falta_dex"><span class="hc-icon" aria-hidden="true">📊</span><span class="hc-label">{c.falta_dex}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
   <a class="hc-tile" href={watchlistHref} data-key="watchlist"><span class="hc-icon" aria-hidden="true">👀</span><span class="hc-label">{c.watchlist}</span><span class="hc-count tabular-nums" aria-hidden="true"></span></a>
 </nav>
+
+<!-- Anon: discreet single-line CTA. Visible by default so it paints on the
+     first frame (no auth round-trip needed). The script hides it once an
+     authenticated session is detected. -->
+<p class="hc-anon-cta mb-6 text-sm text-zinc-600 dark:text-zinc-400">
+  <a href={signInHref} class="font-medium text-emerald-700 dark:text-emerald-400 hover:underline">
+    {c.anon_cta.text} <span aria-hidden="true">→</span>
+  </a>
+</p>
 
 <style>
   .hc-tile { display:flex; align-items:center; gap:.5rem; padding:.6rem .75rem; border:1px solid rgb(228 228 231); border-radius:.75rem; font-size:.875rem; transition:border-color .15s; }
@@ -25,14 +39,27 @@ const watchlistHref = lang === 'es' ? '/es/explorar/seguimiento/' : '/en/explore
 </style>
 
 <script>
-  import { getSupabase, getCachedUser } from '../../lib/supabase';
+  import { getSupabase, getCachedUser, onAuthChange } from '../../lib/supabase';
   import { loadInboxCount, loadValidateCount, loadFaltaDexCount } from '../../lib/home-loaders';
 
-  async function init() {
+  async function paint() {
     const root = document.querySelector<HTMLElement>('.hc-root');
+    const anonCta = document.querySelector<HTMLElement>('.hc-anon-cta');
     if (!root) return;
+
     const user = await getCachedUser();
-    if (!user) return;
+    if (!user) {
+      // Anon: keep chips hidden, keep the CTA visible. Idempotent so an
+      // auth-change → signed-out flip restores the anon view cleanly.
+      root.classList.add('hidden');
+      anonCta?.classList.remove('hidden');
+      return;
+    }
+
+    // Signed-in: reveal chips, hide the CTA.
+    anonCta?.classList.add('hidden');
+    root.classList.remove('hidden');
+
     let c; try { c = getSupabase(); } catch { return; }
 
     const [inbox, validate, falta] = await Promise.all([
@@ -55,5 +82,8 @@ const watchlistHref = lang === 'es' ? '/es/explorar/seguimiento/' : '/en/explore
     // remains as a navigation affordance.
   }
 
-  init().catch(() => {});
+  paint().catch(() => {});
+  try {
+    onAuthChange(() => { paint().catch(() => {}); });
+  } catch { /* env not set */ }
 </script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -212,7 +212,11 @@
         "validate": "Validate",
         "falta_dex": "Falta-dex",
         "watchlist": "Watchlist",
-        "count_overflow": "99+"
+        "count_overflow": "99+",
+        "anon_cta": {
+          "text": "Sign in to track species, validate observations, and see your dex",
+          "link": "/en/sign-in/"
+        }
       },
       "near_you_title": "Near you right now",
       "near_you_subtitle": "Observations within {{radius}} km",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -212,7 +212,11 @@
         "validate": "Validar",
         "falta_dex": "Falta-dex",
         "watchlist": "Lista",
-        "count_overflow": "99+"
+        "count_overflow": "99+",
+        "anon_cta": {
+          "text": "Inicia sesión para seguir especies, validar observaciones y ver tu dex",
+          "link": "/es/ingresar/"
+        }
       },
       "near_you_title": "Cerca de ti ahora",
       "near_you_subtitle": "Observaciones en {{radius}} km",

--- a/tests/unit/home-anon-chips.test.ts
+++ b/tests/unit/home-anon-chips.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Home anon-CTA / signed-in chips guard.
+ *
+ * Background — the journey audit on rastrum.org/es/ flagged that the four
+ * personalized chips (Bandeja, Validar, Falta-dex, Lista) on the homepage
+ * landed anon visitors on a sign-in wall, all destinations require an
+ * authenticated session. This test pins the fix in place:
+ *
+ *   1. The .hc-root nav (chips) starts `hidden` in the source.
+ *   2. HomeChips renders a `.hc-anon-cta` block.
+ *   3. The script reveals chips only when getCachedUser() returns a user
+ *      and otherwise hides them; the anon CTA is the inverse.
+ *   4. The CTA i18n key exists in both EN and ES.
+ *   5. The sign-in href is locale-paired (/sign-in vs /ingresar).
+ *   6. HomeChips is rendered OUTSIDE the `home-widgets hidden` section
+ *      (otherwise the anon CTA would never paint).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const chipsSrc = readFileSync(
+  join(process.cwd(), 'src/components/home/HomeChips.astro'),
+  'utf8',
+);
+const widgetsSrc = readFileSync(
+  join(process.cwd(), 'src/components/HomeWidgets.astro'),
+  'utf8',
+);
+const enJson = JSON.parse(
+  readFileSync(join(process.cwd(), 'src/i18n/en.json'), 'utf8'),
+);
+const esJson = JSON.parse(
+  readFileSync(join(process.cwd(), 'src/i18n/es.json'), 'utf8'),
+);
+
+describe('HomeChips anon gating', () => {
+  it('the chips nav starts hidden in markup', () => {
+    expect(chipsSrc).toMatch(/class="hc-root hidden/);
+  });
+
+  it('renders an anon CTA element that the script can flip', () => {
+    expect(chipsSrc).toMatch(/class="hc-anon-cta/);
+  });
+
+  it('script gates on getCachedUser() and uses onAuthChange (no direct supabase.auth.onAuthStateChange)', () => {
+    expect(chipsSrc).toMatch(/getCachedUser/);
+    expect(chipsSrc).toMatch(/onAuthChange/);
+    expect(chipsSrc).not.toMatch(/supabase\.auth\.onAuthStateChange/);
+  });
+
+  it('script reveals chips on signed-in and hides the anon CTA (and vice versa)', () => {
+    // Signed-in: chips visible, CTA hidden.
+    expect(chipsSrc).toMatch(/anonCta\?\.classList\.add\('hidden'\)/);
+    expect(chipsSrc).toMatch(/root\.classList\.remove\('hidden'\)/);
+    // Anon: chips hidden, CTA visible.
+    expect(chipsSrc).toMatch(/root\.classList\.add\('hidden'\)/);
+    expect(chipsSrc).toMatch(/anonCta\?\.classList\.remove\('hidden'\)/);
+  });
+});
+
+describe('HomeChips lives outside the .home-widgets hidden section', () => {
+  it('HomeWidgets renders HomeChips outside the section that starts hidden', () => {
+    const chipsIdx = widgetsSrc.indexOf('<HomeChips');
+    const sectionOpenIdx = widgetsSrc.indexOf(
+      '<section\n  class="home-widgets hidden',
+    );
+    expect(chipsIdx).toBeGreaterThan(-1);
+    expect(sectionOpenIdx).toBeGreaterThan(-1);
+    // The component must be placed BEFORE the hidden section.
+    expect(chipsIdx).toBeLessThan(sectionOpenIdx);
+  });
+});
+
+describe('chips.anon_cta i18n parity', () => {
+  it('exists in EN', () => {
+    expect(enJson.home.widgets.chips.anon_cta).toBeDefined();
+    expect(typeof enJson.home.widgets.chips.anon_cta.text).toBe('string');
+    expect(enJson.home.widgets.chips.anon_cta.text.length).toBeGreaterThan(0);
+  });
+
+  it('exists in ES', () => {
+    expect(esJson.home.widgets.chips.anon_cta).toBeDefined();
+    expect(typeof esJson.home.widgets.chips.anon_cta.text).toBe('string');
+    expect(esJson.home.widgets.chips.anon_cta.text.length).toBeGreaterThan(0);
+  });
+
+  it('uses the locale-paired sign-in path (en=/sign-in/, es=/ingresar/)', () => {
+    expect(enJson.home.widgets.chips.anon_cta.link).toBe('/en/sign-in/');
+    expect(esJson.home.widgets.chips.anon_cta.link).toBe('/es/ingresar/');
+  });
+
+  it('component renders the locale-paired sign-in href', () => {
+    expect(chipsSrc).toMatch(
+      /lang === 'es' \? '\/es\/ingresar\/' : '\/en\/sign-in\/'/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Journey audit finding: anon users see personalized chips (Bandeja/Validar/Falta-dex/Lista) on homepage — all require auth → click → sign-in wall. Promise broken.

**Fix**: HomeChips reveals only when `getCachedUser()` returns. Anon gets a positive sign-in CTA instead.

- Markup ships `hidden` (no flash of content)
- Self-gates on `onAuthChange()` per `reference_auth_onauthchange_invariant`
- EN/ES parity (`home.widgets.chips.anon_cta.{text,link}`)
- Defense-in-depth: also moved out of parent `.hidden` section

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run home-anon-chips home-widgets-wired home-loaders` — 23/23 pass
- [x] `npm run build` — 255 pages, both EN/ES `index.html` render CTA copy

Closes Tier 2 PR9 of journey audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)