### PR TITLE
refactor(onboarding): centralize 18+ legacy keys behind onboardingState helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,6 +399,19 @@ The onboarding tour exposes two public DOM events:
 that takes an Anthropic key — it's a `max_tokens:1` probe that costs
 ≈ nothing per call. Reuse it before persisting any BYO key.
 
+**`src/lib/onboarding-state.ts` is the centralised onboarding/user-state
+store.** Replaces the 18 ad-hoc `rastrum.*` localStorage keys
+(`rastrum.onboarding.seen`, `rastrum.console.onboardingDone`,
+`rastrum.obs2.onboarding_shown`, every `rastrum.guide.*`, `rastrum.visitCount`,
+`rastrum.installHintDismissed`, etc.) with a single typed JSON document
+under `rastrum.user.onboardingState`. The first read does a one-time
+non-destructive migration from the legacy keys; legacy reads still work
+during the gradual call-site port. Use `getOnboardingState()`,
+`setOnboardingState(patch)`, and the convenience accessors
+(`markTourCompleted`, `markGuideSeen`, `incrementVisitCount`, …) for any
+new UX-state flag — do NOT mint a new top-level `rastrum.*` key.
+Full notes: [`docs/runbooks/onboarding-state.md`](docs/runbooks/onboarding-state.md).
+
 Full notes: [`docs/runbooks/onboarding-events.md`](docs/runbooks/onboarding-events.md).
 
 CI runs **`infra/smoke-model-assets.sh`** after every deploy and during

--- a/docs/runbooks/onboarding-state.md
+++ b/docs/runbooks/onboarding-state.md
@@ -1,0 +1,150 @@
+# Onboarding state runbook
+
+> Sibling to [`onboarding-events.md`](onboarding-events.md). That doc covers
+> the DOM events the tour emits / accepts. This one covers the **storage
+> layer** that backs the user's onboarding journey.
+
+## Why this exists
+
+Audited 2026-05-24: the codebase had grown to **18+** distinct
+`localStorage` keys under the `rastrum.*` / `rastrum_*` prefix to track
+"one-time UX flags" — tour completion, per-feature guide views, visit
+counts, install hints, console onboarding, observe2 onboarding, identify
+mode notice, etc.
+
+Each surface owned its own key with its own value vocabulary (`'true'`,
+`'1'`, `'done'`, `'v1'`, ISO timestamps…). No shared schema, no single
+"is the user new?" predicate, no dump-everything helper for debugging or
+support.
+
+`src/lib/onboarding-state.ts` centralises all of this under a single
+JSON document while remaining backwards-compatible with the legacy keys.
+
+## What's in scope
+
+The helper covers UX-state flags that fit a single user-journey model:
+
+| Field | Type | Migrates from |
+|---|---|---|
+| `version` | `1` | n/a (forward-compat marker) |
+| `tourCompletedAt` | ISO string \| null | `rastrum.onboarding.seen` |
+| `consoleOnboardingDone` | boolean | `rastrum.console.onboardingDone` |
+| `obs2OnboardingShown` | boolean | `rastrum.obs2.onboarding_shown` |
+| `firstObsCelebrated` | boolean | `rastrum.firstObservationCelebrated` |
+| `firstObsSyncedAt` | ISO string \| null | `rastrum.obs.firstSyncedAt` (#1186) |
+| `privacyPreset` | enum \| null | `rastrum.onboarding.privacyPreset` |
+| `visitCount` | number | `rastrum.visitCount` |
+| `installHintDismissed` | boolean | `rastrum.installHintDismissed` |
+| `pwaInstalled` | boolean | `rastrum.pwaInstalled` |
+| `guidesSeen` | `Record<id, value>` | every `rastrum.guide.*` key |
+| `identifyModeNoticeShown` | boolean | `rastrum_identify_mode_notice_v1` |
+
+## What's out of scope
+
+These intentionally do NOT belong to this helper because they hold
+**operational state**, not journey progress:
+
+- `rastrum.byoKeys` — BYO API key store, owned by `src/lib/byo-keys.ts`
+- `rastrum.lang` — language preference (not "onboarding")
+- `rastrum.theme.seasonal` — theme picker
+- `rastrum.community.gps` — session-only; sessionStorage, never localStorage
+- `rastrum.feedback.responses` / `rastrum.survey.*` — survey responses
+- `rastrum.pendingObservation` — outbox handoff
+- `rastrum.formAutoSave.v1` — draft autosave (large payload)
+- `rastrum.headerName` / `rastrum.headerAvatar` — first-paint cache
+- `rastrum.lastSyncAt` — sync clock
+- `rastrum.audio.volume`, `rastrum.chat.modelPicker`, etc. — feature prefs
+
+Those can graduate later if a clear "user state" model justifies it; the
+helper's shape is intentionally narrow today.
+
+## API
+
+```ts
+import {
+  getOnboardingState,        // read full state (default + migration on first call)
+  setOnboardingState,        // merge a partial patch + persist
+  markTourCompleted,         // sugar for tourCompletedAt = now()
+  markConsoleOnboarded,
+  markObs2OnboardingShown,
+  markFirstObsCelebrated,
+  markFirstObsSynced,        // idempotent: only stamps the first time
+  setPrivacyPreset,
+  incrementVisitCount,       // accepts a step (default 1)
+  markInstallHintDismissed,
+  markPwaInstalled,
+  markGuideSeen,             // accepts bare 'observe' or 'rastrum.guide.observe'
+  hasSeenGuide,
+  markIdentifyModeNoticeShown,
+  dumpLegacyKeys,            // debug: snapshot of every legacy key
+  clearOnboardingState,      // wipe the central key (leaves legacy keys alone)
+} from '../lib/onboarding-state';
+```
+
+All accessors are **SSR-safe**: they short-circuit when `localStorage`
+is undefined (Astro static build, Node test runners without a shim) and
+never throw. The first call to `getOnboardingState()` performs a
+one-time, non-destructive migration from the legacy keys and persists
+the resulting JSON under `rastrum.user.onboardingState`. Subsequent
+reads come from memory.
+
+## Migration strategy
+
+This PR is **additive only**:
+
+1. The new helper exists and is fully tested.
+2. The 18 legacy call-sites continue to read/write their own keys —
+   nothing was rewritten.
+3. The migration is non-destructive: legacy keys are read once, mirrored
+   into the new JSON, then **left in place**. Any call-site that still
+   writes its own key continues to work; the next migration sweep will
+   pick up the new value.
+
+Why not rewrite the call-sites in this PR?
+
+- Each surface has its own subtleties (the OnboardingTour's preset write
+  also PATCHes Supabase, the InstallDiscoveryHint reads visitCount on
+  every page load to drive the cycle, JourneySpotlight uses a templated
+  storage key per guide id, etc.). One PR per surface keeps reviews
+  scoped and reversible.
+- The legacy-key reads in this helper are deliberately tolerant so the
+  port can land surface-by-surface without coordinating a flag day.
+
+Recommended migration order (one PR each, no rush):
+
+1. `InstallDiscoveryHint.astro` — visitCount + installHintDismissed
+2. `ConsoleOnboarding.astro` — consoleOnboardingDone
+3. `FirstObservationCelebration.astro` — firstObsCelebrated
+4. `ObserveView2.astro` — obs2OnboardingShown (also identifyModeNotice)
+5. `OnboardingTour.astro` — tourCompletedAt + privacyPreset
+6. `JourneySpotlight.astro` + `journey-guides.ts` — guidesSeen map
+
+When the last call-site is ported, a separate sweep can delete the
+legacy keys from existing users' storage with a one-shot cleanup. Until
+then, both halves coexist.
+
+## Debugging
+
+For support: paste this into the browser console.
+
+```js
+JSON.parse(localStorage.getItem('rastrum.user.onboardingState') ?? 'null')
+```
+
+For diffing centralised vs legacy state, the helper exports
+`dumpLegacyKeys()` for the operator console / "export my state" affordance.
+
+## Schema versioning
+
+`version: 1` is the wire-format marker. Bumping it means a future
+migration step ran (e.g. dropping the legacy fallback once the last
+call-site is ported). `setOnboardingState` always normalises back to
+`1` regardless of the patch so downstream code can rely on the field.
+
+## See also
+
+- `src/lib/onboarding-state.ts` — implementation
+- `tests/unit/onboarding-state.test.ts` — coverage
+- [`onboarding-events.md`](onboarding-events.md) — DOM events the tour emits
+- [`onboarding-funnel.md`](onboarding-funnel.md) — what we measure on top
+- [`onboarding-patterns-audit.md`](onboarding-patterns-audit.md) — the audit that motivated the helper

--- a/src/lib/onboarding-state.ts
+++ b/src/lib/onboarding-state.ts
@@ -1,0 +1,336 @@
+/**
+ * Centralised onboarding / "user state" helper.
+ *
+ * Background: the codebase had grown ~18 distinct localStorage keys
+ * under the `rastrum.*` / `rastrum_*` prefix for tracking onboarding,
+ * tour completion, per-feature guide views, visit counts, and similar
+ * one-time-flag UX state. Each surface wrote its own key with no
+ * shared schema, making it hard to:
+ *
+ *   - Reason about "where is the user in their journey?" without
+ *     reading every component file.
+ *   - Export / reset / inspect the full user state for debugging.
+ *   - Migrate the storage layer (e.g. to IndexedDB or a server-side
+ *     mirror) without touching every call site.
+ *
+ * This module exposes a single JSON document under `STORAGE_KEY` plus
+ * typed accessors. It performs a transparent one-time migration from
+ * the legacy keys on first read, but does NOT delete the legacy values
+ * — some surfaces still own their own key, and the migration is
+ * intentionally non-destructive while call-sites are ported.
+ *
+ * SSR-safe: every accessor short-circuits when `localStorage` is
+ * undefined (Astro static build, Node test runners without a shim).
+ */
+
+const STORAGE_KEY = 'rastrum.user.onboardingState';
+const MIGRATION_MARKER_KEY = 'rastrum.user.onboardingState.migrated';
+
+export const LEGACY_KEYS = {
+  tourSeen: 'rastrum.onboarding.seen',
+  tourSeenValue: 'v1',
+  consoleOnboarding: 'rastrum.console.onboardingDone',
+  obs2Onboarding: 'rastrum.obs2.onboarding_shown',
+  firstObsCelebrated: 'rastrum.firstObservationCelebrated',
+  firstObsSyncedAt: 'rastrum.obs.firstSyncedAt',
+  privacyPreset: 'rastrum.onboarding.privacyPreset',
+  visitCount: 'rastrum.visitCount',
+  installHintDismissed: 'rastrum.installHintDismissed',
+  pwaInstalled: 'rastrum.pwaInstalled',
+  guidePrefix: 'rastrum.guide.',
+  identifyModeNotice: 'rastrum_identify_mode_notice_v1',
+} as const;
+
+export type PrivacyPreset = 'open_scientist' | 'researcher' | 'private_observer';
+
+export interface UserOnboardingState {
+  version: 1;
+  /** ISO timestamp when the main OnboardingTour completed. */
+  tourCompletedAt: string | null;
+  /** Whether the /console onboarding modal has been dismissed. */
+  consoleOnboardingDone: boolean;
+  /** Whether the ObserveView2 onboarding hint has been shown. */
+  obs2OnboardingShown: boolean;
+  /** Whether the FirstObservationCelebration has fired (once). */
+  firstObsCelebrated: boolean;
+  /** ISO timestamp of the user's first sync (introduced by #1186). */
+  firstObsSyncedAt: string | null;
+  /** Privacy preset chosen during onboarding. */
+  privacyPreset: PrivacyPreset | null;
+  /** Total recorded visits — drives Install hint and similar. */
+  visitCount: number;
+  /** Whether the user dismissed the PWA install hint. */
+  installHintDismissed: boolean;
+  /** Whether the PWA install completed (matches `rastrum.pwaInstalled`). */
+  pwaInstalled: boolean;
+  /**
+   * Per-feature guide completion map. Key is the guide id without the
+   * `rastrum.guide.` prefix (e.g. `observe`, `community`, `console`).
+   * Value is `'done'` or an ISO date for forward compat.
+   */
+  guidesSeen: Record<string, string>;
+  /** Whether the identify-mode migration notice has been shown. */
+  identifyModeNoticeShown: boolean;
+}
+
+function defaultState(): UserOnboardingState {
+  return {
+    version: 1,
+    tourCompletedAt: null,
+    consoleOnboardingDone: false,
+    obs2OnboardingShown: false,
+    firstObsCelebrated: false,
+    firstObsSyncedAt: null,
+    privacyPreset: null,
+    visitCount: 0,
+    installHintDismissed: false,
+    pwaInstalled: false,
+    guidesSeen: {},
+    identifyModeNoticeShown: false,
+  };
+}
+
+function hasStorage(): boolean {
+  return typeof localStorage !== 'undefined';
+}
+
+function readStored(): UserOnboardingState | null {
+  if (!hasStorage()) return null;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<UserOnboardingState>;
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    return { ...defaultState(), ...parsed, version: 1 };
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(state: UserOnboardingState): void {
+  if (!hasStorage()) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* quota / private mode — silently ignored, in-memory state still works */
+  }
+}
+
+/**
+ * Read a legacy key, returning null if storage is unavailable or the
+ * key is unset. Tolerates empty strings (treated as unset).
+ */
+function readLegacy(key: string): string | null {
+  if (!hasStorage()) return null;
+  try {
+    const v = localStorage.getItem(key);
+    return v && v.trim() !== '' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function migrateFromLegacy(): UserOnboardingState {
+  const state = defaultState();
+
+  if (readLegacy(LEGACY_KEYS.tourSeen) === LEGACY_KEYS.tourSeenValue) {
+    state.tourCompletedAt = state.tourCompletedAt ?? new Date(0).toISOString();
+  }
+  if (readLegacy(LEGACY_KEYS.consoleOnboarding) === 'true') {
+    state.consoleOnboardingDone = true;
+  }
+  if (readLegacy(LEGACY_KEYS.obs2Onboarding) === '1') {
+    state.obs2OnboardingShown = true;
+  }
+  if (readLegacy(LEGACY_KEYS.firstObsCelebrated) === 'true') {
+    state.firstObsCelebrated = true;
+  }
+  const firstSynced = readLegacy(LEGACY_KEYS.firstObsSyncedAt);
+  if (firstSynced) {
+    state.firstObsSyncedAt = firstSynced;
+  }
+  const preset = readLegacy(LEGACY_KEYS.privacyPreset);
+  if (preset === 'open_scientist' || preset === 'researcher' || preset === 'private_observer') {
+    state.privacyPreset = preset;
+  }
+  const visitRaw = readLegacy(LEGACY_KEYS.visitCount);
+  if (visitRaw) {
+    const n = Number.parseInt(visitRaw, 10);
+    if (Number.isFinite(n) && n > 0) state.visitCount = n;
+  }
+  if (readLegacy(LEGACY_KEYS.installHintDismissed) === 'true') {
+    state.installHintDismissed = true;
+  }
+  if (readLegacy(LEGACY_KEYS.pwaInstalled) === 'true') {
+    state.pwaInstalled = true;
+  }
+  if (readLegacy(LEGACY_KEYS.identifyModeNotice)) {
+    state.identifyModeNoticeShown = true;
+  }
+
+  if (hasStorage()) {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (!k || !k.startsWith(LEGACY_KEYS.guidePrefix)) continue;
+      const value = readLegacy(k);
+      if (!value) continue;
+      const id = k.slice(LEGACY_KEYS.guidePrefix.length);
+      if (id) state.guidesSeen[id] = value;
+    }
+  }
+
+  return state;
+}
+
+let cached: UserOnboardingState | null = null;
+
+/**
+ * Reset the in-memory cache. Tests call this between cases to force
+ * re-reads against a freshly populated `localStorage`.
+ */
+export function resetCache(): void {
+  cached = null;
+}
+
+export function getOnboardingState(): UserOnboardingState {
+  if (cached) return cached;
+  const stored = readStored();
+  if (stored) {
+    cached = stored;
+    return cached;
+  }
+
+  const migrated = migrateFromLegacy();
+  if (hasStorage()) {
+    writeStored(migrated);
+    try {
+      localStorage.setItem(MIGRATION_MARKER_KEY, new Date().toISOString());
+    } catch {
+      /* noop */
+    }
+  }
+  cached = migrated;
+  return cached;
+}
+
+export function setOnboardingState(patch: Partial<UserOnboardingState>): UserOnboardingState {
+  const current = getOnboardingState();
+  const next: UserOnboardingState = {
+    ...current,
+    ...patch,
+    guidesSeen: patch.guidesSeen
+      ? { ...current.guidesSeen, ...patch.guidesSeen }
+      : current.guidesSeen,
+    version: 1,
+  };
+  cached = next;
+  writeStored(next);
+  return next;
+}
+
+export function markTourCompleted(at: Date = new Date()): UserOnboardingState {
+  return setOnboardingState({ tourCompletedAt: at.toISOString() });
+}
+
+export function markConsoleOnboarded(): UserOnboardingState {
+  return setOnboardingState({ consoleOnboardingDone: true });
+}
+
+export function markObs2OnboardingShown(): UserOnboardingState {
+  return setOnboardingState({ obs2OnboardingShown: true });
+}
+
+export function markFirstObsCelebrated(): UserOnboardingState {
+  return setOnboardingState({ firstObsCelebrated: true });
+}
+
+export function markFirstObsSynced(at: Date = new Date()): UserOnboardingState {
+  const current = getOnboardingState();
+  if (current.firstObsSyncedAt) return current;
+  return setOnboardingState({ firstObsSyncedAt: at.toISOString() });
+}
+
+export function setPrivacyPreset(preset: PrivacyPreset): UserOnboardingState {
+  return setOnboardingState({ privacyPreset: preset });
+}
+
+export function incrementVisitCount(by = 1): UserOnboardingState {
+  const current = getOnboardingState();
+  return setOnboardingState({ visitCount: current.visitCount + by });
+}
+
+export function markInstallHintDismissed(): UserOnboardingState {
+  return setOnboardingState({ installHintDismissed: true });
+}
+
+export function markPwaInstalled(): UserOnboardingState {
+  return setOnboardingState({ pwaInstalled: true });
+}
+
+export function markGuideSeen(guideId: string, value = 'done'): UserOnboardingState {
+  const id = guideId.startsWith(LEGACY_KEYS.guidePrefix)
+    ? guideId.slice(LEGACY_KEYS.guidePrefix.length)
+    : guideId;
+  return setOnboardingState({ guidesSeen: { [id]: value } });
+}
+
+export function hasSeenGuide(guideId: string): boolean {
+  const id = guideId.startsWith(LEGACY_KEYS.guidePrefix)
+    ? guideId.slice(LEGACY_KEYS.guidePrefix.length)
+    : guideId;
+  return Boolean(getOnboardingState().guidesSeen[id]);
+}
+
+export function markIdentifyModeNoticeShown(): UserOnboardingState {
+  return setOnboardingState({ identifyModeNoticeShown: true });
+}
+
+/**
+ * Debug helper: snapshot of every legacy key the migration looks at,
+ * for the "Export my state" affordance and operator diagnostics.
+ * Returns an empty object when storage is unavailable.
+ */
+export function dumpLegacyKeys(): Record<string, string> {
+  if (!hasStorage()) return {};
+  const out: Record<string, string> = {};
+  const tracked = new Set<string>([
+    LEGACY_KEYS.tourSeen,
+    LEGACY_KEYS.consoleOnboarding,
+    LEGACY_KEYS.obs2Onboarding,
+    LEGACY_KEYS.firstObsCelebrated,
+    LEGACY_KEYS.firstObsSyncedAt,
+    LEGACY_KEYS.privacyPreset,
+    LEGACY_KEYS.visitCount,
+    LEGACY_KEYS.installHintDismissed,
+    LEGACY_KEYS.pwaInstalled,
+    LEGACY_KEYS.identifyModeNotice,
+  ]);
+  for (const k of tracked) {
+    const v = readLegacy(k);
+    if (v !== null) out[k] = v;
+  }
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (k && k.startsWith(LEGACY_KEYS.guidePrefix)) {
+      const v = readLegacy(k);
+      if (v !== null) out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Clear the centralised state. Does NOT touch the legacy keys (some
+ * surfaces still own their own key during the gradual migration).
+ * Tests use this between cases.
+ */
+export function clearOnboardingState(): void {
+  cached = null;
+  if (!hasStorage()) return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(MIGRATION_MARKER_KEY);
+  } catch {
+    /* noop */
+  }
+}

--- a/tests/unit/onboarding-state.test.ts
+++ b/tests/unit/onboarding-state.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Node 22's experimental localStorage is missing methods needed by the
+// module (notably `length` + `key(i)`). Install our own Map-backed shim
+// before the module-under-test imports, mirroring the pattern in
+// `src/lib/byo-keys.test.ts`.
+const _store = new Map<string, string>();
+const shim: Storage = {
+  get length() { return _store.size; },
+  clear() { _store.clear(); },
+  getItem(k) { return _store.get(k) ?? null; },
+  key(i) { return Array.from(_store.keys())[i] ?? null; },
+  removeItem(k) { _store.delete(k); },
+  setItem(k, v) { _store.set(k, String(v)); },
+};
+Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: shim });
+
+import {
+  LEGACY_KEYS,
+  getOnboardingState,
+  setOnboardingState,
+  markTourCompleted,
+  markConsoleOnboarded,
+  markObs2OnboardingShown,
+  markFirstObsCelebrated,
+  markFirstObsSynced,
+  setPrivacyPreset,
+  incrementVisitCount,
+  markInstallHintDismissed,
+  markPwaInstalled,
+  markGuideSeen,
+  hasSeenGuide,
+  markIdentifyModeNoticeShown,
+  dumpLegacyKeys,
+  clearOnboardingState,
+  resetCache,
+} from '../../src/lib/onboarding-state';
+
+beforeEach(() => {
+  _store.clear();
+  resetCache();
+});
+
+describe('onboarding-state — defaults', () => {
+  it('returns a default state when localStorage is empty', () => {
+    const s = getOnboardingState();
+    expect(s.version).toBe(1);
+    expect(s.tourCompletedAt).toBeNull();
+    expect(s.consoleOnboardingDone).toBe(false);
+    expect(s.obs2OnboardingShown).toBe(false);
+    expect(s.firstObsCelebrated).toBe(false);
+    expect(s.firstObsSyncedAt).toBeNull();
+    expect(s.privacyPreset).toBeNull();
+    expect(s.visitCount).toBe(0);
+    expect(s.installHintDismissed).toBe(false);
+    expect(s.pwaInstalled).toBe(false);
+    expect(s.guidesSeen).toEqual({});
+    expect(s.identifyModeNoticeShown).toBe(false);
+  });
+
+  it('persists the default state on first read so a re-read is fast', () => {
+    getOnboardingState();
+    expect(localStorage.getItem('rastrum.user.onboardingState')).not.toBeNull();
+  });
+});
+
+describe('onboarding-state — legacy migration', () => {
+  it('migrates rastrum.onboarding.seen=v1 into tourCompletedAt', () => {
+    localStorage.setItem(LEGACY_KEYS.tourSeen, LEGACY_KEYS.tourSeenValue);
+    const s = getOnboardingState();
+    expect(s.tourCompletedAt).not.toBeNull();
+  });
+
+  it('migrates rastrum.console.onboardingDone=true', () => {
+    localStorage.setItem(LEGACY_KEYS.consoleOnboarding, 'true');
+    expect(getOnboardingState().consoleOnboardingDone).toBe(true);
+  });
+
+  it('migrates rastrum.obs2.onboarding_shown=1', () => {
+    localStorage.setItem(LEGACY_KEYS.obs2Onboarding, '1');
+    expect(getOnboardingState().obs2OnboardingShown).toBe(true);
+  });
+
+  it('migrates rastrum.firstObservationCelebrated=true', () => {
+    localStorage.setItem(LEGACY_KEYS.firstObsCelebrated, 'true');
+    expect(getOnboardingState().firstObsCelebrated).toBe(true);
+  });
+
+  it('migrates rastrum.obs.firstSyncedAt verbatim', () => {
+    const iso = '2026-05-01T12:00:00.000Z';
+    localStorage.setItem(LEGACY_KEYS.firstObsSyncedAt, iso);
+    expect(getOnboardingState().firstObsSyncedAt).toBe(iso);
+  });
+
+  it('migrates rastrum.onboarding.privacyPreset only for the 3 known values', () => {
+    localStorage.setItem(LEGACY_KEYS.privacyPreset, 'researcher');
+    expect(getOnboardingState().privacyPreset).toBe('researcher');
+
+    _store.clear();
+    resetCache();
+    localStorage.setItem(LEGACY_KEYS.privacyPreset, 'open_scientist');
+    expect(getOnboardingState().privacyPreset).toBe('open_scientist');
+
+    _store.clear();
+    resetCache();
+    localStorage.setItem(LEGACY_KEYS.privacyPreset, 'private_observer');
+    expect(getOnboardingState().privacyPreset).toBe('private_observer');
+
+    _store.clear();
+    resetCache();
+    localStorage.setItem(LEGACY_KEYS.privacyPreset, 'random_garbage');
+    expect(getOnboardingState().privacyPreset).toBeNull();
+  });
+
+  it('migrates rastrum.visitCount as a positive integer', () => {
+    localStorage.setItem(LEGACY_KEYS.visitCount, '7');
+    expect(getOnboardingState().visitCount).toBe(7);
+  });
+
+  it('ignores garbage visitCount values', () => {
+    localStorage.setItem(LEGACY_KEYS.visitCount, 'not-a-number');
+    expect(getOnboardingState().visitCount).toBe(0);
+  });
+
+  it('migrates rastrum.installHintDismissed + rastrum.pwaInstalled', () => {
+    localStorage.setItem(LEGACY_KEYS.installHintDismissed, 'true');
+    localStorage.setItem(LEGACY_KEYS.pwaInstalled, 'true');
+    const s = getOnboardingState();
+    expect(s.installHintDismissed).toBe(true);
+    expect(s.pwaInstalled).toBe(true);
+  });
+
+  it('migrates every rastrum.guide.* key into guidesSeen', () => {
+    localStorage.setItem('rastrum.guide.observe', 'done');
+    localStorage.setItem('rastrum.guide.community', 'done');
+    localStorage.setItem('rastrum.guide.console', 'done');
+    const s = getOnboardingState();
+    expect(s.guidesSeen).toEqual({
+      observe: 'done',
+      community: 'done',
+      console: 'done',
+    });
+  });
+
+  it('migrates the identify-mode notice marker', () => {
+    localStorage.setItem(LEGACY_KEYS.identifyModeNotice, '1');
+    expect(getOnboardingState().identifyModeNoticeShown).toBe(true);
+  });
+
+  it('does NOT delete the legacy keys (migration is non-destructive)', () => {
+    localStorage.setItem(LEGACY_KEYS.tourSeen, LEGACY_KEYS.tourSeenValue);
+    localStorage.setItem(LEGACY_KEYS.visitCount, '3');
+    getOnboardingState();
+    expect(localStorage.getItem(LEGACY_KEYS.tourSeen)).toBe(LEGACY_KEYS.tourSeenValue);
+    expect(localStorage.getItem(LEGACY_KEYS.visitCount)).toBe('3');
+  });
+
+  it('migration runs only once — second read returns the persisted state', () => {
+    localStorage.setItem(LEGACY_KEYS.visitCount, '5');
+    expect(getOnboardingState().visitCount).toBe(5);
+
+    // Mutate the legacy key after the first read — second read MUST
+    // ignore it (stored state is the source of truth from now on).
+    localStorage.setItem(LEGACY_KEYS.visitCount, '999');
+    resetCache();
+    expect(getOnboardingState().visitCount).toBe(5);
+  });
+});
+
+describe('onboarding-state — setOnboardingState', () => {
+  it('merges patch into current state and persists', () => {
+    setOnboardingState({ visitCount: 4, consoleOnboardingDone: true });
+    resetCache();
+    const s = getOnboardingState();
+    expect(s.visitCount).toBe(4);
+    expect(s.consoleOnboardingDone).toBe(true);
+    expect(s.obs2OnboardingShown).toBe(false); // untouched
+  });
+
+  it('deep-merges guidesSeen rather than replacing it', () => {
+    setOnboardingState({ guidesSeen: { observe: 'done' } });
+    setOnboardingState({ guidesSeen: { community: 'done' } });
+    const s = getOnboardingState();
+    expect(s.guidesSeen).toEqual({ observe: 'done', community: 'done' });
+  });
+
+  it('always forces version=1 regardless of patch', () => {
+    setOnboardingState({ version: 99 as unknown as 1 });
+    expect(getOnboardingState().version).toBe(1);
+  });
+});
+
+describe('onboarding-state — convenience accessors', () => {
+  it('markTourCompleted writes an ISO timestamp', () => {
+    const at = new Date('2026-05-24T10:00:00.000Z');
+    markTourCompleted(at);
+    expect(getOnboardingState().tourCompletedAt).toBe(at.toISOString());
+  });
+
+  it('markConsoleOnboarded flips the flag', () => {
+    markConsoleOnboarded();
+    expect(getOnboardingState().consoleOnboardingDone).toBe(true);
+  });
+
+  it('markObs2OnboardingShown flips the flag', () => {
+    markObs2OnboardingShown();
+    expect(getOnboardingState().obs2OnboardingShown).toBe(true);
+  });
+
+  it('markFirstObsCelebrated flips the flag', () => {
+    markFirstObsCelebrated();
+    expect(getOnboardingState().firstObsCelebrated).toBe(true);
+  });
+
+  it('markFirstObsSynced is idempotent — only stamps once', () => {
+    const first = new Date('2026-05-01T00:00:00.000Z');
+    const later = new Date('2026-05-10T00:00:00.000Z');
+    markFirstObsSynced(first);
+    markFirstObsSynced(later);
+    expect(getOnboardingState().firstObsSyncedAt).toBe(first.toISOString());
+  });
+
+  it('setPrivacyPreset records the choice', () => {
+    setPrivacyPreset('researcher');
+    expect(getOnboardingState().privacyPreset).toBe('researcher');
+  });
+
+  it('incrementVisitCount adds by 1 by default and N when passed', () => {
+    incrementVisitCount();
+    incrementVisitCount(3);
+    expect(getOnboardingState().visitCount).toBe(4);
+  });
+
+  it('markInstallHintDismissed + markPwaInstalled set their flags', () => {
+    markInstallHintDismissed();
+    markPwaInstalled();
+    const s = getOnboardingState();
+    expect(s.installHintDismissed).toBe(true);
+    expect(s.pwaInstalled).toBe(true);
+  });
+
+  it('markGuideSeen accepts bare ids or the rastrum.guide.* form', () => {
+    markGuideSeen('observe');
+    markGuideSeen('rastrum.guide.community');
+    const s = getOnboardingState();
+    expect(s.guidesSeen.observe).toBe('done');
+    expect(s.guidesSeen.community).toBe('done');
+  });
+
+  it('hasSeenGuide returns true after markGuideSeen and false otherwise', () => {
+    expect(hasSeenGuide('observe')).toBe(false);
+    markGuideSeen('observe');
+    expect(hasSeenGuide('observe')).toBe(true);
+    expect(hasSeenGuide('rastrum.guide.observe')).toBe(true);
+  });
+
+  it('markIdentifyModeNoticeShown flips the flag', () => {
+    markIdentifyModeNoticeShown();
+    expect(getOnboardingState().identifyModeNoticeShown).toBe(true);
+  });
+});
+
+describe('onboarding-state — dumpLegacyKeys', () => {
+  it('returns the populated legacy values', () => {
+    localStorage.setItem(LEGACY_KEYS.tourSeen, 'v1');
+    localStorage.setItem(LEGACY_KEYS.visitCount, '12');
+    localStorage.setItem('rastrum.guide.observe', 'done');
+    const dump = dumpLegacyKeys();
+    expect(dump[LEGACY_KEYS.tourSeen]).toBe('v1');
+    expect(dump[LEGACY_KEYS.visitCount]).toBe('12');
+    expect(dump['rastrum.guide.observe']).toBe('done');
+  });
+
+  it('returns an empty object when no legacy keys exist', () => {
+    expect(dumpLegacyKeys()).toEqual({});
+  });
+});
+
+describe('onboarding-state — clearOnboardingState', () => {
+  it('removes the centralised key but leaves legacy keys untouched', () => {
+    localStorage.setItem(LEGACY_KEYS.visitCount, '5');
+    incrementVisitCount(); // forces migration + write
+    expect(localStorage.getItem('rastrum.user.onboardingState')).not.toBeNull();
+
+    clearOnboardingState();
+    expect(localStorage.getItem('rastrum.user.onboardingState')).toBeNull();
+    expect(localStorage.getItem(LEGACY_KEYS.visitCount)).toBe('5');
+  });
+
+  it('clears the in-memory cache so the next read re-migrates', () => {
+    localStorage.setItem(LEGACY_KEYS.visitCount, '8');
+    expect(getOnboardingState().visitCount).toBe(8);
+    clearOnboardingState();
+    expect(getOnboardingState().visitCount).toBe(8); // re-migrated from legacy
+  });
+});
+
+describe('onboarding-state — SSR safety', () => {
+  it('returns a default state and no-ops when localStorage is undefined', () => {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: undefined });
+    resetCache();
+    try {
+      const s = getOnboardingState();
+      expect(s.version).toBe(1);
+      expect(s.visitCount).toBe(0);
+
+      // Mutating accessors must not throw.
+      expect(() => incrementVisitCount()).not.toThrow();
+      expect(() => markTourCompleted()).not.toThrow();
+      expect(() => markGuideSeen('observe')).not.toThrow();
+      expect(() => clearOnboardingState()).not.toThrow();
+      expect(dumpLegacyKeys()).toEqual({});
+    } finally {
+      if (desc) Object.defineProperty(globalThis, 'localStorage', desc);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Journey audit (2026-05-24) found 18 scattered `localStorage` keys for onboarding/seen/guide/visit state. Chronic fragmentation, no central model of "new user".

**This PR**: introduces `src/lib/onboarding-state.ts` as a centralised helper. Additive — no call-site migrations. Future PRs can port surface-by-surface as files are touched.

| Surface | Coverage |
|---|---|
| 18 legacy keys read | ✅ one-time non-destructive migration |
| Single SoT key | `rastrum.user.onboardingState` |
| Sugar accessors | 11 (markTourCompleted, markFirstObsSynced, …) |
| SSR-safe | ✅ every mutator short-circuits on `typeof localStorage === 'undefined'` |
| Tests | 34/34 across 7 describe blocks |

## API surface (selected)

```ts
getOnboardingState(): UserOnboardingState
setOnboardingState(patch: Partial<UserOnboardingState>): UserOnboardingState
markTourCompleted() / markFirstObsSynced() / setPrivacyPreset(p)
markGuideSeen(id) / hasSeenGuide(id)
dumpLegacyKeys() / clearOnboardingState() / LEGACY_KEYS
```

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run onboarding-state` — 34/34 pass
- [x] `npm run build` — 255 pages

Closes Tier 2 PR5 of journey audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)