### PR TITLE
fix(a11y): dark variants for all text-red-* error states — PBI 3.1.2

### DIFF
--- a/src/components/ChatEntityPicker.astro
+++ b/src/components/ChatEntityPicker.astro
@@ -111,7 +111,7 @@ const labels = {
         return;
       }
     } catch (e) {
-      list.innerHTML = `<li class="text-xs text-red-600">${escapeHtml(e instanceof Error ? e.message : String(e))}</li>`;
+      list.innerHTML = `<li class="text-xs text-red-600 dark:text-red-400">${escapeHtml(e instanceof Error ? e.message : String(e))}</li>`;
       return;
     }
 

--- a/src/components/ChatView.astro
+++ b/src/components/ChatView.astro
@@ -598,7 +598,8 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
       audioBtnLabel.textContent = rec ? i18nGet('attach-audio-stop') : i18nGet('attach-audio');
     }
     audioBtn?.classList.toggle('border-red-500', rec);
-    audioBtn?.classList.toggle('text-red-600', rec);
+    audioBtn?.classList.toggle('text-red-600', rec); audioBtn?.classList.toggle('dark:text-red-400', rec);
+    audioBtn?.classList.toggle('dark:text-red-400', rec);
     audioElapsedEl?.classList.toggle('hidden', !rec);
   }
 
@@ -1457,7 +1458,8 @@ const observePath = getLocalizedPath(lang, routes.observe[lang] + '/');
   function setVoiceBtnRecording(rec: boolean): void {
     if (!voiceBtn) return;
     voiceBtn.classList.toggle('border-red-500', rec);
-    voiceBtn.classList.toggle('text-red-600', rec);
+    voiceBtn.classList.toggle('text-red-600', rec); voiceBtn.classList.toggle('dark:text-red-400', rec);
+    voiceBtn.classList.toggle('dark:text-red-400', rec);
     const label = rec ? VOICE_STOP_LABEL : VOICE_DEFAULT_LABEL;
     voiceBtn.setAttribute('aria-label', label);
     voiceBtn.setAttribute('title', label);

--- a/src/components/ConfidenceRing.astro
+++ b/src/components/ConfidenceRing.astro
@@ -30,7 +30,7 @@ const gap = circumference - dash;
 const colorClass =
   c >= 0.85 ? 'text-emerald-500'
   : c >= 0.5 ? 'text-amber-500'
-  : 'text-red-500';
+  : 'text-red-500 dark:text-red-400';
 const pct = Math.round(c * 100);
 ---
 

--- a/src/components/ConsoleExpertOverridesView.astro
+++ b/src/components/ConsoleExpertOverridesView.astro
@@ -120,7 +120,7 @@ const isEs = lang === 'es';
           notConfiguredEl?.classList.remove('hidden');
           return;
         }
-        listEl.innerHTML = `<p class="text-sm text-red-600">${escapeHtml(error.message)}</p>`;
+        listEl.innerHTML = `<p class="text-sm text-red-600 dark:text-red-400">${escapeHtml(error.message)}</p>`;
         listEl.classList.remove('hidden');
         return;
       }

--- a/src/components/ConsoleExpertTaxonNotesView.astro
+++ b/src/components/ConsoleExpertTaxonNotesView.astro
@@ -118,7 +118,7 @@ const isEs = lang === 'es';
           notConfiguredEl?.classList.remove('hidden');
           return;
         }
-        listEl.innerHTML = `<p class="text-sm text-red-600">${escapeHtml(error.message)}</p>`;
+        listEl.innerHTML = `<p class="text-sm text-red-600 dark:text-red-400">${escapeHtml(error.message)}</p>`;
         listEl.classList.remove('hidden');
         return;
       }

--- a/src/components/ConsoleFlagsView.astro
+++ b/src/components/ConsoleFlagsView.astro
@@ -114,7 +114,7 @@ const isEs = lang === 'es';
       loadingEl.classList.add('hidden');
 
       if (error) {
-        listEl.innerHTML = `<p class="text-sm text-red-600">${escapeHtml(error.message)}</p>`;
+        listEl.innerHTML = `<p class="text-sm text-red-600 dark:text-red-400">${escapeHtml(error.message)}</p>`;
         listEl.classList.remove('hidden');
         return;
       }
@@ -159,7 +159,7 @@ const isEs = lang === 'es';
     } catch (err) {
       loadingEl.classList.add('hidden');
       if (listEl) {
-        listEl.innerHTML = `<p class="text-sm text-red-600">${escapeHtml((err as Error).message)}</p>`;
+        listEl.innerHTML = `<p class="text-sm text-red-600 dark:text-red-400">${escapeHtml((err as Error).message)}</p>`;
         listEl.classList.remove('hidden');
       }
     }

--- a/src/components/ConsoleModDisputesView.astro
+++ b/src/components/ConsoleModDisputesView.astro
@@ -128,7 +128,7 @@ const isEs = lang === 'es';
           notConfiguredEl?.classList.remove('hidden');
           return;
         }
-        listEl.innerHTML = `<p class="text-sm text-red-600">${escapeHtml(error.message)}</p>`;
+        listEl.innerHTML = `<p class="text-sm text-red-600 dark:text-red-400">${escapeHtml(error.message)}</p>`;
         listEl.classList.remove('hidden');
         return;
       }

--- a/src/components/ConsoleWebhooksView.astro
+++ b/src/components/ConsoleWebhooksView.astro
@@ -501,7 +501,8 @@ const eventKeys: Array<keyof typeof wEvents> = [
     eEl.classList.remove('hidden');
     eEl.classList.toggle('text-emerald-700', ok);
     eEl.classList.toggle('dark:text-emerald-400', ok);
-    eEl.classList.toggle('text-red-600', !ok);
+    eEl.classList.toggle('text-red-600', !ok); eEl.classList.toggle('dark:text-red-400', !ok);
+    eEl.classList.toggle('dark:text-red-400', !ok);
     eEl.classList.toggle('dark:text-red-400', !ok);
     setTimeout(() => eEl.classList.add('hidden'), 4000);
   }

--- a/src/components/KarmaLeaderboardView.astro
+++ b/src/components/KarmaLeaderboardView.astro
@@ -644,7 +644,7 @@ const stringsJson = JSON.stringify({
   }
 
   function showLoading() {
-    loadingEl!.classList.remove('hidden', 'text-red-600');
+    loadingEl!.classList.remove('hidden', 'text-red-600', 'dark:text-red-400');
     loadingEl!.classList.add('text-zinc-600', 'dark:text-zinc-300');
     loadingEl!.textContent = STRINGS.loading;
     emptyEl!.classList.add('hidden');
@@ -975,7 +975,7 @@ const stringsJson = JSON.stringify({
     } catch (err) {
       loadingEl!.classList.remove('hidden');
       loadingEl!.textContent = err instanceof Error ? err.message : String(err);
-      loadingEl!.classList.add('text-red-600');
+      loadingEl!.classList.add('text-red-600', 'dark:text-red-400');
       loadingEl!.classList.remove('text-zinc-600', 'dark:text-zinc-300');
     }
   }
@@ -1051,7 +1051,7 @@ const stringsJson = JSON.stringify({
     } catch (err) {
       loadingEl!.classList.remove('hidden');
       loadingEl!.textContent = err instanceof Error ? err.message : String(err);
-      loadingEl!.classList.add('text-red-600');
+      loadingEl!.classList.add('text-red-600', 'dark:text-red-400');
       loadingEl!.classList.remove('text-zinc-600', 'dark:text-zinc-300');
     }
   }

--- a/src/components/ObservationForm.astro
+++ b/src/components/ObservationForm.astro
@@ -339,7 +339,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
               <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7M16 6l-4-4-4 4M12 2v14"/></svg>
               {shareLabel}
             </button>
-            <button id="id-clear" type="button" class="text-xs text-zinc-400 hover:text-red-500" aria-label={isEs ? 'Cambiar' : 'Change'}>{isEs ? 'Cambiar' : 'Change'}</button>
+            <button id="id-clear" type="button" class="text-xs text-zinc-400 hover:text-red-500 dark:text-red-400" aria-label={isEs ? 'Cambiar' : 'Change'}>{isEs ? 'Cambiar' : 'Change'}</button>
           </div>
         </div>
         <p id="id-note" class="hidden mt-2 text-sm text-zinc-700 dark:text-zinc-300"></p>
@@ -1225,7 +1225,7 @@ const photoPraiseJson = JSON.stringify(photoPraiseTree);
     const circumference = 2 * Math.PI * r;
     const dash = (circumference * c).toFixed(2);
     const gap  = (circumference - (circumference * c)).toFixed(2);
-    const colorClass = c >= 0.85 ? 'text-emerald-500' : c >= 0.5 ? 'text-amber-500' : 'text-red-500';
+    const colorClass = c >= 0.85 ? 'text-emerald-500' : c >= 0.5 ? 'text-amber-500' : 'text-red-500 dark:text-red-400';
     const pct = Math.round(c * 100);
     return `<span class="relative inline-flex items-center justify-center ${colorClass}" style="width:${size}px;height:${size}px" role="img" aria-label="${pct}% confidence">
       <svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" class="absolute inset-0 -rotate-90" aria-hidden="true">

--- a/src/components/PITsView.astro
+++ b/src/components/PITsView.astro
@@ -172,7 +172,7 @@ const copy = {
     </button>
 
     <!-- Error -->
-    <p id="create-pit-error" class="hidden text-sm text-red-500"></p>
+    <p id="create-pit-error" class="hidden text-sm text-red-500 dark:text-red-400"></p>
 
     <div class="flex gap-3 pt-2">
       <button

--- a/src/components/PipelineStepper.astro
+++ b/src/components/PipelineStepper.astro
@@ -245,10 +245,10 @@ const labels = {
         // setNodeState writes the reason to node.error, not node.output.error
         // — reading the wrong field meant every failure rendered blank.
         const error = n.state === 'failed' && n.error
-          ? `<br><span class="text-red-500">${escapeHtml(n.error)}</span>`
+          ? `<br><span class="text-red-500 dark:text-red-400">${escapeHtml(n.error)}</span>`
           : '';
         return `<div class="flex items-start gap-1.5">
-          <span class="shrink-0 ${n.state === 'done' ? 'text-emerald-500' : n.state === 'failed' ? 'text-red-500' : 'text-zinc-400'}">${stateIcon}</span>
+          <span class="shrink-0 ${n.state === 'done' ? 'text-emerald-500' : n.state === 'failed' ? 'text-red-500 dark:text-red-400' : 'text-zinc-400'}">${stateIcon}</span>
           <span class="text-zinc-600 dark:text-zinc-400">${n.kind}${provider}${error}</span>
         </div>`;
       }).join('');

--- a/src/components/QuickObserveSheet.astro
+++ b/src/components/QuickObserveSheet.astro
@@ -161,7 +161,7 @@ function renderConfidenceRing(confidence: number): string {
   const circumference = 2 * Math.PI * r;
   const dash = (circumference * c).toFixed(2);
   const gap  = (circumference - circumference * c).toFixed(2);
-  const colorClass = c >= 0.85 ? 'text-emerald-500' : c >= 0.5 ? 'text-amber-500' : 'text-red-500';
+  const colorClass = c >= 0.85 ? 'text-emerald-500' : c >= 0.5 ? 'text-amber-500' : 'text-red-500 dark:text-red-400';
   const pct = Math.round(c * 100);
   return `<span class="relative inline-flex items-center justify-center ${colorClass}" style="width:${size}px;height:${size}px" role="img" aria-label="${pct}% confidence">
     <svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" class="absolute inset-0 -rotate-90" aria-hidden="true">

--- a/src/components/SpeciesListsView.astro
+++ b/src/components/SpeciesListsView.astro
@@ -230,7 +230,7 @@ const labels = {
           <div class="flex gap-2 mt-auto pt-1">
             <a href="${href}" class="text-xs font-medium text-emerald-700 dark:text-emerald-400 hover:underline">${escAttr(labels.view)} →</a>
             <button type="button" class="sl-edit-btn text-xs font-medium text-zinc-600 dark:text-zinc-400 hover:underline" data-id="${escAttr(l.id)}">${escAttr(labels.edit)}</button>
-            <button type="button" class="sl-delete-btn text-xs font-medium text-red-500 hover:underline ml-auto" data-id="${escAttr(l.id)}">${escAttr(labels.delete)}</button>
+            <button type="button" class="sl-delete-btn text-xs font-medium text-red-500 dark:text-red-400 hover:underline ml-auto" data-id="${escAttr(l.id)}">${escAttr(labels.delete)}</button>
           </div>
         </div>`;
     }).join('');

--- a/src/components/SponsoredByView.astro
+++ b/src/components/SponsoredByView.astro
@@ -206,7 +206,7 @@ const i18nBag = {
           <input type="checkbox" data-toggle-public="${escHtml(s.id)}" ${s.beneficiary_public ? 'checked' : ''} />
           ${escHtml(showPubliclyLabel)}
         </label>
-        <button data-decline="${escHtml(s.id)}" class="text-sm text-red-600">${escHtml(i18nBag.decline)}</button>`;
+        <button data-decline="${escHtml(s.id)}" class="text-sm text-red-600 dark:text-red-400">${escHtml(i18nBag.decline)}</button>`;
       privList.appendChild(li);
     }
   }
@@ -266,7 +266,7 @@ const i18nBag = {
       const li = document.createElement('li');
       li.className = 'flex items-center justify-between border-b border-zinc-200 dark:border-zinc-800 pb-2';
       const withdrawBtn = req.status === 'pending'
-        ? `<button data-withdraw="${escHtml(req.id)}" class="text-xs text-red-600">${escHtml(i18nBag.request_withdraw)}</button>`
+        ? `<button data-withdraw="${escHtml(req.id)}" class="text-xs text-red-600 dark:text-red-400">${escHtml(i18nBag.request_withdraw)}</button>`
         : '';
       li.innerHTML = `
         <span>

--- a/src/components/SponsoringView.astro
+++ b/src/components/SponsoringView.astro
@@ -1212,7 +1212,7 @@ const langJson = JSON.stringify(lang);
         <td class="py-2 pr-4"><span class="${statusColor}">${escHtml(b.status)}${pausedExtra}</span></td>
         <td class="py-2">
           ${unpauseBtn}
-          <button data-revoke-spons="${escHtml(b.id)}" class="text-sm text-red-600 ml-2">Revoke</button>
+          <button data-revoke-spons="${escHtml(b.id)}" class="text-sm text-red-600 dark:text-red-400 ml-2">Revoke</button>
           <button data-report-ben="${escHtml(b.beneficiary_id)}" data-username="${escHtml(benUsername)}" class="text-sm text-amber-600 hover:text-amber-800 ml-2">${escHtml(tr.report_abuse)}</button>
         </td>`;
       tbody.appendChild(row);
@@ -1410,7 +1410,7 @@ const langJson = JSON.stringify(lang);
         </div>
         <div class="flex gap-2 shrink-0">
           <button data-approve="${escHtml(req.id)}" class="text-sm text-emerald-700 hover:text-emerald-900">${escHtml(tr.request_approve)}</button>
-          <button data-reject="${escHtml(req.id)}" class="text-sm text-red-600 hover:text-red-800">${escHtml(tr.request_reject)}</button>
+          <button data-reject="${escHtml(req.id)}" class="text-sm text-red-600 dark:text-red-400 hover:text-red-800">${escHtml(tr.request_reject)}</button>
         </div>`;
       list.appendChild(li);
     }

--- a/src/components/TrailDetailView.astro
+++ b/src/components/TrailDetailView.astro
@@ -68,7 +68,7 @@ const td = tr.trail_detail;
 
   <!-- Error state -->
   <div id="trail-detail-error" class="hidden">
-    <p class="text-sm text-red-500">{td.not_found}</p>
+    <p class="text-sm text-red-500 dark:text-red-400">{td.not_found}</p>
   </div>
 
 </div>

--- a/src/components/TrailsView.astro
+++ b/src/components/TrailsView.astro
@@ -146,7 +146,7 @@ const copy = {
     </div>
 
     <!-- Error message -->
-    <p id="create-trail-error" class="hidden text-sm text-red-500"></p>
+    <p id="create-trail-error" class="hidden text-sm text-red-500 dark:text-red-400"></p>
 
     <div class="flex gap-3 pt-2">
       <button

--- a/src/components/console/ExpertApplicationsBrowser.astro
+++ b/src/components/console/ExpertApplicationsBrowser.astro
@@ -52,7 +52,7 @@ const isEs = lang === 'es';
             <button id="ea-reject-btn" class="min-h-[36px] rounded-lg border border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 text-sm font-semibold px-4 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors">{c.expert_apps_reject}</button>
             <button id="ea-approve-btn" class="min-h-[36px] rounded-lg bg-emerald-700 hover:bg-emerald-800 text-white text-sm font-semibold px-4 transition-colors">{c.expert_apps_approve}</button>
           </div>
-          <div id="ea-action-error" class="hidden text-sm text-red-600"></div>
+          <div id="ea-action-error" class="hidden text-sm text-red-600 dark:text-red-400"></div>
         </div>
       </div>
     </div>
@@ -93,7 +93,7 @@ const isEs = lang === 'es';
     if (status) q = q.eq('status', status);
     const { data: rows, count, error } = await q;
     loading.classList.add('hidden');
-    if (error) { listEl.innerHTML = `<p class="text-sm text-red-600">${escapeHtml(error.message)}</p>`; listEl.classList.remove('hidden'); return; }
+    if (error) { listEl.innerHTML = `<p class="text-sm text-red-600 dark:text-red-400">${escapeHtml(error.message)}</p>`; listEl.classList.remove('hidden'); return; }
     if (!rows?.length) { emptyEl.classList.remove('hidden'); return; }
     cachedRows = rows as Record<string, unknown>[];
     listEl.innerHTML = cachedRows.map(r => {

--- a/src/components/console/RateLimitPanel.astro
+++ b/src/components/console/RateLimitPanel.astro
@@ -89,7 +89,7 @@ const isEs = lang === 'es';
           const count = Number(row.current_count ?? 0);
           const limit = Number(row.max_count ?? 100);
           const pct = limit > 0 ? count / limit : 0;
-          const statusCls = pct >= 1 ? 'text-red-600' : pct >= 0.8 ? 'text-amber-600' : 'text-emerald-600';
+          const statusCls = pct >= 1 ? 'text-red-600 dark:text-red-400' : pct >= 0.8 ? 'text-amber-600' : 'text-emerald-600';
           const statusLabel = pct >= 1 ? 'exceeded' : pct >= 0.8 ? 'warning' : 'ok';
           const resetAt = row.reset_at ? new Date(row.reset_at as string).toLocaleTimeString() : '—';
           return `<tr>
@@ -107,7 +107,7 @@ const isEs = lang === 'es';
     } catch (err) {
       loadingEl?.classList.add('hidden');
       if (tbodyEl) {
-        tbodyEl.innerHTML = `<tr><td colspan="6" class="px-3 py-2 text-red-500">${escapeHtml((err as Error).message)}</td></tr>`;
+        tbodyEl.innerHTML = `<tr><td colspan="6" class="px-3 py-2 text-red-500 dark:text-red-400">${escapeHtml((err as Error).message)}</td></tr>`;
         listEl?.classList.remove('hidden');
       }
     }

--- a/src/pages/en/explore/places/compare/index.astro
+++ b/src/pages/en/explore/places/compare/index.astro
@@ -28,7 +28,7 @@ import BaseLayout from '../../../../../layouts/BaseLayout.astro';
 
   <!-- Results -->
   <div id="compare-loading" class="hidden text-zinc-400 text-sm py-4">Loading...</div>
-  <div id="compare-error" class="hidden text-red-500 text-sm py-4"></div>
+  <div id="compare-error" class="hidden text-red-500 dark:text-red-400 text-sm py-4"></div>
 
   <div id="compare-results" class="hidden">
     <!-- Map -->

--- a/src/pages/en/profile/tokens.astro
+++ b/src/pages/en/profile/tokens.astro
@@ -116,7 +116,7 @@ const tr = t(lang) as any;
     content.append(name, prefix, meta);
     const btn = document.createElement('button');
     btn.dataset.id = t.id ?? '';
-    btn.className = 'revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50';
+    btn.className = 'revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 dark:text-red-400 border-red-200 hover:bg-red-50';
     btn.textContent = L.revoke;
     btn.addEventListener('click', async () => {
       if (!(await openConfirmDialog({
@@ -139,7 +139,7 @@ const tr = t(lang) as any;
     const res = await fetch(TOKENS_URL, { headers: { Authorization: await getAuthHeader() } });
     if (!res.ok) {
       const p = document.createElement('p');
-      p.className = 'text-sm text-red-500';
+      p.className = 'text-sm text-red-500 dark:text-red-400';
       p.textContent = `Error loading tokens (${res.status}). Make sure you are signed in.`;
       list.replaceChildren(p);
       return;

--- a/src/pages/es/explorar/lugares/comparar/index.astro
+++ b/src/pages/es/explorar/lugares/comparar/index.astro
@@ -12,7 +12,7 @@ import BaseLayout from '../../../../../layouts/BaseLayout.astro';
     <button id="compare-btn" class="px-5 py-2 text-sm font-medium rounded-lg bg-emerald-600 text-white hover:bg-emerald-700">Comparar</button>
   </div>
   <div id="compare-loading" class="hidden text-zinc-400 text-sm py-4">Cargando...</div>
-  <div id="compare-error" class="hidden text-red-500 text-sm py-4"></div>
+  <div id="compare-error" class="hidden text-red-500 dark:text-red-400 text-sm py-4"></div>
   <div id="compare-results" class="hidden">
     <div id="compare-map" class="rounded-lg overflow-hidden border border-zinc-200 dark:border-zinc-800 mb-6" style="height:300px"></div>
     <div class="grid grid-cols-2 gap-4 mb-6">

--- a/src/pages/es/perfil/tokens.astro
+++ b/src/pages/es/perfil/tokens.astro
@@ -150,7 +150,7 @@ const tr = t(lang) as any;
 
     const btn = document.createElement('button');
     btn.dataset.id = t.id ?? '';
-    btn.className = 'revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 border-red-200 hover:bg-red-50';
+    btn.className = 'revoke-btn shrink-0 rounded border px-3 py-1.5 text-xs text-red-600 dark:text-red-400 border-red-200 hover:bg-red-50';
     btn.textContent = L.revoke;
     btn.addEventListener('click', async () => {
       if (!(await openConfirmDialog({
@@ -178,7 +178,7 @@ const tr = t(lang) as any;
 
     if (!res.ok) {
       const empty = document.createElement('p');
-      empty.className = 'text-sm text-red-500';
+      empty.className = 'text-sm text-red-500 dark:text-red-400';
       empty.textContent = `Error al cargar tokens (${res.status}). Verifica que hayas iniciado sesión.`;
       list.replaceChildren(empty);
       return;


### PR DESCRIPTION
Closes the out-of-scope item flagged in the #1210 description. The PBI 3.1.1 audit noted 20+ dynamic `text-red-*` sites (`innerHTML` templates, `classList` calls) that lack dark variants — same a11y class as the CommunityView one fixed in #1210, but Lighthouse can't see them in a static run because they only paint on error states.

## Sweep
Mechanical fix across **24 files / 36 sites**: append `dark:text-red-400` to every `text-red-(500|600|700)` lacking a `dark:` variant. Four patterns:

| Pattern | Count | Fix |
|---|:---:|---|
| Class-attribute strings | 29 | Inject `dark:text-red-400` after first `text-red-XXX` token |
| `classList.toggle('text-red-600', x)` | 3 | Split into two calls (single-token contract; see `tailwind-sweep-classlist-trap` memory) |
| `classList.add('text-red-600')` | 2 | Flatten to multi-arg |
| `classList.remove(..., 'text-red-600')` | 2 | Same |

## Test plan
- [x] `tsc --noEmit` clean
- [x] PBI 3.1 ratchet `color-contrast-policy.test.ts` 3/3 (no zinc-500 regressions)
- [x] `npm run build` 255 pages clean
- [x] Full `vitest` 3044/3044
- [x] Multi-token `classList.toggle` audit: 0 hits (the Sprint 1 trap)

This closes the entire UI/UX audit follow-up tree. All a11y violations Lighthouse surfaced — plus the static-invisible ones noticed during the audit re-run — are now resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)