### PR TITLE
fix(auth): passkey button styling parity with OAuth options — PBI 5.2

### DIFF
--- a/src/components/SignInForm.astro
+++ b/src/components/SignInForm.astro
@@ -34,8 +34,8 @@ const tr = t(lang);
   </div>
 
   <!-- Passkey -->
-  <button id="passkey-btn" type="button" class="hidden mt-2 w-full flex items-center justify-center gap-3 rounded-lg border border-emerald-600/60 bg-emerald-50 dark:bg-emerald-900/20 px-4 py-2.5 text-sm font-medium text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/30 transition-colors">
-    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+  <button id="passkey-btn" type="button" class="hidden mt-2 w-full flex items-center justify-center gap-3 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M12 11c1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3 1.34 3 3 3zm0 2c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4z"/>
     </svg>
     {tr.auth.use_passkey}

--- a/tests/unit/signin-passkey-styling.test.ts
+++ b/tests/unit/signin-passkey-styling.test.ts
@@ -1,0 +1,90 @@
+/**
+ * PBI 5.2 — passkey button styling parity with Google + GitHub OAuth
+ * buttons.
+ *
+ * The current defect was an emerald-tinted passkey button that visually
+ * implied "recommended default", contradicting the magic-link-first
+ * onboarding. This pins the passkey button to the same neutral white /
+ * gray-border surface used by the Google and GitHub buttons.
+ *
+ * Source-string assertions on SignInForm.astro, matching the shape of
+ * `signin-microcopy.test.ts`: the client logic lives inside an Astro
+ * `<script>`, so we test the SSR markup directly rather than mounting.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const componentSrc = readFileSync(
+  join(process.cwd(), 'src/components/SignInForm.astro'),
+  'utf8',
+);
+
+function extractButtonClass(id: string): string {
+  const re = new RegExp(`<button[^>]*id="${id}"[^>]*class="([^"]+)"`, 'i');
+  const match = componentSrc.match(re);
+  if (!match) throw new Error(`Could not find #${id} button in SignInForm.astro`);
+  return match[1];
+}
+
+describe('PBI 5.2 — passkey button styling parity', () => {
+  const passkeyClass = extractButtonClass('passkey-btn');
+  const googleClass = extractButtonClass('google-btn');
+  const githubClass = extractButtonClass('github-btn');
+
+  it('passkey button has no emerald-tinted background', () => {
+    expect(passkeyClass.toLowerCase()).not.toMatch(/\bbg-emerald-\d+/);
+    // dark:bg-emerald-* counts too
+    expect(passkeyClass.toLowerCase()).not.toMatch(/bg-emerald-\d/);
+  });
+
+  it('passkey button has no emerald-tinted border', () => {
+    expect(passkeyClass.toLowerCase()).not.toMatch(/border-emerald/);
+  });
+
+  it('passkey button has no emerald-tinted text', () => {
+    expect(passkeyClass.toLowerCase()).not.toMatch(/\btext-emerald-\d+/);
+  });
+
+  it('passkey button has no emerald-tinted hover state', () => {
+    expect(passkeyClass.toLowerCase()).not.toMatch(/hover:bg-emerald/);
+  });
+
+  it('passkey button uses the same neutral OAuth surface as Google', () => {
+    // The neutral OAuth surface: white background, zinc border, zinc text.
+    const expectedTokens = [
+      'bg-white',
+      'dark:bg-zinc-900',
+      'border-zinc-300',
+      'dark:border-zinc-700',
+      'text-zinc-700',
+      'dark:text-zinc-200',
+      'hover:bg-zinc-50',
+      'dark:hover:bg-zinc-800/40',
+    ];
+    for (const token of expectedTokens) {
+      expect(passkeyClass).toContain(token);
+      expect(googleClass).toContain(token);
+    }
+  });
+
+  it('passkey button matches GitHub button on the OAuth surface tokens', () => {
+    const surfaceTokens = [
+      'bg-white',
+      'dark:bg-zinc-900',
+      'border-zinc-300',
+      'dark:border-zinc-700',
+    ];
+    for (const token of surfaceTokens) {
+      expect(passkeyClass).toContain(token);
+      expect(githubClass).toContain(token);
+    }
+  });
+
+  it('passkey button keeps its hidden-until-WebAuthn-detected default', () => {
+    // The reveal logic flips this off via classList.remove('hidden')
+    // when passkeySupported() is true — regression guard for the prior
+    // visibility contract.
+    expect(passkeyClass).toMatch(/\bhidden\b/);
+  });
+});


### PR DESCRIPTION
Implements PBI 5.2 from #1193. The emerald-tinted passkey button wrongly implied it was the recommended default. Swap to the white-bg/gray-border treatment matching Google + GitHub OAuth buttons. Added aria-hidden="true" to the passkey SVG for parity. Tests: 7 unit; build 255 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)