### PR TITLE
feat(chat): dynamic on-device model badge — PBI 4.3

### DIFF
--- a/src/components/ChatView.astro
+++ b/src/components/ChatView.astro
@@ -19,7 +19,7 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
       <h1 class="text-2xl font-bold tracking-tight">{tr.chat.title}</h1>
       <span id="chat-model-badge" class="inline-flex items-center gap-1 rounded-full border border-emerald-300 dark:border-emerald-700/40 bg-emerald-50 dark:bg-emerald-900/10 px-2 py-0.5 text-[10px] font-medium text-emerald-800 dark:text-emerald-300">
         <span aria-hidden="true">✨</span>
-        <span id="chat-model-badge-text">{lang === 'es' ? 'En el dispositivo' : 'On-device'}</span>
+        <span id="chat-model-badge-text">{tr.chat.badge.fallback}</span>
       </span>
     </div>
     <button
@@ -181,6 +181,21 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
   }
   function writeModelPick(v: ModelPickerChoice): void {
     if (typeof localStorage !== 'undefined') localStorage.setItem(MODEL_PICKER_KEY, v);
+  }
+
+  type ChatEngineChoice = 'gemma' | 'llama';
+  const CHAT_ENGINE_KEY = 'rastrum.chat.engine';
+  const MODEL_DISPLAY_NAMES: Record<ChatEngineChoice, string> = {
+    gemma: 'Gemma 4 E2B',
+    llama: 'Llama 3.2 1B',
+  };
+  function readChatEngine(): ChatEngineChoice | null {
+    if (typeof localStorage === 'undefined') return null;
+    const v = localStorage.getItem(CHAT_ENGINE_KEY);
+    return v === 'gemma' || v === 'llama' ? v : null;
+  }
+  function writeChatEngine(v: ChatEngineChoice): void {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(CHAT_ENGINE_KEY, v);
   }
 
   const isEs = (document.documentElement.lang === 'es');
@@ -508,6 +523,46 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
     });
   });
 
+  // ── Chat model badge ──
+  // Reflects the user's chat-engine choice in <localStorage[rastrum.chat.engine]>.
+  // Falls back to a "Choose a model" anchor pointing at the in-page picker.
+  const badgeContainer = document.getElementById('chat-model-badge');
+  const BADGE_SUFFIX   = i18nGet('badge-suffix')   || (isEs ? 'en el dispositivo' : 'on-device');
+  const BADGE_UNSET    = i18nGet('badge-unset')    || (isEs ? 'Elige un modelo'   : 'Choose a model');
+  const BADGE_FALLBACK = i18nGet('badge-fallback') || (isEs ? 'En el dispositivo' : 'On-device');
+  function paintModelBadge(): void {
+    if (!badgeContainer) return;
+    const engine = readChatEngine();
+    if (engine) {
+      const name = MODEL_DISPLAY_NAMES[engine];
+      badgeContainer.innerHTML = `<span aria-hidden="true">✨</span> <span id="chat-model-badge-text">${name} · ${BADGE_SUFFIX}</span>`;
+      badgeContainer.removeAttribute('aria-describedby');
+      return;
+    }
+    const consentVisible = !document.getElementById('chat-consent')?.classList.contains('hidden');
+    if (!consentVisible) {
+      badgeContainer.innerHTML = `<span aria-hidden="true">✨</span> <span id="chat-model-badge-text">${BADGE_FALLBACK}</span>`;
+      badgeContainer.removeAttribute('aria-describedby');
+      return;
+    }
+    badgeContainer.innerHTML = `<span aria-hidden="true">✨</span> <a id="chat-model-badge-text" href="#chat-consent" class="underline decoration-dotted underline-offset-2">${BADGE_UNSET}</a> <span>· ${BADGE_SUFFIX}</span>`;
+    badgeContainer.setAttribute('aria-describedby', 'chat-consent');
+  }
+  paintModelBadge();
+  // Back-compat: a user who downloaded Gemma before this code shipped has
+  // the cache populated but no engine key. Probe once and backfill.
+  if (readChatEngine() === null) {
+    void import('../lib/onnx-vision').then(async (lib) => {
+      try {
+        const status = await lib.getGemmaCacheStatus();
+        if (status.cached) {
+          writeChatEngine('gemma');
+          paintModelBadge();
+        }
+      } catch { /* ignore */ }
+    });
+  }
+
   // ── File pickers ──
   photoBtn?.addEventListener('click', () => photoInput?.click());
   galleryBtn?.addEventListener('click', () => galleryInput?.click());
@@ -750,6 +805,8 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
       await lib.loadTextEngine((p) => {
         if (dlProgress) dlProgress.textContent = `${Math.round((p.progress ?? 0) * 100)}%  ${p.text ?? ''}`;
       });
+      writeChatEngine('llama');
+      paintModelBadge();
       modelReady = true;
       consentBox?.classList.add('hidden');
       historyEl?.classList.remove('hidden');
@@ -774,6 +831,8 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
       await lib.loadGemmaTextEngine((p) => {
         if (dlProgress) dlProgress.textContent = `${Math.round((p.progress ?? 0) * 100)}%  ${p.text ?? ''}`;
       });
+      writeChatEngine('gemma');
+      paintModelBadge();
       modelReady = true;
       consentBox?.classList.add('hidden');
       historyEl?.classList.remove('hidden');
@@ -1518,29 +1577,7 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
       });
     });
 
-    // Model badge: reflect Gemma vs Llama state when consent is granted.
-    const badgeText = document.getElementById('chat-model-badge-text');
-    function paintModelBadge(): void {
-      if (!badgeText) return;
-      const isReady = !document.getElementById('chat-consent')?.classList.contains('hidden') ? false : true;
-      if (!isReady) {
-        badgeText.textContent = isEs ? 'En el dispositivo' : 'On-device';
-        return;
-      }
-      // Probe which engine got loaded by checking the cache status.
-      void import('../lib/onnx-vision').then(async (lib) => {
-        try {
-          const status = await lib.getGemmaCacheStatus();
-          badgeText.textContent = status.cached
-            ? (isEs ? 'Gemma 4 · en el dispositivo' : 'Gemma 4 · on-device')
-            : (isEs ? 'Llama 1B · en el dispositivo' : 'Llama 1B · on-device');
-        } catch {
-          badgeText.textContent = isEs ? 'En el dispositivo' : 'On-device';
-        }
-      });
-    }
-    paintModelBadge();
-    // Re-paint after a small delay (the consent gate may flip after model load).
+    // Re-paint badge after small delay (consent box may flip after init).
     setTimeout(paintModelBadge, 1500);
   })().catch((e) => {
     console.warn('[chat] entity wiring init failed', e);

--- a/src/components/chat/ChatComposer.astro
+++ b/src/components/chat/ChatComposer.astro
@@ -228,4 +228,7 @@ const tr = t(lang);
   data-compare-heading={tr.chat.compare_heading}
   data-compare-unavailable={tr.chat.compare_unavailable}
   data-compare-no-id={tr.chat.compare_no_id}
+  data-badge-suffix={tr.chat.badge.suffix}
+  data-badge-unset={tr.chat.badge.unset}
+  data-badge-fallback={tr.chat.badge.fallback}
 ></div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1164,7 +1164,12 @@
     "compare_running": "Running every model in parallel…",
     "compare_heading": "Per-model results",
     "compare_unavailable": "Not available — set up in Profile → Edit",
-    "compare_no_id": "(no candidate)"
+    "compare_no_id": "(no candidate)",
+    "badge": {
+      "suffix": "on-device",
+      "unset": "Choose a model",
+      "fallback": "On-device"
+    }
   },
   "onboarding": {
     "skip": "Skip",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1164,7 +1164,12 @@
     "compare_running": "Corriendo todos los modelos en paralelo…",
     "compare_heading": "Resultados por modelo",
     "compare_unavailable": "No disponible — configúralo en Perfil → Editar",
-    "compare_no_id": "(sin candidato)"
+    "compare_no_id": "(sin candidato)",
+    "badge": {
+      "suffix": "en el dispositivo",
+      "unset": "Elige un modelo",
+      "fallback": "En el dispositivo"
+    }
   },
   "onboarding": {
     "skip": "Omitir",

--- a/tests/unit/chat-badge-dynamic.test.ts
+++ b/tests/unit/chat-badge-dynamic.test.ts
@@ -1,0 +1,52 @@
+/**
+ * PBI 4.3 — Chat header badge reflects the user's model choice instead of a
+ * hardcoded "Llama 1B". Source-string asserts (no DOM) that ChatView wires the
+ * dynamic mapping + the unset fallback string.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const chatViewSource = readFileSync(
+  resolve(here, '../../src/components/ChatView.astro'),
+  'utf8',
+);
+const enSource = readFileSync(
+  resolve(here, '../../src/i18n/en.json'),
+  'utf8',
+);
+const esSource = readFileSync(
+  resolve(here, '../../src/i18n/es.json'),
+  'utf8',
+);
+
+describe('PBI 4.3 — chat badge is dynamic, not hardcoded', () => {
+  it('no longer hardcodes "Llama 1B · …" outside the display-name map', () => {
+    const hits = chatViewSource.match(/Llama 1B/g) ?? [];
+    expect(hits.length).toBe(0);
+  });
+
+  it('exposes a MODEL_DISPLAY_NAMES mapping in the script', () => {
+    expect(chatViewSource).toMatch(/MODEL_DISPLAY_NAMES/);
+  });
+
+  it('reads the engine choice from a stable localStorage key', () => {
+    expect(chatViewSource).toMatch(/rastrum\.chat\.engine/);
+  });
+
+  it('writes the engine choice when the user clicks a download button', () => {
+    expect(chatViewSource).toMatch(/writeChatEngine\('gemma'\)/);
+    expect(chatViewSource).toMatch(/writeChatEngine\('llama'\)/);
+  });
+
+  it('falls back to "Choose a model" / "Elige un modelo" when no choice exists', () => {
+    expect(enSource).toMatch(/"unset":\s*"Choose a model"/);
+    expect(esSource).toMatch(/"unset":\s*"Elige un modelo"/);
+  });
+
+  it('renders an anchor to the model picker in the unset fallback', () => {
+    expect(chatViewSource).toMatch(/href="#chat-consent"/);
+  });
+});


### PR DESCRIPTION
## Summary
Implements PBI 4.3 from the UI/UX audit roadmap (#1193). Replaces the hardcoded "Llama 1B · on-device" header badge with one that reflects the user's recorded engine choice.

- New \`rastrum.chat.engine\` localStorage key (binary: gemma | llama).
- \`MODEL_DISPLAY_NAMES\` mapping: gemma → "Gemma 4 E2B", llama → "Llama 3.2 1B".
- Unset state: "Choose a model · on-device" / "Elige un modelo · en el dispositivo" with anchor link to #chat-consent.
- One-shot back-compat migration probes the existing Gemma IndexedDB cache so returning users don't see the unset state.

## Why a new key vs. \`rastrum.chat.modelPicker\`
The picker is the per-photo identifier override (7 values incl. auto/compare). The badge needs the *chat LLM engine* choice (binary). Conflating them would default to "Auto · on-device" which is wrong.

## Test plan
- [x] \`tests/unit/chat-badge-dynamic.test.ts\` (6/6) — no hardcoded "Llama 1B", display map present, engine key referenced, click handlers persist, EN+ES fallback copy wired, anchor links to #chat-consent.
- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` — 255 pages
- [x] Existing chat-* tests (50/50) and i18n-zap.test.ts (38/38) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)