### PR TITLE
fix(observe): wire map-picked location into save + draft-gate GPS-less submits

### DIFF
--- a/src/components/ObserveView2.astro
+++ b/src/components/ObserveView2.astro
@@ -361,7 +361,7 @@ const isEs = lang === 'es';
 const tr = t(lang);
 
 let pipelineState: PipelineState | null = null;
-let location: { lat: number; lng: number; accuracyM: number; altitudeM: number | null } | null = null;
+let location: { lat: number; lng: number; accuracyM: number; altitudeM: number | null; capturedFrom: 'gps' | 'manual' } | null = null;
 let bestResult: { scientific_name: string; common_name_en: string | null; confidence: number; source: string } | null = null;
 let identifyErrorReason: string | null = null;
 let cardAttempts: import('../lib/identify-cascade-client').IdentifyAttempt[] = [];
@@ -1171,15 +1171,20 @@ function startGPS() {
   if (gpsStatus) gpsStatus.textContent = isEs ? 'Obteniendo GPS...' : 'Acquiring GPS...';
   navigator.geolocation.getCurrentPosition(
     pos => {
+      // The observer's explicit map pick is sovereign over a late GPS fix.
+      if (location?.capturedFrom === 'manual') return;
       location = {
         lat: pos.coords.latitude,
         lng: pos.coords.longitude,
         accuracyM: pos.coords.accuracy,
         altitudeM: pos.coords.altitude,
+        capturedFrom: 'gps',
       };
       if (gpsStatus) gpsStatus.textContent = `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)} (±${Math.round(location.accuracyM)}m)`;
-      // Notify map picker
-      window.dispatchEvent(new CustomEvent('rastrum:mappicker-set', {
+      // Notify map picker. The obs2 picker is mode="edit", which only
+      // listens to `rastrum:mappicker-set-initial` (`-set` hydrates
+      // view-mode pickers and is a silent no-op here).
+      window.dispatchEvent(new CustomEvent('rastrum:mappicker-set-initial', {
         detail: { id: 'obs2-map', coords: { lat: location.lat, lng: location.lng } },
       }));
       // Notify contextual chip strip (#723) — only on the first GPS fix per visit.
@@ -1193,14 +1198,41 @@ function startGPS() {
       }
     },
     (err) => {
+      if (location) return; // a map pick already resolved the location
       const msg = err.code === 1
-        ? (isEs ? 'Permiso de ubicación denegado' : 'Location permission denied')
+        ? (isEs ? 'Permiso de ubicación denegado — usa el mapa para elegir' : 'Location permission denied — use the map to pick one')
         : (isEs ? 'No se pudo obtener ubicación — usa el mapa para elegir' : 'Could not get location — use the map to pick one');
       if (gpsStatus) gpsStatus.textContent = msg;
     },
     { enableHighAccuracy: true, timeout: 20000 },
   );
 }
+
+// Map pick from the edit-mode MapPicker (pickerId "obs2-map"). This is the
+// only location path for observers without GPS — the promise in the
+// template comment ("Users without GPS can still pick a location via the
+// map") lives or dies on this listener.
+window.addEventListener('rastrum:mappicker-save', (ev) => {
+  const e = ev as CustomEvent<{ id: string; coords: { lat: number; lng: number } }>;
+  if (e.detail.id !== 'obs2-map') return;
+  location = {
+    lat: e.detail.coords.lat,
+    lng: e.detail.coords.lng,
+    accuracyM: 50,
+    altitudeM: null,
+    capturedFrom: 'manual',
+  };
+  if (gpsStatus) gpsStatus.textContent = `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)}`;
+  // Sync the picker's initial coords so re-opening the modal centers on
+  // the pick instead of the default Mexico view.
+  window.dispatchEvent(new CustomEvent('rastrum:mappicker-set-initial', {
+    detail: { id: 'obs2-map', coords: { lat: location.lat, lng: location.lng } },
+  }));
+  if (pipelineState) {
+    const locNode = pipelineState.nodes.find(n => n.kind === 'location');
+    if (locNode) setNodeState(pipelineState, locNode.id, 'done');
+  }
+});
 
 // ── Show post form ─────────────────────────────────────────────────────────
 function showPostForm() {
@@ -1315,10 +1347,15 @@ postForm?.addEventListener('submit', async (e) => {
     const observerOwned = observerAffirmed || (!!taxonInput && taxonInput !== machineName);
     const identifiedSpecies = taxonInput || observerAffirmedTaxon || machineName;
 
+    // No GPS fix and no map pick → save as a draft (sync engine skips it
+    // until a location is added) instead of syncing a (0,0) null-island
+    // record that ExploreMap filters out. Mirrors QuickObserveSheet.
+    const savedAsDraft = !location;
     const obs = await saveObservationToOutbox({
       observerRef,
       media: mediaInputs,
       location: location ?? { lat: 0, lng: 0, accuracyM: 0, altitudeM: null, capturedFrom: 'gps' },
+      asDraft: savedAsDraft,
       identification: identifiedSpecies ? {
         scientificName: identifiedSpecies,
         confidence: observerOwned ? 0 : (bestResult?.confidence ?? 0),
@@ -1382,7 +1419,14 @@ postForm?.addEventListener('submit', async (e) => {
     postForm?.classList.add('hidden');
     successEl?.classList.remove('hidden');
     const linkEl = document.getElementById('obs2-success-link');
-    if (linkEl && obs.id) {
+    if (linkEl && savedAsDraft) {
+      // Drafts never sync, so the "View observation" link (and its
+      // "Syncing…" gate) would dead-end. Tell the truth instead.
+      const draftMsg = document.createElement('span');
+      draftMsg.className = 'text-zinc-600 dark:text-zinc-400 text-sm';
+      draftMsg.textContent = tr.observe.draft_saved_offline;
+      linkEl.replaceChildren(draftMsg);
+    } else if (linkEl && obs.id) {
       // The /share/obs/?id= page reads from Supabase, so it 404s
       // ("Observation not found") until the outbox row reaches the
       // server. Gate the CTA on the existing sync-row-done event
@@ -1429,7 +1473,9 @@ postForm?.addEventListener('submit', async (e) => {
     toastEl.setAttribute('role', 'status');
     toastEl.setAttribute('aria-live', 'polite');
     toastEl.className = 'fixed bottom-6 left-1/2 -translate-x-1/2 z-50 rounded-xl bg-emerald-700 text-white px-5 py-3 text-sm shadow-lg max-w-[340px] text-center pointer-events-none transition-opacity duration-300';
-    toastEl.textContent = isEs ? '¡Observación guardada!' : 'Observation saved!';
+    toastEl.textContent = savedAsDraft
+      ? tr.observe.draft_saved_offline
+      : (isEs ? '¡Observación guardada!' : 'Observation saved!');
     document.body.appendChild(toastEl);
     setTimeout(() => { toastEl.style.opacity = '0'; setTimeout(() => toastEl.remove(), 300); }, 3000);
   } catch (err) {
@@ -1444,6 +1490,11 @@ postForm?.addEventListener('submit', async (e) => {
 // ── New observation ────────────────────────────────────────────────────────
 document.getElementById('obs2-new-btn')?.addEventListener('click', () => {
   location = null;
+  // Clear the picker's stale pin from the previous observation.
+  window.dispatchEvent(new CustomEvent('rastrum:mappicker-set-initial', {
+    detail: { id: 'obs2-map', coords: null },
+  }));
+  if (gpsStatus) gpsStatus.textContent = isEs ? 'Obteniendo GPS...' : 'Acquiring GPS...';
   bestResult = null;
   identifyErrorReason = null;
   cardAttempts = [];

--- a/tests/e2e/observe-location.spec.ts
+++ b/tests/e2e/observe-location.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Observe 2.0 location wiring — data-integrity seam.
+ *
+ * The ObserveView2 client `<script>` is e2e-gated (tsc/vitest/build never
+ * execute it). This spec drives it deterministically — no Supabase writes,
+ * no real GPS hardware, no identifier runners: the synthetic audio file has
+ * no BirdNET model cached, so the cascade deterministically lands on the
+ * "audio skipped" warning and we continue into the post-form. The context
+ * goes offline before submit so the outbox row never syncs anywhere.
+ *
+ * Covers three bugs from the location audit:
+ *  1. `rastrum:mappicker-save` (detail.id === 'obs2-map') must update the
+ *     location the form will save, the visible GPS status line, and the
+ *     picker's initial coords (so re-opening the modal centers on the pick).
+ *  2. Submitting with no GPS fix and no picked location must save a DRAFT
+ *     (`sync_status: 'draft'`, skipped by the sync engine) — never a
+ *     syncable (0,0) null-island record.
+ *  3. A GPS fix must reach the edit-mode picker via
+ *     `rastrum:mappicker-set-initial` (the `rastrum:mappicker-set` event
+ *     only hydrates view-mode pickers).
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const PICK = { lat: 19.4326, lng: -99.1332 };
+
+async function dropAudioFile(page: Page) {
+  await page.evaluate(() => {
+    const file = new File([new Uint8Array(2048)], 'call.webm', { type: 'audio/webm' });
+    document.dispatchEvent(new CustomEvent('rastrum:files-dropped', { detail: { files: [file] } }));
+  });
+}
+
+async function continueToPostForm(page: Page) {
+  // No BirdNET model cached -> the lone audio identify node is skipped ->
+  // AudioSkippedWarning shows its continue button.
+  await page.locator('#obs2-audio-skip-continue').click({ timeout: 15_000 });
+  await expect(page.locator('#obs2-post-form')).toBeVisible();
+}
+
+async function dispatchMapPickerSave(page: Page, coords: { lat: number; lng: number }) {
+  await page.evaluate((c) => {
+    window.dispatchEvent(new CustomEvent('rastrum:mappicker-save', {
+      detail: { id: 'obs2-map', coords: c },
+    }));
+  }, coords);
+}
+
+function readOutboxRows(page: Page) {
+  return page.evaluate(() => new Promise<Array<{
+    sync_status: string;
+    data: { location: { lat: number; lng: number }; syncStatus: string };
+  }>>((resolve, reject) => {
+    const req = indexedDB.open('rastrum-v1');
+    req.onsuccess = () => {
+      const db = req.result;
+      const all = db.transaction('observations', 'readonly').objectStore('observations').getAll();
+      all.onsuccess = () => { resolve(all.result); db.close(); };
+      all.onerror = () => reject(all.error);
+    };
+    req.onerror = () => reject(req.error);
+  }));
+}
+
+for (const path of ['/en/observe/', '/es/observar/']) {
+  test(`mappicker-save for obs2-map updates the form location on ${path}`, async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+    await dispatchMapPickerSave(page, PICK);
+
+    // Visible status line reflects the pick (this is the observable the
+    // observer uses to confirm "the form has my location").
+    await expect(page.locator('#obs2-gps-status')).toContainText('19.4326');
+    await expect(page.locator('#obs2-gps-status')).toContainText('-99.1332');
+
+    // The edit picker's initial coords were synced back, so re-opening the
+    // modal centers on the pick instead of the default Mexico view.
+    const modal = page.locator('[data-mappicker-modal="obs2-map"]');
+    await expect(modal).toHaveAttribute('data-mappicker-initial-lat', '19.4326');
+    await expect(modal).toHaveAttribute('data-mappicker-initial-lng', '-99.1332');
+
+    expect(errors, `pageerror on ${path}`).toEqual([]);
+  });
+}
+
+test('submit with no GPS and no picked location saves a draft, never a synced (0,0) record', async ({ page }) => {
+  await page.goto('/en/observe/', { waitUntil: 'domcontentloaded' });
+  await dropAudioFile(page);
+  await continueToPostForm(page);
+
+  // Hermetic: nothing may leave the machine after submit.
+  await page.context().setOffline(true);
+  await page.locator('#obs2-save-btn').click();
+  await expect(page.locator('#obs2-success')).toBeVisible();
+
+  const rows = await readOutboxRows(page);
+  expect(rows).toHaveLength(1);
+  // Null-island fallback must be a draft the sync engine skips — not a
+  // syncable record that vanishes from every map (ExploreMap filters 0,0).
+  expect(rows[0].sync_status).toBe('draft');
+  expect(rows[0].data.syncStatus).toBe('draft');
+
+  // The observer is told it's a draft, not a lie about a saved observation.
+  await expect(page.locator('#obs2-success-link')).toContainText(/draft/i);
+});
+
+test('picked location is what lands in the outbox record (asDraft false)', async ({ page }) => {
+  await page.goto('/en/observe/', { waitUntil: 'domcontentloaded' });
+  await dropAudioFile(page);
+  await continueToPostForm(page);
+
+  await dispatchMapPickerSave(page, PICK);
+  await expect(page.locator('#obs2-gps-status')).toContainText('19.4326');
+
+  await page.context().setOffline(true);
+  await page.locator('#obs2-save-btn').click();
+  await expect(page.locator('#obs2-success')).toBeVisible();
+
+  const rows = await readOutboxRows(page);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].sync_status).not.toBe('draft');
+  expect(rows[0].data.location.lat).toBeCloseTo(PICK.lat, 5);
+  expect(rows[0].data.location.lng).toBeCloseTo(PICK.lng, 5);
+});
+
+test.describe('GPS fix centers the edit picker', () => {
+  test.use({
+    geolocation: { latitude: PICK.lat, longitude: PICK.lng, accuracy: 10 },
+    permissions: ['geolocation'],
+  });
+
+  test('startGPS dispatches mappicker-set-initial so obs2-map opens at the fix', async ({ page }) => {
+    await page.goto('/en/observe/', { waitUntil: 'domcontentloaded' });
+    await dropAudioFile(page); // startGPS() runs on files-dropped
+
+    await expect(page.locator('#obs2-gps-status')).toContainText('19.4326');
+
+    // Edit-mode pickers only listen to `rastrum:mappicker-set-initial` —
+    // the `-set` event hydrates view-mode pickers and is a silent no-op here.
+    const modal = page.locator('[data-mappicker-modal="obs2-map"]');
+    await expect(modal).toHaveAttribute('data-mappicker-initial-lat', '19.4326');
+    await expect(modal).toHaveAttribute('data-mappicker-initial-lng', '-99.1332');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the critical data-integrity bug from the 2026-06-09 audit (§2.2-C1 of `docs/site-and-code-audit-2026-06-09.md`):

1. **`rastrum:mappicker-save` listener** (filtered to `obs2-map`) — the "pick a location via the map" path promised in the code comment now actually updates the saved location, the `#obs2-gps-status` line, and the pipeline node.
2. **`asDraft: !location` on submit** (QuickObserveSheet's convention) — a GPS-less, pick-less submit lands in the outbox as a draft with the existing `observe.draft_saved_offline` copy, instead of syncing a (0,0) null-island record that `ExploreMap` then silently filters out.
3. **GPS fix dispatches `rastrum:mappicker-set-initial`** (was `-set`, view-mode only) so the edit picker opens centered on the fix. A manual pick stays sovereign over a late GPS fix.

No new i18n strings (reuses `observe.draft_saved_offline`, EN/ES parity verified).

## Test plan (TDD)

- New `tests/e2e/observe-location.spec.ts` (deterministic: offline context, IndexedDB outbox assertions) was **red 5/5 against the unmodified build** on exactly the bug surfaces, green after.
- `npx playwright test tests/e2e/observe-card.spec.ts tests/e2e/observe-location.spec.ts --project=chromium` → 7 passed.
- Adjacent specs (`observe-form-map`, `observe-form`, `observe-v2-empty-state`, `guided-first-observation`) → 14 passed.
- `npx tsc --noEmit` ✓ · `vitest run` 3,045 tests ✓ · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)