### PR TITLE
perf: defer MapLibre CSS + idle-schedule AmbientLight probe — PBI 5.4

### DIFF
--- a/src/components/CommunityMapView.astro
+++ b/src/components/CommunityMapView.astro
@@ -124,7 +124,14 @@ const stringsJson = JSON.stringify({
   </div>
 </section>
 
-<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.0/dist/maplibre-gl.css" />
+<!-- PBI 5.4 — defer MapLibre CSS off the critical path; see MapPicker.astro. -->
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/maplibre-gl@4.7.0/dist/maplibre-gl.css"
+  media="print"
+  onload="this.media='all'; this.onload=null;"
+/>
+<noscript><link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.0/dist/maplibre-gl.css" /></noscript>
 
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';

--- a/src/components/ExploreMap.astro
+++ b/src/components/ExploreMap.astro
@@ -38,7 +38,14 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
   <TimeSlider lang={lang} />
 </div>
 
-<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
+<!-- PBI 5.4 — defer MapLibre CSS off the critical path; see MapPicker.astro. -->
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css"
+  media="print"
+  onload="this.media='all'; this.onload=null;"
+/>
+<noscript><link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" /></noscript>
 
 <script>
   import maplibregl from 'maplibre-gl';

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -229,7 +229,14 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
   </div>
 </section>
 
-<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
+<!-- PBI 5.4 — defer MapLibre CSS off the critical path; see MapPicker.astro. -->
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css"
+  media="print"
+  onload="this.media='all'; this.onload=null;"
+/>
+<noscript><link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" /></noscript>
 
 <script>
   import { getCachedUser, getSupabase } from '../lib/supabase';

--- a/src/components/MapPicker.astro
+++ b/src/components/MapPicker.astro
@@ -150,7 +150,19 @@ const initialLng  = initialCoords?.lng ?? '';
   </>
 )}
 
-<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.0/dist/maplibre-gl.css" />
+<!-- PBI 5.4 — defer MapLibre CSS off the critical path. The map mounts
+     client-side after the layout has painted, so its stylesheet does not
+     need to block first paint. `media="print"` skips the render-blocking
+     parse; `onload` swaps it back to `all` once the network fetch
+     resolves. The `<noscript>` fallback keeps the page styled for users
+     with JS disabled. -->
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/maplibre-gl@4.7.0/dist/maplibre-gl.css"
+  media="print"
+  onload="this.media='all'; this.onload=null;"
+/>
+<noscript><link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.0/dist/maplibre-gl.css" /></noscript>
 
 <script>
   import { MEXICO_DEFAULT_CENTER, isValidLatLng } from '../lib/media-helpers';

--- a/src/components/PublicProfileViewV2.astro
+++ b/src/components/PublicProfileViewV2.astro
@@ -245,7 +245,14 @@ const sponsoringI18n = {
   </article>
 </div>
 
-<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
+<!-- PBI 5.4 — defer MapLibre CSS off the critical path; see MapPicker.astro. -->
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css"
+  media="print"
+  onload="this.media='all'; this.onload=null;"
+/>
+<noscript><link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" /></noscript>
 
 <script type="application/json" id="public-profile-i18n" set:html={JSON.stringify(sponsoringI18n)}></script>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -338,32 +338,44 @@ const resolvedOgImage = ogImage ?? `${SITE_URL}/og/${ogLang}/${ogSlugForPath(cur
         of the API just means manual override is the only path. We never
         prompt for permission unconditionally — the sensor is constructed
         in a try/catch and we listen for SecurityError to back off silently.
+
+        PBI 5.4 — deferred off the critical path via requestIdleCallback.
+        First paint never depends on this probe; we run it once the main
+        thread is idle so it doesn't compete with the theme/field/seasonal
+        boot scripts above.
       */
       (function () {
-        var FIELD_LUX = 5000;
-        var stored = localStorage.getItem('theme');
-        if (stored && stored !== 'auto') return;
-        if (typeof AmbientLightSensor === 'undefined') return;
-        try {
-          var sensor = new AmbientLightSensor({ frequency: 1 });
-          sensor.addEventListener('reading', function () {
-            var lux = sensor.illuminance;
-            if (typeof lux !== 'number') return;
-            var current = localStorage.getItem('theme');
-            if (current && current !== 'auto') return;
-            var el = document.documentElement.classList;
-            if (lux > FIELD_LUX) {
-              el.add('dark'); el.add('field');
-            } else if (el.contains('field')) {
-              el.remove('field');
-              var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-              if (!prefersDark) el.remove('dark');
-            }
-          });
-          sensor.addEventListener('error', function () { /* permission denied or unavailable */ });
-          sensor.start();
-        } catch (e) {
-          /* ReferenceError, SecurityError, NotSupportedError — manual-only fallback */
+        function runAmbientLightProbe() {
+          var FIELD_LUX = 5000;
+          var stored = localStorage.getItem('theme');
+          if (stored && stored !== 'auto') return;
+          if (typeof AmbientLightSensor === 'undefined') return;
+          try {
+            var sensor = new AmbientLightSensor({ frequency: 1 });
+            sensor.addEventListener('reading', function () {
+              var lux = sensor.illuminance;
+              if (typeof lux !== 'number') return;
+              var current = localStorage.getItem('theme');
+              if (current && current !== 'auto') return;
+              var el = document.documentElement.classList;
+              if (lux > FIELD_LUX) {
+                el.add('dark'); el.add('field');
+              } else if (el.contains('field')) {
+                el.remove('field');
+                var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+                if (!prefersDark) el.remove('dark');
+              }
+            });
+            sensor.addEventListener('error', function () { /* permission denied or unavailable */ });
+            sensor.start();
+          } catch (e) {
+            /* ReferenceError, SecurityError, NotSupportedError — manual-only fallback */
+          }
+        }
+        if (typeof requestIdleCallback === 'function') {
+          requestIdleCallback(runAmbientLightProbe, { timeout: 2000 });
+        } else {
+          setTimeout(runAmbientLightProbe, 1000);
         }
       })();
     </script>

--- a/src/pages/en/explore/places/compare/index.astro
+++ b/src/pages/en/explore/places/compare/index.astro
@@ -68,7 +68,14 @@ import BaseLayout from '../../../../../layouts/BaseLayout.astro';
   </div>
 </div>
 
-<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
+<!-- PBI 5.4 — defer MapLibre CSS off the critical path; see MapPicker.astro. -->
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css"
+  media="print"
+  onload="this.media='all'; this.onload=null;"
+/>
+<noscript><link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" /></noscript>
 <script>
   import { getSupabase } from '../../../../../lib/supabase';
 

--- a/src/pages/es/explorar/lugares/comparar/index.astro
+++ b/src/pages/es/explorar/lugares/comparar/index.astro
@@ -39,7 +39,14 @@ import BaseLayout from '../../../../../layouts/BaseLayout.astro';
     </div>
   </div>
 </div>
-<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
+<!-- PBI 5.4 — defer MapLibre CSS off the critical path; see MapPicker.astro. -->
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css"
+  media="print"
+  onload="this.media='all'; this.onload=null;"
+/>
+<noscript><link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" /></noscript>
 <script>
   import { getSupabase } from '../../../../../lib/supabase';
   const params = new URLSearchParams(window.location.search);

--- a/tests/unit/render-blocking.test.ts
+++ b/tests/unit/render-blocking.test.ts
@@ -1,0 +1,116 @@
+/**
+ * PBI 5.4 — render-blocking resources budget.
+ *
+ * Lighthouse's `render-blocking-resources` audit flags external CSS and
+ * synchronous external JS that block first paint. This source-level scan
+ * pins the patterns we apply to keep the audit at 0 ms savings on the 3
+ * priority pages (`/`, `/observe/`, `/sign-in/`):
+ *
+ *   1. The MapLibre CDN stylesheet (≈ 65 KB) is deferred via the
+ *      `media="print" onload="this.media='all'"` pattern in every
+ *      component that mounts a map client-side. A `<noscript>` fallback
+ *      preserves the no-JS path.
+ *   2. No render-blocking external `<link rel="stylesheet">` lives in
+ *      `BaseLayout.astro` — only Astro's bundled CSS reaches the head
+ *      (emitted automatically by the build, critical for first paint).
+ *   3. No external `<script src="…">` is added without `defer` /
+ *      `async` / `type="module"` (which is auto-deferred per the HTML
+ *      spec). Inline boot scripts (theme, consent, SW registration,
+ *      ambient-light) stay synchronous because they must run before
+ *      paint (theme/consent) or are themselves wrapped in
+ *      `addEventListener('load', …)` / `requestIdleCallback(…)`.
+ *
+ * This is a source-level regex scan, not a runtime check. It catches
+ * accidental reintroduction of the blocking pattern at PR time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function read(rel: string): string {
+  return readFileSync(join(ROOT, rel), 'utf8');
+}
+
+/**
+ * Files that historically imported `maplibre-gl.css` from unpkg as a
+ * render-blocking `<link>` and should now ship the deferred pattern.
+ * Adding a new map-using component? Append the path here AND apply the
+ * pattern at the component's link site.
+ */
+const MAPLIBRE_CSS_CONSUMERS = [
+  'src/components/MapPicker.astro',
+  'src/components/ExploreMap.astro',
+  'src/components/ExploreSpeciesView.astro',
+  'src/components/PublicProfileViewV2.astro',
+  'src/components/CommunityMapView.astro',
+  'src/pages/en/explore/places/compare/index.astro',
+  'src/pages/es/explorar/lugares/comparar/index.astro',
+];
+
+describe('PBI 5.4 — render-blocking resources budget', () => {
+  describe('BaseLayout.astro', () => {
+    const layout = read('src/layouts/BaseLayout.astro');
+
+    it('contains zero external <link rel="stylesheet"> (Astro emits the bundled CSS automatically)', () => {
+      // Astro injects the compiled Tailwind/CSS bundle at build time; any
+      // hand-written stylesheet link here is render-blocking and unwanted.
+      const externalLinks = layout.match(/<link[^>]+rel="stylesheet"[^>]*>/g) ?? [];
+      expect(externalLinks).toEqual([]);
+    });
+
+    it('contains zero <script src="…"> (all client-side JS is module-bundled by Astro)', () => {
+      // `<script>` blocks without `src` (i.e. inline) are fine — they're
+      // size-bounded by the layout source and don't fetch from the network.
+      // The concern is external script tags that block parsing.
+      const externalScripts = layout.match(/<script[^>]+src="[^"]+"[^>]*>/g) ?? [];
+      expect(externalScripts).toEqual([]);
+    });
+
+    it('defers the AmbientLightSensor probe via requestIdleCallback', () => {
+      // First paint must not wait on a sensor permission probe.
+      expect(layout).toMatch(/requestIdleCallback\(runAmbientLightProbe/);
+    });
+
+    it('keeps the theme boot script synchronous (must run before first paint)', () => {
+      // Theme resolution writes .dark / .field on <html> before paint to
+      // avoid a flash of wrong-theme. Deferring it would regress UX.
+      expect(layout).toContain("var stored = localStorage.getItem('theme');");
+    });
+  });
+
+  describe('MapLibre CSS consumers — deferred-load pattern', () => {
+    for (const rel of MAPLIBRE_CSS_CONSUMERS) {
+      it(`${rel} uses the media="print" onload pattern for maplibre-gl.css`, () => {
+        const src = read(rel);
+
+        // 1. The href is present (we still ship the stylesheet).
+        expect(src).toMatch(/href="https:\/\/unpkg\.com\/maplibre-gl@[^"]+\/dist\/maplibre-gl\.css"/);
+
+        // 2. At least one occurrence uses the deferred pattern.
+        const deferredPattern =
+          /<link\s+rel="stylesheet"\s+href="https:\/\/unpkg\.com\/maplibre-gl@[^"]+\/dist\/maplibre-gl\.css"\s+media="print"\s+onload="this\.media='all'/;
+        expect(src).toMatch(deferredPattern);
+
+        // 3. There's a <noscript> fallback so users with JS disabled still
+        //    get the stylesheet.
+        expect(src).toMatch(/<noscript><link rel="stylesheet" href="https:\/\/unpkg\.com\/maplibre-gl@[^"]+\/dist\/maplibre-gl\.css" \/><\/noscript>/);
+
+        // 4. No bare render-blocking <link> for maplibre-gl.css remains.
+        //    (Filter out the deferred + noscript lines, then assert.)
+        const lines = src.split('\n');
+        const bareBlockingLinks = lines.filter((line) => {
+          if (!line.includes('maplibre-gl.css')) return false;
+          if (line.includes('media="print"')) return false; // deferred
+          if (line.includes('<noscript>')) return false;    // fallback
+          if (!line.includes('rel="stylesheet"')) return false;
+          return true;
+        });
+        expect(bareBlockingLinks).toEqual([]);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Implements PBI 5.4 from #1193. Defers the 65 KB unpkg MapLibre CSS link emitted on every map-touching component via the Filament Group loadCSS pattern (`media="print" onload="this.media='all'"` + `<noscript>` fallback). AmbientLightSensor probe in BaseLayout moved into `requestIdleCallback` (setTimeout fallback). Critical resources (theme boot, Tailwind bundle, consent script) untouched. Tests: 11 unit + full 3017/3017; `size-limit` clean (no budget regression vs #1173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)