### PR TITLE
fix(a11y): close remaining color-contrast gaps from audit re-run — PBI 3.1.1

### DIFF
--- a/src/components/ArchitectureView.astro
+++ b/src/components/ArchitectureView.astro
@@ -41,7 +41,7 @@ const intro = isEs
   <!-- ========================================================== -->
   <section>
     <h2 id="overview" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-2 flex items-center gap-2">
-      <span class="text-zinc-400 dark:text-zinc-600 font-mono">01</span>
+      <span class="text-zinc-600 dark:text-zinc-400 font-mono">01</span>
       <a href="#overview" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Vista del sistema' : 'System overview'}</a>
     </h2>
     <p class="text-sm text-zinc-600 dark:text-zinc-400 max-w-3xl mb-4">
@@ -202,7 +202,7 @@ const intro = isEs
   <section>
     <h2 id="cascade" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-2 flex items-center gap-2">
       <span id="identifier-cascade" class="sr-only"></span>
-      <span class="text-zinc-400 dark:text-zinc-600 font-mono">02</span>
+      <span class="text-zinc-600 dark:text-zinc-400 font-mono">02</span>
       <a href="#cascade" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Cascada de identificación' : 'Identification cascade'}</a>
     </h2>
     <p class="text-sm text-zinc-600 dark:text-zinc-400 max-w-3xl mb-4">
@@ -340,7 +340,7 @@ const intro = isEs
   <!-- ========================================================== -->
   <section>
     <h2 id="offline" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-2 flex items-center gap-2">
-      <span class="text-zinc-400 dark:text-zinc-600 font-mono">03</span>
+      <span class="text-zinc-600 dark:text-zinc-400 font-mono">03</span>
       <a href="#offline" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Sincronización offline-first' : 'Offline-first sync flow'}</a>
     </h2>
     <p class="text-sm text-zinc-600 dark:text-zinc-400 max-w-3xl mb-4">
@@ -442,7 +442,7 @@ const intro = isEs
   <!-- ========================================================== -->
   <section>
     <h2 id="auth" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-2 flex items-center gap-2">
-      <span class="text-zinc-400 dark:text-zinc-600 font-mono">04</span>
+      <span class="text-zinc-600 dark:text-zinc-400 font-mono">04</span>
       <a href="#auth" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Auth + superficie de tokens' : 'Auth + token surface'}</a>
     </h2>
     <p class="text-sm text-zinc-600 dark:text-zinc-400 max-w-3xl mb-4">
@@ -564,7 +564,7 @@ const intro = isEs
   <section>
     <h2 id="stack" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-3 flex items-center gap-2">
       <span id="in-browser-ai" class="sr-only"></span>
-      <span class="text-zinc-400 dark:text-zinc-600 font-mono">05</span>
+      <span class="text-zinc-600 dark:text-zinc-400 font-mono">05</span>
       <a href="#stack" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Decisiones de stack' : 'Stack decisions'}</a>
     </h2>
     <div class="not-prose overflow-x-auto rounded-xl border border-zinc-200 dark:border-zinc-800">
@@ -592,7 +592,7 @@ const intro = isEs
   <!-- External services -->
   <section>
     <h2 id="external" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-3 flex items-center gap-2">
-      <span class="text-zinc-400 dark:text-zinc-600 font-mono">06</span>
+      <span class="text-zinc-600 dark:text-zinc-400 font-mono">06</span>
       <a href="#external" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Servicios externos' : 'External services'}</a>
     </h2>
     <div class="not-prose grid sm:grid-cols-2 gap-3">
@@ -608,7 +608,7 @@ const intro = isEs
   <!-- Trade-offs -->
   <section>
     <h2 id="tradeoffs" class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 mb-3 flex items-center gap-2">
-      <span class="text-zinc-400 dark:text-zinc-600 font-mono">07</span>
+      <span class="text-zinc-600 dark:text-zinc-400 font-mono">07</span>
       <a href="#tradeoffs" class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{isEs ? 'Compromisos clave' : 'Key trade-offs'}</a>
     </h2>
     <ul class="space-y-2 text-sm text-zinc-700 dark:text-zinc-300 max-w-3xl list-disc pl-5">

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -88,7 +88,7 @@ if (isDocsPage && docSlug) {
   <nav aria-label="Breadcrumb" class="text-xs text-zinc-600 dark:text-zinc-400 mb-4 flex items-center gap-1.5 overflow-x-auto whitespace-nowrap">
     {trail.map((crumb, i) => (
       <>
-        {i > 0 && <span class="text-zinc-400 dark:text-zinc-600 select-none" aria-hidden="true">›</span>}
+        {i > 0 && <span class="text-zinc-600 dark:text-zinc-400 select-none" aria-hidden="true">›</span>}
         {crumb.href ? (
           <a href={crumb.href} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors shrink-0">{crumb.label}</a>
         ) : (

--- a/src/components/ChatView.astro
+++ b/src/components/ChatView.astro
@@ -53,7 +53,7 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
             {lang === 'es' ? 'Recomendado' : 'Recommended'}
           </span>
         </span>
-        <span class="text-[11px] font-normal text-emerald-100/80 mt-0.5">
+        <span class="text-[11px] font-normal text-white/95 mt-0.5">
           {lang === 'es'
             ? '~500 MB · razona mejor · también para fotos'
             : '~500 MB · stronger reasoning · works for photos too'}

--- a/src/components/CommunityView.astro
+++ b/src/components/CommunityView.astro
@@ -539,7 +539,7 @@ const stringsJson = JSON.stringify({
       next!.disabled = filters.page * COMMUNITY_PAGE_SIZE >= total;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      list!.innerHTML = `<p class="text-sm text-red-600">${escapeHtml(msg)}</p>`;
+      list!.innerHTML = `<p class="text-sm text-red-600 dark:text-red-400">${escapeHtml(msg)}</p>`;
     }
   }
 

--- a/src/components/ConsentBanner.astro
+++ b/src/components/ConsentBanner.astro
@@ -50,7 +50,7 @@ const tr = lang === 'es' ? esStrings.consent : enStrings.consent;
       </button>
       <button
         id="rastrum-consent-accept"
-        class="rounded-lg px-3 py-1.5 text-xs sm:text-sm font-medium bg-emerald-600 text-white hover:bg-emerald-700 transition-colors"
+        class="rounded-lg px-3 py-1.5 text-xs sm:text-sm font-medium bg-emerald-700 text-white hover:bg-emerald-800 transition-colors"
       >
         {tr.accept}
       </button>

--- a/src/components/ConsoleAppealsView.astro
+++ b/src/components/ConsoleAppealsView.astro
@@ -40,7 +40,7 @@ const c = tr.console as unknown as Record<string, string>;
       </aside>
 
       <!-- Right: appeal detail -->
-      <div id="appeals-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+      <div id="appeals-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
         {c.mod_appeals_select_prompt}
       </div>
       <div id="appeals-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 overflow-y-auto space-y-4">

--- a/src/components/ConsoleBadgesView.astro
+++ b/src/components/ConsoleBadgesView.astro
@@ -48,7 +48,7 @@ const tr = t(lang);
     </aside>
 
     <!-- Right: badge detail -->
-    <div id="badges-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+    <div id="badges-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
       {tr.console.badges_select_prompt}
     </div>
     <div id="badges-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-5 overflow-y-auto space-y-5">

--- a/src/components/ConsoleBansView.astro
+++ b/src/components/ConsoleBansView.astro
@@ -44,7 +44,7 @@ const tr = t(lang);
       </aside>
 
       <!-- Right: ban detail -->
-      <div id="bans-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+      <div id="bans-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
         {tr.console.bans_select_prompt}
       </div>
       <div id="bans-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 overflow-y-auto space-y-4">

--- a/src/components/ConsoleBioblitzView.astro
+++ b/src/components/ConsoleBioblitzView.astro
@@ -66,7 +66,7 @@ const tr = t(lang);
       </aside>
 
       <!-- Right: event detail -->
-      <div id="bioblitz-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+      <div id="bioblitz-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
         {tr.console.bioblitz_select_prompt}
       </div>
       <div id="bioblitz-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-5 overflow-y-auto space-y-4">

--- a/src/components/ConsoleCommentsView.astro
+++ b/src/components/ConsoleCommentsView.astro
@@ -51,7 +51,7 @@ const tr = t(lang);
       </aside>
 
       <!-- Right: comment detail -->
-      <div id="modcom-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+      <div id="modcom-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
         {tr.console.modcom_select_prompt}
       </div>
       <div id="modcom-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 overflow-y-auto space-y-4">

--- a/src/components/ConsoleCredentialsView.astro
+++ b/src/components/ConsoleCredentialsView.astro
@@ -38,7 +38,7 @@ const tr = t(lang);
     </aside>
 
     <!-- Right: user detail -->
-    <div id="creds-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+    <div id="creds-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
       {tr.console.users_select_prompt}
     </div>
     <div id="creds-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 overflow-y-auto space-y-5">

--- a/src/components/ConsoleFlagQueueView.astro
+++ b/src/components/ConsoleFlagQueueView.astro
@@ -59,7 +59,7 @@ const tr = t(lang);
       </aside>
 
       <!-- Right: report detail -->
-      <div id="flagq-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+      <div id="flagq-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
         {tr.console.flagq_select_prompt}
       </div>
       <div id="flagq-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 overflow-y-auto space-y-4">
@@ -94,7 +94,7 @@ const tr = t(lang);
             </span>
           </a>
         </div>
-        <p id="flagq-preview-unavailable" class="hidden text-xs text-zinc-400 dark:text-zinc-600 italic">{tr.console.flagq_preview_unavailable}</p>
+        <p id="flagq-preview-unavailable" class="hidden text-xs text-zinc-600 dark:text-zinc-400 italic">{tr.console.flagq_preview_unavailable}</p>
 
         <div id="flagq-detail-note-row" class="hidden text-sm">
           <span class="text-zinc-600 dark:text-zinc-300">{tr.console.flagq_note_label}: </span>

--- a/src/components/ConsoleObservationsView.astro
+++ b/src/components/ConsoleObservationsView.astro
@@ -67,7 +67,7 @@ const tr = t(lang);
       </aside>
 
       <!-- Right: observation detail -->
-      <div id="obs-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+      <div id="obs-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
         {tr.console.obs_select_prompt}
       </div>
       <div id="obs-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 overflow-y-auto space-y-4">

--- a/src/components/ConsoleTaxaView.astro
+++ b/src/components/ConsoleTaxaView.astro
@@ -45,7 +45,7 @@ const tr = t(lang);
     </aside>
 
     <!-- Right: taxon detail -->
-    <div id="taxa-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+    <div id="taxa-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
       {tr.console.taxa_select_prompt}
     </div>
     <div id="taxa-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-5 overflow-y-auto space-y-5">

--- a/src/components/ConsoleUsersView.astro
+++ b/src/components/ConsoleUsersView.astro
@@ -40,7 +40,7 @@ const tr = t(lang);
     </aside>
 
     <!-- Right: user detail -->
-    <div id="users-detail-empty" class="flex items-center justify-center text-sm text-zinc-400 dark:text-zinc-600 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
+    <div id="users-detail-empty" class="flex items-center justify-center text-sm text-zinc-600 dark:text-zinc-400 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg">
       {tr.console.users_select_prompt}
     </div>
     <div id="users-detail" class="hidden border border-zinc-200 dark:border-zinc-800 rounded-lg p-4 overflow-y-auto space-y-5">

--- a/src/components/DropZone.astro
+++ b/src/components/DropZone.astro
@@ -96,7 +96,7 @@ const editPhotoLabel = isEs ? 'Editar foto' : 'Edit photo';
       </button>
     </div>
 
-    <p class="text-[10px] text-zinc-400 dark:text-zinc-600 mt-1">{pasteHint}</p>
+    <p class="text-[10px] text-zinc-600 dark:text-zinc-400 mt-1">{pasteHint}</p>
   </div>
 
   <!-- Drag-over overlay -->

--- a/src/components/ExploreMapView.astro
+++ b/src/components/ExploreMapView.astro
@@ -144,7 +144,7 @@ const copy = {
         <button
           id="explore-filter-apply"
           type="submit"
-          class="rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-1.5 text-xs font-semibold text-white transition-colors"
+          class="rounded-lg bg-emerald-700 hover:bg-emerald-800 px-4 py-1.5 text-xs font-semibold text-white transition-colors"
         >{copy.applyLabel}</button>
       </div>
     </form>

--- a/src/components/FeaturesView.astro
+++ b/src/components/FeaturesView.astro
@@ -291,7 +291,7 @@ const heroSub = isEs
         </span>
         <div>
           <h2 id={s.id} class="text-xl font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-2">
-            <span class="text-zinc-400 dark:text-zinc-600 font-mono text-base">{String(idx + 1).padStart(2, '0')}</span>
+            <span class="text-zinc-600 dark:text-zinc-400 font-mono text-base">{String(idx + 1).padStart(2, '0')}</span>
             <a href={`#${s.id}`} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{s.title}</a>
           </h2>
           <p class="text-sm text-zinc-600 dark:text-zinc-400 max-w-2xl mt-1 leading-relaxed">{s.blurb}</p>
@@ -308,7 +308,7 @@ const heroSub = isEs
     </section>
   ))}
 
-  <p class="text-xs text-zinc-600 dark:text-zinc-600 pt-4 border-t border-zinc-200 dark:border-zinc-800">
+  <p class="text-xs text-zinc-600 dark:text-zinc-300 pt-4 border-t border-zinc-200 dark:border-zinc-800">
     {isEs
       ? 'Fuente de la verdad: docs/progress.json (v0.1 → v1.0 ítems hechos), src/lib/identifiers/index.ts (plugins registrados) y supabase/functions/ (Edge Functions desplegadas).'
       : 'Source of truth: docs/progress.json (v0.1 → v1.0 done items), src/lib/identifiers/index.ts (registered plugins), and supabase/functions/ (deployed Edge Functions).'}

--- a/src/components/PipelineStepper.astro
+++ b/src/components/PipelineStepper.astro
@@ -102,7 +102,7 @@ const labels = {
     aria-atomic="true"
   ></p>
 
-  <p class="mt-1 text-center text-[10px] text-zinc-400 dark:text-zinc-600">
+  <p class="mt-1 text-center text-[10px] text-zinc-600 dark:text-zinc-400">
     {labels.tapHint}
   </p>
 </div>

--- a/src/components/RoadmapView.astro
+++ b/src/components/RoadmapView.astro
@@ -241,11 +241,11 @@ const payloadJson = JSON.stringify({
                   "text-lg font-bold tabular-nums",
                   pct === 100 ? "text-sky-600 dark:text-sky-400" :
                   pct > 0     ? "text-emerald-600 dark:text-emerald-400" :
-                                "text-zinc-400 dark:text-zinc-600"
+                                "text-zinc-600 dark:text-zinc-400"
                 ]}>
-                  {doneCount}<span class="text-zinc-400 dark:text-zinc-600 font-normal">/{total}</span>
+                  {doneCount}<span class="text-zinc-600 dark:text-zinc-400 font-normal">/{total}</span>
                 </span>
-                <p class="text-[10px] text-zinc-400 dark:text-zinc-600 uppercase tracking-wide">{itemsLabel}</p>
+                <p class="text-[10px] text-zinc-600 dark:text-zinc-400 uppercase tracking-wide">{itemsLabel}</p>
               </div>
             </div>
 
@@ -337,7 +337,7 @@ const payloadJson = JSON.stringify({
     </div>
   )}
 
-  <p class="text-xs text-zinc-600 dark:text-zinc-600 px-1 pt-2">{helpText}</p>
+  <p class="text-xs text-zinc-600 dark:text-zinc-300 px-1 pt-2">{helpText}</p>
 
   <script type="application/json" data-roadmap-data set:html={payloadJson}></script>
 

--- a/src/components/TasksView.astro
+++ b/src/components/TasksView.astro
@@ -172,11 +172,11 @@ const updated = isEs ? 'Actualizado' : 'Updated';
                     <span class:list={[
                       "text-sm font-semibold",
                       prog.pct === 100 ? "text-sky-600 dark:text-sky-400" :
-                      prog.pct > 0 ? "text-emerald-600 dark:text-emerald-400" : "text-zinc-400 dark:text-zinc-600"
+                      prog.pct > 0 ? "text-emerald-600 dark:text-emerald-400" : "text-zinc-600 dark:text-zinc-400"
                     ]}>
                       {prog.done}/{prog.total}
                     </span>
-                    <p class="text-xs text-zinc-400 dark:text-zinc-600">{isEs ? 'subtareas' : 'subtasks'}</p>
+                    <p class="text-xs text-zinc-600 dark:text-zinc-400">{isEs ? 'subtareas' : 'subtasks'}</p>
                   </div>
                 </summary>
 
@@ -217,7 +217,7 @@ const updated = isEs ? 'Actualizado' : 'Updated';
     );
   })}
 
-  <p class="text-xs text-zinc-600 dark:text-zinc-600 mt-8">
+  <p class="text-xs text-zinc-600 dark:text-zinc-300 mt-8">
     {isEs ? 'Edita ' : 'Edit '}<code class="bg-zinc-100 dark:bg-zinc-800 px-1 rounded">docs/tasks.json</code>
     {isEs ? ' para actualizar. La página se reconstruye en cada push.' : ' to update. The page rebuilds on every push.'}
   </p>

--- a/src/components/TimeSlider.astro
+++ b/src/components/TimeSlider.astro
@@ -65,7 +65,7 @@ const showingAll = slider.showing_all ?? 'Showing all months';
   >
     <button
       type="button"
-      class="ts-btn snap-start shrink-0 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border border-zinc-300 dark:border-zinc-700 px-4 py-2 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"
+      class="ts-btn snap-start shrink-0 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border border-zinc-300 dark:border-zinc-700 px-4 py-2 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-800 data-[active=true]:text-white data-[active=true]:border-emerald-800"
       data-month="all"
       data-active="true"
       role="radio"
@@ -76,7 +76,7 @@ const showingAll = slider.showing_all ?? 'Showing all months';
     {months.map((label, i) => (
       <button
         type="button"
-        class="ts-btn snap-start shrink-0 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-700 data-[active=true]:text-white data-[active=true]:border-emerald-700"
+        class="ts-btn snap-start shrink-0 inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-xs font-semibold text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 data-[active=true]:bg-emerald-800 data-[active=true]:text-white data-[active=true]:border-emerald-800"
         data-month={String(i)}
         data-active="false"
         role="radio"

--- a/src/layouts/DocLayout.astro
+++ b/src/layouts/DocLayout.astro
@@ -41,7 +41,7 @@ const crumbs: { name: string; url?: string }[] = sectionLabel
     <a href={getDocPath(lang)} class="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Docs</a>
     {section && (
       <>
-        <span class="text-zinc-400 dark:text-zinc-600">/</span>
+        <span class="text-zinc-600 dark:text-zinc-400">/</span>
         <span class="text-zinc-900 dark:text-zinc-100">{title}</span>
       </>
     )}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -154,21 +154,21 @@ const explorePath = getLocalizedPath(lang, routes.explore[lang as 'en' | 'es'] +
     {/* --- Field Notes Metadata --- */}
     <div class="w-full max-w-sm mx-auto mt-4">
       <div class="border border-zinc-200 dark:border-zinc-800 rounded-lg bg-zinc-50 dark:bg-zinc-900/50 p-4 font-mono text-xs text-left space-y-1.5">
-        <p class="text-zinc-600 dark:text-zinc-600 uppercase tracking-widest text-[10px] mb-2 border-b border-zinc-200 dark:border-zinc-800 pb-1.5">
+        <p class="text-zinc-600 dark:text-zinc-300 uppercase tracking-widest text-[10px] mb-2 border-b border-zinc-200 dark:border-zinc-800 pb-1.5">
           {txt.field_label} #RST-404
         </p>
         <div class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
-          <span class="text-zinc-400 dark:text-zinc-600">{txt.catalog}</span>
+          <span class="text-zinc-600 dark:text-zinc-400">{txt.catalog}</span>
           <span class="text-zinc-600 dark:text-zinc-400">{txt.catalogVal}</span>
-          <span class="text-zinc-400 dark:text-zinc-600">{txt.coords}</span>
+          <span class="text-zinc-600 dark:text-zinc-400">{txt.coords}</span>
           <span class="text-zinc-600 dark:text-zinc-400">{txt.coordsVal}</span>
-          <span class="text-zinc-400 dark:text-zinc-600">{txt.status}</span>
+          <span class="text-zinc-600 dark:text-zinc-400">{txt.status}</span>
           <span class="text-red-500 dark:text-red-400">{txt.statusVal}</span>
-          <span class="text-zinc-400 dark:text-zinc-600">{txt.confidence}</span>
+          <span class="text-zinc-600 dark:text-zinc-400">{txt.confidence}</span>
           <span class="text-zinc-600 dark:text-zinc-400">{txt.confidenceVal}</span>
-          <span class="text-zinc-400 dark:text-zinc-600">{txt.observer}</span>
+          <span class="text-zinc-600 dark:text-zinc-400">{txt.observer}</span>
           <span class="text-zinc-600 dark:text-zinc-400">{txt.observerVal}</span>
-          <span class="text-zinc-400 dark:text-zinc-600">{txt.date}</span>
+          <span class="text-zinc-600 dark:text-zinc-400">{txt.date}</span>
           <span class="text-zinc-600 dark:text-zinc-400">{txt.dateVal}</span>
         </div>
       </div>

--- a/src/pages/en/docs/funding.astro
+++ b/src/pages/en/docs/funding.astro
@@ -10,7 +10,7 @@ const tr = t(lang);
   <article class="space-y-8">
     <div>
       <h1 class="text-3xl font-bold tracking-tight mb-4">{tr.docs.sections.funding}</h1>
-      <p class="text-lg text-zinc-600 dark:text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.funding}</p>
+      <p class="text-lg text-zinc-600 dark:text-zinc-300 max-w-3xl">{tr.docs.descriptions.funding}</p>
     </div>
 
     <!-- Dual Entity -->

--- a/src/pages/en/docs/indigenous.astro
+++ b/src/pages/en/docs/indigenous.astro
@@ -10,7 +10,7 @@ const tr = t(lang);
   <article class="space-y-8">
     <div>
       <h1 class="text-3xl font-bold tracking-tight mb-4">{tr.docs.sections.indigenous}</h1>
-      <p class="text-lg text-zinc-600 dark:text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.indigenous}</p>
+      <p class="text-lg text-zinc-600 dark:text-zinc-300 max-w-3xl">{tr.docs.descriptions.indigenous}</p>
     </div>
 
     <!-- CARE Principles -->

--- a/src/pages/en/docs/market.astro
+++ b/src/pages/en/docs/market.astro
@@ -22,7 +22,7 @@ const matrix = [
 function cellDisplay(v: boolean | string) {
   if (v === true)      return { text: '\u2713', cls: 'text-emerald-600 dark:text-emerald-400 font-bold' };
   if (v === 'partial') return { text: '~',      cls: 'text-yellow-600 dark:text-yellow-400' };
-  return                       { text: '\u2717', cls: 'text-zinc-600 dark:text-zinc-400 dark:text-zinc-600' };
+  return                       { text: '\u2717', cls: 'text-zinc-600 dark:text-zinc-600 dark:text-zinc-400' };
 }
 ---
 
@@ -30,7 +30,7 @@ function cellDisplay(v: boolean | string) {
   <article class="space-y-8">
     <div>
       <h1 class="text-3xl font-bold tracking-tight mb-4">{tr.docs.sections.market}</h1>
-      <p class="text-lg text-zinc-600 dark:text-zinc-600 dark:text-zinc-400 max-w-3xl">{tr.docs.descriptions.market}</p>
+      <p class="text-lg text-zinc-600 dark:text-zinc-300 max-w-3xl">{tr.docs.descriptions.market}</p>
     </div>
 
     <!-- Competitive Matrix -->
@@ -63,12 +63,12 @@ function cellDisplay(v: boolean | string) {
             ))}
           </tbody>
         </table>
-        <p class="text-xs text-zinc-600 dark:text-zinc-400 dark:text-zinc-600 mt-2">
+        <p class="text-xs text-zinc-600 dark:text-zinc-600 dark:text-zinc-400 mt-2">
           <span class="text-emerald-600 dark:text-emerald-400 font-bold">{'\u2713'}</span> full support
           <span class="mx-2 text-zinc-700 dark:text-zinc-300 dark:text-zinc-700">|</span>
           <span class="text-yellow-600 dark:text-yellow-400">~</span> partial
           <span class="mx-2 text-zinc-700 dark:text-zinc-300 dark:text-zinc-700">|</span>
-          <span class="text-zinc-600 dark:text-zinc-400 dark:text-zinc-600">{'\u2717'}</span> not supported
+          <span class="text-zinc-600 dark:text-zinc-600 dark:text-zinc-400">{'\u2717'}</span> not supported
         </p>
       </div>
     </section>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -28,7 +28,7 @@ const tr = t(lang);
         class="inline-flex flex-col items-center px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
       >
         <span>{tr.home.cta}</span>
-        <span class="text-xs font-normal opacity-80">{tr.home.cta_subtitle}</span>
+        <span class="text-xs font-normal opacity-95">{tr.home.cta_subtitle}</span>
       </a>
       <!-- Secondary CTAs -->
       <a

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -28,7 +28,7 @@ const tr = t(lang);
         class="inline-flex flex-col items-center px-6 py-3 bg-emerald-700 hover:bg-emerald-800 text-white font-medium rounded-lg transition-colors"
       >
         <span>{tr.home.cta}</span>
-        <span class="text-xs font-normal opacity-80">{tr.home.cta_subtitle}</span>
+        <span class="text-xs font-normal opacity-95">{tr.home.cta_subtitle}</span>
       </a>
       <!-- CTAs secundarios -->
       <a

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -512,7 +512,7 @@ const lang: 'en' | 'es' = 'en';
                 if (!isLoggedIn) {
                   // Not logged in: show read-only count, disable button with hint
                   btnEl.textContent = isEs ? '\ud83d\udcf8 Inicia sesi\u00f3n para nominar' : '\ud83d\udcf8 Sign in to nominate';
-                  btnEl.className = 'text-xs text-zinc-400 dark:text-zinc-600 cursor-not-allowed';
+                  btnEl.className = 'text-xs text-zinc-600 dark:text-zinc-400 cursor-not-allowed';
                   btnEl.disabled = true;
                   btnEl.title = isEs ? 'Necesitas iniciar sesi\u00f3n para nominar fotos' : 'You need to sign in to nominate photos';
                 } else {


### PR DESCRIPTION
Audit re-run on the 17/17-shipped roadmap (#1193) revealed 9 unique elements still failing `color-contrast` across 13 pages, in two patterns:

**1. Brand emerald-600 buttons with white text** (3.76 contrast, below AA 4.5):
- ConsentBanner accept button → `bg-emerald-700 hover:bg-emerald-800` (13 pages affected)
- ExploreMapView filter-apply, TimeSlider active button → `-800`
- Home CTA inner subtitle `opacity-80` → `opacity-95`
- Chat Gemma download span `text-emerald-100/80` → `text-white/95`

**2. Zinc patterns the PBI 3.1 sweep missed:**
- `text-zinc-400 dark:text-zinc-600` (RoadmapView stats, DropZone) → canonical `text-zinc-600 dark:text-zinc-400`
- `text-zinc-600 dark:text-zinc-600` (PBI 3.1 wrote the wrong dark variant — FeaturesView, RoadmapView, TasksView, 404, 3 docs pages) → `text-zinc-600 dark:text-zinc-300`
- CommunityView error message → `text-red-600 dark:text-red-400`

## Audit verdict
**Before PBI 3.1:** 13/13 FAIL  
**After PBI 3.1 only:** 1/13 PASS  
**After this PR:** **13/13 PASS** ✓ — confirmed by lhci re-run

Ratchet test (`tests/unit/color-contrast-policy.test.ts`) still passes: zero `text-zinc-500` defaults, zero `dark:text-zinc-500` anywhere.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest` ratchet 3/3 pass
- [x] `npm run build` 255 pages
- [x] `npx lhci autorun` color-contrast 13/13 PASS
- [ ] Post-merge: confirm prod Lighthouse matches

## Out of scope (follow-up)
20 other `text-red-600` sites without dark variants exist but aren't visible to Lighthouse (error states / dynamic renders). They're the same a11y class; file as a v1.1 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)