### PR TITLE
fix(explore): survive cdn-cgi image-variant failures + halve quota burn

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,3 +116,4 @@ jobs:
           PUBLIC_ONNX_BASE_URL:            ${{ secrets.PUBLIC_ONNX_BASE_URL }}
           PUBLIC_PMTILES_MX_URL:           ${{ secrets.PUBLIC_PMTILES_MX_URL }}
           PUBLIC_MEGADETECTOR_WEIGHTS_URL: ${{ secrets.PUBLIC_MEGADETECTOR_WEIGHTS_URL }}
+          SMOKE_CDN_IMAGE_PROBE_URL:       ${{ secrets.SMOKE_CDN_IMAGE_PROBE_URL }}

--- a/infra/smoke-model-assets.sh
+++ b/infra/smoke-model-assets.sh
@@ -9,6 +9,9 @@
 # but the file behind it is unreachable, has the wrong content-length,
 # or returns no `access-control-allow-origin` header.
 #
+# SMOKE_CDN_IMAGE_PROBE_URL (optional) additionally probes the
+# Cloudflare Image Transformations endpoint — see check_cdn_image below.
+#
 # Wired into:
 #   - .github/workflows/deploy.yml (post-build, after `npm run build`)
 #   - .github/workflows/nightly-smoke.yml (09:17 UTC daily)
@@ -68,6 +71,52 @@ check() {
   printf "        ✓ %s%s, CORS=%s\n" "$status_line" "${len:+, $len bytes}" "$cors"
 }
 
+# Cloudflare Image Transformations probe (cdn-cgi 503 incident, PBI 2.1).
+# SMOKE_CDN_IMAGE_PROBE_URL is a known-stable observation photo on
+# media.rastrum.org; we request the exact width=320 AVIF variant the
+# explore cards emit (same source + options combo = no extra unique
+# transformation against the 5,000/month quota) and assert HTTP 200 +
+# an image content-type. Catches the feature being disabled or the
+# quota exhausted before users see degraded cards. No CORS assertion —
+# variants load via <img>/<picture>, not fetch().
+check_cdn_image() {
+  local label="cdn-cgi image"
+  local url="${SMOKE_CDN_IMAGE_PROBE_URL:-}"
+
+  if [[ -z "$url" ]]; then
+    printf "  skip  %-22s (env var not configured)\n" "$label"
+    return 0
+  fi
+
+  local path="${url#*://*/}"
+  local probe="https://media.rastrum.org/cdn-cgi/image/width=320,format=avif,fit=cover,quality=80/${path}"
+
+  checked=$((checked + 1))
+  printf "  ▶     %-22s → %s\n" "$label" "$probe"
+
+  local headers
+  if ! headers=$(curl -fsSI --max-time 30 "$probe" 2>&1); then
+    printf "        ✗ unreachable — transformations disabled or quota exhausted? %s\n" "$headers"
+    failed=$((failed + 1))
+    return 1
+  fi
+
+  headers=${headers//$'\r'/}
+
+  local status_line
+  status_line=$(printf "%s" "$headers" | head -n1)
+  local ctype
+  ctype=$(printf "%s" "$headers" | grep -i '^content-type:' | head -1 | awk '{print $2}')
+
+  if [[ "$ctype" != image/* ]]; then
+    printf "        ✗ content-type=%s is not an image — transformation not applied?\n" "${ctype:-<missing>}"
+    failed=$((failed + 1))
+    return 1
+  fi
+
+  printf "        ✓ %s, content-type=%s\n" "$status_line" "$ctype"
+}
+
 echo "Smoke-testing on-device model assets…"
 echo
 
@@ -86,6 +135,9 @@ check "pmtiles MX"       "${PUBLIC_PMTILES_MX_URL:-}" 30000000
 # MegaDetector v5a INT8 ONNX. ~134 MB — the wire format the on-device
 # camera-trap plugin expects.
 check "MegaDetector v5a" "${PUBLIC_MEGADETECTOR_WEIGHTS_URL:+${PUBLIC_MEGADETECTOR_WEIGHTS_URL%/}/megadetector_v5a.onnx}" 100000000
+
+# Cloudflare Image Transformations (explore-card AVIF variants).
+check_cdn_image
 
 echo
 if [[ "$failed" -eq 0 ]]; then

--- a/src/components/ExploreRecentView.astro
+++ b/src/components/ExploreRecentView.astro
@@ -272,6 +272,15 @@ const distancePage = page as unknown as Record<string, string>;
     return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' } as Record<string, string>)[c]);
   }
 
+  // <picture> never falls back to <img src> when the selected <source>
+  // fails at the network level — a cdn-cgi 503 (transformations disabled
+  // or monthly quota exhausted) renders a broken image. This onerror
+  // strips the <source> siblings and reloads the raw upload instead.
+  // Inline because the cards are injected via innerHTML (addEventListener
+  // would miss images that error before wiring); the data-degraded guard
+  // makes it one-shot so a failing raw URL can't loop.
+  const CDN_DEGRADE_ONERROR = `onerror="if(this.dataset.degraded)return;this.dataset.degraded='1';var p=this.parentElement;if(p&&p.tagName==='PICTURE')p.querySelectorAll('source').forEach(function(s){s.remove()});this.src=this.src;"`;
+
   function colorForConfidence(c: number): string {
     if (c >= 0.85) return 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300 border-emerald-300/60 dark:border-emerald-700/60';
     if (c >= 0.5)  return 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 border-amber-300/60 dark:border-amber-700/60';
@@ -409,18 +418,18 @@ const distancePage = page as unknown as Record<string, string>;
     // PBI 2.1 (#1193): the first card is the LCP candidate — it gets
     // fetchpriority=high + loading=eager so the browser stops deferring it
     // behind the icon/sprite waterfall. Everything else stays lazy. When the
-    // URL is on a Cloudflare resizing host we also emit AVIF + WebP variants
-    // via <picture> so the worker negotiates the best format per client.
+    // URL is on a Cloudflare resizing host we also emit AVIF sized variants
+    // via <picture> (AVIF-only post-incident — see image-variants.ts).
     let photoHtml = '';
     if (photo) {
       const v = buildImageVariants(photo);
       const loadAttrs = isLCPCandidate
         ? 'loading="eager" fetchpriority="high"'
         : 'loading="lazy" fetchpriority="auto"';
-      const imgTag = `<img src="${escapeText(v.fallback)}" alt="${escapeText(sci)}" ${loadAttrs} decoding="async" class="w-full h-full object-cover" />`;
+      const imgAttrs = `src="${escapeText(v.fallback)}" alt="${escapeText(sci)}" ${loadAttrs} decoding="async" class="w-full h-full object-cover"`;
       photoHtml = v.hasVariants
-        ? `<picture><source type="image/avif" srcset="${escapeText(v.avifSrcset)}" sizes="${EXPLORE_CARD_SIZES}" /><source type="image/webp" srcset="${escapeText(v.webpSrcset)}" sizes="${EXPLORE_CARD_SIZES}" />${imgTag}</picture>`
-        : imgTag;
+        ? `<picture><source type="image/avif" srcset="${escapeText(v.avifSrcset)}" sizes="${EXPLORE_CARD_SIZES}" /><img ${imgAttrs} ${CDN_DEGRADE_ONERROR} /></picture>`
+        : `<img ${imgAttrs} />`;
     }
 
     const obsAriaLabel = labels.observationLinkAria.replace('{species}', sci);
@@ -665,15 +674,16 @@ const distancePage = page as unknown as Record<string, string>;
           ? `<span class="absolute bottom-1 right-1 inline-flex items-center rounded bg-black/60 px-1 py-0.5 text-[9px] text-white font-semibold">📷${photoMedia.length}</span>`
           : '';
       // PBI 2.1 — list-view thumb is fixed 56 px (w-14), so srcset only
-      // needs 1× / 2× / 3× widths. Lazy + auto priority for every list row
-      // since none of them are the page's LCP element.
+      // needs 1× / 2× widths (3× dropped against the transformations
+      // quota). Lazy + auto priority for every list row since none of
+      // them are the page's LCP element.
       let listThumbHtml = '';
       if (photo) {
-        const v = buildImageVariants(photo, [80, 160, 240]);
-        const imgTag = `<img src="${escapeText(v.fallback)}" alt="${escapeText(sciText)}" loading="lazy" decoding="async" class="w-full h-full object-cover" />`;
+        const v = buildImageVariants(photo, [80, 160]);
+        const imgAttrs = `src="${escapeText(v.fallback)}" alt="${escapeText(sciText)}" loading="lazy" decoding="async" class="w-full h-full object-cover"`;
         const picture = v.hasVariants
-          ? `<picture><source type="image/avif" srcset="${escapeText(v.avifSrcset)}" sizes="56px" /><source type="image/webp" srcset="${escapeText(v.webpSrcset)}" sizes="56px" />${imgTag}</picture>`
-          : imgTag;
+          ? `<picture><source type="image/avif" srcset="${escapeText(v.avifSrcset)}" sizes="56px" /><img ${imgAttrs} ${CDN_DEGRADE_ONERROR} /></picture>`
+          : `<img ${imgAttrs} />`;
         listThumbHtml = `<div class="relative w-14 h-14 shrink-0 overflow-hidden rounded-lg bg-zinc-100 dark:bg-zinc-800">${picture}${mediaBadge}</div>`;
       }
       const thumb = photo

--- a/src/lib/image-variants.ts
+++ b/src/lib/image-variants.ts
@@ -5,8 +5,17 @@
  * upload to every card, blowing the LCP on `/en/explore/recent/` to ~1.5 s.
  * R2 stores a single resized JPEG per upload (see module 10) but
  * `media.rastrum.org` is fronted by Cloudflare's image-resizing endpoint
- * (`/cdn-cgi/image/...`), so we can derive AVIF / WebP / sized variants by
- * URL rewrite — no upload pipeline change required.
+ * (`/cdn-cgi/image/...`), so we can derive sized variants by URL rewrite
+ * — no upload pipeline change required.
+ *
+ * Quota math (post-incident): the Cloudflare plan includes 5,000 unique
+ * transformations/month, where unique = source image × options combo. The
+ * original 3 widths × 2 formats = 6 variants/photo capped us at ~830 new
+ * photos/month; the matrix is now 2 widths × AVIF only = 2 variants/photo
+ * (~2,500 photos/month). AVIF-only because every target browser (Chrome
+ * 85+, Firefox 93+, Safari 16.4+) decodes AVIF — WebP as a second format
+ * bought nothing but doubled quota burn, so `webpSrcset` is always `''`
+ * (field kept for interface stability).
  *
  * When the URL is not on a resizing-enabled host (e.g. Supabase Storage
  * fallback, local dev, third-party hotlink), `buildImageVariants()`
@@ -15,20 +24,20 @@
  * a CDN that has no idea what `/cdn-cgi/image/...` means.
  */
 
-const DEFAULT_WIDTHS = [320, 640, 1280] as const;
+const DEFAULT_WIDTHS = [320, 640] as const;
 
 const RESIZING_HOSTS = new Set<string>([
   'media.rastrum.org',
 ]);
 
 export interface ImageVariantSet {
-  /** Raw URL — what `<img src>` falls back to when AVIF/WebP both fail. */
+  /** Raw URL — what `<img src>` falls back to when the variants fail. */
   fallback: string;
   /** True when the URL is on a Cloudflare resizing-enabled host. */
   hasVariants: boolean;
-  /** AVIF srcset entries (e.g. `["url 320w", "url 640w", "url 1280w"]`). */
+  /** AVIF srcset entries (e.g. `["url 320w", "url 640w"]`). */
   avifSrcset: string;
-  /** WebP srcset entries. */
+  /** Always `''` — WebP dropped for quota (see module doc above). */
   webpSrcset: string;
 }
 
@@ -40,14 +49,14 @@ function getHost(url: string): string | null {
   }
 }
 
-function cdnTransform(url: string, width: number, format: 'avif' | 'webp'): string {
+function cdnTransform(url: string, width: number): string {
   // Cloudflare URL-based image resizing:
   //   https://<host>/cdn-cgi/image/<options>/<origin-path>
   // The origin path is everything after the host of the original URL.
   // We re-anchor on the same host so the worker pulls from the same R2
   // bucket via the same custom-domain binding.
   const parsed = new URL(url);
-  const opts = `width=${width},format=${format},fit=cover,quality=80`;
+  const opts = `width=${width},format=avif,fit=cover,quality=80`;
   // Strip any leading slash from the pathname so `/cdn-cgi/image/<opts>/<path>`
   // has exactly one separator between the option string and the origin path.
   const path = parsed.pathname.replace(/^\/+/, '');
@@ -56,9 +65,10 @@ function cdnTransform(url: string, width: number, format: 'avif' | 'webp'): stri
 
 /**
  * Build a variant set for a single image URL. `widths` defaults to
- * [320, 640, 1280] which covers mobile-1col → desktop-2col cards. Pass
- * a smaller set for tiny thumbnails (e.g. list view) to keep the srcset
- * string short.
+ * [320, 640] which covers mobile-1col → desktop-2col cards. Pass a
+ * smaller set for tiny thumbnails (e.g. list view) — but keep the total
+ * variant count per photo low; every width is a unique transformation
+ * against the 5,000/month quota.
  */
 export function buildImageVariants(
   url: string | null | undefined,
@@ -73,16 +83,16 @@ export function buildImageVariants(
   if (!eligible) {
     return { fallback: trimmed, hasVariants: false, avifSrcset: '', webpSrcset: '' };
   }
-  const avifSrcset = widths.map((w) => `${cdnTransform(trimmed, w, 'avif')} ${w}w`).join(', ');
-  const webpSrcset = widths.map((w) => `${cdnTransform(trimmed, w, 'webp')} ${w}w`).join(', ');
-  return { fallback: trimmed, hasVariants: true, avifSrcset, webpSrcset };
+  const avifSrcset = widths.map((w) => `${cdnTransform(trimmed, w)} ${w}w`).join(', ');
+  return { fallback: trimmed, hasVariants: true, avifSrcset, webpSrcset: '' };
 }
 
 /**
  * Sizes attribute for the explore-recent card grid:
  *   - mobile (≤640 px) — 1 col → ~100vw
  *   - sm+ (≥641 px) — 2 col → ~50vw
- * Grid view (3-col on md+) hits these same buckets; the 1280 w variant
- * stays the upper bound at retina-2x desktop widths.
+ * Grid view (3-col on md+) hits these same buckets; the 640 w variant is
+ * the upper bound — at retina-2x desktop widths the browser upscales it,
+ * an accepted trade against the transformations quota.
  */
 export const EXPLORE_CARD_SIZES = '(max-width: 640px) 100vw, 50vw';

--- a/tests/unit/explore-recent-lcp.test.ts
+++ b/tests/unit/explore-recent-lcp.test.ts
@@ -6,8 +6,10 @@
  * thumbnail shipped at the full 1200 px R2 upload size with no AVIF/WebP
  * fallback. This spec pins:
  *   - `fetchpriority="high"` appears in the card-render template
- *   - `<picture>` wraps the card image with AVIF + WebP sources
- *   - the `<img>` srcset (via <source>) ships at least 3 widths
+ *   - `<picture>` wraps the card image with an AVIF-only source
+ *     (WebP dropped post-incident — 5,000 transforms/month quota)
+ *   - the `<img>` carries a guarded onerror that strips <source>s so a
+ *     cdn-cgi 503 degrades to the raw upload instead of a broken image
  *   - the first card is the LCP candidate (i === 0 → isLCP=true)
  */
 import { describe, it, expect } from 'vitest';
@@ -48,27 +50,38 @@ describe('PBI 2.1 — ExploreRecentView LCP fix', () => {
     expect(source).toMatch(/rowMarkup\([^)]*isLCP\)/);
   });
 
-  it('wraps card thumbs in <picture> with AVIF + WebP <source> elements', () => {
+  it('wraps card thumbs in <picture> with an AVIF-only <source>', () => {
     expect(source).toContain('<picture>');
     expect(source).toContain('type="image/avif"');
-    expect(source).toContain('type="image/webp"');
+    // WebP dropped post-incident — never emit an (empty) webp <source>,
+    // and never re-add it without revisiting the transformations quota.
+    expect(source).not.toContain('type="image/webp"');
     expect(source).toContain('</picture>');
   });
 
-  it('emits responsive srcset on each <source>', () => {
-    // We pass avifSrcset / webpSrcset into srcset attributes on the sources.
+  it('emits responsive srcset on the AVIF <source>', () => {
     expect(source).toMatch(/srcset="\$\{escapeText\(v\.avifSrcset\)\}"/);
-    expect(source).toMatch(/srcset="\$\{escapeText\(v\.webpSrcset\)\}"/);
+    expect(source).not.toContain('v.webpSrcset');
   });
 
   it('uses the EXPLORE_CARD_SIZES attribute on the card <source>', () => {
     expect(source).toContain('sizes="${EXPLORE_CARD_SIZES}"');
   });
 
+  it('degrades to the raw upload when a cdn-cgi variant errors', () => {
+    // <picture> does NOT fall back to <img src> on a network-level
+    // <source> failure (503 = quota exhausted / feature disabled), so the
+    // injected markup carries a guarded inline onerror that removes the
+    // <source> siblings and reloads the raw src — at most once.
+    expect(source).toContain('onerror=');
+    expect(source).toMatch(/this\.dataset\.degraded/);
+    expect(source).toMatch(/querySelectorAll\('source'\)/);
+  });
+
   it('uses a small custom srcset for the 56px list-view thumb', () => {
-    // List thumb is w-14 (56 px); we pass [80, 160, 240] to keep the
-    // srcset compact and the sizes attr fixed at 56px.
-    expect(source).toMatch(/buildImageVariants\(photo,\s*\[80,\s*160,\s*240\]\)/);
+    // List thumb is w-14 (56 px); 80/160 covers 1×–2× DPR. 240 (3×) was
+    // dropped with the quota shrink.
+    expect(source).toMatch(/buildImageVariants\(photo,\s*\[80,\s*160\]\)/);
     expect(source).toContain('sizes="56px"');
   });
 

--- a/tests/unit/image-variants.test.ts
+++ b/tests/unit/image-variants.test.ts
@@ -1,27 +1,34 @@
 /**
  * PBI 2.1 (#1193) — image-variants URL builder.
- * Pins the AVIF/WebP/multi-width contract so a careless change to the
+ * Pins the AVIF/multi-width contract so a careless change to the
  * Cloudflare resizing URL shape (or the host allowlist) trips this gate.
+ *
+ * Post-incident (cdn-cgi 503 outage): the plan includes 5,000 unique
+ * transformations/month, so the matrix is pinned at 2 widths × AVIF only
+ * = exactly 2 variants per photo. WebP is gone — `webpSrcset` must stay
+ * empty so the quota isn't silently doubled by a re-added format.
  */
 import { describe, it, expect } from 'vitest';
 import { buildImageVariants, EXPLORE_CARD_SIZES } from '../../src/lib/image-variants';
 
 describe('buildImageVariants', () => {
-  it('emits AVIF + WebP srcsets at 320/640/1280 for media.rastrum.org', () => {
+  it('emits an AVIF-only srcset at 320/640 for media.rastrum.org', () => {
     const v = buildImageVariants('https://media.rastrum.org/observations/abc/primary.jpg');
     expect(v.hasVariants).toBe(true);
     expect(v.fallback).toBe('https://media.rastrum.org/observations/abc/primary.jpg');
     expect(v.avifSrcset).toContain('format=avif');
     expect(v.avifSrcset).toContain('width=320');
     expect(v.avifSrcset).toContain('width=640');
-    expect(v.avifSrcset).toContain('width=1280');
     expect(v.avifSrcset).toMatch(/ 320w/);
     expect(v.avifSrcset).toMatch(/ 640w/);
-    expect(v.avifSrcset).toMatch(/ 1280w/);
-    expect(v.webpSrcset).toContain('format=webp');
-    expect(v.webpSrcset).toContain('width=320');
-    expect(v.webpSrcset).toContain('width=640');
-    expect(v.webpSrcset).toContain('width=1280');
+  });
+
+  it('emits exactly 2 AVIF entries and no WebP (5,000 transforms/month quota)', () => {
+    const v = buildImageVariants('https://media.rastrum.org/observations/abc/primary.jpg');
+    expect(v.avifSrcset.split(', ')).toHaveLength(2);
+    expect(v.avifSrcset).not.toContain('width=1280');
+    expect(v.avifSrcset).not.toContain('format=webp');
+    expect(v.webpSrcset).toBe('');
   });
 
   it('rewrites onto the same host via /cdn-cgi/image/ so R2 binding stays intact', () => {
@@ -56,12 +63,12 @@ describe('buildImageVariants', () => {
     expect(v.avifSrcset).toBe('');
   });
 
-  it('accepts a custom widths list for tiny thumbnails', () => {
+  it('accepts a custom widths list for tiny thumbnails — still AVIF-only', () => {
     const v = buildImageVariants('https://media.rastrum.org/observations/abc/primary.jpg', [80, 160]);
     expect(v.avifSrcset).toMatch(/ 80w/);
     expect(v.avifSrcset).toMatch(/ 160w/);
     expect(v.avifSrcset).not.toMatch(/ 320w/);
-    expect(v.avifSrcset).not.toMatch(/ 1280w/);
+    expect(v.webpSrcset).toBe('');
   });
 
   it('exposes the explore-card sizes attribute', () => {


### PR DESCRIPTION
## Summary

Production incident from the 2026-06-09 audit (§1.1 of `docs/site-and-code-audit-2026-06-09.md`): every photo on `/explore/recent/` rendered broken because the `/cdn-cgi/image/` variants returned 503 (feature disabled) and `<picture>` never falls back to the raw `src` on a network failure of the selected source. Transformations are re-enabled, but the plan's **5,000 unique transformations/month** quota makes a recurrence likely as content grows.

- **Matrix 3×2 → 2×1 (AVIF only)**: 6 → 2 unique transformations per photo (~830 → ~2,500 photos/month headroom). List-view thumbs trimmed `[80,160,240]` → `[80,160]`.
- **Graceful degradation**: one-shot `onerror` on the card `<img>` removes sibling `<source>`s and reloads the raw JPEG — quota exhaustion now degrades invisibly instead of breaking the page.
- **Nightly detection**: `check_cdn_image()` in `infra/smoke-model-assets.sh` probes the exact card variant when `SMOKE_CDN_IMAGE_PROBE_URL` is set (skip notice otherwise), wired into `deploy.yml`.

## Test plan

- TDD: `tests/unit/image-variants.test.ts` updated first (red), then green; `tests/unit/explore-recent-lcp.test.ts` pins no-webp-source, 2-entry AVIF srcset, guarded onerror.
- `npx tsc --noEmit` ✓ · full `vitest run` 259 files / 3,047 tests ✓ · `bash -n infra/smoke-model-assets.sh` ✓
- Operator follow-up: set the `SMOKE_CDN_IMAGE_PROBE_URL` repo secret to a stable observation photo URL to arm the probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)