### PR TITLE
fix(a11y): 44x44 px touch targets + underline inline links — PBI 3.3

### DIFF
--- a/src/components/ExploreMap.astro
+++ b/src/components/ExploreMap.astro
@@ -15,7 +15,7 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
   <h1 class="text-2xl font-bold tracking-tight mb-2">{tr.map.title}</h1>
   <p class="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
     {tr.map.cross_link.prompt}{' '}
-    <a href={observersMapHref} class="text-emerald-600 dark:text-emerald-400 hover:underline">
+    <a href={observersMapHref} class="text-emerald-600 dark:text-emerald-400 underline decoration-emerald-300 dark:decoration-emerald-700 underline-offset-2 hover:decoration-emerald-500">
       {tr.map.cross_link.cta}
     </a>
   </p>
@@ -26,7 +26,7 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
     <!-- Places layer toggle -->
     <button
       id="places-layer-toggle"
-      class="hidden absolute top-3 right-3 z-10 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 shadow-sm hover:border-emerald-400 transition-colors"
+      class="hidden absolute top-3 right-3 z-10 flex min-h-[44px] min-w-[44px] items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-lg bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 shadow-sm hover:border-emerald-400 transition-colors"
       data-active="false"
     >
       <span>🗺️</span>
@@ -467,7 +467,7 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
           : hasAudio
             ? `<div id="map-media-thumb-${obsId}" data-media-kind="audio" style="width:100%;height:100px;border-radius:6px 6px 0 0;overflow:hidden"></div>`
             : `<div style="width:100%;height:60px;background:${isDark ? '#1e293b' : '#f4f4f5'};border-radius:6px 6px 0 0;display:flex;align-items:center;justify-content:center;color:${isDark ? '#64748b' : '#a1a1aa'};font-size:20px">🌿</div>`;
-      const html = `<div style="min-width:180px;max-width:220px;font-family:system-ui;overflow:hidden;border-radius:6px">${mediaHtml}<div style="padding:8px 10px"><div style="font-size:13px;font-weight:600;font-style:italic;color:${isDark ? '#f1f5f9' : '#18181b'};white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${speciesName}</div>${date ? `<div style="font-size:11px;color:${isDark ? '#94a3b8' : '#71717a'};margin-top:2px">${date}</div>` : ''}<a href="${shareBase}?id=${obsId}" style="display:inline-block;margin-top:6px;font-size:11px;color:#10b981;text-decoration:none;font-weight:500">${isEs ? 'Ver observación →' : 'View observation →'}</a></div></div>`;
+      const html = `<div style="min-width:180px;max-width:220px;font-family:system-ui;overflow:hidden;border-radius:6px">${mediaHtml}<div style="padding:8px 10px"><div style="font-size:13px;font-weight:600;font-style:italic;color:${isDark ? '#f1f5f9' : '#18181b'};white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${speciesName}</div>${date ? `<div style="font-size:11px;color:${isDark ? '#94a3b8' : '#71717a'};margin-top:2px">${date}</div>` : ''}<a href="${shareBase}?id=${obsId}" style="display:inline-block;margin-top:6px;font-size:11px;color:#10b981;text-decoration:underline;text-underline-offset:2px;font-weight:500">${isEs ? 'Ver observación →' : 'View observation →'}</a></div></div>`;
       const popup = new maplibregl.Popup({ closeButton: true, maxWidth: '240px', offset: 12 })
         .setLngLat(coords)
         .setHTML(html)
@@ -559,7 +559,7 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
             if (!props?.slug) return;
             new maplibregl.Popup({ closeButton: true, maxWidth: '240px' })
               .setLngLat(e.lngLat)
-              .setHTML(`<div class="text-sm font-medium">${props.name ?? props.slug}</div><div class="text-xs text-zinc-500 mt-0.5">${props.obs_count ?? 0} obs</div><a href="${placeBase}${props.slug}" class="text-xs text-emerald-600 hover:underline mt-1 block">${isEs ? 'Ver lugar →' : 'View place →'}</a>`)
+              .setHTML(`<div class="text-sm font-medium">${props.name ?? props.slug}</div><div class="text-xs text-zinc-500 mt-0.5">${props.obs_count ?? 0} obs</div><a href="${placeBase}${props.slug}" class="text-xs text-emerald-600 underline decoration-emerald-300 underline-offset-2 mt-1 block">${isEs ? 'Ver lugar →' : 'View place →'}</a>`)
               .addTo(map);
           });
           map.on('mouseenter', 'places-fill', () => { map.getCanvas().style.cursor = 'pointer'; });

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -86,7 +86,7 @@ const distancePage = page as unknown as Record<string, string>;
       >
         <button
           type="button"
-          class="er-view-btn er-view-cards inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          class="er-view-btn er-view-cards inline-flex h-11 w-11 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
           data-mode="cards"
           aria-label={view.cards}
           aria-pressed="true"
@@ -96,7 +96,7 @@ const distancePage = page as unknown as Record<string, string>;
         </button>
         <button
           type="button"
-          class="er-view-btn er-view-grid inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          class="er-view-btn er-view-grid inline-flex h-11 w-11 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
           data-mode="grid"
           aria-label={view.grid}
           aria-pressed="false"
@@ -106,7 +106,7 @@ const distancePage = page as unknown as Record<string, string>;
         </button>
         <button
           type="button"
-          class="er-view-btn er-view-list inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          class="er-view-btn er-view-list inline-flex h-11 w-11 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
           data-mode="list"
           aria-label={(view as unknown as Record<string, string>).list_aria ?? 'List view'}
           aria-pressed="false"
@@ -116,7 +116,7 @@ const distancePage = page as unknown as Record<string, string>;
         </button>
         <button
           type="button"
-          class="er-view-btn er-view-map inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          class="er-view-btn er-view-map inline-flex h-11 w-11 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
           data-mode="map"
           aria-label={(view as unknown as Record<string, string>).map_aria ?? 'Map view'}
           aria-pressed="false"
@@ -126,7 +126,7 @@ const distancePage = page as unknown as Record<string, string>;
         </button>
         <button
           type="button"
-          class="er-view-btn er-view-timeline inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
+          class="er-view-btn er-view-timeline inline-flex h-11 w-11 items-center justify-center rounded-md text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 aria-pressed:bg-emerald-100 dark:aria-pressed:bg-emerald-900/40 aria-pressed:text-emerald-800 dark:aria-pressed:text-emerald-300"
           data-mode="timeline"
           aria-label={(view as unknown as Record<string, string>).timeline_aria ?? 'Timeline view'}
           aria-pressed="false"
@@ -341,7 +341,7 @@ const distancePage = page as unknown as Record<string, string>;
       : '';
 
     const observerHtml = isPublic && observerUsername
-      ? `${avatarHtml}<a href="${profileBase}?username=${encodeURIComponent(observerUsername)}" class="text-emerald-700 dark:text-emerald-400 hover:underline" data-stop>${escapeText(observerName || observerUsername)}</a>`
+      ? `${avatarHtml}<a href="${profileBase}?username=${encodeURIComponent(observerUsername)}" class="text-emerald-700 dark:text-emerald-400 underline decoration-emerald-300 dark:decoration-emerald-700 underline-offset-2 hover:decoration-emerald-500" data-stop>${escapeText(observerName || observerUsername)}</a>`
       : `<span class="text-zinc-500">${escapeText(anonLabel)}</span>`;
 
     const confidencePill = confidence !== null
@@ -360,7 +360,7 @@ const distancePage = page as unknown as Record<string, string>;
       ? `<div class="er-overflow absolute right-2 top-2 z-10" data-observer-id="${escapeText(r.observer_id)}" data-observer-handle="${escapeText(observer?.username ?? '')}" data-obs-id="${escapeText(r.id)}" data-obs-label="${escapeText(sci)}">
           <button
             type="button"
-            class="er-overflow-trigger inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/90 dark:bg-zinc-900/90 text-zinc-700 dark:text-zinc-300 ring-1 ring-zinc-200 dark:ring-zinc-800 hover:bg-white dark:hover:bg-zinc-900 shadow-sm transition-colors"
+            class="er-overflow-trigger inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/90 dark:bg-zinc-900/90 text-zinc-700 dark:text-zinc-300 ring-1 ring-zinc-200 dark:ring-zinc-800 hover:bg-white dark:hover:bg-zinc-900 shadow-sm transition-colors"
             aria-label="${escapeText(labels.moreActions)}"
             aria-haspopup="menu"
             aria-expanded="false"
@@ -368,11 +368,11 @@ const distancePage = page as unknown as Record<string, string>;
             <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></svg>
           </button>
           <div class="er-overflow-menu hidden absolute right-0 top-10 min-w-[180px] rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 shadow-lg overflow-hidden" role="menu">
-            <button type="button" class="er-action-block flex w-full items-center gap-2.5 px-3.5 py-2.5 text-sm text-zinc-800 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors" role="menuitem" aria-label="${escapeText(labels.blockObserverAria)}">
+            <button type="button" class="er-action-block flex w-full min-h-[44px] items-center gap-2.5 px-3.5 py-2.5 text-sm text-zinc-800 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors" role="menuitem" aria-label="${escapeText(labels.blockObserverAria)}">
               <svg class="h-4 w-4 text-zinc-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
               <span>${escapeText(labels.block)}</span>
             </button>
-            <button type="button" class="er-action-report flex w-full items-center gap-2.5 px-3.5 py-2.5 text-sm text-zinc-800 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors border-t border-zinc-100 dark:border-zinc-800" role="menuitem" aria-label="${escapeText(labels.reportAria)}">
+            <button type="button" class="er-action-report flex w-full min-h-[44px] items-center gap-2.5 px-3.5 py-2.5 text-sm text-zinc-800 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors border-t border-zinc-100 dark:border-zinc-800" role="menuitem" aria-label="${escapeText(labels.reportAria)}">
               <svg class="h-4 w-4 text-zinc-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 22V4a2 2 0 0 1 2-2h11l4 6-4 6H6"/><line x1="4" y1="22" x2="4" y2="14"/></svg>
               <span>${escapeText(labels.report)}</span>
             </button>
@@ -393,7 +393,7 @@ const distancePage = page as unknown as Record<string, string>;
 
     // --- Fave chip — now an interactive toggle button ---
     // Populated (count + pressed state) after batched fetch in paintReactionCounts.
-    const faveChipHtml = `<button type="button" class="er-fave-chip hidden inline-flex items-center gap-1 rounded-full bg-rose-50 dark:bg-rose-950/40 border border-rose-200 dark:border-rose-900/60 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:text-rose-300 hover:bg-rose-100 dark:hover:bg-rose-950/60 transition-colors disabled:opacity-50" data-fave-target="${escapeText(r.id)}" aria-label="Favorite" aria-pressed="false"><svg class="er-fave-icon w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/></svg><span class="er-fave-count tabular-nums">0</span></button>`;
+    const faveChipHtml = `<button type="button" class="er-fave-chip hidden inline-flex min-h-[44px] min-w-[44px] items-center justify-center gap-1 rounded-full bg-rose-50 dark:bg-rose-950/40 border border-rose-200 dark:border-rose-900/60 px-3 py-1 text-[11px] font-semibold text-rose-700 dark:text-rose-300 hover:bg-rose-100 dark:hover:bg-rose-950/60 transition-colors disabled:opacity-50" data-fave-target="${escapeText(r.id)}" aria-label="Favorite" aria-pressed="false"><svg class="er-fave-icon w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/></svg><span class="er-fave-count tabular-nums">0</span></button>`;
 
     return `<li class="relative">
       ${overflowHtml}
@@ -565,7 +565,7 @@ const distancePage = page as unknown as Record<string, string>;
         const active = km === null && distanceFilterKm === null;
         return `<button
           type="button"
-          class="er-dist-btn inline-flex h-7 items-center rounded-full border px-3 text-xs font-medium transition-colors
+          class="er-dist-btn inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border px-4 text-xs font-medium transition-colors
             ${active
               ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300'
               : 'border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900/50 text-zinc-600 dark:text-zinc-400 hover:border-emerald-400'
@@ -643,7 +643,7 @@ const distancePage = page as unknown as Record<string, string>;
         ? `<span class="inline-flex h-6 w-6 shrink-0 rounded-full items-center justify-center overflow-hidden bg-emerald-100 dark:bg-emerald-950 ${listRingClass} ring-offset-1 ring-offset-white dark:ring-offset-zinc-900">${listAvatarUrl ? `<img src="${escapeText(listAvatarUrl)}" alt="" class="w-full h-full object-cover" loading="lazy" />` : `<span class="text-[9px] font-bold text-emerald-700 dark:text-emerald-300">${escapeText(listInitials)}</span>`}</span>`
         : '';
       const observerHtml = isPublic && observerUsername
-        ? `${listAvatarHtml}<a href="${profileBase}?username=${encodeURIComponent(observerUsername)}" class="text-emerald-700 dark:text-emerald-400 hover:underline">${escapeText(observerName || observerUsername)}</a>`
+        ? `${listAvatarHtml}<a href="${profileBase}?username=${encodeURIComponent(observerUsername)}" class="text-emerald-700 dark:text-emerald-400 underline decoration-emerald-300 dark:decoration-emerald-700 underline-offset-2 hover:decoration-emerald-500">${escapeText(observerName || observerUsername)}</a>`
         : `<span class="text-zinc-500">${escapeText(anonLabel)}</span>`;
       // Media type badge for list thumbnail
       const mediaBadge = hasAudioOnly

--- a/src/components/TimeSlider.astro
+++ b/src/components/TimeSlider.astro
@@ -65,7 +65,7 @@ const showingAll = slider.showing_all ?? 'Showing all months';
   >
     <button
       type="button"
-      class="ts-btn snap-start shrink-0 inline-flex min-h-[40px] items-center rounded-full border border-zinc-300 dark:border-zinc-700 px-4 py-1.5 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"
+      class="ts-btn snap-start shrink-0 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border border-zinc-300 dark:border-zinc-700 px-4 py-2 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"
       data-month="all"
       data-active="true"
       role="radio"
@@ -76,7 +76,7 @@ const showingAll = slider.showing_all ?? 'Showing all months';
     {months.map((label, i) => (
       <button
         type="button"
-        class="ts-btn snap-start shrink-0 inline-flex min-h-[40px] items-center rounded-full border border-zinc-300 dark:border-zinc-700 px-3 py-1.5 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"
+        class="ts-btn snap-start shrink-0 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"
         data-month={String(i)}
         data-active="false"
         role="radio"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -197,6 +197,14 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
         line-height: 1;
         display: inline-block;
       }
+      /* PBI 3.3 — WCAG target-size (44x44) for MapLibre native controls
+         (zoom in/out, geolocate, attribution toggle). MapLibre renders these
+         button.maplibregl-ctrl-* inside .maplibregl-ctrl divs at ~29px by
+         default which fails Lighthouse target-size on mobile. */
+      .maplibregl-ctrl button {
+        min-width: 44px !important;
+        min-height: 44px !important;
+      }
     </style>
     <script is:inline>
       (function() {

--- a/tests/unit/touch-targets.test.ts
+++ b/tests/unit/touch-targets.test.ts
@@ -1,0 +1,109 @@
+/**
+ * PBI 3.3 — WCAG target-size + link-in-text-block regression guard.
+ *
+ * Source-string greps that pin down:
+ * - ExploreMap.astro + ExploreRecentView.astro + TimeSlider.astro all use
+ *   the 44x44 minimum hit-area pattern (`min-h-[44px]` / `min-w-[44px]`)
+ *   on their clickable elements.
+ * - BaseLayout.astro ships a `.maplibregl-ctrl button` rule that pins
+ *   MapLibre's native zoom/geolocate controls to 44x44.
+ * - Inline links inside text paragraphs use `underline` (or `decoration-*`)
+ *   so they aren't distinguished by colour alone (WCAG 1.4.1).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const read = (rel: string): string => readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+
+describe('PBI 3.3 — 44x44 touch targets', () => {
+  it('ExploreMap.astro places-layer-toggle uses min-h-[44px] min-w-[44px]', () => {
+    const src = read('src/components/ExploreMap.astro');
+    expect(src).toContain('id="places-layer-toggle"');
+    const toggleBlock = src.slice(src.indexOf('id="places-layer-toggle"'));
+    expect(toggleBlock).toMatch(/min-h-\[44px\]/);
+    expect(toggleBlock).toMatch(/min-w-\[44px\]/);
+  });
+
+  it('ExploreRecentView.astro view switcher buttons are >= 44x44 (h-11 w-11)', () => {
+    const src = read('src/components/ExploreRecentView.astro');
+    // The five view-switcher buttons share the inline-flex sizing classes.
+    expect(src).toContain('inline-flex h-11 w-11 items-center justify-center rounded-md');
+    // And no leftover h-9 w-9 view buttons.
+    expect(src).not.toMatch(/er-view-btn[^"]*h-9 w-9/);
+  });
+
+  it('ExploreRecentView.astro overflow trigger, fave chip, distance chips use min-h-[44px]', () => {
+    const src = read('src/components/ExploreRecentView.astro');
+    // Overflow trigger (h-11 w-11)
+    expect(src).toMatch(/er-overflow-trigger[^"]*h-11 w-11/);
+    // Fave chip uses explicit min-h/min-w
+    const faveIdx = src.indexOf('er-fave-chip');
+    expect(faveIdx).toBeGreaterThan(-1);
+    const faveBlock = src.slice(faveIdx, faveIdx + 400);
+    expect(faveBlock).toMatch(/min-h-\[44px\]/);
+    expect(faveBlock).toMatch(/min-w-\[44px\]/);
+    // Distance chips
+    const distIdx = src.indexOf('er-dist-btn');
+    expect(distIdx).toBeGreaterThan(-1);
+    const distBlock = src.slice(distIdx, distIdx + 400);
+    expect(distBlock).toMatch(/min-h-\[44px\]/);
+    expect(distBlock).toMatch(/min-w-\[44px\]/);
+    // Overflow menu items
+    expect(src).toMatch(/flex w-full min-h-\[44px\] items-center/);
+  });
+
+  it('TimeSlider.astro ts-btn buttons use min-h-[44px] min-w-[44px]', () => {
+    const src = read('src/components/TimeSlider.astro');
+    // Both the "all year" + month buttons share the sizing classes.
+    const occurrences = src.match(/ts-btn[^"]*min-h-\[44px\][^"]*min-w-\[44px\]/g);
+    expect(occurrences).not.toBeNull();
+    expect((occurrences ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('BaseLayout.astro pins .maplibregl-ctrl button to >= 44x44', () => {
+    const src = read('src/layouts/BaseLayout.astro');
+    // Allow optional spacing inside the selector.
+    expect(src).toMatch(/\.maplibregl-ctrl\s+button\s*\{[\s\S]*?min-width:\s*44px[\s\S]*?min-height:\s*44px[\s\S]*?\}/);
+  });
+});
+
+describe('PBI 3.3 — link-in-text-block (WCAG 1.4.1)', () => {
+  it('ExploreMap.astro cross-link uses underline, not colour alone', () => {
+    const src = read('src/components/ExploreMap.astro');
+    const linkIdx = src.indexOf('tr.map.cross_link.cta');
+    expect(linkIdx).toBeGreaterThan(-1);
+    // Walk backwards a bit to capture the anchor element.
+    const block = src.slice(Math.max(0, linkIdx - 400), linkIdx + 100);
+    expect(block).toMatch(/<a\b[^>]*class="[^"]*\bunderline\b/);
+  });
+
+  it('ExploreMap.astro place-popup link uses text-decoration (not hover-only)', () => {
+    const src = read('src/components/ExploreMap.astro');
+    // Inline-style popup link must have text-decoration:underline (not :none)
+    const idx = src.indexOf('Ver lugar');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(Math.max(0, idx - 400), idx + 80);
+    expect(block).toMatch(/decoration-emerald|text-decoration:\s*underline|class="[^"]*\bunderline\b/);
+  });
+
+  it('ExploreMap.astro observation popup link uses text-decoration:underline', () => {
+    const src = read('src/components/ExploreMap.astro');
+    const idx = src.indexOf('Ver observación');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(Math.max(0, idx - 400), idx + 80);
+    expect(block).toMatch(/text-decoration:\s*underline/);
+  });
+
+  it('ExploreRecentView.astro observer links carry underline decoration', () => {
+    const src = read('src/components/ExploreRecentView.astro');
+    // Both observer link sites (cards + list view) should use underline
+    const matches = src.match(/text-emerald-700[^"`]*underline\b/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+    // No remaining hover-only link styling for these anchor sites.
+    // Sanity: the bare "hover:underline" pattern (with no preceding underline)
+    // shouldn't survive on the observer links.
+    expect(src).not.toMatch(/text-emerald-700 dark:text-emerald-400 hover:underline"/);
+  });
+});


### PR DESCRIPTION
Implements PBI 3.3 from #1193. WCAG 2.5.5 + 1.4.1 — every clickable on /explore/map/ + /explore/recent/ + the global MapLibre controls now meet the 44×44 px hit area minimum; inline links no longer rely on color alone (underline + offset). Tests: 9 unit; build 255 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)