### PR TITLE
feat(home): post-tour first-observation CTA empty state

### DIFF
--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -5,6 +5,7 @@ import HomeChips from './home/HomeChips.astro';
 import HomeRecent from './home/HomeRecent.astro';
 import HomeNearby from './home/HomeNearby.astro';
 import HomeObservadorDelMes from './home/HomeObservadorDelMes.astro';
+import FirstObservationCTA from './home/FirstObservationCTA.astro';
 
 interface Props {
   lang: 'en' | 'es';
@@ -75,6 +76,8 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
 
   <HomeHero lang={lang} />
   <HomeChips lang={lang} />
+
+  <FirstObservationCTA lang={lang} />
 
   <!-- #710 Daily Challenge -->
   <div class="home-widgets-challenge hidden">

--- a/src/components/home/FirstObservationCTA.astro
+++ b/src/components/home/FirstObservationCTA.astro
@@ -1,0 +1,93 @@
+---
+import { t } from '../../i18n/utils';
+
+interface Props { lang: 'en' | 'es'; }
+const { lang } = Astro.props;
+const tr = t(lang);
+const c = tr.home.widgets.first_obs_cta;
+const observeHref = lang === 'es' ? '/es/observar/' : '/en/observe/';
+---
+
+<section
+  class="first-obs-cta hidden mb-6 rounded-2xl border border-emerald-200 dark:border-emerald-800/60 bg-emerald-50/70 dark:bg-emerald-950/30 p-6 sm:p-8"
+  data-first-obs-cta
+  data-tour-seen-key="rastrum.onboarding.seen"
+  data-tour-seen-value="v1"
+  data-dismissed-key="rastrum.user.onboardingState.firstObsCtaDismissed"
+  aria-labelledby="first-obs-cta-heading"
+>
+  <h2 id="first-obs-cta-heading" class="text-xl sm:text-2xl font-bold tracking-tight text-emerald-900 dark:text-emerald-100">
+    {c.heading}
+  </h2>
+  <p class="mt-2 text-sm sm:text-base text-emerald-800/90 dark:text-emerald-200/80">
+    {c.body}
+  </p>
+  <div class="mt-5 flex flex-wrap items-center gap-x-5 gap-y-2">
+    <a
+      href={observeHref}
+      class="inline-flex items-center justify-center rounded-full bg-emerald-700 hover:bg-emerald-800 text-white font-semibold px-5 py-2.5 text-sm sm:text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+      data-first-obs-cta-primary
+    >
+      {c.primary}
+    </a>
+    <button
+      type="button"
+      class="text-sm font-medium text-emerald-800/80 dark:text-emerald-300/80 hover:text-emerald-900 dark:hover:text-emerald-100 underline-offset-2 hover:underline"
+      data-first-obs-cta-dismiss
+    >
+      {c.secondary}
+    </button>
+  </div>
+</section>
+
+<script>
+  import { getSupabase, getCachedUser } from '../../lib/supabase';
+
+  async function init() {
+    const root = document.querySelector<HTMLElement>('[data-first-obs-cta]');
+    if (!root) return;
+
+    const seenKey = root.dataset.tourSeenKey ?? 'rastrum.onboarding.seen';
+    const seenVal = root.dataset.tourSeenValue ?? 'v1';
+    const dismissedKey = root.dataset.dismissedKey
+      ?? 'rastrum.user.onboardingState.firstObsCtaDismissed';
+
+    let tourSeen = false;
+    let dismissed = false;
+    try {
+      tourSeen = localStorage.getItem(seenKey) === seenVal;
+      dismissed = localStorage.getItem(dismissedKey) === 'true';
+    } catch { /* localStorage unavailable */ }
+
+    if (!tourSeen || dismissed) return;
+
+    const user = await getCachedUser();
+    if (!user) return;
+
+    let supabase;
+    try { supabase = getSupabase(); } catch { return; }
+
+    try {
+      const { data, error } = await supabase
+        .from('observations')
+        .select('id')
+        .eq('observer_id', user.id)
+        .limit(1);
+      if (error) return;
+      const hasFirstObs = !!data && data.length > 0;
+      if (hasFirstObs) return;
+    } catch {
+      return;
+    }
+
+    const dismissBtn = root.querySelector<HTMLButtonElement>('[data-first-obs-cta-dismiss]');
+    dismissBtn?.addEventListener('click', () => {
+      try { localStorage.setItem(dismissedKey, 'true'); } catch { /* ignore */ }
+      root.classList.add('hidden');
+    });
+
+    root.classList.remove('hidden');
+  }
+
+  init().catch(() => { /* silent — surface is optional */ });
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -214,6 +214,12 @@
         "watchlist": "Watchlist",
         "count_overflow": "99+"
       },
+      "first_obs_cta": {
+        "heading": "Your first observation is waiting",
+        "body": "Tap the camera button to record any species — photo, audio, or video work.",
+        "primary": "Take a photo now →",
+        "secondary": "Skip for now"
+      },
       "near_you_title": "Near you right now",
       "near_you_subtitle": "Observations within {{radius}} km",
       "near_you_loading": "Finding nearby observations…",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -214,6 +214,12 @@
         "watchlist": "Lista",
         "count_overflow": "99+"
       },
+      "first_obs_cta": {
+        "heading": "Tu primera observación te espera",
+        "body": "Toca el botón de cámara para registrar cualquier especie — foto, audio o video funcionan.",
+        "primary": "Tomar foto ahora →",
+        "secondary": "Por ahora no"
+      },
       "near_you_title": "Cerca de ti ahora",
       "near_you_subtitle": "Observaciones en {{radius}} km",
       "near_you_loading": "Buscando observaciones cercanas…",

--- a/tests/unit/first-observation-cta.test.ts
+++ b/tests/unit/first-observation-cta.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Source-string assertions for the post-tour first-observation empty
+ * state — a prominent emerald card that lands users on the action
+ * primary (Take a photo now) immediately after the onboarding tour.
+ *
+ * Why source-strings instead of DOM-driven: the gate runs inside an
+ * Astro client `<script>` (not the SSR pass), so jsdom-style asserts
+ * would require booting the page. The contract worth pinning is
+ * structural (default-hidden + gate-condition + locale-paired link
+ * + i18n parity + dismiss-flag persistence), which source-strings
+ * cover cheaply.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const componentPath = join(
+  process.cwd(),
+  'src/components/home/FirstObservationCTA.astro',
+);
+const componentSrc = readFileSync(componentPath, 'utf8');
+
+const homeWidgetsSrc = readFileSync(
+  join(process.cwd(), 'src/components/HomeWidgets.astro'),
+  'utf8',
+);
+
+const enJson = JSON.parse(
+  readFileSync(join(process.cwd(), 'src/i18n/en.json'), 'utf8'),
+) as Record<string, unknown>;
+const esJson = JSON.parse(
+  readFileSync(join(process.cwd(), 'src/i18n/es.json'), 'utf8'),
+) as Record<string, unknown>;
+
+interface I18nShape {
+  home: {
+    widgets: {
+      first_obs_cta: {
+        heading: string;
+        body: string;
+        primary: string;
+        secondary: string;
+      };
+    };
+  };
+}
+
+describe('FirstObservationCTA — post-tour empty state', () => {
+  it('ships hidden by default (SSR cloak; client reveals after gate)', () => {
+    expect(componentSrc).toMatch(
+      /class="first-obs-cta hidden\b[^"]*"/,
+    );
+  });
+
+  it('the dismiss flag is persisted to localStorage on click', () => {
+    expect(componentSrc).toMatch(
+      /localStorage\.setItem\(\s*dismissedKey\s*,\s*'true'\s*\)/,
+    );
+    expect(componentSrc).toMatch(
+      /rastrum\.user\.onboardingState\.firstObsCtaDismissed/,
+    );
+  });
+
+  it('gates on all three conditions: tour seen, not dismissed, no first obs', () => {
+    expect(componentSrc).toMatch(/tourSeen\s*=\s*localStorage\.getItem\(seenKey\)\s*===\s*seenVal/);
+    expect(componentSrc).toMatch(/dismissed\s*=\s*localStorage\.getItem\(dismissedKey\)\s*===\s*'true'/);
+    expect(componentSrc).toMatch(/if\s*\(\s*!tourSeen\s*\|\|\s*dismissed\s*\)\s*return/);
+    expect(componentSrc).toMatch(/\.from\(\s*'observations'\s*\)/);
+    expect(componentSrc).toMatch(/\.eq\(\s*'observer_id'\s*,\s*user\.id\s*\)/);
+    expect(componentSrc).toMatch(/\.limit\(\s*1\s*\)/);
+    expect(componentSrc).toMatch(/hasFirstObs/);
+    expect(componentSrc).toMatch(/if\s*\(\s*hasFirstObs\s*\)\s*return/);
+  });
+
+  it('reveals via classList.remove("hidden") after gate passes', () => {
+    expect(componentSrc).toMatch(/root\.classList\.remove\(\s*['"]hidden['"]\s*\)/);
+  });
+
+  it('uses the legacy tour-completed key rastrum.onboarding.seen=v1', () => {
+    expect(componentSrc).toMatch(/data-tour-seen-key="rastrum\.onboarding\.seen"/);
+    expect(componentSrc).toMatch(/data-tour-seen-value="v1"/);
+  });
+
+  it('does not regress the bounded-probe rule (#1072): no count:exact, no head:true', () => {
+    expect(componentSrc).not.toMatch(/count:\s*'exact'/);
+    expect(componentSrc).not.toMatch(/head:\s*true/);
+  });
+
+  it('uses locale-paired observe link (EN /observe/, ES /observar/)', () => {
+    expect(componentSrc).toMatch(/lang === 'es'\s*\?\s*'\/es\/observar\/'\s*:\s*'\/en\/observe\/'/);
+  });
+});
+
+describe('FirstObservationCTA — i18n parity (EN + ES)', () => {
+  for (const [name, root] of [
+    ['en', enJson],
+    ['es', esJson],
+  ] as const) {
+    it(`${name} has every first_obs_cta key (heading/body/primary/secondary)`, () => {
+      const c = (root as unknown as I18nShape).home.widgets.first_obs_cta;
+      expect(c.heading).toBeTruthy();
+      expect(c.body).toBeTruthy();
+      expect(c.primary).toBeTruthy();
+      expect(c.secondary).toBeTruthy();
+    });
+  }
+
+  it('EN heading is "Your first observation is waiting"', () => {
+    const c = (enJson as unknown as I18nShape).home.widgets.first_obs_cta;
+    expect(c.heading).toBe('Your first observation is waiting');
+  });
+
+  it('ES heading is "Tu primera observación te espera"', () => {
+    const c = (esJson as unknown as I18nShape).home.widgets.first_obs_cta;
+    expect(c.heading).toBe('Tu primera observación te espera');
+  });
+
+  it('EN primary CTA is "Take a photo now →"', () => {
+    const c = (enJson as unknown as I18nShape).home.widgets.first_obs_cta;
+    expect(c.primary).toBe('Take a photo now →');
+  });
+
+  it('ES primary CTA is "Tomar foto ahora →"', () => {
+    const c = (esJson as unknown as I18nShape).home.widgets.first_obs_cta;
+    expect(c.primary).toBe('Tomar foto ahora →');
+  });
+
+  it('EN/ES diverge (proves both files were actually translated)', () => {
+    const en = (enJson as unknown as I18nShape).home.widgets.first_obs_cta;
+    const es = (esJson as unknown as I18nShape).home.widgets.first_obs_cta;
+    expect(en.heading).not.toBe(es.heading);
+    expect(en.body).not.toBe(es.body);
+    expect(en.secondary).not.toBe(es.secondary);
+  });
+});
+
+describe('FirstObservationCTA — mounted in HomeWidgets above HomeRecent', () => {
+  it('imports FirstObservationCTA', () => {
+    expect(homeWidgetsSrc).toMatch(
+      /import FirstObservationCTA from '\.\/home\/FirstObservationCTA\.astro'/,
+    );
+  });
+
+  it('renders <FirstObservationCTA lang={lang} />', () => {
+    expect(homeWidgetsSrc).toMatch(/<FirstObservationCTA\s+lang=\{lang\}\s*\/>/);
+  });
+
+  it('sits above HomeRecent (so signed-in users see "your first" before "others recent")', () => {
+    const ctaIdx = homeWidgetsSrc.indexOf('<FirstObservationCTA');
+    const recentIdx = homeWidgetsSrc.indexOf('<HomeRecent');
+    expect(ctaIdx).toBeGreaterThan(-1);
+    expect(recentIdx).toBeGreaterThan(-1);
+    expect(ctaIdx).toBeLessThan(recentIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Journey audit found: after the tour ends, the user lands on the homepage with no momentum towards the primary action. This card fills that gap with a large, contextual "your first observation is waiting" CTA.

| State | Behavior |
|---|---|
| Tour not completed | hidden |
| Tour completed + no first obs + not dismissed | **shown** (emerald card, primary CTA to observe) |
| First obs synced | hidden |
| Dismissed via "Skip for now" | hidden |

Uses `getCachedUser()` + bounded `.limit(1)` Supabase probe (no `count: exact` per #1072 regression).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run first-observation-cta` — 17/17 pass
- [x] `npm run build` — 255 pages

Closes Tier 1 PR4 of journey audit (post-tour empty state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)