### PR TITLE
feat(auth): sign-in post-submit confirmation + 60s resend — PBI 4.2

### DIFF
--- a/src/components/SignInForm.astro
+++ b/src/components/SignInForm.astro
@@ -66,9 +66,23 @@ const tr = t(lang);
 
   <!-- Code step -->
   <form id="code-form" class="hidden space-y-4 mt-2" novalidate>
-    <div class="rounded-lg border border-emerald-200 dark:border-emerald-900 bg-emerald-50 dark:bg-emerald-900/20 p-4">
+    <div
+      id="rastrum-signin-confirmation"
+      class="rounded-lg border border-emerald-200 dark:border-emerald-900 bg-emerald-50 dark:bg-emerald-900/20 p-4"
+      data-template-en="📩 Code sent to <strong>{email}</strong>. Should arrive in ~30s. Check spam if not."
+      data-template-es="📩 Código enviado a <strong>{email}</strong>. Debería llegar en ~30s. Revisa tu spam si no aparece."
+    >
       <h2 class="text-sm font-semibold text-emerald-900 dark:text-emerald-200">{tr.auth.code_sent_title}</h2>
-      <p id="sent-body" class="mt-1 text-sm text-emerald-800 dark:text-emerald-300"></p>
+      <p id="sent-body" class="mt-1 text-sm text-emerald-800 dark:text-emerald-300" aria-live="polite"></p>
+      <div class="mt-3 text-xs text-emerald-800 dark:text-emerald-300">
+        <span id="resend-wait" class="hidden"
+          data-template-en="Wait {seconds}s before resending"
+          data-template-es="Espera {seconds}s para reenviar"
+        ></span>
+        <button type="button" id="resend-btn" class="hidden underline underline-offset-2 hover:text-emerald-900 dark:hover:text-emerald-100 disabled:opacity-50 disabled:cursor-not-allowed">
+          <span data-label>{lang === 'es' ? 'Reenviar código' : 'Resend code'}</span>
+        </button>
+      </div>
     </div>
     <div>
       <label for="code" class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
@@ -126,6 +140,10 @@ const tr = t(lang);
   const verifyLabel= verifyBtn?.querySelector('[data-label]') as HTMLElement | null;
   const codeErr    = document.getElementById('code-err') as HTMLParagraphElement | null;
   const sentBody   = document.getElementById('sent-body') as HTMLElement | null;
+  const confirmBox = document.getElementById('rastrum-signin-confirmation') as HTMLElement | null;
+  const resendBtn  = document.getElementById('resend-btn') as HTMLButtonElement | null;
+  const resendLabel = resendBtn?.querySelector('[data-label]') as HTMLElement | null;
+  const resendWait = document.getElementById('resend-wait') as HTMLElement | null;
   const backBtn    = document.getElementById('back-btn');
 
   const isEs = document.documentElement.lang === 'es';
@@ -136,6 +154,49 @@ const tr = t(lang);
   }
 
   let pendingEmail = '';
+  let resendTimer: ReturnType<typeof setInterval> | null = null;
+  const RESEND_COOLDOWN_MS = 60 * 1000;
+
+  function clearResendTimer() {
+    if (resendTimer !== null) {
+      clearInterval(resendTimer);
+      resendTimer = null;
+    }
+  }
+
+  function renderConfirmation(email: string) {
+    if (!confirmBox || !sentBody) return;
+    const tplAttr = isEs ? 'data-template-es' : 'data-template-en';
+    const tpl = confirmBox.getAttribute(tplAttr) ?? '';
+    sentBody.innerHTML = tpl.replace('{email}', email);
+  }
+
+  function startResendCooldown() {
+    if (!resendBtn || !resendWait) return;
+    clearResendTimer();
+    const tplAttr = isEs ? 'data-template-es' : 'data-template-en';
+    const waitTpl = resendWait.getAttribute(tplAttr) ?? '';
+    let remaining = Math.floor(RESEND_COOLDOWN_MS / 1000);
+
+    const paint = () => {
+      if (remaining > 0) {
+        resendWait.textContent = waitTpl.replace('{seconds}', String(remaining));
+        resendWait.classList.remove('hidden');
+        resendBtn.classList.add('hidden');
+      } else {
+        resendWait.classList.add('hidden');
+        resendBtn.classList.remove('hidden');
+        resendBtn.disabled = false;
+        clearResendTimer();
+      }
+    };
+
+    paint();
+    resendTimer = setInterval(() => {
+      remaining -= 1;
+      paint();
+    }, 1000);
+  }
 
   // ── OAuth ──
   googleBtn?.addEventListener('click', async () => {
@@ -186,24 +247,41 @@ const tr = t(lang);
     window.posthog?.capture('sign_in_initiated', { method: 'email_otp' });
 
     const { error } = await requestEmailOtp(email);
-    sendBtn.disabled = false;
-    sendLabel.textContent = isEs ? 'Enviar código' : 'Send code';
     if (error) {
+      sendBtn.disabled = false;
+      sendLabel.textContent = isEs ? 'Enviar código' : 'Send code';
       window.posthog?.capture('sign_in_failed', { method: 'email_otp', error: error.message });
       if (emailErr) { emailErr.textContent = error.message; emailErr.classList.remove('hidden'); }
       return;
     }
 
+    sendBtn.disabled = true;
+    sendLabel.textContent = isEs ? 'Enviar código' : 'Send code';
     pendingEmail = email;
     emailForm.classList.add('hidden');
     codeForm?.classList.remove('hidden');
-    if (sentBody) {
-      const tpl = isEs
-        ? 'Enviamos un código de 6 dígitos a {email}. Pégalo abajo — o haz clic en el enlace mágico del correo.'
-        : 'We sent a 6-digit code to {email}. Paste it below — or click the magic link in the email.';
-      sentBody.textContent = tpl.replace('{email}', email);
-    }
+    renderConfirmation(email);
+    startResendCooldown();
     codeInput?.focus();
+  });
+
+  resendBtn?.addEventListener('click', async () => {
+    if (!pendingEmail || !resendBtn || !resendLabel) return;
+    resendBtn.disabled = true;
+    const originalLabel = resendLabel.textContent;
+    resendLabel.textContent = isEs ? 'Enviando…' : 'Sending…';
+    codeErr?.classList.add('hidden');
+    window.posthog?.capture('sign_in_initiated', { method: 'email_otp_resend' });
+    const { error } = await requestEmailOtp(pendingEmail);
+    resendLabel.textContent = originalLabel;
+    if (error) {
+      resendBtn.disabled = false;
+      window.posthog?.capture('sign_in_failed', { method: 'email_otp_resend', error: error.message });
+      if (codeErr) { codeErr.textContent = error.message; codeErr.classList.remove('hidden'); }
+      return;
+    }
+    renderConfirmation(pendingEmail);
+    startResendCooldown();
   });
 
   // ── OTP verify ──
@@ -237,5 +315,9 @@ const tr = t(lang);
     codeForm?.classList.add('hidden');
     emailForm?.classList.remove('hidden');
     if (codeInput) codeInput.value = '';
+    clearResendTimer();
+    resendBtn?.classList.add('hidden');
+    resendWait?.classList.add('hidden');
+    if (sendBtn) sendBtn.disabled = false;
   });
 </script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -535,6 +535,14 @@
     "speciesnet_attribution": "Distilled SpeciesNet ONNX. License depends on training data.",
     "speciesnet_weights_url_missing": "Weights are not hosted yet — set PUBLIC_SPECIESNET_WEIGHTS_URL to enable."
   },
+  "signin": {
+    "confirm": {
+      "sent": "📩 Code sent to **{email}**. Should arrive in ~30s. Check spam if not.",
+      "resend": "Resend code",
+      "resending": "Sending…",
+      "wait": "Wait {seconds}s before resending"
+    }
+  },
   "community": {
     "page_title": "Community observers",
     "page_subtitle": "Find observers by activity, expertise, location, or country.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -535,6 +535,14 @@
     "speciesnet_attribution": "ONNX SpeciesNet destilado. La licencia depende de los datos de entrenamiento.",
     "speciesnet_weights_url_missing": "Los pesos aún no están alojados — define PUBLIC_SPECIESNET_WEIGHTS_URL para habilitar."
   },
+  "signin": {
+    "confirm": {
+      "sent": "📩 Código enviado a **{email}**. Debería llegar en ~30s. Revisa tu spam si no aparece.",
+      "resend": "Reenviar código",
+      "resending": "Enviando…",
+      "wait": "Espera {seconds}s para reenviar"
+    }
+  },
   "community": {
     "page_title": "Observadores de la comunidad",
     "page_subtitle": "Encuentra observadores por actividad, experiencia, ubicación o país.",

--- a/tests/unit/signin-microcopy.test.ts
+++ b/tests/unit/signin-microcopy.test.ts
@@ -1,0 +1,138 @@
+/**
+ * PBI 4.2 — post-submit confirmation state + resend affordance.
+ *
+ * Source-string assertions for SignInForm.astro and i18n parity, in
+ * the same shape as `first-observation-cta.test.ts`: the client logic
+ * runs inside an Astro `<script>` (not the SSR pass), so we pin the
+ * structural contract that matters — i18n keys, the confirmation
+ * element id, the 60-second timer constant, and the Send-code
+ * disabled-state on success.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const componentSrc = readFileSync(
+  join(process.cwd(), 'src/components/SignInForm.astro'),
+  'utf8',
+);
+
+const enJson = JSON.parse(
+  readFileSync(join(process.cwd(), 'src/i18n/en.json'), 'utf8'),
+) as Record<string, unknown>;
+
+const esJson = JSON.parse(
+  readFileSync(join(process.cwd(), 'src/i18n/es.json'), 'utf8'),
+) as Record<string, unknown>;
+
+interface SigninConfirm {
+  sent: string;
+  resend: string;
+  resending: string;
+  wait: string;
+}
+
+function pickConfirm(doc: Record<string, unknown>): SigninConfirm {
+  const signin = doc.signin as Record<string, unknown> | undefined;
+  const confirm = signin?.confirm as Record<string, unknown> | undefined;
+  return {
+    sent: String(confirm?.sent ?? ''),
+    resend: String(confirm?.resend ?? ''),
+    resending: String(confirm?.resending ?? ''),
+    wait: String(confirm?.wait ?? ''),
+  };
+}
+
+describe('PBI 4.2 — signin confirmation microcopy', () => {
+  describe('i18n', () => {
+    const en = pickConfirm(enJson);
+    const es = pickConfirm(esJson);
+
+    it('exposes signin.confirm.sent in EN with the {email} placeholder + ~30s + spam hint', () => {
+      expect(en.sent).toContain('{email}');
+      expect(en.sent).toMatch(/~?30s/);
+      expect(en.sent.toLowerCase()).toContain('spam');
+    });
+
+    it('exposes signin.confirm.sent in ES with the {email} placeholder + ~30s + spam hint', () => {
+      expect(es.sent).toContain('{email}');
+      expect(es.sent).toMatch(/~?30s/);
+      expect(es.sent.toLowerCase()).toContain('spam');
+    });
+
+    it('exposes signin.confirm.resend in EN+ES', () => {
+      expect(en.resend).toBe('Resend code');
+      expect(es.resend).toBe('Reenviar código');
+    });
+
+    it('exposes signin.confirm.resending in EN+ES', () => {
+      expect(en.resending.length).toBeGreaterThan(0);
+      expect(es.resending.length).toBeGreaterThan(0);
+    });
+
+    it('exposes signin.confirm.wait in EN+ES with a {seconds} placeholder', () => {
+      expect(en.wait).toContain('{seconds}');
+      expect(es.wait).toContain('{seconds}');
+    });
+
+    it('EN and ES have parity on the four signin.confirm.* keys', () => {
+      const enKeys = Object.keys(
+        ((enJson.signin as Record<string, unknown>)?.confirm ?? {}) as Record<string, unknown>,
+      ).sort();
+      const esKeys = Object.keys(
+        ((esJson.signin as Record<string, unknown>)?.confirm ?? {}) as Record<string, unknown>,
+      ).sort();
+      expect(enKeys).toEqual(['resend', 'resending', 'sent', 'wait']);
+      expect(esKeys).toEqual(['resend', 'resending', 'sent', 'wait']);
+    });
+  });
+
+  describe('SignInForm.astro source contract', () => {
+    it('renders the confirmation element with id="rastrum-signin-confirmation"', () => {
+      expect(componentSrc).toMatch(/id="rastrum-signin-confirmation"/);
+    });
+
+    it('uses a data-template attribute pair (en/es) for runtime email interpolation', () => {
+      expect(componentSrc).toMatch(/data-template-en=/);
+      expect(componentSrc).toMatch(/data-template-es=/);
+      expect(componentSrc).toContain('{email}');
+    });
+
+    it('encodes a 60-second resend cooldown (60 * 1000)', () => {
+      // Either the literal 60_000 or the readable 60 * 1000 form is acceptable.
+      const hasMs = /60\s*\*\s*1000/.test(componentSrc) || /60000\b/.test(componentSrc);
+      expect(hasMs).toBe(true);
+    });
+
+    it('disables the Send code button after a successful submit', () => {
+      // The handler must set sendBtn.disabled = true on the success branch,
+      // not just during the in-flight request.
+      expect(componentSrc).toMatch(/sendBtn\.disabled\s*=\s*true/);
+    });
+
+    it('renders a Resend code button (#resend-btn) starting hidden', () => {
+      expect(componentSrc).toMatch(/id="resend-btn"/);
+      // The Resend button must start hidden — it appears only after the cooldown.
+      expect(componentSrc).toMatch(/id="resend-btn"[^>]*class="[^"]*\bhidden\b/);
+    });
+
+    it('renders a #resend-wait countdown sibling', () => {
+      expect(componentSrc).toMatch(/id="resend-wait"/);
+    });
+
+    it('wires the resend handler to re-fire requestEmailOtp', () => {
+      // The resend click must reuse the existing requestEmailOtp() helper.
+      expect(componentSrc).toMatch(/resendBtn\?\.addEventListener\('click'/);
+      expect(componentSrc).toMatch(/requestEmailOtp\(pendingEmail\)/);
+    });
+
+    it('only shows the confirmation when the OTP request succeeds', () => {
+      // The success branch (post-error early-return) is what triggers the
+      // confirmation; an errored request must NOT swap to the code form.
+      const idx = componentSrc.indexOf('renderConfirmation(email)');
+      const errIdx = componentSrc.indexOf("if (error) {");
+      expect(idx).toBeGreaterThan(errIdx);
+      expect(errIdx).toBeGreaterThan(-1);
+    });
+  });
+});


### PR DESCRIPTION
Implements PBI 4.2 from #1193 — after "Send code", the form flips to a richer confirmation: "Code sent to <bold email>. Should arrive in ~30s. Check spam if not." 60-second cooldown counts down; **Resend code** becomes clickable when it hits zero. Existing OTP entry + back-button escape hatch preserved. Tests: 14 unit + full 2922/2922; build 255 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)