### PR TITLE
fix(a11y): aria-label on avatar + observation links — PBI 3.2

### DIFF
--- a/src/components/CommunityView.astro
+++ b/src/components/CommunityView.astro
@@ -73,6 +73,7 @@ const stringsJson = JSON.stringify({
   obsTpl: cm.card.obs,
   speciesTpl: cm.card.species,
   lastSeenTpl: cm.card.last_seen,
+  profileLinkAriaTpl: cm.card.profile_link_aria ?? 'Open profile: {name}',
   loading: cm.loading,
   emptyNoMatch: cm.empty.no_match,
   emptyNoMatchFilters: cm.empty.no_match_filters,
@@ -196,7 +197,8 @@ const stringsJson = JSON.stringify({
       href={editProfileHref}
       class="inline-block text-emerald-700 dark:text-emerald-400 font-medium hover:underline"
       data-privacy-cta
-    ></a>
+      aria-label={cm.empty.privacy_explainer.cta_edit_profile}
+    >{cm.empty.privacy_explainer.cta_edit_profile}</a>
   </aside>
 
   <nav id="community-pager" class="hidden mt-6 flex items-center justify-between text-sm">
@@ -233,6 +235,7 @@ const stringsJson = JSON.stringify({
     obsTpl: string;
     speciesTpl: string;
     lastSeenTpl: string;
+    profileLinkAriaTpl: string;
     loading: string;
     emptyNoMatch: string;
     emptyNoMatchFilters: string;
@@ -363,10 +366,11 @@ const stringsJson = JSON.stringify({
 
     const karmaRingTier = tierForKarma(row.karma_total ?? 0);
     const karmaRingClass = karmaRingTier.staticRingClass ?? karmaRingTier.ringClass;
+    const profileAriaLabel = STRINGS.profileLinkAriaTpl.replace('{name}', displayName);
     const el = document.createElement('article');
     el.className = 'rounded-lg border border-zinc-200 dark:border-zinc-800 p-4 flex items-start gap-3';
     el.innerHTML = `
-      <a href="${profileHref}" class="flex-none">
+      <a href="${profileHref}" class="flex-none" aria-label="${escapeHtml(profileAriaLabel)}">
         ${row.avatar_url
           ? `<span class="inline-block rounded-full ring-offset-1 ring-offset-white dark:ring-offset-zinc-900 ${escapeHtml(karmaRingClass)}"><img src="${escapeHtml(row.avatar_url)}" alt="" loading="lazy" class="w-12 h-12 rounded-full bg-zinc-200 dark:bg-zinc-800 object-cover block"></span>`
           : `<div class="w-12 h-12 rounded-full bg-emerald-700 text-white flex items-center justify-center font-semibold">${escapeHtml(displayName.slice(0, 1).toUpperCase())}</div>`}

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -72,6 +72,8 @@ const distancePage = page as unknown as Record<string, string>;
   data-label-distance-no-location={distancePage.distance_filter_no_location ?? 'Enable location to filter by distance'}
   data-label-distance-locating={distancePage.distance_filter_locating ?? 'Getting your location…'}
   data-label-distance-show={distancePage.distance_filter_show ?? 'Show observations near me'}
+  data-label-observation-link-aria={distancePage.observation_link_aria ?? 'Open observation: {species}'}
+  data-label-profile-link-aria={distancePage.profile_link_aria ?? 'Open profile: {name}'}
 >
   <header class="space-y-3 py-6">
     <div class="flex items-start justify-between gap-3">
@@ -344,8 +346,9 @@ const distancePage = page as unknown as Record<string, string>;
       ? `<img src="${escapeText(avatarUrl)}" alt="" class="w-full h-full object-cover" loading="lazy" onerror="this.parentElement.innerHTML='<span class=\'text-[8px] font-bold text-emerald-700 dark:text-emerald-300\'>${escapeText(initials)}</span>'" />`
       : `<span class="text-[8px] font-bold text-emerald-700 dark:text-emerald-300">${escapeText(initials)}</span>`;
     const avatarWrapClass = `er-observer-avatar inline-flex h-5 w-5 shrink-0 rounded-full items-center justify-center overflow-hidden bg-emerald-100 dark:bg-emerald-950 ${karmaRingClass} ring-offset-1 ring-offset-white dark:ring-offset-zinc-900`;
+    const avatarAriaLabel = labels.profileLinkAria.replace('{name}', observerName || observerUsername);
     const avatarHtml = isPublic && observerUsername
-      ? `<a href="${profileBase}?username=${encodeURIComponent(observerUsername)}" class="shrink-0" tabindex="-1" aria-hidden="true"><span class="${avatarWrapClass}">${avatarImgHtml}</span></a>`
+      ? `<a href="${profileBase}?username=${encodeURIComponent(observerUsername)}" class="shrink-0" tabindex="-1" aria-label="${escapeText(avatarAriaLabel)}"><span class="${avatarWrapClass}">${avatarImgHtml}</span></a>`
       : '';
 
     const observerHtml = isPublic && observerUsername
@@ -420,11 +423,13 @@ const distancePage = page as unknown as Record<string, string>;
         : imgTag;
     }
 
+    const obsAriaLabel = labels.observationLinkAria.replace('{species}', sci);
     return `<li class="relative">
       ${overflowHtml}
       <a
         href="${shareBase}?id=${encodeURIComponent(r.id)}"
         class="er-card block overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors"
+        aria-label="${escapeText(obsAriaLabel)}"
       >
         <div class="relative aspect-square w-full bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
           ${photo
@@ -476,6 +481,8 @@ const distancePage = page as unknown as Record<string, string>;
       faveAriaOther: root.dataset.labelFaveAriaOther ?? '{{count}} people favorited this',
       timelineToday: root.dataset.labelTimelineToday ?? (lang === 'es' ? 'Hoy' : 'Today'),
       timelineYesterday: root.dataset.labelTimelineYesterday ?? (lang === 'es' ? 'Ayer' : 'Yesterday'),
+      observationLinkAria: root.dataset.labelObservationLinkAria ?? 'Open observation: {species}',
+      profileLinkAria: root.dataset.labelProfileLinkAria ?? 'Open profile: {name}',
     };
 
     const listEl = root.querySelector('.er-list') as HTMLUListElement | null;
@@ -674,7 +681,8 @@ const distancePage = page as unknown as Record<string, string>;
         : hasAudioOnly
           ? `<div class="relative w-14 h-14 rounded-lg shrink-0 bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center" role="img" aria-label="Audio observation"><svg class="w-5 h-5 text-zinc-400 dark:text-zinc-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/></svg></div>`
           : `<div class="w-14 h-14 rounded-lg shrink-0 bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center text-zinc-400 dark:text-zinc-500" role="img" aria-label="No photo"><svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22c4.97 0 9-4.03 9-9 0-3.5-2-6.5-5-8 .5 3-1.5 4.5-3.5 6S9 14 9.5 17C7.5 16 6 13.5 6 11c0 0-2 2-2 5 0 3.31 3.58 6 8 6z"/></svg></div>`;
-      return `<a href="${shareBase}?id=${encodeURIComponent(r.id)}" class="flex items-center gap-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors px-3 py-2">
+      const listObsAriaLabel = labels.observationLinkAria.replace('{species}', sciText);
+      return `<a href="${shareBase}?id=${encodeURIComponent(r.id)}" class="flex items-center gap-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 hover:border-emerald-400 dark:hover:border-emerald-700 transition-colors px-3 py-2" aria-label="${escapeText(listObsAriaLabel)}">
         ${thumb}
         <div class="min-w-0 flex-1">
           <p class="text-sm italic font-semibold text-zinc-900 dark:text-zinc-100 truncate">${escapeText(sciText)}</p>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -584,7 +584,8 @@
       "species": "{n} species",
       "last_seen": "last seen {when}",
       "follow": "Follow",
-      "following": "Following"
+      "following": "Following",
+      "profile_link_aria": "Open profile: {name}"
     },
     "empty": {
       "no_match": "No observers match these filters. Try removing one.",
@@ -2224,7 +2225,9 @@
       "distance_filter_km": "{{km}} km",
       "distance_filter_no_location": "Enable location to filter by distance",
       "distance_filter_locating": "Getting your location…",
-      "distance_filter_show": "Show observations near me"
+      "distance_filter_show": "Show observations near me",
+      "observation_link_aria": "Open observation: {species}",
+      "profile_link_aria": "Open profile: {name}"
     },
     "watchlist": {
       "title": "Watchlist",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -584,7 +584,8 @@
       "species": "{n} especies",
       "last_seen": "última vez {when}",
       "follow": "Seguir",
-      "following": "Siguiendo"
+      "following": "Siguiendo",
+      "profile_link_aria": "Abrir perfil: {name}"
     },
     "empty": {
       "no_match": "Ningún observador coincide con estos filtros. Prueba quitar uno.",
@@ -2224,7 +2225,9 @@
       "distance_filter_km": "{{km}} km",
       "distance_filter_no_location": "Activa la ubicación para filtrar por distancia",
       "distance_filter_locating": "Obteniendo tu ubicación…",
-      "distance_filter_show": "Mostrar observaciones cerca de mí"
+      "distance_filter_show": "Mostrar observaciones cerca de mí",
+      "observation_link_aria": "Abrir observación: {species}",
+      "profile_link_aria": "Abrir perfil: {name}"
     },
     "watchlist": {
       "title": "Seguimiento",

--- a/tests/unit/accessible-links.test.ts
+++ b/tests/unit/accessible-links.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// PBI 3.2 regression guard (UI/UX audit roadmap #1193).
+//
+// Lighthouse `link-name` axe rule fails when an <a> has no programmatically
+// determinable accessible name. The most common cause in this repo is an
+// avatar <img alt=""> wrapped in <a> with no aria-label, or an <a> that
+// wraps only an <svg>. Both pages flagged by the audit
+// (/community/observers/ and /explore/recent/) build their cards from
+// template literals inside <script> blocks, so the test is a source-string
+// grep against the relevant Astro components.
+
+const REPO_ROOT = resolve(__dirname, '../..');
+
+const FILES = [
+  'src/components/CommunityView.astro',
+  'src/components/ExploreRecentView.astro',
+];
+
+/**
+ * Extract every `<a …>…</a>` block from a source string. The parser is
+ * intentionally simple — it handles the multi-line template-literal anchors
+ * used by both components. Returns the inner-tag attribute string plus the
+ * raw block (open tag + children) for child inspection.
+ */
+function extractAnchorBlocks(src: string): Array<{ openTag: string; inner: string; full: string }> {
+  const blocks: Array<{ openTag: string; inner: string; full: string }> = [];
+  // Match `<a` … `>` … `</a>` non-greedy, dotall.
+  const re = /<a\b([^>]*)>([\s\S]*?)<\/a>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) {
+    blocks.push({ openTag: m[1] ?? '', inner: m[2] ?? '', full: m[0] });
+  }
+  return blocks;
+}
+
+/**
+ * Heuristic: does the inner content (between <a>…</a>) contain plain
+ * text that could serve as the accessible name? "Plain text" here means
+ * any non-whitespace character that is not inside an HTML tag and not a
+ * template-literal interpolation that we can't statically resolve.
+ *
+ * If the inner only contains tags (img/svg/span+img/div+svg/…) and no
+ * raw text, the anchor MUST carry aria-label or aria-labelledby.
+ */
+function innerHasPlainText(inner: string): boolean {
+  // Strip every HTML tag and its attributes.
+  const noTags = inner.replace(/<[^>]+>/g, ' ');
+  // Strip template-literal interpolations `${…}` — they may or may not
+  // resolve to text at runtime; if a block depends on `${someText}` for
+  // its accessible name and has no fallback, that's still risky, but it
+  // is out of scope for a static linter. We accept it as text.
+  const withInterp = noTags;
+  // Whitespace-only is "no text".
+  return /\S/.test(withInterp);
+}
+
+function hasAriaLabel(openTag: string): boolean {
+  return /\baria-label\s*=/.test(openTag) || /\baria-labelledby\s*=/.test(openTag);
+}
+
+function isAriaHidden(openTag: string): boolean {
+  // aria-hidden="true" removes the element from the accessibility tree,
+  // so axe's link-name rule does not apply. We still count it as "named"
+  // for this lint.
+  return /\baria-hidden\s*=\s*["']true["']/.test(openTag);
+}
+
+describe('accessible-links — every avatar/icon anchor has aria-label (PBI 3.2)', () => {
+  for (const relPath of FILES) {
+    describe(relPath, () => {
+      const src = readFileSync(resolve(REPO_ROOT, relPath), 'utf8');
+      const anchors = extractAnchorBlocks(src);
+
+      it('finds anchor blocks to scan', () => {
+        expect(anchors.length).toBeGreaterThan(0);
+      });
+
+      it('every <a> that wraps only <img>/<svg>/icon markup carries aria-label or aria-labelledby', () => {
+        const violations: string[] = [];
+        for (const a of anchors) {
+          if (hasAriaLabel(a.openTag)) continue;
+          if (isAriaHidden(a.openTag)) continue;
+          if (innerHasPlainText(a.inner)) continue;
+          // No aria-label, not hidden, no inner text — violation.
+          violations.push(a.full.slice(0, 200).replace(/\s+/g, ' '));
+        }
+        expect(violations).toEqual([]);
+      });
+
+      it('at least one new aria-label is present (positive smoke)', () => {
+        // Both files should have grown an aria-label on at least one
+        // avatar/observation anchor. If somebody reverts the fix, this
+        // catches it.
+        expect(src).toMatch(/aria-label\s*=\s*["'`]/);
+      });
+    });
+  }
+});


### PR DESCRIPTION
Implements PBI 3.2 from #1193. Lighthouse `link-name` failed on /community/observers/ and /explore/recent/ because avatar `<a>` wrappers carried only an `<img>` (or `<svg>` initials) with no programmatically determinable name. Added aria-label across 4 link patterns (CommunityView card row + privacy CTA; ExploreRecentView outer card link + card byline avatar + list-view row outer link). New i18n keys with EN+ES parity. Tests: 6 unit + full 3012/3012; build 255 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)