### PR TITLE
fix(onboarding): tooltip never overlaps target or top nav — PBI 1.2

### DIFF
--- a/src/components/OnboardingTour.astro
+++ b/src/components/OnboardingTour.astro
@@ -320,6 +320,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
   import { getCachedSession, getCachedUser, getSupabase } from '../lib/supabase';
   import { resolveFirstVisible } from '../lib/onboarding-target';
   import { pickDemoSpecies, formatDemoSpeciesLabel } from '../lib/onboarding-demo-species';
+  import { computeTooltipPosition } from '../lib/tour-position';
 
   type StepDef = { title: string; body: string; target: string | null; kind?: 'privacy_preset' | 'first_observation_demo' };
 
@@ -486,11 +487,23 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     );
   }
 
+  function measureInset(selector: string): number {
+    const el = document.querySelector(selector) as HTMLElement | null;
+    if (!el) return 0;
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return 0;
+    return r.height;
+  }
+
   function positionTooltip(targetEl: Element | null): void {
     if (!targetEl) {
-      tooltip.style.left   = '50%';
-      tooltip.style.top    = '50%';
-      tooltip.style.transform = 'translate(-50%, -50%)';
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const TW = tooltip.getBoundingClientRect().width  || 320;
+      const TH = tooltip.getBoundingClientRect().height || 180;
+      tooltip.style.left      = `${Math.max(8, vw / 2 - TW / 2)}px`;
+      tooltip.style.top       = `${Math.max(8, vh / 2 - TH / 2) + window.scrollY}px`;
+      tooltip.style.transform = 'none';
       ring.classList.add('hidden');
       ring.classList.remove('onb-pulse');
       backdrop.style.clipPath = 'none';
@@ -498,12 +511,7 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     }
 
     const tr = getSpotlightRect(targetEl);
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
 
-    // Spotlight ring — pulse hint helps the eye find the target on dense
-    // mobile chrome (the bottom-bar FAB in particular). prefers-reduced-motion
-    // is honoured by the CSS rule.
     ring.style.left   = `${tr.left}px`;
     ring.style.top    = `${tr.top  + window.scrollY}px`;
     ring.style.width  = `${tr.width}px`;
@@ -511,7 +519,6 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
     ring.classList.remove('hidden');
     ring.classList.add('onb-pulse');
 
-    // Backdrop with circular hole (polygon with outer box + inner rect)
     if (!reduced) {
       const x0 = tr.left;   const y0 = tr.top;
       const x1 = tr.right;  const y1 = tr.bottom;
@@ -525,29 +532,22 @@ const presetPrivate = onb.preset_private_observer ?? 'Private observer';
       backdrop.style.clipPath = 'none';
     }
 
-    // Tooltip placement: prefer below or above the spotlight rect
-    const TW = tooltip.getBoundingClientRect().width || 320;
+    const TW = tooltip.getBoundingClientRect().width  || 320;
     const TH = tooltip.getBoundingClientRect().height || 180;
-    const MARGIN = 12;
 
-    let tx: number;
-    let ty: number;
+    const headerEl     = document.querySelector('header') as HTMLElement | null;
+    const headerHeight = headerEl ? headerEl.getBoundingClientRect().height : 0;
+    const bottomBarHeight = measureInset('#mobile-bottom-bar');
 
-    // Horizontal: center on target, clamp to viewport
-    tx = tr.left + tr.width / 2 - TW / 2;
-    tx = Math.max(MARGIN, Math.min(tx, vw - TW - MARGIN));
+    const pos = computeTooltipPosition(
+      { left: tr.left, top: tr.top, width: tr.width, height: tr.height },
+      { width: TW, height: TH },
+      { width: window.innerWidth, height: window.innerHeight },
+      { headerHeight, bottomBarHeight },
+    );
 
-    // Vertical: prefer below, fall back to above, then center
-    if (tr.bottom + MARGIN + TH <= vh) {
-      ty = tr.bottom + MARGIN;
-    } else if (tr.top - MARGIN - TH >= 0) {
-      ty = tr.top - MARGIN - TH;
-    } else {
-      ty = Math.max(MARGIN, Math.min(vh / 2 - TH / 2, vh - TH - MARGIN));
-    }
-
-    tooltip.style.left      = `${tx}px`;
-    tooltip.style.top       = `${ty + window.scrollY}px`;
+    tooltip.style.left      = `${pos.left}px`;
+    tooltip.style.top       = `${pos.top + window.scrollY}px`;
     tooltip.style.transform = 'none';
   }
 

--- a/src/lib/tour-position.ts
+++ b/src/lib/tour-position.ts
@@ -1,0 +1,142 @@
+/**
+ * Pure tooltip placement for the OnboardingTour overlay.
+ *
+ * Splits target placement into two stages:
+ *   1. `pickSide(target, viewport)` — auto-flip logic. Top quartile of the
+ *      viewport ⇒ render below; bottom quartile ⇒ above; otherwise lateral
+ *      (right preferred, left fallback) so the tooltip never sits *on top
+ *      of* the spotlight.
+ *   2. `computeTooltipPosition(...)` — clamp the chosen side against the
+ *      header (top), bottom-bar (mobile bottom), and viewport gutters. If
+ *      clamping forces the tooltip to overlap the spotlight rect, the side
+ *      is flipped once (preferring the axis with more available room).
+ *
+ * Pure — caller passes rects, function returns coords. Re-used by the
+ * Astro client `<script>` block and by `tests/unit/onboarding-tour-
+ * positioning.test.ts`.
+ */
+
+export interface Rect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+export interface Insets {
+  headerHeight: number;
+  bottomBarHeight: number;
+}
+
+export type Side = 'below' | 'above' | 'right' | 'left' | 'center';
+
+export interface TooltipPosition {
+  left: number;
+  top: number;
+  side: Side;
+}
+
+const GUTTER = 8;
+const MARGIN = 12;
+
+export function pickSide(target: Rect, viewport: Viewport): Side {
+  const targetCenterY = target.top + target.height / 2;
+  const topQuartile = viewport.height * 0.25;
+  const bottomQuartile = viewport.height * 0.75;
+  if (targetCenterY <= topQuartile) return 'below';
+  if (targetCenterY >= bottomQuartile) return 'above';
+  return 'right';
+}
+
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return !(
+    a.left + a.width  <= b.left ||
+    b.left + b.width  <= a.left ||
+    a.top  + a.height <= b.top  ||
+    b.top  + b.height <= a.top
+  );
+}
+
+function placeOnSide(
+  side: Side,
+  target: Rect,
+  tooltip: { width: number; height: number },
+  viewport: Viewport,
+  insets: Insets,
+): { left: number; top: number } {
+  const minTop = insets.headerHeight + GUTTER;
+  const maxTop = viewport.height - insets.bottomBarHeight - GUTTER - tooltip.height;
+  const minLeft = GUTTER;
+  const maxLeft = viewport.width - GUTTER - tooltip.width;
+
+  let left: number;
+  let top: number;
+
+  if (side === 'below') {
+    left = target.left + target.width / 2 - tooltip.width / 2;
+    top  = target.top + target.height + MARGIN;
+  } else if (side === 'above') {
+    left = target.left + target.width / 2 - tooltip.width / 2;
+    top  = target.top - MARGIN - tooltip.height;
+  } else if (side === 'right') {
+    left = target.left + target.width + MARGIN;
+    top  = target.top + target.height / 2 - tooltip.height / 2;
+  } else if (side === 'left') {
+    left = target.left - MARGIN - tooltip.width;
+    top  = target.top + target.height / 2 - tooltip.height / 2;
+  } else {
+    left = viewport.width / 2 - tooltip.width / 2;
+    top  = viewport.height / 2 - tooltip.height / 2;
+  }
+
+  left = Math.max(minLeft, Math.min(left, maxLeft));
+  top  = Math.max(minTop,  Math.min(top,  maxTop));
+  return { left, top };
+}
+
+function flip(side: Side): Side {
+  if (side === 'below') return 'above';
+  if (side === 'above') return 'below';
+  if (side === 'right') return 'left';
+  if (side === 'left')  return 'right';
+  return 'center';
+}
+
+export function computeTooltipPosition(
+  target: Rect | null,
+  tooltip: { width: number; height: number },
+  viewport: Viewport,
+  insets: Insets,
+): TooltipPosition {
+  if (!target) {
+    return {
+      left: viewport.width / 2 - tooltip.width / 2,
+      top:  viewport.height / 2 - tooltip.height / 2,
+      side: 'center',
+    };
+  }
+
+  const preferred = pickSide(target, viewport);
+  const first = placeOnSide(preferred, target, tooltip, viewport, insets);
+  const firstRect: Rect = { left: first.left, top: first.top, width: tooltip.width, height: tooltip.height };
+
+  if (!rectsOverlap(firstRect, target)) {
+    return { ...first, side: preferred };
+  }
+
+  const flipped = flip(preferred);
+  const second = placeOnSide(flipped, target, tooltip, viewport, insets);
+  const secondRect: Rect = { left: second.left, top: second.top, width: tooltip.width, height: tooltip.height };
+
+  if (!rectsOverlap(secondRect, target)) {
+    return { ...second, side: flipped };
+  }
+
+  const centered = placeOnSide('center', target, tooltip, viewport, insets);
+  return { ...centered, side: 'center' };
+}

--- a/tests/unit/onboarding-tour-positioning.test.ts
+++ b/tests/unit/onboarding-tour-positioning.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pickSide,
+  computeTooltipPosition,
+  type Rect,
+  type Viewport,
+  type Insets,
+} from '../../src/lib/tour-position';
+
+const TOOLTIP = { width: 320, height: 180 };
+
+const DESKTOP: Viewport = { width: 1366, height: 800 };
+const TABLET:  Viewport = { width: 768,  height: 1024 };
+const MOBILE:  Viewport = { width: 390,  height: 844 };
+
+const HEADER_ONLY: Insets = { headerHeight: 56, bottomBarHeight: 0 };
+const MOBILE_INSETS: Insets = { headerHeight: 56, bottomBarHeight: 64 };
+const NO_INSETS: Insets = { headerHeight: 0, bottomBarHeight: 0 };
+
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return !(
+    a.left + a.width  <= b.left ||
+    b.left + b.width  <= a.left ||
+    a.top  + a.height <= b.top  ||
+    b.top  + b.height <= a.top
+  );
+}
+
+describe('pickSide', () => {
+  it('returns "below" when target is in the top quartile', () => {
+    const target: Rect = { left: 100, top: 20, width: 100, height: 40 };
+    expect(pickSide(target, DESKTOP)).toBe('below');
+  });
+
+  it('returns "above" when target is in the bottom quartile', () => {
+    const target: Rect = { left: 100, top: 700, width: 100, height: 40 };
+    expect(pickSide(target, DESKTOP)).toBe('above');
+  });
+
+  it('returns lateral ("right") when target is in the middle band', () => {
+    const target: Rect = { left: 100, top: 380, width: 100, height: 40 };
+    expect(pickSide(target, DESKTOP)).toBe('right');
+  });
+});
+
+describe('computeTooltipPosition', () => {
+  it('centers tooltip when target is null', () => {
+    const pos = computeTooltipPosition(null, TOOLTIP, DESKTOP, HEADER_ONLY);
+    expect(pos.side).toBe('center');
+    expect(pos.left).toBeCloseTo(DESKTOP.width / 2 - TOOLTIP.width / 2);
+    expect(pos.top).toBeCloseTo(DESKTOP.height / 2 - TOOLTIP.height / 2);
+  });
+
+  it('never lets tooltip overlap the header (top is below headerHeight + 8)', () => {
+    // Target near the top — preferred side is "below", which is naturally
+    // below the header. Force a worst case where target is mid-band so the
+    // lateral placement could ride up — clamp must still respect header.
+    const target: Rect = { left: 0, top: 40, width: 80, height: 40 };
+    const pos = computeTooltipPosition(target, TOOLTIP, DESKTOP, HEADER_ONLY);
+    expect(pos.top).toBeGreaterThanOrEqual(HEADER_ONLY.headerHeight + 8);
+  });
+
+  it('never lets tooltip overlap the mobile bottom bar', () => {
+    // Target near the bottom of a mobile viewport.
+    const target: Rect = { left: 150, top: 740, width: 60, height: 60 };
+    const pos = computeTooltipPosition(target, TOOLTIP, MOBILE, MOBILE_INSETS);
+    expect(pos.top + TOOLTIP.height).toBeLessThanOrEqual(
+      MOBILE.height - MOBILE_INSETS.bottomBarHeight - 8,
+    );
+  });
+
+  it('keeps tooltip inside viewport gutters', () => {
+    // Target at the far right edge: would push the tooltip off-screen.
+    const target: Rect = { left: 1350, top: 380, width: 16, height: 40 };
+    const pos = computeTooltipPosition(target, TOOLTIP, DESKTOP, HEADER_ONLY);
+    expect(pos.left).toBeGreaterThanOrEqual(8);
+    expect(pos.left + TOOLTIP.width).toBeLessThanOrEqual(DESKTOP.width - 8);
+  });
+
+  it('places tooltip below when target is high in the viewport', () => {
+    const target: Rect = { left: 100, top: 30, width: 80, height: 40 };
+    const pos = computeTooltipPosition(target, TOOLTIP, DESKTOP, HEADER_ONLY);
+    expect(pos.side).toBe('below');
+    expect(pos.top).toBeGreaterThanOrEqual(target.top + target.height);
+  });
+
+  it('places tooltip above when target is low in the viewport', () => {
+    const target: Rect = { left: 100, top: 720, width: 80, height: 40 };
+    const pos = computeTooltipPosition(target, TOOLTIP, DESKTOP, HEADER_ONLY);
+    expect(pos.side).toBe('above');
+    expect(pos.top + TOOLTIP.height).toBeLessThanOrEqual(target.top);
+  });
+
+  it('tooltip never overlaps the spotlight target rect (desktop, top-nav case)', () => {
+    // Reproduces the audit defect: spotlight target = "Observe" nav link
+    // near top of viewport on desktop /observe.
+    const target: Rect = { left: 220, top: 20, width: 70, height: 32 };
+    const pos = computeTooltipPosition(target, TOOLTIP, DESKTOP, HEADER_ONLY);
+    const tooltipRect: Rect = { left: pos.left, top: pos.top, width: TOOLTIP.width, height: TOOLTIP.height };
+    expect(rectsOverlap(tooltipRect, target)).toBe(false);
+  });
+
+  it('tooltip never overlaps the spotlight target rect (mobile, sign-in case)', () => {
+    // Reproduces the audit defect: spotlight target = "Sign in" header pill
+    // on mobile observe-es. Target is in top band so tooltip should drop below.
+    const target: Rect = { left: 290, top: 16, width: 80, height: 32 };
+    const pos = computeTooltipPosition(target, TOOLTIP, MOBILE, MOBILE_INSETS);
+    const tooltipRect: Rect = { left: pos.left, top: pos.top, width: TOOLTIP.width, height: TOOLTIP.height };
+    expect(rectsOverlap(tooltipRect, target)).toBe(false);
+  });
+
+  it('all 7 step layouts: render without overlap on 3 viewports', () => {
+    // Synthetic positions corresponding to the 7 tour steps:
+    //   0 welcome (no target — centered, n/a)
+    //   1 fab/observe-nav  → top-left header link, ~y=20
+    //   2 quick-id fab     → top header link (same selector)
+    //   3 first-obs demo (no target)
+    //   4 explore-tab/explore-nav → top header link, ~y=20, further right
+    //   5 privacy preset (no target)
+    //   6 profile/avatar-btn → top-right corner, ~y=18
+    const targets: Array<Rect | null> = [
+      null,
+      { left: 180, top: 20,  width: 70, height: 32 },
+      { left: 180, top: 20,  width: 70, height: 32 },
+      null,
+      { left: 280, top: 20,  width: 80, height: 32 },
+      null,
+      { left: 1320, top: 18, width: 32, height: 32 },
+    ];
+    for (const viewport of [DESKTOP, TABLET, MOBILE]) {
+      const insets = viewport === MOBILE ? MOBILE_INSETS : HEADER_ONLY;
+      for (const t of targets) {
+        const tgt = t === null ? null : { ...t, left: Math.min(t.left, viewport.width - t.width) };
+        const pos = computeTooltipPosition(tgt, TOOLTIP, viewport, insets);
+        expect(pos.left).toBeGreaterThanOrEqual(8);
+        expect(pos.left + TOOLTIP.width).toBeLessThanOrEqual(viewport.width - 8);
+        expect(pos.top).toBeGreaterThanOrEqual(insets.headerHeight === 0 ? 8 : insets.headerHeight + 8 - 0.5);
+        if (insets.bottomBarHeight > 0) {
+          expect(pos.top + TOOLTIP.height).toBeLessThanOrEqual(viewport.height - insets.bottomBarHeight - 8 + 0.5);
+        }
+        if (tgt) {
+          const tooltipRect: Rect = { left: pos.left, top: pos.top, width: TOOLTIP.width, height: TOOLTIP.height };
+          expect(rectsOverlap(tooltipRect, tgt)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('respects header inset even when zero (no header element on page)', () => {
+    const target: Rect = { left: 100, top: 50, width: 80, height: 40 };
+    const pos = computeTooltipPosition(target, TOOLTIP, DESKTOP, NO_INSETS);
+    expect(pos.top).toBeGreaterThanOrEqual(8);
+  });
+});


### PR DESCRIPTION
Implements PBI 1.2 from #1193 — extracts placement math to a pure helper, adds header/bottom-bar inset awareness + auto-flip + overlap-retry. Repro: desktop "Observe" nav overlap + mobile "Sign in" pill overlap (step 2 on /observe/). Sweep test: 7 steps × 3 viewports, zero overlap. Tests: 13 unit + 9 e2e (replay + journey-observer-first-obs) green; full vitest 2921/2921; build 255 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)