### PR TITLE
docs(audit): close roadmap spec + extend ratchet for text-red rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ docs/
 - **No `console.log` in shipped code.** `console.warn` for genuinely
   exceptional ignored errors only.
 - **Below-fold images use `loading="lazy"`.** The hero / first-paint image stays default-loaded for LCP; everything below the fold (doc screenshots, observation thumbnails, profile avatars in lists) gets `loading="lazy"`.
-- **Body copy minimum contrast = `text-zinc-600` / `dark:text-zinc-300` (4.5:1, WCAG AA).** `text-zinc-500` over white is ~3.2:1 and fails. `dark:text-zinc-500` over `bg-zinc-900` is ~3.5:1 and also fails. Regression-guarded by `tests/unit/color-contrast-policy.test.ts` (PBI 3.1).
+- **Body copy minimum contrast = `text-zinc-600` / `dark:text-zinc-300` (4.5:1, WCAG AA).** `text-zinc-500` over white is ~3.2:1 and fails. `dark:text-zinc-500` over `bg-zinc-900` is ~3.5:1 and also fails. Same applies to error states: any `text-red-(500|600|700)` must carry a `dark:text-red-400` (or `-300`) variant — `text-red-600` on `bg-zinc-900` is only 4.1:1. For brand emerald buttons with white text, use `bg-emerald-700` or darker (`bg-emerald-600` + white text is 3.76:1). Regression-guarded by `tests/unit/color-contrast-policy.test.ts` (PBI 3.1 / 3.1.2). For mechanical Tailwind class sweeps that change tokens used in JS (`classList.toggle('text-X', cond)`), see the `tailwind-sweep-classlist-trap` memory — single-token strings only.
 
 ### Astro JSX gotcha — `Record<…>` is parsed as a tag
 Inline TypeScript casts like `(foo as Record<string, unknown>).bar` inside

--- a/docs/superpowers/specs/2026-05-25-ui-ux-audit-roadmap.md
+++ b/docs/superpowers/specs/2026-05-25-ui-ux-audit-roadmap.md
@@ -71,7 +71,7 @@ Epic-3 PBIs are 1–2 days. The 78-point total is a planning estimate
 | 🟢 | Done (PR merged + audit re-run confirms target met) |
 | ⚪ | Deferred (linked issue, outside this roadmap) |
 
-All 17 PBIs in this roadmap are currently 🔴.
+**Status as of 2026-05-28: 16 🟢 shipped / 1 ⚪ closed as not-a-defect.**
 
 ---
 
@@ -126,7 +126,7 @@ graph LR
   reference memory `reference_observeview2_script_e2e_gate` mandates a
   Playwright run before declaring done.
 
-### PBI 1.1 — Cookie banner: collapse to bottom-sheet pattern · 🔴
+### PBI 1.1 — Cookie banner: collapse to bottom-sheet pattern · 🟢 (#1195)
 
 **Why.** Banner persistently covers the **Record Observation** CTA on
 home mobile, the form on `/observar/` mobile, footer copy on
@@ -161,7 +161,7 @@ shows CTA in above-the-fold viewport for `/en/` home on mobile.
 
 ---
 
-### PBI 1.2 — OnboardingTour tooltip positioning bug on `/observe/` · 🔴
+### PBI 1.2 — OnboardingTour tooltip positioning bug on `/observe/` · 🟢 (#1199)
 
 **Why.** Tooltip *"Rastrum identifies species automatically…"* overlays
 the **Observe** nav link on desktop and the **Sign in** button on mobile.
@@ -193,7 +193,7 @@ all 7 steps shows no overlap; e2e suite green.
 
 ---
 
-### PBI 1.3 — Defer geolocation requests behind explicit action · 🔴
+### PBI 1.3 — Defer geolocation requests behind explicit action · 🟢 (#1197)
 
 **Why.** Lighthouse `geolocation-on-start` flagged on `/en/`, `/es/`,
 and `/en/explore/recent/`. Asking for location permission on page load
@@ -241,7 +241,7 @@ any home widget that triggers the prompt (search via `grep -r
   emits AVIF/WebP variants before assuming an `astro:image` config swap
   is sufficient.
 
-### PBI 2.1 — `/explore/recent/` LCP overhaul · 🔴
+### PBI 2.1 — `/explore/recent/` LCP overhaul · 🟢 (#1206)
 
 **Why.** Lighthouse on this page: **LCP 1481 ms** (3× slower than other
 pages), LCP image was **lazy-loaded** (a priority bug), 2729 KiB total
@@ -277,7 +277,7 @@ variants per CLAUDE.md M03).
 
 ---
 
-### PBI 2.2 — Bundle hygiene: unused CSS purge + per-route code split · 🔴
+### PBI 2.2 — Bundle hygiene: unused CSS purge + per-route code split · 🟢 (#1204)
 
 **Why.** Lighthouse flags ~13 KiB unused CSS + ~40 KiB unused JS on
 **every** page (201 KiB on `/explore/map/`). MapLibre is loaded on
@@ -324,7 +324,7 @@ shows `unused-*` under threshold; size-limit budgets unchanged.
   verify both the MapLibre control cluster and the filter chips remain
   reachable on iPhone 13 viewport.
 
-### PBI 3.1 — Color-contrast universal sweep · 🔴
+### PBI 3.1 — Color-contrast universal sweep · 🟢 (#1209)
 
 **Why.** `color-contrast` fails on **all 13 audited pages**. Likely
 culprit: `text-zinc-500` over `bg-zinc-50` or similar combos. WCAG AA
@@ -355,7 +355,7 @@ forbidden `text-zinc-400` / `text-zinc-500` patterns on body copy.
 
 ---
 
-### PBI 3.2 — link-name + label-content-name-mismatch · 🔴
+### PBI 3.2 — link-name + label-content-name-mismatch · 🟢 (#1208)
 
 **Why.** `/community/observers/` and `/explore/recent/` flag links
 without discernible names — likely avatar `<img>` wrapped in `<a>`
@@ -388,7 +388,7 @@ avatars-as-links exist.
 
 ---
 
-### PBI 3.3 — Touch targets + link-in-text-block on `/explore/map/` · 🔴
+### PBI 3.3 — Touch targets + link-in-text-block on `/explore/map/` · 🟢 (#1202)
 
 **Why.** `target-size` fails on mobile (buttons < 44×44 px).
 `link-in-text-block` means inline links rely on color alone to be
@@ -416,7 +416,7 @@ components, possibly a global Tailwind `@layer components` for a
 
 ---
 
-### PBI 3.4 — crawlable-anchors on `/observe/` (SEO 92 → 100) · 🔴
+### PBI 3.4 — crawlable-anchors on `/observe/` (SEO 92 → 100) · 🟢 (#1198)
 
 **Why.** Lighthouse SEO flags `crawlable-anchors` on EN + ES observe
 pages. Likely `<a href="#">` or `onclick=`-driven links. Tanks search
@@ -458,7 +458,7 @@ this code mostly intact).
 - *Sign-in microcopy timing claims ("~30 s") are operator-dependent* —
   pick a copy that holds even if Resend/Gmail SMTP retries.
 
-### PBI 4.1 — Anon empty states for `/profile/` + `/console/` · 🔴
+### PBI 4.1 — Anon empty states for `/profile/` + `/console/` · 🟢 (#1201)
 
 **Why.** `/profile/` for anon shows 80% empty viewport with just *"Sign
 in to view your profile"*. `/console/` shows *"Sign in required."* with
@@ -492,7 +492,7 @@ current "Sign in" two-liner.
 
 ---
 
-### PBI 4.2 — Sign-in microcopy + post-submit state · 🔴
+### PBI 4.2 — Sign-in microcopy + post-submit state · 🟢 (#1196)
 
 **Why.** Verified in the journey audit: pressing **Send code** submits
 but no expectation is set on email arrival time, spam folder, or what
@@ -520,7 +520,7 @@ to do next. Drop-off risk during the email wait.
 
 ---
 
-### PBI 4.3 — Chat badge dynamic vs hardcoded · 🔴
+### PBI 4.3 — Chat badge dynamic vs hardcoded · 🟢 (#1194)
 
 **Why.** Header badge says *"Llama 1B · on-device"* but cards offer
 Gemma 4 E2B (recommended) + Llama 3.2 1B. Stale string that bit-rots
@@ -562,7 +562,7 @@ each model selected.
 - *PBI 5.4 depends on 2.2 because* render-blocking cleanup that assumes
   pre-purge CSS will under-perform after Sprint 2.
 
-### PBI 5.1 — Drop the redundant help FAB on `/observe/` · 🔴
+### PBI 5.1 — Drop the redundant help FAB on `/observe/` · ⚪ — closed as not-a-defect
 
 **Why.** `/observe/` has both a `❓` help FAB bottom-left **and** the
 chat bubble bottom-right. The help FAB duplicates Docs navigation.
@@ -590,7 +590,7 @@ help-bubble component with route gating.
 
 ---
 
-### PBI 5.2 — Sign-in passkey button: match other auth options · 🔴
+### PBI 5.2 — Sign-in passkey button: match other auth options · 🟢 (#1205)
 
 **Why.** Currently the passkey button has a highlighted (emerald-tinted)
 background suggesting it's selected/default. Other OAuth buttons are
@@ -617,7 +617,7 @@ in fact magic-link is the default for first-time users.
 
 ---
 
-### PBI 5.3 — `/docs/roadmap/` DOM size virtualization · 🔴
+### PBI 5.3 — `/docs/roadmap/` DOM size virtualization · 🟢 (#1200)
 
 **Why.** Lighthouse `dom-size` flagged **2194 elements** (highest in
 the audit). Indicates ~60+ roadmap items rendered server-side. This
@@ -645,7 +645,7 @@ content reachable by scroll; deep-link smoke verified.
 
 ---
 
-### PBI 5.4 — Render-blocking resources baseline reduction · 🔴
+### PBI 5.4 — Render-blocking resources baseline reduction · 🟢 (#1207)
 
 **Why.** Universal Lighthouse flag — ~40 ms savings per page from
 render-blocking CSS/JS. Small individually but compounds across the
@@ -778,3 +778,6 @@ re-run any time after `npm run build` to capture a fresh visual diff.
 |------|--------|
 | 2026-05-25 | Initial roadmap from comprehensive audit (54 screenshots + 13 Lighthouse reports). |
 | 2026-05-25 | Polish pass: TL;DR, TOC, mermaid dependency graph, status legend, per-PBI evidence links, file-path verification (ConsoleLayout, CommunityView), Epic-level risks. |
+| 2026-05-26 | All 16 in-scope PBIs merged via PRs #1194–#1209. PBI 5.1 closed as not-a-defect (no help FAB exists on /observe/; audit author confused a transient toast for a fixed element). Audit re-run surfaced 9 residual contrast elements (brand emerald-600 buttons + zinc-400 stat cards + a stale `dark:text-zinc-600` pair the sweep mis-wrote). PBI 3.1.1 (#1210) fixed them — 13/13 pages now PASS `color-contrast`. |
+| 2026-05-27 | PBI 3.1.2 (#1211) defensive sweep: 36 dynamic `text-red-*` error states gained `dark:text-red-400` variants — same a11y class as the CommunityView fix in #1210, but Lighthouse can't see them in a static run. Ratchet test extended to enforce the rule forward. |
+| 2026-05-28 | Spec closed. 19 PRs merged end-to-end. Lighthouse on main: color-contrast 13/13 ✓, geolocation-on-start 13/13 ✓, link-name 13/13 ✓, target-size on flagged routes ✓, LCP on `/explore/recent/` 1481 ms → 635 ms (-57%), DOM size on `/docs/roadmap/` 2194 → 1435 (-35%). |

--- a/tests/unit/color-contrast-policy.test.ts
+++ b/tests/unit/color-contrast-policy.test.ts
@@ -1,32 +1,24 @@
 /**
- * Regression test for PBI 3.1 — WCAG AA color-contrast universal sweep.
+ * Regression test for PBI 3.1 + 3.1.1 + 3.1.2 — WCAG AA color-contrast policy.
  *
- * Lighthouse `color-contrast` was failing on every audited page because
- * `text-zinc-500` (#71717a) over white renders at ~3.2:1, below the 4.5:1
- * AA threshold for body text. The fix was a global swap:
+ * Three rules, all enforced by source-grep:
  *
- *   - light-mode body text: `text-zinc-500` → `text-zinc-600`
- *   - dark-mode body text:  `dark:text-zinc-500` → `dark:text-zinc-300`
- *   - lines with bare `text-zinc-600` (no dark variant) got
- *     `dark:text-zinc-300` appended so dark mode contrast also passes
- *     (`text-zinc-600` on `bg-zinc-900` ≈ 2.1:1 — fails AA)
+ *   1. Zero `text-zinc-500` defaults (#71717a on white = 3.2:1 — fails AA).
+ *   2. Zero `dark:text-zinc-500` (on bg-zinc-900 ≈ 3.5:1 — also fails AA).
+ *   3. Every `text-red-(500|600|700)` carries a `dark:text-red-{400|300}`
+ *      variant — text-red-600 on bg-zinc-900 = 4.11:1, which fails AA.
+ *      (Light-mode is fine: text-red-600 on white = 4.83:1, passes.)
  *
- * This test is a **ratchet** — it asserts the codebase contains
- *   - ZERO occurrences of `text-zinc-500` as a default class (no prefix)
- *   - ZERO occurrences of `dark:text-zinc-500` (always fails dark AA)
+ * Tailwind state-prefixes (`hover:`, `focus:`, `placeholder:` etc.) are
+ * stripped before scanning — those are bound to state changes, not
+ * default render colors.
  *
- * `text-zinc-400` is allowed as a default class because:
- *   - In dark mode (`dark:text-zinc-400` on `bg-zinc-900`) ≈ 4.7:1 — passes AA.
- *   - On light backgrounds it survives the audit only for decorative/aria-hidden
- *     glyphs, em-dashes, loading/empty placeholders, and `hover:` targets.
- *     A future sweep can tighten these case by case; this test does not
- *     regulate them.
+ * Decorative `text-zinc-400` (em-dashes, loading placeholders, hover
+ * states) is allowed — the audit treats it case-by-case, this test
+ * doesn't regulate it.
  *
- * If a legitimate future use of `text-zinc-500` arises (e.g. an SVG icon
- * mid-emphasis on a `bg-zinc-100` panel that meets 3:1 large-text AA),
- * add the exact match to the `ALLOWED_TEXT_ZINC_500` allowlist below with
- * a comment explaining WHY. The bar is high: the audit is page-wide, so
- * a single new violation is a regression.
+ * To add a legitimate exception, append to the allowlist with a `// WHY`
+ * comment. The bar is high: each new entry weakens the policy.
  */
 import { describe, expect, it } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
@@ -38,46 +30,31 @@ function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     const st = statSync(full);
-    if (st.isDirectory()) {
-      walk(full, out);
-    } else if (/\.(astro|ts|tsx)$/.test(entry)) {
-      out.push(full);
-    }
+    if (st.isDirectory()) walk(full, out);
+    else if (/\.(astro|ts|tsx)$/.test(entry)) out.push(full);
   }
   return out;
 }
 
 const ALL_FILES = walk(ROOT);
 
-/**
- * Allowlist of LITERAL substrings that may legitimately contain
- * `text-zinc-500` even after the PBI 3.1 sweep. Each entry should be
- * accompanied by a comment explaining the WHY. Today: empty.
- */
+const STATE_PREFIX_RE =
+  /(hover|focus|focus-visible|group-hover|peer-hover|placeholder|active|disabled|aria-\[\w+\]):/g;
+
 const ALLOWED_TEXT_ZINC_500: string[] = [];
-
-/**
- * Allowlist for `dark:text-zinc-500` — never legitimate today.
- */
 const ALLOWED_DARK_TEXT_ZINC_500: string[] = [];
+const ALLOWED_BARE_TEXT_RED: string[] = [];
 
-describe('PBI 3.1: WCAG AA color-contrast policy', () => {
-  it('has no `text-zinc-500` default class anywhere in src/ (use text-zinc-600+)', () => {
+describe('color-contrast policy', () => {
+  it('has no `text-zinc-500` default class anywhere in src/ (PBI 3.1)', () => {
     const violations: Array<{ file: string; line: number; text: string }> = [];
     for (const file of ALL_FILES) {
-      const body = readFileSync(file, 'utf8');
-      const lines = body.split('\n');
+      const lines = readFileSync(file, 'utf8').split('\n');
       lines.forEach((line, idx) => {
-        // Strip `dark:text-zinc-500` matches from the line BEFORE scanning so
-        // the bare-class regex doesn't double-count them — the dark-mode
-        // assertion below covers those separately.
-        const sanitized = line.replace(/dark:text-zinc-500/g, '');
-        // Strip hover:/focus:/group-hover:/peer-hover:/placeholder: prefixes too —
-        // those are state-bound, not default render colors.
-        const cleaned = sanitized.replace(
-          /(hover|focus|focus-visible|group-hover|peer-hover|placeholder|active|disabled|aria-\[\w+\]):text-zinc-500/g,
-          '',
-        );
+        // Strip dark: variants + state-prefixes before scanning.
+        const cleaned = line
+          .replace(/dark:text-zinc-500/g, '')
+          .replace(/(hover|focus|focus-visible|group-hover|peer-hover|placeholder|active|disabled|aria-\[\w+\]):text-zinc-500/g, '');
         if (/\btext-zinc-500\b/.test(cleaned)) {
           if (ALLOWED_TEXT_ZINC_500.some((s) => line.includes(s))) return;
           violations.push({ file, line: idx + 1, text: line.trim() });
@@ -85,25 +62,21 @@ describe('PBI 3.1: WCAG AA color-contrast policy', () => {
       });
     }
     if (violations.length > 0) {
-      const sample = violations
-        .slice(0, 5)
-        .map((v) => `  ${v.file}:${v.line}\n    ${v.text}`)
-        .join('\n');
+      const sample = violations.slice(0, 5)
+        .map((v) => `  ${v.file}:${v.line}\n    ${v.text}`).join('\n');
       const more = violations.length > 5 ? `\n  …and ${violations.length - 5} more` : '';
       throw new Error(
-        `Found ${violations.length} bare \`text-zinc-500\` occurrence(s). ` +
-          `Body text should use \`text-zinc-600\` (or \`text-zinc-700\` for ` +
-          `\`sm\` text on light cards) to meet WCAG AA (4.5:1).\n\n${sample}${more}`,
+        `Found ${violations.length} bare \`text-zinc-500\`. Use \`text-zinc-600\` ` +
+          `(4.83:1 on white, passes WCAG AA).\n\n${sample}${more}`,
       );
     }
     expect(violations).toEqual([]);
   });
 
-  it('has no `dark:text-zinc-500` anywhere in src/ (use dark:text-zinc-300+)', () => {
+  it('has no `dark:text-zinc-500` anywhere in src/ (PBI 3.1)', () => {
     const violations: Array<{ file: string; line: number; text: string }> = [];
     for (const file of ALL_FILES) {
-      const body = readFileSync(file, 'utf8');
-      const lines = body.split('\n');
+      const lines = readFileSync(file, 'utf8').split('\n');
       lines.forEach((line, idx) => {
         if (/\bdark:text-zinc-500\b/.test(line)) {
           if (ALLOWED_DARK_TEXT_ZINC_500.some((s) => line.includes(s))) return;
@@ -112,23 +85,47 @@ describe('PBI 3.1: WCAG AA color-contrast policy', () => {
       });
     }
     if (violations.length > 0) {
-      const sample = violations
-        .slice(0, 5)
-        .map((v) => `  ${v.file}:${v.line}\n    ${v.text}`)
-        .join('\n');
+      const sample = violations.slice(0, 5)
+        .map((v) => `  ${v.file}:${v.line}\n    ${v.text}`).join('\n');
       const more = violations.length > 5 ? `\n  …and ${violations.length - 5} more` : '';
       throw new Error(
-        `Found ${violations.length} \`dark:text-zinc-500\` occurrence(s). ` +
-          `\`text-zinc-500\` on \`bg-zinc-900\` ≈ 3.5:1 — fails WCAG AA. ` +
-          `Use \`dark:text-zinc-300\` (≈ 9.4:1) instead.\n\n${sample}${more}`,
+        `Found ${violations.length} \`dark:text-zinc-500\`. Use \`dark:text-zinc-300\` ` +
+          `(9.4:1 on bg-zinc-900, passes WCAG AA).\n\n${sample}${more}`,
       );
     }
     expect(violations).toEqual([]);
   });
 
-  it('did the sweep find files (sanity check)', () => {
-    // Guard against the walker regressing to empty (e.g. cwd change in a
-    // future refactor); the assertions above would silently pass otherwise.
+  it('every `text-red-(500|600|700)` has a `dark:text-red-*` variant (PBI 3.1.2)', () => {
+    const redRe = /\btext-red-(500|600|700)\b/;
+    const darkRe = /\bdark:text-red-/;
+    const violations: Array<{ file: string; line: number; text: string }> = [];
+    for (const file of ALL_FILES) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, idx) => {
+        if (!redRe.test(line)) return;
+        if (darkRe.test(line)) return; // already paired
+        // State-prefix exempt: hover:text-red-600 etc. are state-bound colors
+        const cleaned = line.replace(STATE_PREFIX_RE, '');
+        if (!redRe.test(cleaned)) return;
+        if (ALLOWED_BARE_TEXT_RED.some((s) => line.includes(s))) return;
+        violations.push({ file, line: idx + 1, text: line.trim() });
+      });
+    }
+    if (violations.length > 0) {
+      const sample = violations.slice(0, 5)
+        .map((v) => `  ${v.file}:${v.line}\n    ${v.text}`).join('\n');
+      const more = violations.length > 5 ? `\n  …and ${violations.length - 5} more` : '';
+      throw new Error(
+        `Found ${violations.length} \`text-red-(500|600|700)\` without a dark variant. ` +
+          `Append \`dark:text-red-400\` (\`text-red-400\` on bg-zinc-900 ≈ 6.9:1, passes AA). ` +
+          `For \`classList.toggle\` callers, split into two single-token calls.\n\n${sample}${more}`,
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('sanity: walker found > 100 files', () => {
     expect(ALL_FILES.length).toBeGreaterThan(100);
   });
 });


### PR DESCRIPTION
Three closures of the 2026-05-25 UI/UX audit roadmap (#1193):

## 1. Spec doc closed
Flips 16 PBI statuses 🔴 → 🟢 with merge PR refs; marks PBI 5.1 as ⚪ closed-as-not-a-defect (no help FAB exists on /observe/; the audit author confused a transient toast for a fixed element). Appends 3 dated change-log entries summarising the in-scope sprint, the #1210 contrast re-run follow-up, and the #1211 `text-red-*` defensive sweep.

## 2. Ratchet test extended
`tests/unit/color-contrast-policy.test.ts` gains a third assertion: any `text-red-(500|600|700)` must carry a `dark:text-red-*` variant. Locks in the #1211 sweep so future error-state code can't reintroduce the gap. State-prefixes (`hover:`, `focus:` etc.) are stripped before scanning — those are state-bound, not default colors.

## 3. CLAUDE.md convention expanded
The existing body-copy contrast bullet now covers `text-red` + brand `bg-emerald-600` patterns + cross-links the `tailwind-sweep-classlist-trap` memory.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Ratchet 4/4 pass (the new text-red rule passes on the current main — confirms #1211 was complete)
- [x] `npm run build` 255 pages

This is the final close-out PR for the UI/UX audit. Net 19 + 1 PRs end-to-end, covering all detected items + the policy enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)