### PR TITLE
fix(privacy): defer geolocation behind explicit CTA — PBI 1.3

### DIFF
--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -71,6 +71,7 @@ const distancePage = page as unknown as Record<string, string>;
   data-label-distance-km={distancePage.distance_filter_km ?? '{{km}} km'}
   data-label-distance-no-location={distancePage.distance_filter_no_location ?? 'Enable location to filter by distance'}
   data-label-distance-locating={distancePage.distance_filter_locating ?? 'Getting your location…'}
+  data-label-distance-show={distancePage.distance_filter_show ?? 'Show observations near me'}
 >
   <header class="space-y-3 py-6">
     <div class="flex items-start justify-between gap-3">
@@ -137,17 +138,23 @@ const distancePage = page as unknown as Record<string, string>;
       </div>
     </div>
 
-    <!-- #712 Distance filter — fires after geolocation; non-blocking -->
+    <!-- #712 Distance filter — PBI 1.3: deferred behind explicit user action. -->
     <div
-      class="er-distance-filter hidden items-center gap-2 flex-wrap"
+      class="er-distance-filter flex items-center gap-2 flex-wrap"
       role="group"
       aria-label={distancePage.distance_filter_label ?? 'Filter by distance'}
     >
       <span class="text-xs font-medium text-zinc-600 dark:text-zinc-400 shrink-0">
         {distancePage.distance_filter_label ?? 'Filter by distance'}:
       </span>
-      <!-- Buttons are injected by the client script after geolocation resolves -->
-      <p class="er-distance-locating text-xs text-zinc-400 dark:text-zinc-500">
+      <button
+        type="button"
+        class="er-distance-show inline-flex items-center gap-1.5 rounded-full border border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 px-3 py-1 text-xs font-medium text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100 dark:hover:bg-emerald-900/60 transition-colors"
+      >
+        <span aria-hidden="true">📍</span>
+        <span>{distancePage.distance_filter_show ?? 'Show observations near me'}</span>
+      </button>
+      <p class="er-distance-locating hidden text-xs text-zinc-400 dark:text-zinc-500">
         {distancePage.distance_filter_locating ?? 'Getting your location…'}
       </p>
       <p class="er-distance-no-loc hidden text-xs text-zinc-400 dark:text-zinc-500">
@@ -518,41 +525,22 @@ const distancePage = page as unknown as Record<string, string>;
     }
 
     /**
-     * Initialise the distance filter UI. Fires after geolocation resolves.
-     * Non-blocking — called from init() with .catch(() => {}).
+     * Wire the distance filter UI after a location is known.
+     * PBI 1.3: never calls `getCurrentPosition` itself — the caller
+     * provides coords either from cache or from an explicit user click.
      */
-    async function initDistanceFilter(): Promise<void> {
-      const filterWrap = root.querySelector<HTMLElement>('.er-distance-filter');
+    function renderDistanceButtons(lat: number, lng: number): void {
       const locatingEl = root.querySelector<HTMLElement>('.er-distance-locating');
       const noLocEl = root.querySelector<HTMLElement>('.er-distance-no-loc');
+      const showBtn = root.querySelector<HTMLButtonElement>('.er-distance-show');
       const btnsEl = root.querySelector<HTMLElement>('.er-distance-btns');
-      if (!filterWrap || !btnsEl) return;
+      if (!btnsEl) return;
 
-      filterWrap.classList.remove('hidden');
-      filterWrap.classList.add('flex');
-
-      // Try cached location first.
-      let lat: number, lng: number;
-      const cached = getCachedLoc();
-      if (cached) {
-        lat = cached.lat; lng = cached.lng;
-      } else {
-        try {
-          const pos = await new Promise<GeolocationPosition>((res, rej) =>
-            navigator.geolocation.getCurrentPosition(res, rej, { timeout: 8000, maximumAge: LOCATION_TTL_MS }),
-          );
-          lat = pos.coords.latitude;
-          lng = pos.coords.longitude;
-          setCachedLoc(lat, lng);
-        } catch {
-          locatingEl?.classList.add('hidden');
-          noLocEl?.classList.remove('hidden');
-          return;
-        }
-      }
       userLat = lat; userLng = lng;
 
+      showBtn?.classList.add('hidden');
       locatingEl?.classList.add('hidden');
+      noLocEl?.classList.add('hidden');
       btnsEl.classList.remove('hidden');
       btnsEl.classList.add('flex');
 
@@ -1065,8 +1053,38 @@ const distancePage = page as unknown as Record<string, string>;
       loadMore().catch(() => { /* surfaced via errEl */ });
     });
 
-    // #712 — Start distance filter setup non-blocking after main content loads
-    initDistanceFilter().catch(() => { /* geolocation denied or unavailable */ });
+    // #712 / PBI 1.3 — Distance filter is wired here but geolocation is
+    // ONLY requested behind an explicit click on the "Show observations
+    // near me" CTA. A cached location from a prior visit (sessionStorage,
+    // 5-min TTL) is honoured without prompting.
+    const distanceShowBtn = root.querySelector<HTMLButtonElement>('.er-distance-show');
+    const distanceLocatingEl = root.querySelector<HTMLElement>('.er-distance-locating');
+    const distanceNoLocEl = root.querySelector<HTMLElement>('.er-distance-no-loc');
+    const cachedDistanceLoc = getCachedLoc();
+    if (cachedDistanceLoc) {
+      renderDistanceButtons(cachedDistanceLoc.lat, cachedDistanceLoc.lng);
+    } else {
+      distanceShowBtn?.addEventListener('click', () => {
+        if (distanceShowBtn.disabled) return;
+        distanceShowBtn.disabled = true;
+        distanceShowBtn.classList.add('hidden');
+        distanceNoLocEl?.classList.add('hidden');
+        distanceLocatingEl?.classList.remove('hidden');
+        new Promise<GeolocationPosition>((res, rej) =>
+          navigator.geolocation.getCurrentPosition(res, rej, { timeout: 8000, maximumAge: LOCATION_TTL_MS }),
+        )
+          .then((pos) => {
+            const lat = pos.coords.latitude;
+            const lng = pos.coords.longitude;
+            setCachedLoc(lat, lng);
+            renderDistanceButtons(lat, lng);
+          })
+          .catch(() => {
+            distanceLocatingEl?.classList.add('hidden');
+            distanceNoLocEl?.classList.remove('hidden');
+          });
+      });
+    }
 
     await loadMore();
   }

--- a/src/components/HomeWidgets.astro
+++ b/src/components/HomeWidgets.astro
@@ -101,17 +101,26 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     data-label-no-location={suggestions.no_location}
     data-label-loading={suggestions.loading}
     data-label-empty={suggestions.empty}
+    data-label-show={suggestions.show ?? 'Show suggestions for my area'}
   >
     <div class="flex items-baseline justify-between gap-3 mb-3">
       <h2 class="text-sm font-semibold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">{suggestions.heading}</h2>
       <button
         type="button"
-        class="hw-suggestions-refresh text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline"
+        class="hw-suggestions-refresh hidden text-sm font-medium text-emerald-700 dark:text-emerald-400 hover:underline"
       >{suggestions.refresh}</button>
     </div>
     <p class="hw-suggestions-subtitle text-xs text-zinc-500 dark:text-zinc-400 mb-3"></p>
-    <p class="hw-suggestions-loading text-sm text-zinc-500 dark:text-zinc-400">{suggestions.loading}</p>
+    <button
+      type="button"
+      class="hw-suggestions-show inline-flex items-center gap-2 rounded-full border border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 px-4 py-2 text-sm font-medium text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100 dark:hover:bg-emerald-900/60 transition-colors"
+    >
+      <span aria-hidden="true">📍</span>
+      <span>{suggestions.show ?? 'Show suggestions for my area'}</span>
+    </button>
+    <p class="hw-suggestions-loading hidden text-sm text-zinc-500 dark:text-zinc-400">{suggestions.loading}</p>
     <p class="hw-suggestions-empty hidden text-sm text-zinc-500 dark:text-zinc-400">{suggestions.empty}</p>
+    <p class="hw-suggestions-no-location hidden text-sm text-zinc-500 dark:text-zinc-400">{suggestions.no_location}</p>
     <ul class="hw-suggestions-list grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-3"></ul>
   </div>
 
@@ -239,11 +248,47 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     return new Date().toLocaleString(lang === 'es' ? 'es-MX' : 'en-US', { month: 'long' });
   }
 
+  const SUGGESTIONS_LOC_KEY = 'rastrum.user_location';
+  const SUGGESTIONS_LOC_TTL_MS = 5 * 60 * 1000;
+
+  function getCachedSuggestionsLoc(): { lat: number; lng: number } | null {
+    try {
+      const raw = sessionStorage.getItem(SUGGESTIONS_LOC_KEY);
+      if (!raw) return null;
+      const loc = JSON.parse(raw) as { lat: number; lng: number; ts: number };
+      if (Date.now() - loc.ts > SUGGESTIONS_LOC_TTL_MS) return null;
+      return { lat: loc.lat, lng: loc.lng };
+    } catch {
+      return null;
+    }
+  }
+
+  async function requestSuggestionsLocation(): Promise<{ lat: number; lng: number }> {
+    const cached = getCachedSuggestionsLoc();
+    if (cached) return cached;
+    const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        timeout: 8000,
+        maximumAge: SUGGESTIONS_LOC_TTL_MS,
+      });
+    });
+    const lat = pos.coords.latitude;
+    const lng = pos.coords.longitude;
+    try {
+      sessionStorage.setItem(
+        SUGGESTIONS_LOC_KEY,
+        JSON.stringify({ lat, lng, ts: Date.now() }),
+      );
+    } catch { /* quota — ignore */ }
+    return { lat, lng };
+  }
+
   async function paintSuggestions(
     root: HTMLElement,
     lang: Lang,
     userId: string,
-    seed: number
+    seed: number,
+    loc: { lat: number; lng: number },
   ): Promise<void> {
     const sugRoot = root.querySelector<HTMLElement>('.home-widgets-suggestions');
     if (!sugRoot) return;
@@ -252,6 +297,7 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     const loadingEl = sugRoot.querySelector<HTMLElement>('.hw-suggestions-loading');
     const emptyEl = sugRoot.querySelector<HTMLElement>('.hw-suggestions-empty');
     const subtitleEl = sugRoot.querySelector<HTMLElement>('.hw-suggestions-subtitle');
+    const refreshBtn = sugRoot.querySelector<HTMLButtonElement>('.hw-suggestions-refresh');
     if (!listEl) return;
 
     if (subtitleEl) {
@@ -263,28 +309,14 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     emptyEl?.classList.add('hidden');
     listEl.innerHTML = '';
 
-    let lat: number, lng: number;
-    try {
-      const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(resolve, reject, {
-          timeout: 8000,
-          maximumAge: 5 * 60 * 1000,
-        });
-      });
-      lat = pos.coords.latitude;
-      lng = pos.coords.longitude;
-    } catch {
-      loadingEl?.classList.add('hidden');
-      return;
-    }
-
     try {
       const limit = 10 + (seed % 5);
-      const all = await fetchSuggestions(userId, lat, lng, { limit });
+      const all = await fetchSuggestions(userId, loc.lat, loc.lng, { limit });
       const dismissed = getDismissed();
       const filtered = all.filter(s => !dismissed.has(s.taxon_id)).slice(0, 5);
 
       loadingEl?.classList.add('hidden');
+      refreshBtn?.classList.remove('hidden');
 
       if (filtered.length === 0) {
         emptyEl?.classList.remove('hidden');
@@ -622,15 +654,43 @@ const profileHref = lang === 'es' ? '/es/perfil/' : '/en/profile/';
     await paintNextBadge(root, lang, user.id);
     await paintChallenge(root, lang, user.id);
 
-    // Suggestions runs in parallel via geolocation; doesn't block.
+    // PBI 1.3: never call geolocation on load. Honour a cached
+    // location from a prior session; otherwise wait for an explicit
+    // user click on the "Show suggestions for my area" CTA.
     let suggestionSeed = 0;
-    paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional */});
-
     const sugRoot = root.querySelector<HTMLElement>('.home-widgets-suggestions');
+    const showBtn = sugRoot?.querySelector<HTMLButtonElement>('.hw-suggestions-show');
+    const noLocEl = sugRoot?.querySelector<HTMLElement>('.hw-suggestions-no-location');
+    const loadingEl = sugRoot?.querySelector<HTMLElement>('.hw-suggestions-loading');
+
+    sugRoot?.classList.remove('hidden');
+
+    const cachedLoc = getCachedSuggestionsLoc();
+    if (cachedLoc) {
+      showBtn?.classList.add('hidden');
+      paintSuggestions(root, lang, user.id, suggestionSeed, cachedLoc).catch(() => {/* optional */});
+    } else {
+      showBtn?.addEventListener('click', () => {
+        if (showBtn.disabled) return;
+        showBtn.disabled = true;
+        showBtn.classList.add('hidden');
+        noLocEl?.classList.add('hidden');
+        loadingEl?.classList.remove('hidden');
+        requestSuggestionsLocation()
+          .then(loc => paintSuggestions(root, lang, user.id, suggestionSeed, loc))
+          .catch(() => {
+            loadingEl?.classList.add('hidden');
+            noLocEl?.classList.remove('hidden');
+          });
+      });
+    }
+
     sugRoot?.querySelector<HTMLButtonElement>('.hw-suggestions-refresh')?.addEventListener('click', () => {
       suggestionSeed = (suggestionSeed + 1) % 100;
       try { sessionStorage.removeItem(DISMISSED_KEY); } catch { /* ignore */ }
-      paintSuggestions(root, lang, user.id, suggestionSeed).catch(() => {/* optional */});
+      const loc = getCachedSuggestionsLoc();
+      if (!loc) return;
+      paintSuggestions(root, lang, user.id, suggestionSeed, loc).catch(() => {/* optional */});
     });
   }
 

--- a/src/components/home/HomeNearby.astro
+++ b/src/components/home/HomeNearby.astro
@@ -4,14 +4,12 @@
  *
  * Issue #712: Deeper location integration.
  *
- * Fires after `navigator.geolocation` resolves (non-blocking — home
- * page loads fully without it). Queries `observations` within the
- * configured radius (default 10 km) via Supabase PostGIS RPC
- * `nearby_observations(lat, lng, radius_km, limit)`.
- *
- * Location coordinates are stored in `sessionStorage` (key:
- * `rastrum.user_location`) and refreshed every 5 minutes so subsequent
- * navigation within the session is fast.
+ * PBI 1.3 (Lighthouse `geolocation-on-start`): geolocation is now
+ * deferred behind an explicit user click on the "Show observations near
+ * me" CTA — the page renders the section's header + CTA on load but
+ * never calls `navigator.geolocation.getCurrentPosition` until the
+ * user opts in. A cached location from a prior visit (sessionStorage
+ * `rastrum.user_location`, 5-minute TTL) is honoured without prompting.
  *
  * Species chips use location context (already implemented — see
  * HomeChips.astro + `src/lib/suggestions.ts`). This component adds the
@@ -48,6 +46,8 @@ const shareBase = '/share/obs/';
   data-label-no-location={w.near_you_no_location ?? 'Enable location to see nearby observations.'}
   data-label-km-away={w.near_you_km_away ?? '{{dist}} km away'}
   data-label-view-all={w.near_you_view_all ?? 'View on map'}
+  data-label-show-nearby={w.near_you_show_nearby ?? 'Show observations near me'}
+  data-label-locating={w.near_you_locating ?? 'Getting your location…'}
   aria-live="polite"
 >
   <div class="flex items-baseline justify-between gap-3 mb-3">
@@ -62,7 +62,14 @@ const shareBase = '/share/obs/';
     </a>
   </div>
   <p class="hn-subtitle mb-3 text-xs text-zinc-500 dark:text-zinc-400"></p>
-  <p class="hn-loading text-sm text-zinc-500 dark:text-zinc-400">
+  <button
+    type="button"
+    class="hn-show-cta inline-flex items-center gap-2 rounded-full border border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 px-4 py-2 text-sm font-medium text-emerald-800 dark:text-emerald-200 hover:bg-emerald-100 dark:hover:bg-emerald-900/60 transition-colors"
+  >
+    <span aria-hidden="true">📍</span>
+    <span>{w.near_you_show_nearby ?? 'Show observations near me'}</span>
+  </button>
+  <p class="hn-loading hidden text-sm text-zinc-500 dark:text-zinc-400">
     {w.near_you_loading ?? 'Finding nearby observations…'}
   </p>
   <p class="hn-empty hidden text-sm text-zinc-500 dark:text-zinc-400"></p>
@@ -180,10 +187,11 @@ const shareBase = '/share/obs/';
     </li>`;
   }
 
-  async function init() {
-    const root = document.querySelector<HTMLElement>('.hn-root');
-    if (!root) return;
-
+  async function loadNearby(
+    root: HTMLElement,
+    lat: number,
+    lng: number,
+  ): Promise<void> {
     const lang = (root.dataset.lang as Lang) ?? 'en';
     const radiusKm = Number(root.dataset.radius ?? 10);
     const lim = Number(root.dataset.limit ?? 6);
@@ -193,37 +201,18 @@ const shareBase = '/share/obs/';
     const loadingEl = root.querySelector<HTMLElement>('.hn-loading');
     const emptyEl = root.querySelector<HTMLElement>('.hn-empty');
     const noLocEl = root.querySelector<HTMLElement>('.hn-no-location');
-    const subtitleEl = root.querySelector<HTMLElement>('.hn-subtitle');
     const listEl = root.querySelector<HTMLUListElement>('.hn-list');
     const mapLink = root.querySelector<HTMLAnchorElement>('.hn-map-link');
     if (!listEl) return;
 
-    // Update subtitle with radius
-    if (subtitleEl) {
-      const tpl = root.dataset.labelSubtitle ?? '';
-      subtitleEl.textContent = tpl.replace('{{radius}}', String(radiusKm));
-    }
+    noLocEl?.classList.add('hidden');
+    loadingEl?.classList.remove('hidden');
 
-    // Show section skeleton while waiting for geolocation
-    root.classList.remove('hidden');
-
-    // Get location — non-blocking; if user denies we show the no-location message.
-    let lat: number, lng: number;
-    try {
-      ({ lat, lng } = await getLocation());
-    } catch {
-      loadingEl?.classList.add('hidden');
-      noLocEl?.classList.remove('hidden');
-      return;
-    }
-
-    // Update map link to include location context
     if (mapLink) {
       mapLink.href = `${mapHref}?lat=${lat}&lng=${lng}&radius=${radiusKm}`;
       mapLink.classList.remove('hidden');
     }
 
-    // Query nearby observations via Supabase PostGIS RPC.
     let supabase;
     try { supabase = getSupabase(); } catch {
       loadingEl?.classList.add('hidden');
@@ -273,7 +262,6 @@ const shareBase = '/share/obs/';
       common_name_es: r.common_name_es,
       photo_url: r.photo_url,
       observed_at: r.observed_at,
-      // Use PostGIS distance if available, otherwise compute client-side.
       distance_m: r.distance_m
         ?? (r.lat != null && r.lng != null
           ? haversineKm(lat, lng, r.lat, r.lng) * 1000
@@ -285,5 +273,45 @@ const shareBase = '/share/obs/';
       .join('');
   }
 
-  init().catch(() => {});
+  function init(): void {
+    const root = document.querySelector<HTMLElement>('.hn-root');
+    if (!root) return;
+
+    const radiusKm = Number(root.dataset.radius ?? 10);
+    const subtitleEl = root.querySelector<HTMLElement>('.hn-subtitle');
+    const ctaBtn = root.querySelector<HTMLButtonElement>('.hn-show-cta');
+    const loadingEl = root.querySelector<HTMLElement>('.hn-loading');
+    const noLocEl = root.querySelector<HTMLElement>('.hn-no-location');
+
+    if (subtitleEl) {
+      const tpl = root.dataset.labelSubtitle ?? '';
+      subtitleEl.textContent = tpl.replace('{{radius}}', String(radiusKm));
+    }
+
+    root.classList.remove('hidden');
+
+    // PBI 1.3: never call getCurrentPosition on load. Honour a cached
+    // location from a prior session (sessionStorage, 5-min TTL) without
+    // prompting; otherwise wait for the user to click the CTA.
+    const cached = getCachedLocation();
+    if (cached) {
+      ctaBtn?.classList.add('hidden');
+      loadNearby(root, cached.lat, cached.lng).catch(() => {});
+      return;
+    }
+
+    ctaBtn?.addEventListener('click', () => {
+      ctaBtn.disabled = true;
+      ctaBtn.classList.add('hidden');
+      loadingEl?.classList.remove('hidden');
+      getLocation()
+        .then(({ lat, lng }) => loadNearby(root, lat, lng))
+        .catch(() => {
+          loadingEl?.classList.add('hidden');
+          noLocEl?.classList.remove('hidden');
+        });
+    });
+  }
+
+  init();
 </script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -167,7 +167,8 @@
         "dismiss_aria": "Not interested in {{name}}",
         "no_location": "Allow location access to see suggestions",
         "loading": "Finding species near you…",
-        "empty": "No new suggestions nearby. Check back next month."
+        "empty": "No new suggestions nearby. Check back next month.",
+        "show": "Show suggestions for my area"
       },
       "challenge": {
         "title": "Today's Challenge",
@@ -230,7 +231,9 @@
       "near_you_empty": "No observations found within {{radius}} km.",
       "near_you_no_location": "Enable location to see nearby observations.",
       "near_you_km_away": "{{dist}} km away",
-      "near_you_view_all": "View on map"
+      "near_you_view_all": "View on map",
+      "near_you_show_nearby": "Show observations near me",
+      "near_you_locating": "Getting your location…"
     }
   },
   "identify": {
@@ -2207,7 +2210,8 @@
       "distance_filter_all": "All",
       "distance_filter_km": "{{km}} km",
       "distance_filter_no_location": "Enable location to filter by distance",
-      "distance_filter_locating": "Getting your location…"
+      "distance_filter_locating": "Getting your location…",
+      "distance_filter_show": "Show observations near me"
     },
     "watchlist": {
       "title": "Watchlist",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -167,7 +167,8 @@
         "dismiss_aria": "No me interesa {{name}}",
         "no_location": "Permite el acceso a tu ubicación para ver sugerencias",
         "loading": "Buscando especies cerca de ti…",
-        "empty": "Sin nuevas sugerencias cercanas. Vuelve el próximo mes."
+        "empty": "Sin nuevas sugerencias cercanas. Vuelve el próximo mes.",
+        "show": "Mostrar sugerencias para mi zona"
       },
       "challenge": {
         "title": "Reto del día",
@@ -230,7 +231,9 @@
       "near_you_empty": "Sin observaciones en {{radius}} km.",
       "near_you_no_location": "Activa la ubicación para ver observaciones cercanas.",
       "near_you_km_away": "{{dist}} km de distancia",
-      "near_you_view_all": "Ver en el mapa"
+      "near_you_view_all": "Ver en el mapa",
+      "near_you_show_nearby": "Mostrar observaciones cerca de mí",
+      "near_you_locating": "Obteniendo tu ubicación…"
     }
   },
   "identify": {
@@ -2207,7 +2210,8 @@
       "distance_filter_all": "Todos",
       "distance_filter_km": "{{km}} km",
       "distance_filter_no_location": "Activa la ubicación para filtrar por distancia",
-      "distance_filter_locating": "Obteniendo tu ubicación…"
+      "distance_filter_locating": "Obteniendo tu ubicación…",
+      "distance_filter_show": "Mostrar observaciones cerca de mí"
     },
     "watchlist": {
       "title": "Seguimiento",

--- a/tests/unit/no-geolocation-on-start.test.ts
+++ b/tests/unit/no-geolocation-on-start.test.ts
@@ -1,0 +1,150 @@
+/**
+ * PBI 1.3 — Defer geolocation requests behind explicit user action.
+ *
+ * Lighthouse's `geolocation-on-start` audit fails when a page calls
+ * `navigator.geolocation.getCurrentPosition` or `watchPosition` during
+ * page load. The audit fired on `/en/`, `/es/`, and `/en/explore/recent/`
+ * before this PBI because three components auto-fired geolocation
+ * from their `init()` / wire flow:
+ *
+ *   1. `HomeWidgets.astro`     — paintSuggestions (home page)
+ *   2. `home/HomeNearby.astro` — "Near you right now" (home page)
+ *   3. `ExploreRecentView.astro` — distance filter (explore/recent)
+ *
+ * Each was refactored to render a "Show observations near me" /
+ * "Show suggestions for my area" CTA on load; geolocation is only
+ * called from the button's `click` handler. A cached location from a
+ * prior session (sessionStorage `rastrum.user_location`, 5-minute TTL)
+ * is honoured without re-prompting.
+ *
+ * This test pins that contract by source-string greps: for each of
+ * the three files, every `getCurrentPosition` (or `watchPosition`)
+ * call must be inside an event-handler block, NOT at the top of the
+ * page's IIFE / init body. The check uses a simple lookbehind heuristic
+ * — find each occurrence and assert there's an `addEventListener` or
+ * `.then(` callback boundary between it and the nearest `function ` /
+ * `async function ` / top-level script start.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+
+const SUSPECT_FILES = [
+  'src/components/HomeWidgets.astro',
+  'src/components/home/HomeNearby.astro',
+  'src/components/ExploreRecentView.astro',
+] as const;
+
+function readSource(rel: string): string {
+  return readFileSync(resolve(repoRoot, rel), 'utf8');
+}
+
+/**
+ * Strip JS/HTML comments so the geolocation grep doesn't false-positive
+ * on doc strings that mention `navigator.geolocation.getCurrentPosition`
+ * in prose. Preserves indices loosely (we don't care about the offset
+ * being exact, only that we don't match inside a comment).
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, m => ' '.repeat(m.length))
+    .replace(/\/\/[^\n]*/g, m => ' '.repeat(m.length))
+    .replace(/<!--[\s\S]*?-->/g, m => ' '.repeat(m.length));
+}
+
+/**
+ * Find each `navigator.geolocation.getCurrentPosition` / `watchPosition`
+ * occurrence in `src` and return the preceding ~600 chars of context.
+ */
+function findGeolocationCalls(src: string): Array<{ idx: number; context: string }> {
+  const pattern = /navigator\.geolocation\.(?:getCurrentPosition|watchPosition)/g;
+  const hits: Array<{ idx: number; context: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(src)) !== null) {
+    const start = Math.max(0, m.index - 600);
+    hits.push({ idx: m.index, context: src.slice(start, m.index) });
+  }
+  return hits;
+}
+
+/**
+ * Heuristic: an event-handler-gated call has one of these markers in
+ * the ~600 chars preceding it (within the same handler scope):
+ *   - `.addEventListener(...` (anywhere — `click`, `submit`, etc.)
+ *   - `.then(` / `.catch(` (Promise chain inside a handler)
+ *   - `onClick=` / `onclick=` (inline handler attribute)
+ *   - `function requestSuggestionsLocation` (PBI 1.3: explicit
+ *     "request" helper that is itself only invoked from a click)
+ *   - a hoisted async function whose name starts with
+ *     `request`/`tryGeolocation`/`getLocation` (helpers that are
+ *     invoked from a handler in the same file).
+ */
+function isHandlerGated(context: string): boolean {
+  return (
+    /\.addEventListener\s*\(/.test(context) ||
+    /\bonclick\s*=/i.test(context) ||
+    /\bfunction\s+(?:request|tryGeolocation|getLocation)/.test(context) ||
+    /\basync\s+function\s+(?:request|tryGeolocation|getLocation)/.test(context) ||
+    /const\s+(?:tryGeolocation|getLocation|requestLocation)\s*=/.test(context)
+  );
+}
+
+describe('PBI 1.3 — no geolocation on page start', () => {
+  for (const rel of SUSPECT_FILES) {
+    it(`${rel}: every getCurrentPosition / watchPosition is event-handler-gated`, () => {
+      const src = stripComments(readSource(rel));
+      const hits = findGeolocationCalls(src);
+      expect(
+        hits.length,
+        `Expected at least one geolocation call in ${rel}; if it was removed, drop it from SUSPECT_FILES.`,
+      ).toBeGreaterThan(0);
+
+      for (const { idx, context } of hits) {
+        expect(
+          isHandlerGated(context),
+          `In ${rel}, the navigator.geolocation call at offset ${idx} is NOT inside an event-handler block. ` +
+            `Lighthouse's geolocation-on-start audit will fail. Wrap it in a click/submit handler.`,
+        ).toBe(true);
+      }
+    });
+  }
+
+  it('HomeNearby.astro renders the "show observations near me" CTA', () => {
+    const src = readSource('src/components/home/HomeNearby.astro');
+    expect(src).toMatch(/class="hn-show-cta/);
+    expect(src).toMatch(/near_you_show_nearby/);
+  });
+
+  it('HomeWidgets.astro renders the "show suggestions" CTA and hides it once loaded', () => {
+    const src = readSource('src/components/HomeWidgets.astro');
+    expect(src).toMatch(/class="hw-suggestions-show/);
+    expect(src).toMatch(/suggestions\.show/);
+  });
+
+  it('ExploreRecentView.astro renders the "show observations near me" CTA in the distance filter', () => {
+    const src = readSource('src/components/ExploreRecentView.astro');
+    expect(src).toMatch(/class="er-distance-show/);
+    expect(src).toMatch(/distance_filter_show/);
+  });
+
+  it('i18n: both en.json and es.json carry the new CTA strings', () => {
+    const en = JSON.parse(readSource('src/i18n/en.json')) as Record<string, unknown>;
+    const es = JSON.parse(readSource('src/i18n/es.json')) as Record<string, unknown>;
+    const enHome = (en as { home: { widgets: Record<string, unknown> } }).home.widgets;
+    const esHome = (es as { home: { widgets: Record<string, unknown> } }).home.widgets;
+
+    expect((enHome.suggestions as { show?: string }).show).toBeTypeOf('string');
+    expect((esHome.suggestions as { show?: string }).show).toBeTypeOf('string');
+    expect(enHome.near_you_show_nearby).toBeTypeOf('string');
+    expect(esHome.near_you_show_nearby).toBeTypeOf('string');
+
+    const enExplore = (en as { explore_pages: { recent: Record<string, unknown> } }).explore_pages.recent;
+    const esExplore = (es as { explore_pages: { recent: Record<string, unknown> } }).explore_pages.recent;
+    expect(enExplore.distance_filter_show).toBeTypeOf('string');
+    expect(esExplore.distance_filter_show).toBeTypeOf('string');
+  });
+});


### PR DESCRIPTION
Implements PBI 1.3 from #1193 — HomeWidgets, home/HomeNearby, ExploreRecentView no longer call `getCurrentPosition()` during page load. Each renders a "Show observations/suggestions near me" CTA; geolocation fires only from the click handler. 5-min sessionStorage cache (`rastrum.user_location`) fast-paths returning users. Dist scan: 0 `getCurrentPosition` in /en/, /es/, /en/explore/recent/. Tests: 7 unit + 2915/2915 full suite; build 255 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)