### PR TITLE
perf(explore): /explore/recent/ LCP overhaul — PBI 2.1

### DIFF
--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -220,6 +220,7 @@ const distancePage = page as unknown as Record<string, string>;
   import { getSupabase } from '../lib/supabase';
   import { getCachedUser } from '../lib/supabase';
   import { pickCardImageUrl } from '../lib/media-url';
+  import { buildImageVariants, EXPLORE_CARD_SIZES } from '../lib/image-variants';
   import { formatTimeAgo } from '../lib/social';
   import { wireOverflowMenu } from '../lib/overflow-menu';
   import { showToast } from '../lib/toast';
@@ -302,7 +303,7 @@ const distancePage = page as unknown as Record<string, string>;
     return !!observer.profile_public;
   }
 
-  function rowMarkup(r: Row, lang: Lang, anonLabel: string, unknownLabel: string, shareBase: string, profileBase: string, rgLabel: string, rgTitle: string, viewerAuthed: boolean, viewerId: string | null, labels: Record<string, string>): string {
+  function rowMarkup(r: Row, lang: Lang, anonLabel: string, unknownLabel: string, shareBase: string, profileBase: string, rgLabel: string, rgTitle: string, viewerAuthed: boolean, viewerId: string | null, labels: Record<string, string>, isLCPCandidate: boolean = false): string {
     const ident = pickIdent(r);
     const observer = pickObserver(r);
     const sci = ident?.scientific_name ?? unknownLabel;
@@ -402,6 +403,23 @@ const distancePage = page as unknown as Record<string, string>;
     // Populated (count + pressed state) after batched fetch in paintReactionCounts.
     const faveChipHtml = `<button type="button" class="er-fave-chip hidden inline-flex min-h-[44px] min-w-[44px] items-center justify-center gap-1 rounded-full bg-rose-50 dark:bg-rose-950/40 border border-rose-200 dark:border-rose-900/60 px-3 py-1 text-[11px] font-semibold text-rose-700 dark:text-rose-300 hover:bg-rose-100 dark:hover:bg-rose-950/60 transition-colors disabled:opacity-50" data-fave-target="${escapeText(r.id)}" aria-label="Favorite" aria-pressed="false"><svg class="er-fave-icon w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/></svg><span class="er-fave-count tabular-nums">0</span></button>`;
 
+    // PBI 2.1 (#1193): the first card is the LCP candidate — it gets
+    // fetchpriority=high + loading=eager so the browser stops deferring it
+    // behind the icon/sprite waterfall. Everything else stays lazy. When the
+    // URL is on a Cloudflare resizing host we also emit AVIF + WebP variants
+    // via <picture> so the worker negotiates the best format per client.
+    let photoHtml = '';
+    if (photo) {
+      const v = buildImageVariants(photo);
+      const loadAttrs = isLCPCandidate
+        ? 'loading="eager" fetchpriority="high"'
+        : 'loading="lazy" fetchpriority="auto"';
+      const imgTag = `<img src="${escapeText(v.fallback)}" alt="${escapeText(sci)}" ${loadAttrs} decoding="async" class="w-full h-full object-cover" />`;
+      photoHtml = v.hasVariants
+        ? `<picture><source type="image/avif" srcset="${escapeText(v.avifSrcset)}" sizes="${EXPLORE_CARD_SIZES}" /><source type="image/webp" srcset="${escapeText(v.webpSrcset)}" sizes="${EXPLORE_CARD_SIZES}" />${imgTag}</picture>`
+        : imgTag;
+    }
+
     return `<li class="relative">
       ${overflowHtml}
       <a
@@ -410,7 +428,7 @@ const distancePage = page as unknown as Record<string, string>;
       >
         <div class="relative aspect-square w-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
           ${photo
-            ? `<img src="${escapeText(photo)}" alt="${escapeText(sci)}" loading="lazy" class="w-full h-full object-cover" />`
+            ? photoHtml
             : hasAudioOnly
               ? `<div class="w-full h-full media-player-mount" data-media-url="${escapeText(firstAudioUrl)}" data-media-kind="audio"></div>`
               : hasVideoOnly
@@ -639,8 +657,20 @@ const distancePage = page as unknown as Record<string, string>;
         : photoMedia.length > 1
           ? `<span class="absolute bottom-1 right-1 inline-flex items-center rounded bg-black/60 px-1 py-0.5 text-[9px] text-white font-semibold">📷${photoMedia.length}</span>`
           : '';
+      // PBI 2.1 — list-view thumb is fixed 56 px (w-14), so srcset only
+      // needs 1× / 2× / 3× widths. Lazy + auto priority for every list row
+      // since none of them are the page's LCP element.
+      let listThumbHtml = '';
+      if (photo) {
+        const v = buildImageVariants(photo, [80, 160, 240]);
+        const imgTag = `<img src="${escapeText(v.fallback)}" alt="${escapeText(sciText)}" loading="lazy" decoding="async" class="w-full h-full object-cover" />`;
+        const picture = v.hasVariants
+          ? `<picture><source type="image/avif" srcset="${escapeText(v.avifSrcset)}" sizes="56px" /><source type="image/webp" srcset="${escapeText(v.webpSrcset)}" sizes="56px" />${imgTag}</picture>`
+          : imgTag;
+        listThumbHtml = `<div class="relative w-14 h-14 shrink-0 overflow-hidden rounded-lg bg-zinc-100 dark:bg-zinc-800">${picture}${mediaBadge}</div>`;
+      }
       const thumb = photo
-        ? `<div class="relative w-14 h-14 shrink-0 overflow-hidden rounded-lg bg-zinc-100 dark:bg-zinc-800"><img src="${escapeText(photo)}" alt="${escapeText(sciText)}" loading="lazy" class="w-full h-full object-cover" />${mediaBadge}</div>`
+        ? listThumbHtml
         : hasAudioOnly
           ? `<div class="relative w-14 h-14 rounded-lg shrink-0 bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center" role="img" aria-label="Audio observation"><svg class="w-5 h-5 text-zinc-400 dark:text-zinc-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/></svg></div>`
           : `<div class="w-14 h-14 rounded-lg shrink-0 bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center text-zinc-400 dark:text-zinc-500" role="img" aria-label="No photo"><svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22c4.97 0 9-4.03 9-9 0-3.5-2-6.5-5-8 .5 3-1.5 4.5-3.5 6S9 14 9.5 17C7.5 16 6 13.5 6 11c0 0-2 2-2 5 0 3.31 3.58 6 8 6z"/></svg></div>`;
@@ -999,11 +1029,13 @@ const distancePage = page as unknown as Record<string, string>;
         // Accumulate rows for alternative view modes
         for (const r of page) allRows.push(r);
         if (listEl) {
+          const baseOffset = offset;
           listEl.insertAdjacentHTML(
             'beforeend',
-            page.map(r => {
+            page.map((r, i) => {
               renderedIds.push(r.id);
-              return rowMarkup(r, lang, anonLabel, unknownLabel, shareBase, profileBase, rgLabel, rgTitle, viewerAuthed, viewerId, labels);
+              const isLCP = baseOffset === 0 && i === 0;
+              return rowMarkup(r, lang, anonLabel, unknownLabel, shareBase, profileBase, rgLabel, rgTitle, viewerAuthed, viewerId, labels, isLCP);
             }).join(''),
           );
           wireOverflowMenus(listEl);

--- a/src/lib/image-variants.ts
+++ b/src/lib/image-variants.ts
@@ -1,0 +1,88 @@
+/**
+ * Image-variant URL builder for observation thumbnails.
+ *
+ * PBI 2.1 (#1193) — the explore-recent grid was shipping the full 1200 px
+ * upload to every card, blowing the LCP on `/en/explore/recent/` to ~1.5 s.
+ * R2 stores a single resized JPEG per upload (see module 10) but
+ * `media.rastrum.org` is fronted by Cloudflare's image-resizing endpoint
+ * (`/cdn-cgi/image/...`), so we can derive AVIF / WebP / sized variants by
+ * URL rewrite — no upload pipeline change required.
+ *
+ * When the URL is not on a resizing-enabled host (e.g. Supabase Storage
+ * fallback, local dev, third-party hotlink), `buildImageVariants()`
+ * returns the raw URL only and `hasVariants` is false — callers should
+ * emit a plain `<img>` instead of `<picture>` so we never serve a 404 to
+ * a CDN that has no idea what `/cdn-cgi/image/...` means.
+ */
+
+const DEFAULT_WIDTHS = [320, 640, 1280] as const;
+
+const RESIZING_HOSTS = new Set<string>([
+  'media.rastrum.org',
+]);
+
+export interface ImageVariantSet {
+  /** Raw URL — what `<img src>` falls back to when AVIF/WebP both fail. */
+  fallback: string;
+  /** True when the URL is on a Cloudflare resizing-enabled host. */
+  hasVariants: boolean;
+  /** AVIF srcset entries (e.g. `["url 320w", "url 640w", "url 1280w"]`). */
+  avifSrcset: string;
+  /** WebP srcset entries. */
+  webpSrcset: string;
+}
+
+function getHost(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}
+
+function cdnTransform(url: string, width: number, format: 'avif' | 'webp'): string {
+  // Cloudflare URL-based image resizing:
+  //   https://<host>/cdn-cgi/image/<options>/<origin-path>
+  // The origin path is everything after the host of the original URL.
+  // We re-anchor on the same host so the worker pulls from the same R2
+  // bucket via the same custom-domain binding.
+  const parsed = new URL(url);
+  const opts = `width=${width},format=${format},fit=cover,quality=80`;
+  // Strip any leading slash from the pathname so `/cdn-cgi/image/<opts>/<path>`
+  // has exactly one separator between the option string and the origin path.
+  const path = parsed.pathname.replace(/^\/+/, '');
+  return `${parsed.protocol}//${parsed.host}/cdn-cgi/image/${opts}/${path}${parsed.search}`;
+}
+
+/**
+ * Build a variant set for a single image URL. `widths` defaults to
+ * [320, 640, 1280] which covers mobile-1col → desktop-2col cards. Pass
+ * a smaller set for tiny thumbnails (e.g. list view) to keep the srcset
+ * string short.
+ */
+export function buildImageVariants(
+  url: string | null | undefined,
+  widths: readonly number[] = DEFAULT_WIDTHS,
+): ImageVariantSet {
+  if (!url || !url.trim()) {
+    return { fallback: '', hasVariants: false, avifSrcset: '', webpSrcset: '' };
+  }
+  const trimmed = url.trim();
+  const host = getHost(trimmed);
+  const eligible = !!host && RESIZING_HOSTS.has(host) && !trimmed.includes('/cdn-cgi/image/');
+  if (!eligible) {
+    return { fallback: trimmed, hasVariants: false, avifSrcset: '', webpSrcset: '' };
+  }
+  const avifSrcset = widths.map((w) => `${cdnTransform(trimmed, w, 'avif')} ${w}w`).join(', ');
+  const webpSrcset = widths.map((w) => `${cdnTransform(trimmed, w, 'webp')} ${w}w`).join(', ');
+  return { fallback: trimmed, hasVariants: true, avifSrcset, webpSrcset };
+}
+
+/**
+ * Sizes attribute for the explore-recent card grid:
+ *   - mobile (≤640 px) — 1 col → ~100vw
+ *   - sm+ (≥641 px) — 2 col → ~50vw
+ * Grid view (3-col on md+) hits these same buckets; the 1280 w variant
+ * stays the upper bound at retina-2x desktop widths.
+ */
+export const EXPLORE_CARD_SIZES = '(max-width: 640px) 100vw, 50vw';

--- a/tests/unit/explore-recent-lcp.test.ts
+++ b/tests/unit/explore-recent-lcp.test.ts
@@ -1,0 +1,78 @@
+/**
+ * PBI 2.1 (#1193) — explore-recent LCP fix.
+ *
+ * Lighthouse measured LCP at 1481 ms on `/en/explore/recent/` because the
+ * first observation card was `loading="lazy"` (priority bug) and the
+ * thumbnail shipped at the full 1200 px R2 upload size with no AVIF/WebP
+ * fallback. This spec pins:
+ *   - `fetchpriority="high"` appears in the card-render template
+ *   - `<picture>` wraps the card image with AVIF + WebP sources
+ *   - the `<img>` srcset (via <source>) ships at least 3 widths
+ *   - the first card is the LCP candidate (i === 0 → isLCP=true)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+  resolve(here, '../../src/components/ExploreRecentView.astro'),
+  'utf8',
+);
+
+describe('PBI 2.1 — ExploreRecentView LCP fix', () => {
+  it('imports the image-variants helper', () => {
+    expect(source).toMatch(/import\s*\{\s*buildImageVariants\s*,\s*EXPLORE_CARD_SIZES\s*\}\s*from\s*['"]\.\.\/lib\/image-variants['"]/);
+  });
+
+  it('renders fetchpriority="high" on the LCP candidate card', () => {
+    expect(source).toContain('fetchpriority="high"');
+    // And the non-LCP path stays auto, never high-by-default.
+    expect(source).toContain('fetchpriority="auto"');
+  });
+
+  it('renders loading="eager" only when isLCPCandidate is true', () => {
+    expect(source).toContain('loading="eager"');
+    expect(source).toContain('loading="lazy"');
+    // The eager attr must appear inside the LCP-candidate branch
+    // (right next to fetchpriority="high").
+    const eagerHighRegex = /loading="eager"\s+fetchpriority="high"/;
+    expect(source).toMatch(eagerHighRegex);
+  });
+
+  it('threads the LCP-candidate flag from loadMore (first row of first page)', () => {
+    // The caller marks index 0 of the very first page (baseOffset === 0).
+    expect(source).toMatch(/baseOffset\s*===\s*0\s*&&\s*i\s*===\s*0/);
+    // And forwards it to rowMarkup.
+    expect(source).toMatch(/rowMarkup\([^)]*isLCP\)/);
+  });
+
+  it('wraps card thumbs in <picture> with AVIF + WebP <source> elements', () => {
+    expect(source).toContain('<picture>');
+    expect(source).toContain('type="image/avif"');
+    expect(source).toContain('type="image/webp"');
+    expect(source).toContain('</picture>');
+  });
+
+  it('emits responsive srcset on each <source>', () => {
+    // We pass avifSrcset / webpSrcset into srcset attributes on the sources.
+    expect(source).toMatch(/srcset="\$\{escapeText\(v\.avifSrcset\)\}"/);
+    expect(source).toMatch(/srcset="\$\{escapeText\(v\.webpSrcset\)\}"/);
+  });
+
+  it('uses the EXPLORE_CARD_SIZES attribute on the card <source>', () => {
+    expect(source).toContain('sizes="${EXPLORE_CARD_SIZES}"');
+  });
+
+  it('uses a small custom srcset for the 56px list-view thumb', () => {
+    // List thumb is w-14 (56 px); we pass [80, 160, 240] to keep the
+    // srcset compact and the sizes attr fixed at 56px.
+    expect(source).toMatch(/buildImageVariants\(photo,\s*\[80,\s*160,\s*240\]\)/);
+    expect(source).toContain('sizes="56px"');
+  });
+
+  it('emits decoding="async" so the image decode never blocks the main thread', () => {
+    expect(source).toContain('decoding="async"');
+  });
+});

--- a/tests/unit/image-variants.test.ts
+++ b/tests/unit/image-variants.test.ts
@@ -1,0 +1,70 @@
+/**
+ * PBI 2.1 (#1193) — image-variants URL builder.
+ * Pins the AVIF/WebP/multi-width contract so a careless change to the
+ * Cloudflare resizing URL shape (or the host allowlist) trips this gate.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildImageVariants, EXPLORE_CARD_SIZES } from '../../src/lib/image-variants';
+
+describe('buildImageVariants', () => {
+  it('emits AVIF + WebP srcsets at 320/640/1280 for media.rastrum.org', () => {
+    const v = buildImageVariants('https://media.rastrum.org/observations/abc/primary.jpg');
+    expect(v.hasVariants).toBe(true);
+    expect(v.fallback).toBe('https://media.rastrum.org/observations/abc/primary.jpg');
+    expect(v.avifSrcset).toContain('format=avif');
+    expect(v.avifSrcset).toContain('width=320');
+    expect(v.avifSrcset).toContain('width=640');
+    expect(v.avifSrcset).toContain('width=1280');
+    expect(v.avifSrcset).toMatch(/ 320w/);
+    expect(v.avifSrcset).toMatch(/ 640w/);
+    expect(v.avifSrcset).toMatch(/ 1280w/);
+    expect(v.webpSrcset).toContain('format=webp');
+    expect(v.webpSrcset).toContain('width=320');
+    expect(v.webpSrcset).toContain('width=640');
+    expect(v.webpSrcset).toContain('width=1280');
+  });
+
+  it('rewrites onto the same host via /cdn-cgi/image/ so R2 binding stays intact', () => {
+    const v = buildImageVariants('https://media.rastrum.org/observations/abc/primary.jpg');
+    // The transform URL stays on media.rastrum.org and contains the option string + origin path.
+    expect(v.avifSrcset).toMatch(/^https:\/\/media\.rastrum\.org\/cdn-cgi\/image\//);
+    expect(v.avifSrcset).toContain('/observations/abc/primary.jpg');
+  });
+
+  it('returns raw URL only for non-resizing hosts (Supabase Storage etc.)', () => {
+    const v = buildImageVariants('https://reppvlqejgoqvitturxp.supabase.co/storage/v1/object/public/media/abc.jpg');
+    expect(v.hasVariants).toBe(false);
+    expect(v.fallback).toBe('https://reppvlqejgoqvitturxp.supabase.co/storage/v1/object/public/media/abc.jpg');
+    expect(v.avifSrcset).toBe('');
+    expect(v.webpSrcset).toBe('');
+  });
+
+  it('returns empty fallback for null/undefined/blank input', () => {
+    expect(buildImageVariants(null).fallback).toBe('');
+    expect(buildImageVariants(undefined).fallback).toBe('');
+    expect(buildImageVariants('').fallback).toBe('');
+    expect(buildImageVariants('   ').fallback).toBe('');
+    expect(buildImageVariants(null).hasVariants).toBe(false);
+  });
+
+  it('does not double-wrap an already-transformed URL', () => {
+    const v = buildImageVariants(
+      'https://media.rastrum.org/cdn-cgi/image/width=640,format=auto/observations/abc.jpg',
+    );
+    // Already a /cdn-cgi/image/ URL — treat as opaque, no further rewriting.
+    expect(v.hasVariants).toBe(false);
+    expect(v.avifSrcset).toBe('');
+  });
+
+  it('accepts a custom widths list for tiny thumbnails', () => {
+    const v = buildImageVariants('https://media.rastrum.org/observations/abc/primary.jpg', [80, 160]);
+    expect(v.avifSrcset).toMatch(/ 80w/);
+    expect(v.avifSrcset).toMatch(/ 160w/);
+    expect(v.avifSrcset).not.toMatch(/ 320w/);
+    expect(v.avifSrcset).not.toMatch(/ 1280w/);
+  });
+
+  it('exposes the explore-card sizes attribute', () => {
+    expect(EXPLORE_CARD_SIZES).toBe('(max-width: 640px) 100vw, 50vw');
+  });
+});


### PR DESCRIPTION
Implements PBI 2.1 from #1193. Lighthouse LCP was 1481 ms (3× median); the LCP image was `loading="lazy"` (priority bug). First-card image now ships `fetchpriority="high" loading="eager"`; every other stays lazy. Both card + list-view thumbs use `<picture>` with AVIF + WebP + 320/640/1280 srcset routed through Cloudflare `/cdn-cgi/image/` URL-based resizer for `media.rastrum.org` hosts (graceful fallback for other hosts). New pure helper `src/lib/image-variants.ts` + 16 unit tests + 8/8 e2e green; build 255 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)