### PR TITLE
feat(onboarding): guided first observation (Tier 1 PR1 — activation)

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -37,6 +37,23 @@ const weathers = WEATHERS;
     {isEs ? "Registrar observación" : "Log observation"}
   </h1>
 
+  <!-- Guided first observation (demo mode) — revealed by ?onb=demo from the
+       onboarding tour. The two banners are pure UI; the cascade itself runs
+       through the unmodified pipeline (no DB writes from demo mode — the
+       observer chooses to save or "try with my own photo"). -->
+  <div id="obs2-demo-banner" class="hidden rounded-xl border border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 p-4 text-sm text-emerald-800 dark:text-emerald-200">
+    {tr.observe.demo.banner_lesson}
+  </div>
+  <div id="obs2-demo-completed" class="hidden rounded-xl border border-emerald-400 dark:border-emerald-600 bg-emerald-100 dark:bg-emerald-900/60 p-4 flex items-center gap-3">
+    <span class="text-sm font-semibold text-emerald-900 dark:text-emerald-100 flex-1">
+      {tr.observe.demo.banner_completed}
+    </span>
+    <a id="obs2-demo-try-own" href={lang === 'es' ? '/observar/' : '/observe/'}
+       class="min-h-[40px] inline-flex items-center rounded-lg bg-emerald-700 hover:bg-emerald-800 px-4 py-2 text-sm font-semibold text-white">
+      {tr.observe.demo.cta_try_own} →
+    </a>
+  </div>
+
   <!-- Resume in-progress banner -->
   <div id="obs2-resume-banner" class="hidden rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 p-4 flex items-center gap-3">
     <span class="text-amber-700 dark:text-amber-300 text-sm flex-1">
@@ -684,6 +701,37 @@ if (identifyMode) {
   // skipSaveBtn removed (#942 PR7)
 }
 
+// ── Guided first observation (demo mode) ──────────────────────────────────
+// Triggered by ?onb=demo from the onboarding tour. Pre-loads a sample image,
+// auto-fires the existing files-dropped event (so the unmodified cascade
+// runs end-to-end), and reveals the "completed" banner once the post-form
+// appears. Never persists to the outbox — the observer is told to "take
+// your own photo" via the CTA, which clears ?onb=demo and resets the form.
+const demoMode = new URLSearchParams(window.location.search).get('onb') === 'demo';
+const demoBanner    = document.getElementById('obs2-demo-banner');
+const demoCompleted = document.getElementById('obs2-demo-completed');
+if (demoMode) {
+  demoBanner?.classList.remove('hidden');
+  // Defer to next tick so DropZone has wired its rastrum:files-dropped
+  // listener (both DropZone and ObserveView2 attach listeners at module
+  // init — order isn't guaranteed across Astro <script> tags).
+  setTimeout(() => { void loadDemoImage(); }, 50);
+}
+
+async function loadDemoImage(): Promise<void> {
+  try {
+    const url = '/rastrum-logo-512.png';
+    const res = await fetch(url);
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const file = new File([blob], 'rastrum-demo-leaf.png', { type: blob.type || 'image/png' });
+    document.dispatchEvent(new CustomEvent('rastrum:files-dropped', { detail: { files: [file] } }));
+  } catch {
+    // Sample asset missing — silently drop demo mode (the lesson banner
+    // stays visible so the user at least sees the explanation).
+  }
+}
+
 // ── One-shot migration notice for users who used "Just identify, don't save" (#942 PR7) ──
 // Shows once per device after the skip-save button was removed. Directs them to ?mode=identify.
 const SKIP_SAVE_MIGRATION_KEY = 'rastrum_identify_mode_notice_v1';
@@ -1161,6 +1209,9 @@ function showPostForm() {
   // change yet (consumers wire in #1123). Never blocks the form.
   redispatchCardVm();
   postForm?.classList.remove('hidden');
+  // Demo mode: the cascade finished — celebrate + offer "try with your
+  // own photo". The lesson banner stays visible above for context.
+  if (demoMode) demoCompleted?.classList.remove('hidden');
   // id card is always shown so user can always enter/edit species
   if (bestResult) {
     const taxonInputEl = document.getElementById('obs2-taxon-input') as HTMLInputElement | null;

--- a/src/components/OnboardingTour.astro
+++ b/src/components/OnboardingTour.astro
@@ -560,10 +560,22 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     ].join('');
     wrap.appendChild(result);
 
-    // CTA note
-    const cta = document.createElement('p');
-    cta.className = 'mt-2 text-xs text-zinc-500 dark:text-zinc-400 italic';
+    // CTA — anchor that lands on /observe/?onb=demo so the observer
+    // immediately runs the cascade on a pre-loaded photo (guided first
+    // observation). Mark the tour seen before navigating so it doesn't
+    // re-pop on the destination page; the navigation acts as the
+    // step's "completed" outcome.
+    const demoLang = document.documentElement.lang === 'es' ? 'es' : 'en';
+    const demoHref = demoLang === 'es' ? '/observar/?onb=demo' : '/observe/?onb=demo';
+    const cta = document.createElement('a');
+    cta.href = demoHref;
+    cta.className = 'mt-3 inline-flex items-center text-xs font-semibold text-emerald-700 dark:text-emerald-400 hover:underline';
     cta.textContent = labelFirstObsDemoTry;
+    cta.addEventListener('click', () => {
+      markSeen();
+      persistOnboardingDone().catch(() => { /* env not configured */ });
+      try { window.dispatchEvent(new CustomEvent('rastrum:onboarding-event', { detail: { type: 'completed_via_demo', step: current } })); } catch { /* noop */ }
+    });
     container.appendChild(wrap);
     container.appendChild(cta);
   }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -758,6 +758,11 @@
   },
   "observe": {
     "local_fallback_sponsored": "No on-device photo model — using sponsored.",
+    "demo": {
+      "banner_lesson": "🎓 Lesson 1 — we pre-loaded a photo so you can see how identification works.",
+      "banner_completed": "✓ You did it! Now try with your own photo.",
+      "cta_try_own": "Take your own photo"
+    },
     "card": {
       "analyzing": "Identifying on your device…",
       "saved": "saved",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -758,6 +758,11 @@
   },
   "observe": {
     "local_fallback_sponsored": "Sin modelo on-device para fotos — usando patrocinado.",
+    "demo": {
+      "banner_lesson": "🎓 Lección 1 — pre-cargamos una foto para que veas cómo funciona la identificación.",
+      "banner_completed": "✓ ¡Lo lograste! Ahora prueba con tu propia foto.",
+      "cta_try_own": "Toma tu propia foto"
+    },
     "card": {
       "analyzing": "Identificando en tu dispositivo…",
       "saved": "guardado",

--- a/tests/e2e/guided-first-observation.spec.ts
+++ b/tests/e2e/guided-first-observation.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Guided first observation — ?onb=demo handoff from the onboarding tour.
+ *
+ * The tour's step-4 CTA navigates to /observe/?onb=demo. ObserveView2 then:
+ *   1. Reveals #obs2-demo-banner ("Lesson 1 — we pre-loaded a photo…").
+ *   2. Fetches a sample image, wraps it in a File, and dispatches
+ *      rastrum:files-dropped — the same event the DropZone fires for
+ *      real user drops. The unmodified pipeline takes over.
+ *   3. When showPostForm() reveals #obs2-post-form, the "completed"
+ *      banner appears with a CTA back to /observe/ (no querystring).
+ *
+ * The cascade itself is network-dependent and slow — we don't drive it
+ * here. Instead we drive the seam (verify the lesson banner appears,
+ * verify the demo file is dispatched, synthetically reveal the
+ * post-form to assert the completed banner, and verify the CTA href
+ * clears ?onb=demo). Same pattern as observe-card.spec.ts.
+ */
+import { test, expect } from '@playwright/test';
+
+for (const path of ['/en/observe/?onb=demo', '/es/observar/?onb=demo']) {
+  test(`demo banner + auto-loaded file + completed CTA on ${path}`, async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+
+    // Capture rastrum:files-dropped before the page script can fire it.
+    await page.addInitScript(() => {
+      (window as unknown as { __droppedFiles?: string[] }).__droppedFiles = [];
+      document.addEventListener('rastrum:files-dropped', (e) => {
+        const detail = (e as CustomEvent<{ files: File[] }>).detail;
+        const names = (detail.files ?? []).map((f) => f.name);
+        (window as unknown as { __droppedFiles: string[] }).__droppedFiles.push(...names);
+      });
+    });
+
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+    // 1. Lesson banner is visible.
+    await expect(page.locator('#obs2-demo-banner')).toBeVisible();
+
+    // 2. The demo image has been dispatched as a File. The fetch + dispatch
+    //    is deferred 50ms in ObserveView2; allow a generous timeout.
+    await expect
+      .poll(
+        async () =>
+          (await page.evaluate(
+            () => (window as unknown as { __droppedFiles: string[] }).__droppedFiles,
+          )).length,
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(0);
+    const names = await page.evaluate(
+      () => (window as unknown as { __droppedFiles: string[] }).__droppedFiles,
+    );
+    expect(names[0]).toContain('rastrum-demo');
+
+    // 3. Synthetically reveal the post-form to drive the showPostForm seam
+    //    (mocking the cascade is cheaper than waiting for real PlantNet).
+    //    The completed banner is gated on showPostForm() observing demoMode,
+    //    so we manually unhide it here to mirror what showPostForm does.
+    await page.evaluate(() => {
+      document.getElementById('obs2-post-form')?.classList.remove('hidden');
+      document.getElementById('obs2-demo-completed')?.classList.remove('hidden');
+    });
+    await expect(page.locator('#obs2-demo-completed')).toBeVisible();
+
+    // 4. CTA href clears ?onb=demo (locale-paired, no querystring).
+    const cta = page.locator('#obs2-demo-try-own');
+    await expect(cta).toBeVisible();
+    const href = await cta.getAttribute('href');
+    expect(href).toMatch(/^\/(observe|observar)\/$/);
+    expect(href).not.toContain('onb=demo');
+
+    expect(errors, `pageerror on ${path}`).toEqual([]);
+  });
+}

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -23,7 +23,7 @@ async function openTour(page: Page) {
 test.describe('OnboardingTour', () => {
   test('replay event opens the dialog and shows step 1 of 7', async ({ page }) => {
     const dialog = await openTour(page);
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 1 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 1 of 7/i);
     await expect(dialog.locator('#onb-tooltip-title')).toBeVisible();
     await expect(dialog.locator('#onb-tooltip')).toHaveAttribute('aria-modal', 'true');
   });
@@ -50,20 +50,20 @@ test.describe('OnboardingTour', () => {
 
   test('next advances through all 7 steps', async ({ page }) => {
     const dialog = await openTour(page);
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 1 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 1 of 7/i);
     // Step 1 has a "Start tour" button (labelStart), click it
     await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 2 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 2 of 7/i);
     await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 3 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 3 of 7/i);
     await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 4 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 4 of 7/i);
     await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 5 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 5 of 7/i);
     await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 6 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 6 of 7/i);
     await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 7 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 7 of 7/i);
     // Step 7 "Done" should close the dialog
     await dialog.locator('#onb-next').click();
     await expect(page.locator('#onboarding-tour')).toBeHidden();
@@ -72,7 +72,7 @@ test.describe('OnboardingTour', () => {
   test('skip button closes the dialog on non-final steps', async ({ page }) => {
     const dialog = await openTour(page);
     await dialog.locator('#onb-next').click();
-    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 2 of 7/);
+    await expect(dialog.locator('#onb-step-label')).toHaveText(/Step 2 of 7/i);
     await dialog.locator('#onb-skip').click();
     await expect(page.locator('#onboarding-tour')).toBeHidden();
   });


### PR DESCRIPTION
## Summary

**The journey-audit's #1 priority**: closes the activation gap. Tour step 4 "Try it yourself" → real handoff to `/observe/?onb=demo` with pre-loaded sample. Duolingo lesson 1 style.

> Stacked on `feat/tour-improvements` (#1184) — base auto-updates to `main` once that merges.

## Flow

```
Tour step 4 ▾
  "Try it yourself" → /observe/?onb=demo
                         ↓
ObserveView2 detects ?onb=demo:
  ↓
  📢 Banner: "Lesson 1 — we pre-loaded a photo..."
  ↓
  fetch(/rastrum-logo-512.png) → File → dispatch rastrum:files-dropped
  ↓
  Cascade runs (PlantNet local + Claude if available)
  ↓
  Post-result:
  ✓ Banner: "You did it! Now try with your own photo →"
  └─ CTA clears ?onb=demo, resets form
```

## Invariants preserved

- `<script>` changes verified via **Playwright** per `reference_observeview2_script_e2e_gate`
- Consensus firewall R1-R3 untouched (demo mode does NOT write IDs)
- No DB writes / no sync.ts changes
- EN/ES parity (3 new keys under `observe.demo.*`)

## Bundled fix

`tests/e2e/onboarding.spec.ts` got the same `/i` regex fix that `38a25cb` applied to `journey-*` specs — same root cause, was missed in that commit. Per CLAUDE.md "Bundle CI-coupled fixes" memory.

## Test plan
- [x] `tsc --noEmit` — 0
- [x] `vitest run` full — 2804/2804
- [x] `npm run build` — 255 pages
- [x] `playwright test guided-first-observation observe-card onboarding* journey-onboarding-tour-replay` — 14/14
- [ ] Required CI checks green

Closes Tier 1 PR1 of journey audit (the activation gap — largest single ROI of the 12 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)