### PR TITLE
fix(schema): column-gate precise coordinates + ownership-check primary-ID upsert

### DIFF
--- a/docs/specs/infra/supabase-schema.sql
+++ b/docs/specs/infra/supabase-schema.sql
@@ -318,6 +318,54 @@ ALTER TABLE public.observations ADD COLUMN IF NOT EXISTS review_requested boolea
 CREATE INDEX IF NOT EXISTS idx_obs_review_requested
   ON public.observations(review_requested) WHERE review_requested = true;
 
+-- ── 2026-06 audit F1: public-safe coordinate column ─────────────────────────
+-- RLS gates rows, not columns: obs_public_read admits sensitive rows whose
+-- location_obscured is set, but the table-level SELECT grant exposed the
+-- precise `location` column on those very rows
+-- (GET /rest/v1/observations?select=location&obscure_level=eq.5km leaked
+-- exact coordinates). The fix is column-level SELECT grants (see the
+-- "OBSERVATIONS COLUMN-LEVEL SELECT" block near the end of this file —
+-- it must run AFTER every ADD COLUMN, so it lives at the bottom).
+--
+-- `location_public` is the always-safe coordinate every public surface
+-- (explore map, species map, share page, pins view, chat cards) reads
+-- instead of `location`:
+--   obscure_level = 'none'  → precise location (observer opted into public)
+--   anything else           → location_obscured (NULL if not yet coarsened,
+--                             in which case obs_public_read hides the row
+--                             from non-owners anyway)
+-- GENERATED ALWAYS … STORED keeps it in sync with zero trigger surface.
+ALTER TABLE public.observations ADD COLUMN IF NOT EXISTS location_public
+  geography(Point, 4326) GENERATED ALWAYS AS (
+    CASE WHEN obscure_level = 'none' THEN location ELSE location_obscured END
+  ) STORED;
+CREATE INDEX IF NOT EXISTS idx_obs_location_public
+  ON public.observations USING GIST(location_public);
+
+-- Owner-only precise-coordinate reader. Column grants cannot be
+-- row-conditional, so after `location` is revoked from anon/authenticated
+-- the observer reads their own precise coords through this SECURITY DEFINER
+-- function (a security_invoker view would re-check the column grant and
+-- fail). Internal observer_id = auth.uid() filter means a non-owner gets
+-- zero rows, never an error. NULL p_observation_ids = all own observations
+-- (used by the DwC export).
+CREATE OR REPLACE FUNCTION public.get_own_observation_locations(
+  p_observation_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (observation_id uuid, lat double precision, lng double precision)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT o.id, ST_Y(o.location::geometry), ST_X(o.location::geometry)
+  FROM public.observations o
+  WHERE o.observer_id = (SELECT auth.uid())
+    AND o.location IS NOT NULL
+    AND (p_observation_ids IS NULL OR o.id = ANY(p_observation_ids));
+$$;
+
+REVOKE ALL ON FUNCTION public.get_own_observation_locations(uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_own_observation_locations(uuid[]) TO authenticated, service_role;
+
 -- ============================================================
 -- IDENTIFICATIONS
 -- ============================================================
@@ -2719,11 +2767,11 @@ CREATE OR REPLACE VIEW public.profile_observation_pins AS
 SELECT
   o.observer_id,
   o.id AS observation_id,
-  CASE
-    WHEN o.location_obscured IS NOT NULL
-      THEN o.location_obscured
-    ELSE o.location
-  END AS location,
+  -- 2026-06 audit F1: location_public (obscured for sensitive rows, precise
+  -- only when obscure_level='none'). The previous CASE fell back to the
+  -- precise location when a sensitive row had no obscured point, and — being
+  -- a security_invoker view — would now fail the column-level SELECT grant.
+  o.location_public AS location,
   i.scientific_name,
   i.is_research_grade,
   o.observed_at
@@ -3042,7 +3090,11 @@ WITH base AS (
   LEFT JOIN public.taxon_rarity tr ON tr.taxon_id = i.taxon_id
   WHERE
     o.sync_status = 'synced'
-    AND o.obscure_level <> 'private'
+    -- 2026-06 audit F3: was `<> 'private'` — a value the obscure_level enum
+    -- never holds (none/0.1deg/0.2deg/5km/full), so the filter was a no-op
+    -- and fully-obscured observations leaked into the dex. Sibling views
+    -- (profile_observation_pins, profile_stats_counts) use `<> 'full'`.
+    AND o.obscure_level <> 'full'
     AND i.scientific_name IS NOT NULL
     AND public.can_see_facet(o.observer_id, 'pokedex', (SELECT auth.uid()))
   GROUP BY
@@ -8095,12 +8147,44 @@ SET search_path = public
 AS $$
 DECLARE
   v_id uuid;
+  v_uid uuid := auth.uid();
+  v_confidence numeric := LEAST(GREATEST(p_confidence, 0), 1);
 BEGIN
+  -- 2026-06 audit F2: this function is SECURITY DEFINER and granted to
+  -- `authenticated`, so without an internal ownership check any logged-in
+  -- user could hijack the primary ID on anyone's observation. A NULL
+  -- auth.uid() means the caller is NOT an end-user JWT — only
+  -- `service_role` (the identify Edge Function) can reach that state,
+  -- because EXECUTE is revoked from PUBLIC/anon. Service context is
+  -- trusted; every end-user must own the observation.
+  IF v_uid IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.observations
+      WHERE id = p_observation_id AND observer_id = v_uid
+    ) THEN
+      RAISE EXCEPTION 'not_observation_owner'
+        USING ERRCODE = '42501',
+              HINT = 'Only the observer can set identifications on this observation.';
+    END IF;
+  END IF;
+
+  -- Mirror of the identifications_source_check CHECK constraint. Validated
+  -- here too so a bad source fails loudly BEFORE the demote UPDATE runs,
+  -- with a clean error instead of a constraint violation.
+  IF p_source IS NULL OR p_source NOT IN (
+    'plantnet','claude_haiku','claude_sonnet','onnx_offline','human',
+    'birdnet_lite','onnx_efficientnet_lite0','camera_trap_megadetector','phi_vision',
+    'bedrock','openai','azure_openai','gemini','vertex_ai'
+  ) THEN
+    RAISE EXCEPTION 'invalid_identification_source: %', coalesce(p_source, 'NULL')
+      USING ERRCODE = '23514';
+  END IF;
+
   UPDATE public.identifications
   SET is_primary = false
   WHERE observation_id = p_observation_id
     AND is_primary IS TRUE
-    AND confidence < p_confidence;
+    AND confidence < v_confidence;
 
   IF EXISTS (
     SELECT 1 FROM public.identifications
@@ -8112,7 +8196,7 @@ BEGIN
     )
     VALUES (
       p_observation_id, p_scientific_name, p_taxon_id,
-      p_confidence, p_source, p_raw_response, false
+      v_confidence, p_source, p_raw_response, false
     )
     RETURNING id INTO v_id;
   ELSE
@@ -8122,7 +8206,7 @@ BEGIN
     )
     VALUES (
       p_observation_id, p_scientific_name, p_taxon_id,
-      p_confidence, p_source, p_raw_response, true
+      v_confidence, p_source, p_raw_response, true
     )
     RETURNING id INTO v_id;
   END IF;
@@ -9038,14 +9122,17 @@ BEGIN
   WITH nearby AS (
     SELECT
       i.taxon_id,
-      ST_Distance(o.location, v_point) AS distance_m,
+      -- 2026-06 audit F1: location_public, not location — this function is
+      -- SECURITY INVOKER and anon/authenticated no longer hold SELECT on
+      -- the precise column. Coarsened coords are fine for a 50 km aggregate.
+      ST_Distance(o.location_public, v_point) AS distance_m,
       o.observer_id
     FROM public.observations o
     JOIN public.identifications i
       ON i.observation_id = o.id AND i.is_primary = true
-    WHERE o.location IS NOT NULL
+    WHERE o.location_public IS NOT NULL
       AND i.taxon_id IS NOT NULL
-      AND ST_DWithin(o.location, v_point, 50000)
+      AND ST_DWithin(o.location_public, v_point, 50000)
       AND EXTRACT(MONTH FROM o.observed_at AT TIME ZONE 'UTC')::int = ANY(v_months)
       AND (i.is_research_grade = true OR o.primary_taxon_id IS NOT NULL)
   ),
@@ -10214,7 +10301,10 @@ AS $$
     SELECT
       o.id, o.observer_id, o.observed_at,
       o.primary_taxon_id, o.obscure_level,
-      o.location, o.location_obscured,
+      -- 2026-06 audit F1: SECURITY INVOKER + column-level grants — the
+      -- precise `location` column is no longer readable here. Owner-precise
+      -- coords come from the SECURITY DEFINER helper in the outer query.
+      o.location_public,
       o.state_province, o.notes,
       COALESCE(i.is_research_grade, false) AS is_research_grade,
       t.scientific_name, t.common_name_es, t.common_name_en,
@@ -10247,13 +10337,9 @@ AS $$
       'state_province',  o.state_province,
       'is_research_grade', o.is_research_grade,
       'obscure_level',   o.obscure_level,
-      'lat', CASE WHEN auth.uid() = o.observer_id
-                  THEN ST_Y(o.location::geometry)
-                  ELSE ST_Y(coalesce(o.location_obscured, o.location)::geometry) END,
-      'lng', CASE WHEN auth.uid() = o.observer_id
-                  THEN ST_X(o.location::geometry)
-                  ELSE ST_X(coalesce(o.location_obscured, o.location)::geometry) END,
-      'coords_obscured', (auth.uid() IS DISTINCT FROM o.observer_id AND o.location_obscured IS NOT NULL)
+      'lat', COALESCE(own.lat, ST_Y(o.location_public::geometry)),
+      'lng', COALESCE(own.lng, ST_X(o.location_public::geometry)),
+      'coords_obscured', (auth.uid() IS DISTINCT FROM o.observer_id AND o.obscure_level <> 'none')
     ),
     'suggested_questions', jsonb_build_array(
       'Why is this ' || CASE WHEN o.is_research_grade THEN 'research grade' ELSE 'needs review' END || '?',
@@ -10265,7 +10351,10 @@ AS $$
       'observer_id',      o.observer_id::text
     )
   ) END
-  FROM o;
+  FROM o
+  -- SECURITY DEFINER helper: returns a row only when the caller owns the
+  -- observation, so owners still see their precise coords in the chat card.
+  LEFT JOIN LATERAL public.get_own_observation_locations(ARRAY[o.id]) own ON true;
 $$;
 
 DROP FUNCTION IF EXISTS public.chat_species_card(text);
@@ -10606,7 +10695,8 @@ BEGIN
       WHERE (NOT v_owner_self    OR o.observer_id = auth.uid())
         AND (v_taxon_id    IS NULL OR o.primary_taxon_id = v_taxon_id)
         AND (v_project_id  IS NULL OR o.project_id      = v_project_id)
-        AND (v_near_obs    IS NULL OR ST_DWithin(o.location, near.location, v_radius_km * 1000))
+        -- 2026-06 audit F1: location_public — SECURITY INVOKER, see chat_obs_card.
+        AND (v_near_obs    IS NULL OR ST_DWithin(o.location_public, near.location_public, v_radius_km * 1000))
         AND (NOT v_research_only OR COALESCE(i.is_research_grade, false) = true)
       ORDER BY o.observed_at DESC
       LIMIT greatest(1, least(p_limit, 50))
@@ -12132,14 +12222,17 @@ BEGIN
   WITH nearby AS (
     SELECT
       i.taxon_id,
-      ST_Distance(o.location, v_point) AS distance_m,
+      -- 2026-06 audit F1: location_public, not location — this function is
+      -- SECURITY INVOKER and anon/authenticated no longer hold SELECT on
+      -- the precise column. Coarsened coords are fine for a 50 km aggregate.
+      ST_Distance(o.location_public, v_point) AS distance_m,
       o.observer_id
     FROM public.observations o
     JOIN public.identifications i
       ON i.observation_id = o.id AND i.is_primary = true
-    WHERE o.location IS NOT NULL
+    WHERE o.location_public IS NOT NULL
       AND i.taxon_id IS NOT NULL
-      AND ST_DWithin(o.location, v_point, 50000)
+      AND ST_DWithin(o.location_public, v_point, 50000)
       AND EXTRACT(MONTH FROM o.observed_at AT TIME ZONE 'UTC')::int = ANY(v_months)
       AND (i.is_research_grade = true OR o.primary_taxon_id IS NOT NULL)
   ),
@@ -13182,3 +13275,89 @@ $taxa_dedup$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS taxa_scientific_name_key
   ON public.taxa (scientific_name);
+
+-- ════════════════════════════════════════════════════════════════════════
+-- OBSERVATIONS COLUMN-LEVEL SELECT (2026-06 audit F1)
+-- ════════════════════════════════════════════════════════════════════════
+-- RLS gates rows, not columns. obs_public_read admits sensitive rows (the
+-- ones with location_obscured set), and the blanket table-level SELECT
+-- grant near the top of this file exposed the precise `location` column on
+-- exactly those rows. Column-level REVOKE does NOT subtract from a
+-- table-level GRANT, so the mechanism is: revoke table-level SELECT, then
+-- re-grant an explicit column list that excludes `location`.
+--
+-- Readers use `location_public` (generated column, defined right after the
+-- observations CREATE TABLE). Owners read their own precise coords via the
+-- SECURITY DEFINER `get_own_observation_locations()` RPC. INSERT/UPDATE/
+-- DELETE grants are untouched — owners still write `location` directly
+-- (and via update_observation_location()).
+--
+-- This block MUST stay at the END of the file: it enumerates columns that
+-- are added by ALTER TABLE statements scattered above, and the blanket
+-- `GRANT SELECT ON ALL TABLES` near the top re-grants table-level SELECT
+-- on every replay, which this block then narrows again.
+--
+-- ⚠ MAINTENANCE: any future `ALTER TABLE public.observations ADD COLUMN`
+-- must ALSO add the column here, or anon/authenticated reads of it will
+-- fail with "permission denied" in production (PostgREST `select=*`
+-- expands to ALL columns and fails outright if any is ungranted — client
+-- code must use explicit column lists on this table).
+REVOKE SELECT ON public.observations FROM anon, authenticated;
+GRANT SELECT (
+  id,
+  observer_id,
+  observed_at,
+  location_obscured,
+  location_public,
+  accuracy_m,
+  altitude_m,
+  location_source,
+  state_province,
+  municipality,
+  locality,
+  primary_taxon_id,
+  obscure_level,
+  habitat,
+  weather,
+  notes,
+  individual_count,
+  evidence_type,
+  content_sensitive,
+  license,
+  moon_phase,
+  moon_illumination,
+  photoperiod_hours,
+  temp_celsius,
+  precipitation_24h_mm,
+  precipitation_7d_mm,
+  days_since_rain,
+  post_rain_flag,
+  weather_tag,
+  ndvi_value,
+  phenological_season,
+  fire_proximity_km,
+  captured_at,
+  device_make,
+  device_model,
+  gps_direction_deg,
+  media_quality_score,
+  sync_status,
+  app_version,
+  device_os,
+  created_at,
+  updated_at,
+  review_requested,
+  establishment_means,
+  hidden,
+  hidden_reason,
+  hidden_at,
+  hidden_by,
+  last_material_edit_at,
+  project_id,
+  camera_station_id,
+  place_id,
+  identification_status,
+  is_range_extension,
+  life_stage,
+  vital_status
+) ON public.observations TO anon, authenticated;

--- a/src/components/ExploreMap.astro
+++ b/src/components/ExploreMap.astro
@@ -228,7 +228,7 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
     // RLS still gates the rows.
     const { data, error } = await supabase
       .from('observations')
-      .select('id, location, location_obscured, obscure_level, observed_at, taxa:primary_taxon_id(kingdom), identifications(scientific_name, is_primary), media_files(url, thumbnail_url, is_primary, media_type)')
+      .select('id, location_public, obscure_level, observed_at, taxa:primary_taxon_id(kingdom), identifications(scientific_name, is_primary), media_files(url, thumbnail_url, is_primary, media_type)')
       .eq('sync_status', 'synced')
       .limit(500);
 
@@ -241,14 +241,10 @@ const observersMapHref = getLocalizedPath(lang, routes.communityMap[locale] + '/
     for (const row of data ?? []) {
       // PostgREST returns geography columns as EWKB hex strings, not
       // GeoJSON objects. Use parseLocationToGeoJSON to decode them.
-      // Prefer location_obscured for sensitive observations (non-owner
-      // viewers should see the coarsened point, not precise coords).
-      const rawPrecise = (row as Record<string, unknown>).location;
-      const rawObscured = (row as Record<string, unknown>).location_obscured;
-      const level = (row as { obscure_level?: string }).obscure_level;
-      const precise = parseLocationToGeoJSON(rawPrecise);
-      const obscured = parseLocationToGeoJSON(rawObscured);
-      const parsed = (level && level !== 'none' && obscured?.coordinates) ? obscured : precise;
+      // location_public is the server-computed public-safe coordinate:
+      // precise when obscure_level='none', coarsened otherwise. The
+      // precise `location` column is no longer SELECT-granted to clients.
+      const parsed = parseLocationToGeoJSON((row as Record<string, unknown>).location_public);
       if (!parsed?.coordinates) continue;
       const geom: GeoJSON.Point = { type: 'Point', coordinates: parsed.coordinates };
       const observedAt = (row as { observed_at?: string | null }).observed_at ?? null;

--- a/src/components/ExploreSpeciesView.astro
+++ b/src/components/ExploreSpeciesView.astro
@@ -268,7 +268,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
 
   type ObsRow = {
     id: string;
-    location: GeoJSON.Point | null;
+    location_public: GeoJSON.Point | null;
     observed_at: string;
     media_files: { url: string | null; thumbnail_url?: string | null; is_primary: boolean | null; media_type?: string | null; deleted_at?: string | null }[];
   };
@@ -1454,7 +1454,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     try {
       const { data, error } = await supabase
         .from('observations')
-        .select('id, location, observed_at, media_files(url, thumbnail_url, is_primary, media_type, deleted_at)')
+        .select('id, location_public, observed_at, media_files(url, thumbnail_url, is_primary, media_type, deleted_at)')
         .eq('sync_status', 'synced')
         .eq('primary_taxon_id', taxon.id)
         .order('observed_at', { ascending: false })
@@ -1481,7 +1481,7 @@ const indexBase = `/${lang}/${lang === 'es' ? 'explorar/especies' : 'explore/spe
     if (mapEl) {
       const features: GeoJSON.Feature[] = [];
       for (const r of obsRows) {
-        const geom = r.location;
+        const geom = r.location_public;
         if (!geom?.coordinates) continue;
         features.push({ type: 'Feature', geometry: geom, properties: { id: r.id } });
       }

--- a/src/components/ExportView.astro
+++ b/src/components/ExportView.astro
@@ -132,7 +132,7 @@ const tr = t(lang);
         .from('observations')
         .select(`
           id, observed_at, accuracy_m, obscure_level,
-          state_province, habitat, location,
+          state_province, habitat,
           identifications!inner(scientific_name, confidence, source, is_primary),
           taxa:primary_taxon_id(kingdom)
         `)
@@ -142,14 +142,25 @@ const tr = t(lang);
 
       if (obsErr) throw obsErr;
 
+      // Precise coords for the export come from the owner-only SECURITY
+      // DEFINER RPC — the `location` column itself is no longer
+      // SELECT-granted to clients (2026-06 audit F1).
+      const { data: ownLocs, error: locErr } = await supabase
+        .rpc('get_own_observation_locations');
+      if (locErr) throw locErr;
+      const locById = new Map<string, { lat: number; lng: number }>(
+        ((ownLocs ?? []) as { observation_id: string; lat: number; lng: number }[])
+          .map(l => [l.observation_id, { lat: l.lat, lng: l.lng }]),
+      );
+
       const rows: DwCInput[] = (obs ?? []).map(r => {
-        const loc = (r.location as unknown) as GeoJSON.Point | null;
+        const loc = locById.get(r.id as string) ?? null;
         const id0 = Array.isArray(r.identifications) ? r.identifications[0] : r.identifications;
         return {
           id: r.id as string,
           observed_at: r.observed_at as string,
-          lat: loc?.coordinates?.[1] ?? 0,
-          lng: loc?.coordinates?.[0] ?? 0,
+          lat: loc?.lat ?? 0,
+          lng: loc?.lng ?? 0,
           accuracy_m: r.accuracy_m as number | null,
           obscure_level: (r.obscure_level as string) ?? 'none',
           scientific_name: id0?.scientific_name ?? null,

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -135,9 +135,12 @@ async function syncOne(record: ObservationRecord): Promise<void> {
     try {
       // Only count observations that have been fully synced to the server
       // (sync_status='synced'). Drafts or locally-pending rows don't count.
+      // select('id'), not '*': observations has column-level SELECT grants
+      // (precise `location` is owner-RPC-only) and PostgREST expands '*'
+      // to every column, which now fails with permission denied.
       const { count } = await supabase
         .from('observations')
-        .select('*', { count: 'exact', head: true })
+        .select('id', { count: 'exact', head: true })
         .eq('observer_id', observerRef.id)
         .eq('sync_status', 'synced');
       if (count === 1) {

--- a/src/pages/share/obs/index.astro
+++ b/src/pages/share/obs/index.astro
@@ -110,7 +110,7 @@ const lang: 'en' | 'es' = 'en';
         .from('observations')
         .select(`
           id, observed_at, obscure_level, state_province, habitat, weather, establishment_means, observer_id, notes,
-          last_material_edit_at, is_range_extension, location, location_obscured, evidence_type,
+          last_material_edit_at, is_range_extension, location_public, evidence_type,
           places:place_id(id, slug, name, place_type),
           identifications(scientific_name, is_primary, is_research_grade),
           users:observer_id(display_name, username, profile_public)
@@ -349,15 +349,24 @@ const lang: 'en' | 'es' = 'en';
       }
 
       // Coords readout + view-mode mini-map hydration. PostgREST returns
-      // `location` as EWKB hex for geography columns (e.g. "0101000020E6100000...").
-      // Parse it to {coordinates:[lng,lat]} before use. If it's already an object
-      // (future PostgREST versions or cached GeoJSON), use it directly.
-            // Coords readout + view-mode mini-map hydration. PostgREST returns
-      // `location` as EWKB hex for geography columns — parsed via geo.ts.
-      // For non-owner viewers we prefer `location_obscured` when present.
-      const obsLoc = parseLocationToGeoJSON((obs as Record<string,unknown>).location);
-      const obscuredLoc = parseLocationToGeoJSON((obs as Record<string,unknown>).location_obscured);
-      const usePoint = (!viewerIsObserver && obscuredLoc?.coordinates) ? obscuredLoc : obsLoc;
+      // geography columns as EWKB hex (e.g. "0101000020E6100000...") —
+      // parsed via geo.ts. `location_public` is the public-safe coordinate
+      // (precise only when obscure_level='none'); the precise `location`
+      // column is owner-RPC-only since the 2026-06 audit (F1). For the
+      // owner we fetch precise coords through the SECURITY DEFINER RPC and
+      // stash them on `obs.location` so the manage panel keeps working.
+      let usePoint = parseLocationToGeoJSON((obs as Record<string,unknown>).location_public);
+      if (viewerIsObserver) {
+        try {
+          const { data: ownLoc } = await supabase
+            .rpc('get_own_observation_locations', { p_observation_ids: [id] });
+          const own = Array.isArray(ownLoc) ? ownLoc[0] as { lat?: number; lng?: number } | undefined : undefined;
+          if (own && Number.isFinite(own.lat) && Number.isFinite(own.lng)) {
+            usePoint = { coordinates: [own.lng as number, own.lat as number] };
+          }
+        } catch { /* fall back to the public point — non-fatal */ }
+        (obs as Record<string, unknown>).location = usePoint;
+      }
       const coords = usePoint?.coordinates;
       if (Array.isArray(coords) && coords.length >= 2) {
         const lng = coords[0];

--- a/tests/sql/rls.sql
+++ b/tests/sql/rls.sql
@@ -1042,6 +1042,227 @@ END $$;
 RESET ROLE;
 
 -- ────────────────────────────────────────────────────────────────────────────
+-- 2026-06 audit F1 — observations column-level SELECT grants
+-- (precise `location` revoked from anon/authenticated; public surfaces read
+-- the generated `location_public`; owners use get_own_observation_locations)
+-- + F2 — upsert_primary_identification ownership/source/confidence hardening
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- Seed: precise coords on the public obs (…0001, obscure_level=none) and a
+-- sensitive obs (…0003, obscure_level=5km) with precise + obscured points.
+DO $$
+BEGIN
+  UPDATE public.observations
+     SET location = ST_SetSRID(ST_MakePoint(-99.1332, 19.4326), 4326)::geography
+   WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+  INSERT INTO public.observations
+    (id, observer_id, sync_status, obscure_level, hidden, location, location_obscured)
+  VALUES (
+    'aaaaaaaa-0000-0000-0000-000000000003',
+    '00000000-0000-0000-0000-000000000003',
+    'synced', '5km', false,
+    ST_SetSRID(ST_MakePoint(-99.1332, 19.4326), 4326)::geography,
+    ST_SetSRID(ST_MakePoint(-99.15,   19.45),   4326)::geography
+  )
+  ON CONFLICT (id) DO NOTHING;
+END $$;
+
+SET LOCAL "request.jwt.claim.sub" = '';
+SET LOCAL ROLE anon;
+
+-- F1 test 1: anon reading observations.location → permission denied
+DO $$
+DECLARE
+  v geography;
+BEGIN
+  BEGIN
+    SELECT location INTO v FROM public.observations
+     WHERE id = 'aaaaaaaa-0000-0000-0000-000000000003';
+    RAISE EXCEPTION 'FAIL [F1: anon can SELECT observations.location — precise coords of sensitive species leak]';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL; -- expected
+  END;
+END $$;
+
+-- F1 test 2: anon reads location_obscured + location_public on the sensitive
+-- row, and location_public equals the coarsened point (never the precise one)
+DO $$
+DECLARE
+  v_obsc geography;
+  v_pub  geography;
+BEGIN
+  SELECT location_obscured, location_public INTO v_obsc, v_pub
+    FROM public.observations
+   WHERE id = 'aaaaaaaa-0000-0000-0000-000000000003';
+  IF v_pub IS NULL THEN
+    RAISE EXCEPTION 'FAIL [F1: location_public is NULL for sensitive row — public maps would lose the coarsened point]';
+  END IF;
+  IF ST_X(v_pub::geometry) IS DISTINCT FROM ST_X(v_obsc::geometry)
+     OR ST_Y(v_pub::geometry) IS DISTINCT FROM ST_Y(v_obsc::geometry) THEN
+    RAISE EXCEPTION 'FAIL [F1: location_public on a 5km row is not the obscured point (got %, %)]',
+      ST_X(v_pub::geometry), ST_Y(v_pub::geometry);
+  END IF;
+END $$;
+
+-- F1 test 3: anon location_public on the non-sensitive row is the precise point
+DO $$
+DECLARE
+  v_pub geography;
+BEGIN
+  SELECT location_public INTO v_pub
+    FROM public.observations
+   WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+  IF v_pub IS NULL
+     OR round(ST_X(v_pub::geometry)::numeric, 4) <> -99.1332
+     OR round(ST_Y(v_pub::geometry)::numeric, 4) <> 19.4326 THEN
+    RAISE EXCEPTION 'FAIL [F1: location_public on an obscure_level=none row should be the precise point]';
+  END IF;
+END $$;
+
+-- F1 test 4: anon cannot execute get_own_observation_locations (no grant)
+DO $$
+BEGIN
+  BEGIN
+    PERFORM 1 FROM public.get_own_observation_locations(
+      ARRAY['aaaaaaaa-0000-0000-0000-000000000003']::uuid[]);
+    RAISE EXCEPTION 'FAIL [F1: anon can execute get_own_observation_locations]';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL; -- expected
+  END;
+END $$;
+
+RESET ROLE;
+
+-- Owner context (uid_user owns both observations).
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claim.sub" = '00000000-0000-0000-0000-000000000003';
+
+-- F1 test 5: even the owner cannot SELECT the raw location column
+-- (column grants are not row-conditional — owner path is the RPC)
+DO $$
+DECLARE
+  v geography;
+BEGIN
+  BEGIN
+    SELECT location INTO v FROM public.observations
+     WHERE id = 'aaaaaaaa-0000-0000-0000-000000000003';
+    RAISE EXCEPTION 'FAIL [F1: authenticated can SELECT observations.location]';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL; -- expected
+  END;
+END $$;
+
+-- F1 test 6: owner reads own precise coords via the SECURITY DEFINER RPC
+DO $$
+DECLARE
+  v_lat double precision;
+  v_lng double precision;
+BEGIN
+  SELECT lat, lng INTO v_lat, v_lng
+    FROM public.get_own_observation_locations(
+      ARRAY['aaaaaaaa-0000-0000-0000-000000000003']::uuid[]);
+  IF v_lat IS NULL OR round(v_lat::numeric, 4) <> 19.4326 OR round(v_lng::numeric, 4) <> -99.1332 THEN
+    RAISE EXCEPTION 'FAIL [F1: owner did not get precise coords via get_own_observation_locations (got %, %)]', v_lat, v_lng;
+  END IF;
+END $$;
+
+-- F1 test 7: a different authenticated user gets ZERO rows from the RPC
+SET LOCAL "request.jwt.claim.sub" = '00000000-0000-0000-0000-000000000002';
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  SELECT count(*)::int INTO cnt
+    FROM public.get_own_observation_locations(
+      ARRAY['aaaaaaaa-0000-0000-0000-000000000003']::uuid[]);
+  IF cnt IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'FAIL [F1: non-owner read % precise location rows via get_own_observation_locations]', cnt;
+  END IF;
+END $$;
+
+-- F2 test 1: a non-owner CANNOT hijack the primary identification
+-- (uid_mod is still the active claim from F1 test 7)
+DO $$
+DECLARE
+  v uuid;
+BEGIN
+  BEGIN
+    v := public.upsert_primary_identification(
+      'aaaaaaaa-0000-0000-0000-000000000001',
+      'Hijackus maximus', NULL, 0.99, 'human', NULL);
+    RAISE EXCEPTION 'FAIL [F2: non-owner set a primary identification on another user''s observation]';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL; -- expected
+  END;
+END $$;
+
+-- F2 test 2: owner with an invalid source is rejected before any write
+SET LOCAL "request.jwt.claim.sub" = '00000000-0000-0000-0000-000000000003';
+DO $$
+DECLARE
+  v uuid;
+BEGIN
+  BEGIN
+    v := public.upsert_primary_identification(
+      'aaaaaaaa-0000-0000-0000-000000000001',
+      'Quercus testii', NULL, 0.5, 'not_a_real_source', NULL);
+    RAISE EXCEPTION 'FAIL [F2: invalid identification source accepted]';
+  EXCEPTION WHEN check_violation THEN
+    NULL; -- expected (errcode 23514)
+  END;
+END $$;
+
+-- F2 test 3: owner succeeds; out-of-range confidence is clamped to [0,1]
+DO $$
+DECLARE
+  v_id   uuid;
+  v_conf numeric;
+BEGIN
+  v_id := public.upsert_primary_identification(
+    'aaaaaaaa-0000-0000-0000-000000000001',
+    'Quercus testii', NULL, 1.7, 'human', NULL);
+  IF v_id IS NULL THEN
+    RAISE EXCEPTION 'FAIL [F2: owner upsert_primary_identification returned NULL]';
+  END IF;
+  SELECT confidence INTO v_conf FROM public.identifications WHERE id = v_id;
+  IF v_conf IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'FAIL [F2: confidence not clamped to 1 (got %)]', v_conf;
+  END IF;
+END $$;
+
+RESET ROLE;
+
+-- F3: profile_pokedex obscure_level filter uses a real enum value.
+-- The view previously filtered `<> 'private'` — a value obscure_level never
+-- holds — so fully-obscured ('full') observations leaked into the dex.
+DO $$
+DECLARE
+  leaked int;
+BEGIN
+  -- Seed a 'full' observation with a primary identification for uid_user.
+  INSERT INTO public.observations (id, observer_id, sync_status, obscure_level, hidden)
+  VALUES ('aaaaaaaa-0000-0000-0000-000000000004',
+          '00000000-0000-0000-0000-000000000003', 'synced', 'full', false)
+  ON CONFLICT (id) DO NOTHING;
+  INSERT INTO public.identifications (observation_id, scientific_name, confidence, source, is_primary)
+  VALUES ('aaaaaaaa-0000-0000-0000-000000000004', 'Occultus totalis', 0.9, 'human', true);
+
+  SELECT count(*)::int INTO leaked
+    FROM public.profile_pokedex
+   WHERE user_id = '00000000-0000-0000-0000-000000000003'
+     AND scientific_name = 'Occultus totalis';
+  IF leaked IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'FAIL [F3: profile_pokedex leaks obscure_level=full observations (% rows)]', leaked;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  RAISE NOTICE '2026-06 audit F1/F2/F3 assertions passed (column grants, owner RPC, upsert ownership, pokedex filter)';
+END $$;
+
+-- ────────────────────────────────────────────────────────────────────────────
 -- Summary
 -- ────────────────────────────────────────────────────────────────────────────
 

--- a/tests/sql/rls.sql
+++ b/tests/sql/rls.sql
@@ -1241,12 +1241,23 @@ DECLARE
   leaked int;
 BEGIN
   -- Seed a 'full' observation with a primary identification for uid_user.
-  INSERT INTO public.observations (id, observer_id, sync_status, obscure_level, hidden)
+  -- Order matters: the identification insert fires sync_primary_id_trigger,
+  -- which recomputes obscure_level from the (here non-existent) taxon and
+  -- COALESCEs to 'none'. We must set obscure_level = 'full' *after* that, via
+  -- an observations UPDATE (which does not re-fire the identification trigger
+  -- — only observations_material_edit_check_trg runs, and it touches only
+  -- last_material_edit_at). Seeding 'full' on the initial INSERT would be
+  -- silently clobbered back to 'none' and the assertion below would falsely
+  -- "leak".
+  INSERT INTO public.observations (id, observer_id, sync_status, hidden)
   VALUES ('aaaaaaaa-0000-0000-0000-000000000004',
-          '00000000-0000-0000-0000-000000000003', 'synced', 'full', false)
+          '00000000-0000-0000-0000-000000000003', 'synced', false)
   ON CONFLICT (id) DO NOTHING;
   INSERT INTO public.identifications (observation_id, scientific_name, confidence, source, is_primary)
   VALUES ('aaaaaaaa-0000-0000-0000-000000000004', 'Occultus totalis', 0.9, 'human', true);
+  UPDATE public.observations
+     SET obscure_level = 'full'
+   WHERE id = 'aaaaaaaa-0000-0000-0000-000000000004';
 
   SELECT count(*)::int INTO leaked
     FROM public.profile_pokedex


### PR DESCRIPTION
## Summary

The two critical backend findings + one medium from the 2026-06-09 audit (§2.1 of `docs/site-and-code-audit-2026-06-09.md`).

### F1 — precise coords of sensitive species were anon-readable
`obs_public_read` admits coarsened rows and RLS gates rows, not columns, so `GET /rest/v1/observations?select=location&obscure_level=eq.5km` returned exact coordinates. Mechanism (a bare revoke would have broken public maps for non-sensitive observations):

1. **`location_public` generated column** — precise when `obscure_level='none'`, else `location_obscured`; GIST-indexed; idempotent.
2. **Column-level SELECT grants** — table SELECT revoked from `anon, authenticated`, re-granted on an explicit 56-column list excluding `location` (placed after the blanket re-widening GRANT; loud maintenance comment: future `ADD COLUMN` must extend the list). Write grants untouched; `service_role` untouched (all EFs keep working).
3. **Owner path** — `get_own_observation_locations(uuid[])` SECURITY DEFINER RPC (invoker views can't bypass column grants), `observer_id = auth.uid()` filter, search_path pinned, EXECUTE revoked from PUBLIC.

Blast radius migrated in the same change: `profile_observation_pins`, `chat_obs_card` (owner-precise via LATERAL RPC join), `chat_find_observations`, `probable_taxa_at` (×2), and client call sites `ExploreMap`, `ExploreSpeciesView`, `share/obs` (owner coords re-stashed for the manage panel), `ExportView` (DwC joins precise coords via RPC), `sync.ts` (`select('*')` → `select('id')` — `*` fails under column grants). Independently verified: zero invoker views/functions still reference precise `location`; the 9 remaining references are all SECURITY DEFINER; matviews refresh as owner.

### F2 — `upsert_primary_identification` hijack
SECURITY DEFINER + granted to `authenticated` + no ownership check = any logged-in user could install a `source='human', confidence=1.0` primary on anyone's observation. Now: ownership gate (NULL `auth.uid()` reachable only by `service_role`, which the `identify` EF uses), `p_source` validated against the 14-value CHECK list, confidence clamped. Signature unchanged — `sync.ts` callers unaffected; `consensus-untouched` freeze tests unaffected.

### F3 — `profile_pokedex` dead filter
`obscure_level <> 'private'` (enum never holds it) → `<> 'full'`, closing the presence leak of fully-withheld sensitive observations.

## Test plan

- 11 new assertions in `tests/sql/rls.sql`: anon `SELECT location` → permission denied; `location_public` coalescing on 5km vs none rows; RPC owner/non-owner; hijack rejection; invalid source; clamping; pokedex.
- `bash scripts/check-rls-coverage.sh` → OK (190 policies, 0 untested-not-allowlisted).
- `npx vitest run` full suite ✓ · `npx tsc --noEmit` ✓ · `npm run build` ✓
- e2e on touched surfaces: `journey-guest-browse`, `journey-share-observation-public`, `journey-researcher-export`, `smoke` → **37 passed**.
- The `db-validate` double-apply exercises the generated column + grants against real Postgres.
- After merge + `db-apply`: manually verify `curl '$SUPABASE_URL/rest/v1/observations?select=location&limit=1' -H "apikey: $ANON_KEY"` → 42501, and the explore map still renders pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)